### PR TITLE
feat(proof): route jobs by artifact hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5548,6 +5548,7 @@ dependencies = [
 name = "base-proof-worker"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "async-trait",
  "backon",
  "base-prover-service-client",
@@ -5828,6 +5829,7 @@ dependencies = [
 name = "base-prover-service"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "base-prover-service-db",
  "base-prover-service-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6551,6 +6551,7 @@ dependencies = [
 name = "base-zk-benchmarks-bin"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "base-cli-utils",
  "base-load-tests",
  "base-prover-service-protocol",

--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -6,7 +6,7 @@ use base_cli_utils::{LogConfig, RuntimeManager};
 use base_proof_worker::{
     DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
 };
-use base_proof_zk_backend::SuccinctZkProversConfig;
+use base_proof_zk_backend::{SuccinctZkProversConfig, zk_artifact_hash};
 use base_proof_zk_host::{
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
     DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES, ProofGeneratorHeartbeatConfig,
@@ -231,10 +231,14 @@ impl WorkerArgs {
             args.proof_generator_heartbeat_lock_duration_seconds,
             args.proof_generator_max_consecutive_heartbeat_failures,
         );
+        let artifact_hash = zk_artifact_hash()
+            .await
+            .map_err(|error| eyre::eyre!("failed to derive local ZK artifact hash: {error}"))?;
 
         let worker_id =
             args.worker_id.clone().unwrap_or_else(|| format!("zk-host-{}", Uuid::new_v4()));
         let host_config = ZkHostConfig::sp1(worker_id.clone())
+            .with_supported_artifact_hash(artifact_hash)
             .with_job_discovery_poll_interval(Duration::from_millis(
                 args.job_discovery_poll_interval_ms,
             ))

--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -237,8 +237,7 @@ impl WorkerArgs {
 
         let worker_id =
             args.worker_id.clone().unwrap_or_else(|| format!("zk-host-{}", Uuid::new_v4()));
-        let host_config = ZkHostConfig::sp1(worker_id.clone())
-            .with_supported_artifact_hash(artifact_hash)
+        let host_config = ZkHostConfig::sp1(worker_id.clone(), artifact_hash)
             .with_job_discovery_poll_interval(Duration::from_millis(
                 args.job_discovery_poll_interval_ms,
             ))

--- a/bin/zk-benchmarks/Cargo.toml
+++ b/bin/zk-benchmarks/Cargo.toml
@@ -16,6 +16,9 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+# alloy
+alloy-primitives.workspace = true
+
 # base
 base-cli-utils.workspace = true
 base-load-tests.workspace = true

--- a/bin/zk-benchmarks/src/cli.rs
+++ b/bin/zk-benchmarks/src/cli.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use alloy_primitives::B256;
 use base_cli_utils::RuntimeManager;
 use base_load_tests::{LoadTestDisplay, LoadTestExecutor, LoadTestRunOptions, TestConfig};
 use base_prover_service_protocol::ZkBackend;
@@ -32,6 +33,10 @@ pub(crate) struct ZkBenchArgs {
         default_value = "http://localhost:9000"
     )]
     prover_service_url: url::Url,
+
+    /// Composite ZK artifact hash requested from prover workers.
+    #[arg(long, env = "ZK_ARTIFACT_HASH")]
+    zk_artifact_hash: B256,
 
     /// Load test YAML configuration.
     #[arg(value_name = "CONFIG")]
@@ -68,6 +73,7 @@ async fn run_zk_benchmark(args: ZkBenchArgs) -> Result<()> {
     let test_config = TestConfig::load(&args.config)?;
     let zk_config = ZkBenchConfig {
         zk_backend: args.mode.into(),
+        zk_artifact_hash: args.zk_artifact_hash,
         rollup_rpc_url: args.rollup_rpc_url,
         prover_url: args.prover_service_url,
     };

--- a/crates/infra/basectl/src/commands/proofs.rs
+++ b/crates/infra/basectl/src/commands/proofs.rs
@@ -563,10 +563,12 @@ async fn run_propose(config: MonitoringConfig, args: ProofsProposeArgs) -> Resul
 
     let games_client = GamesClient::connect(factory, &l1_rpc);
     let details = games_client.game_details(game).await?;
+    let zk_artifact_hash = games_client.proof_artifacts(game).await?.zk_artifact_hash();
     let request = ProofProposeRequest::for_game(
         &details,
         prover_address,
         zk_backend,
+        zk_artifact_hash,
         session_id,
         intermediate_root_interval,
     )?;
@@ -680,12 +682,14 @@ async fn run_submit(config: MonitoringConfig, args: ProofsSubmitArgs) -> Result<
 
     let games_client = GamesClient::connect(factory, &l1_rpc);
     let details = games_client.game_details(game).await?;
+    let zk_artifact_hash = games_client.proof_artifacts(game).await?.zk_artifact_hash();
     let derived_session = session_id.is_none();
     let session_id = ProofProposeRequest::session_id_for_game(
         &config.name,
         &details,
         sender,
         zk_backend,
+        zk_artifact_hash,
         session_id,
         intermediate_root_interval,
     )?;
@@ -802,10 +806,12 @@ async fn run_finalize(
         }
     };
     let details = games_client.game_details(game).await?;
+    let zk_artifact_hash = games_client.proof_artifacts(game).await?.zk_artifact_hash();
     let request = ProofProposeRequest::for_game(
         &details,
         sender,
         zk_backend,
+        zk_artifact_hash,
         session_id,
         intermediate_root_interval,
     )?;
@@ -1856,6 +1862,7 @@ mod tests {
             &sample_game_details(),
             Address::repeat_byte(0xDD),
             ZkBackend::Network,
+            B256::repeat_byte(0x33),
             Some("propose-session".to_string()),
             None,
         )

--- a/crates/infra/basectl/src/rpc/games.rs
+++ b/crates/infra/basectl/src/rpc/games.rs
@@ -13,8 +13,8 @@ use alloy_transport::{TransportError, TransportErrorKind};
 pub use base_proof_contracts::GameStatus;
 use base_proof_contracts::{
     AggregateVerifierClient, AggregateVerifierContractClient, ContractError,
-    DisputeGameFactoryClient, DisputeGameFactoryContractClient, decode_create_calldata,
-    encode_extra_data,
+    DisputeGameFactoryClient, DisputeGameFactoryContractClient, ProofArtifacts,
+    decode_create_calldata, encode_extra_data,
 };
 use futures::{StreamExt, stream, try_join};
 use tracing::debug;
@@ -426,6 +426,14 @@ impl GamesClient {
             expected_resolution,
             countered_index: countered_plus_one.checked_sub(1),
         })
+    }
+
+    /// Reads the immutable proof artifacts accepted by a game proxy.
+    pub async fn proof_artifacts(
+        &self,
+        address: Address,
+    ) -> Result<ProofArtifacts, ProofsCommandError> {
+        self.verifier.proof_artifacts(address).await.map_err(|error| self.contract_error(error))
     }
 
     /// Fetches the list-row snapshot for one game.

--- a/crates/infra/basectl/src/rpc/prover.rs
+++ b/crates/infra/basectl/src/rpc/prover.rs
@@ -246,6 +246,7 @@ impl ProofProposeRequest {
                         l1_head: Some(self.l1_head),
                         intermediate_root_interval: Some(self.intermediate_root_interval),
                         schedule_l2_block_number: None,
+                        zk_artifact_hash: None,
                         zk_vm: ZkVm::Sp1,
                         zk_backend: self.zk_backend,
                     },

--- a/crates/infra/basectl/src/rpc/prover.rs
+++ b/crates/infra/basectl/src/rpc/prover.rs
@@ -47,6 +47,8 @@ pub struct ProofProposeRequest {
     pub prover_address: Address,
     /// ZK proving backend that executes the proof.
     pub zk_backend: ZkBackend,
+    /// Composite ZK artifact hash required by the target game.
+    pub zk_artifact_hash: B256,
     /// Explicit session ID override. When `None`, an idempotent session ID is
     /// derived from the network name, game, block range, checkpoint stride,
     /// and prover address.
@@ -71,6 +73,7 @@ impl ProofProposeRequest {
         details: &GameDetails,
         prover_address: Address,
         zk_backend: ZkBackend,
+        zk_artifact_hash: B256,
         session_id: Option<String>,
         intermediate_root_interval: Option<u64>,
     ) -> Result<Self, ProofsCommandError> {
@@ -97,6 +100,7 @@ impl ProofProposeRequest {
             intermediate_root_interval,
             prover_address,
             zk_backend,
+            zk_artifact_hash,
             session_id,
         })
     }
@@ -111,6 +115,7 @@ impl ProofProposeRequest {
         details: &GameDetails,
         prover_address: Address,
         zk_backend: ZkBackend,
+        zk_artifact_hash: B256,
         session_id: Option<String>,
         intermediate_root_interval: Option<u64>,
     ) -> Result<String, ProofsCommandError> {
@@ -127,6 +132,7 @@ impl ProofProposeRequest {
             intermediate_root_interval,
             prover_address,
             zk_backend,
+            zk_artifact_hash,
         ))
     }
 
@@ -200,6 +206,7 @@ impl ProofProposeRequest {
                 self.intermediate_root_interval,
                 self.prover_address,
                 self.zk_backend,
+                self.zk_artifact_hash,
             )
         })
     }
@@ -212,6 +219,7 @@ impl ProofProposeRequest {
         intermediate_root_interval: u64,
         prover_address: Address,
         zk_backend: ZkBackend,
+        zk_artifact_hash: B256,
     ) -> String {
         let subtype = match zk_backend {
             ZkBackend::DryRun => "zk/sp1/snark_plonk/dry_run",
@@ -228,6 +236,7 @@ impl ProofProposeRequest {
                 &num_blocks.to_be_bytes(),
                 &intermediate_root_interval.to_be_bytes(),
                 prover_address.as_slice(),
+                zk_artifact_hash.as_slice(),
             ],
         )
     }
@@ -246,7 +255,7 @@ impl ProofProposeRequest {
                         l1_head: Some(self.l1_head),
                         intermediate_root_interval: Some(self.intermediate_root_interval),
                         schedule_l2_block_number: None,
-                        zk_artifact_hash: None,
+                        zk_artifact_hash: Some(self.zk_artifact_hash),
                         zk_vm: ZkVm::Sp1,
                         zk_backend: self.zk_backend,
                     },
@@ -484,6 +493,7 @@ mod tests {
             &provable_game(),
             Address::repeat_byte(0xDD),
             ZkBackend::Network,
+            B256::repeat_byte(0x33),
             None,
             None,
         )
@@ -515,6 +525,7 @@ mod tests {
                 &details,
                 Address::repeat_byte(0xDD),
                 ZkBackend::Network,
+                B256::repeat_byte(0x33),
                 None,
                 None,
             )
@@ -529,6 +540,7 @@ mod tests {
             &provable_game(),
             Address::ZERO,
             ZkBackend::Network,
+            B256::repeat_byte(0x33),
             None,
             None,
         )
@@ -543,6 +555,7 @@ mod tests {
             &provable_game(),
             Address::repeat_byte(0xDD),
             ZkBackend::Network,
+            B256::repeat_byte(0x33),
             None,
             Some(250),
         )
@@ -558,6 +571,7 @@ mod tests {
                 &no_stride,
                 Address::repeat_byte(0xDD),
                 ZkBackend::Network,
+                B256::repeat_byte(0x33),
                 None,
                 Some(interval),
             )
@@ -577,6 +591,7 @@ mod tests {
             &no_stride,
             Address::repeat_byte(0xDD),
             ZkBackend::Network,
+            B256::repeat_byte(0x33),
             None,
             Some(250),
         )
@@ -594,6 +609,7 @@ mod tests {
             &extra_roots,
             Address::repeat_byte(0xDD),
             ZkBackend::Network,
+            B256::repeat_byte(0x33),
             None,
             None,
         )
@@ -611,6 +627,7 @@ mod tests {
             &no_stride,
             Address::repeat_byte(0xDD),
             ZkBackend::Network,
+            B256::repeat_byte(0x33),
             None,
             Some(500),
         )
@@ -635,12 +652,15 @@ mod tests {
             ProofProposeRequest { zk_backend: ZkBackend::Cluster, ..request.clone() };
         let other_stride =
             ProofProposeRequest { intermediate_root_interval: 200, ..request.clone() };
+        let other_artifact =
+            ProofProposeRequest { zk_artifact_hash: B256::repeat_byte(0x44), ..request.clone() };
 
         let base_id = request.effective_session_id("mainnet");
         assert_ne!(base_id, other_game.effective_session_id("mainnet"));
         assert_ne!(base_id, other_prover.effective_session_id("mainnet"));
         assert_ne!(base_id, other_backend.effective_session_id("mainnet"));
         assert_ne!(base_id, other_stride.effective_session_id("mainnet"));
+        assert_ne!(base_id, other_artifact.effective_session_id("mainnet"));
         assert_ne!(base_id, request.effective_session_id("sepolia"));
     }
 
@@ -668,6 +688,7 @@ mod tests {
             &unavailable,
             Address::repeat_byte(0xDD),
             ZkBackend::Network,
+            B256::repeat_byte(0x33),
             None,
             None,
         )
@@ -689,6 +710,7 @@ mod tests {
                 assert_eq!(snark.proof.sequence_window, None);
                 assert_eq!(snark.proof.l1_head, Some(B256::repeat_byte(0x22)));
                 assert_eq!(snark.proof.intermediate_root_interval, Some(100));
+                assert_eq!(snark.proof.zk_artifact_hash, Some(B256::repeat_byte(0x33)));
                 assert_eq!(snark.proof.zk_vm, ZkVm::Sp1);
                 assert_eq!(snark.proof.zk_backend, ZkBackend::Network);
             }

--- a/crates/infra/snark-e2e/src/snark_e2e.rs
+++ b/crates/infra/snark-e2e/src/snark_e2e.rs
@@ -216,6 +216,7 @@ impl SnarkE2e {
                             l1_head: None,
                             intermediate_root_interval: None,
                             schedule_l2_block_number: None,
+                            zk_artifact_hash: None,
                             zk_vm: ZkVm::Sp1,
                             zk_backend: ZkBackend::Cluster,
                         },

--- a/crates/infra/snark-e2e/src/snark_e2e.rs
+++ b/crates/infra/snark-e2e/src/snark_e2e.rs
@@ -203,6 +203,9 @@ impl SnarkE2e {
         // fallback, which is more robust than the client-side l1_origin + 50
         // heuristic.
         let client = Self::connect()?;
+        let artifact_hash = base_proof_zk_backend::zk_artifact_hash()
+            .await
+            .context("failed to derive local ZK artifact hash")?;
         let session_id = Uuid::new_v4().to_string();
         let prove_resp = client
             .prove_block_range(ProveBlockRangeRequest {
@@ -216,7 +219,7 @@ impl SnarkE2e {
                             l1_head: None,
                             intermediate_root_interval: None,
                             schedule_l2_block_number: None,
-                            zk_artifact_hash: None,
+                            zk_artifact_hash: Some(artifact_hash),
                             zk_vm: ZkVm::Sp1,
                             zk_backend: ZkBackend::Cluster,
                         },

--- a/crates/infra/zk-benchmarks/src/runner.rs
+++ b/crates/infra/zk-benchmarks/src/runner.rs
@@ -108,13 +108,20 @@ impl ZkBenchRunner {
         let start_block_number =
             block_number.checked_sub(1).ok_or_else(|| eyre::eyre!("cannot prove genesis block"))?;
         let zk_backend = config.zk_backend;
+        let zk_artifact_hash = config.zk_artifact_hash;
         let client_config = ProverServiceClientConfig::new(config.prover_url.as_str());
         let proof_timeout = client_config.max_wait();
         let poll_interval = client_config.poll_interval();
         let client = ProofRequesterClient::connect(&client_config)
             .wrap_err_with(|| format!("failed to connect prover service {}", config.prover_url))?;
         let session_id = format!("zk-benchmarks-{}-{}", zk_backend.as_str(), nanoid!());
-        let request = Self::proof_request(session_id, start_block_number, l1_head, zk_backend);
+        let request = Self::proof_request(
+            session_id,
+            start_block_number,
+            l1_head,
+            zk_backend,
+            zk_artifact_hash,
+        );
         let proof_started = Instant::now();
         let response =
             client.prove_block_range(request).await.wrap_err("prove-block-range request failed")?;
@@ -144,6 +151,7 @@ impl ZkBenchRunner {
         start_block_number: u64,
         l1_head: B256,
         zk_backend: ZkBackend,
+        zk_artifact_hash: B256,
     ) -> ProveBlockRangeRequest {
         ProveBlockRangeRequest {
             proof: ProofRequest {
@@ -155,7 +163,7 @@ impl ZkBenchRunner {
                     l1_head: Some(l1_head),
                     intermediate_root_interval: None,
                     schedule_l2_block_number: None,
-                    zk_artifact_hash: None,
+                    zk_artifact_hash: Some(zk_artifact_hash),
                     zk_vm: ZkVm::Sp1,
                     zk_backend,
                 }),
@@ -274,6 +282,7 @@ mod tests {
             9,
             B256::repeat_byte(0xaa),
             ZkBackend::Cluster,
+            B256::repeat_byte(0xbb),
         );
         let ProofRequestKind::Compressed(proof) = request.proof.request else {
             panic!("expected compressed proof request");
@@ -282,6 +291,7 @@ mod tests {
         assert_eq!(proof.start_block_number, 9);
         assert_eq!(proof.number_of_blocks_to_prove, 1);
         assert_eq!(proof.l1_head, Some(B256::repeat_byte(0xaa)));
+        assert_eq!(proof.zk_artifact_hash, Some(B256::repeat_byte(0xbb)));
         assert_eq!(proof.zk_backend, ZkBackend::Cluster);
     }
 

--- a/crates/infra/zk-benchmarks/src/runner.rs
+++ b/crates/infra/zk-benchmarks/src/runner.rs
@@ -155,6 +155,7 @@ impl ZkBenchRunner {
                     l1_head: Some(l1_head),
                     intermediate_root_interval: None,
                     schedule_l2_block_number: None,
+                    zk_artifact_hash: None,
                     zk_vm: ZkVm::Sp1,
                     zk_backend,
                 }),

--- a/crates/infra/zk-benchmarks/src/types.rs
+++ b/crates/infra/zk-benchmarks/src/types.rs
@@ -32,6 +32,8 @@ mod duration_millis {
 pub struct ZkBenchConfig {
     /// Proof backend.
     pub zk_backend: ZkBackend,
+    /// Composite ZK artifact hash to request.
+    pub zk_artifact_hash: B256,
     /// Rollup node RPC URL.
     pub rollup_rpc_url: Url,
     /// ZK prover RPC URL.

--- a/crates/infra/zk-fork-dispute/src/checkpoint.rs
+++ b/crates/infra/zk-fork-dispute/src/checkpoint.rs
@@ -130,6 +130,7 @@ impl Checkpoint {
         prover_address: Address,
         l1_head: B256,
         game_l2_block_number: u64,
+        zk_artifact_hash: B256,
     ) -> Result<Bytes> {
         let client = ProofRequesterClient::connect(&ProverServiceClientConfig::new(
             config.prover_service_url.as_str(),
@@ -153,7 +154,7 @@ impl Checkpoint {
                 l1_head: Some(l1_head),
                 intermediate_root_interval: Some(self.block_count),
                 schedule_l2_block_number: Some(game_l2_block_number),
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(zk_artifact_hash),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: config.zk_backend,
             },
@@ -164,6 +165,7 @@ impl Checkpoint {
             self.index,
             prover_address,
             config.zk_backend.as_str(),
+            zk_artifact_hash,
         );
         let response = client
             .prove_block_range(ProveBlockRangeRequest {
@@ -266,6 +268,7 @@ impl Checkpoint {
         invalid_index: u64,
         prover_address: Address,
         zk_backend: &str,
+        zk_artifact_hash: B256,
     ) -> String {
         let invalid_index = invalid_index.to_be_bytes();
         ProofSessionId::derive_from_components(
@@ -276,6 +279,7 @@ impl Checkpoint {
                 &invalid_index,
                 prover_address.as_slice(),
                 zk_backend.as_bytes(),
+                zk_artifact_hash.as_slice(),
             ],
         )
     }

--- a/crates/infra/zk-fork-dispute/src/checkpoint.rs
+++ b/crates/infra/zk-fork-dispute/src/checkpoint.rs
@@ -153,6 +153,7 @@ impl Checkpoint {
                 l1_head: Some(l1_head),
                 intermediate_root_interval: Some(self.block_count),
                 schedule_l2_block_number: Some(game_l2_block_number),
+                zk_artifact_hash: None,
                 zk_vm: ZkVm::Sp1,
                 zk_backend: config.zk_backend,
             },

--- a/crates/infra/zk-fork-dispute/src/fork_dispute.rs
+++ b/crates/infra/zk-fork-dispute/src/fork_dispute.rs
@@ -68,8 +68,11 @@ impl ZkForkDispute {
         );
 
         let game_l2_block_number = verifier.game_info(config.game_address).await?.l2_block_number;
-        let proof_bytes =
-            checkpoint.request_proof(&config, challenger, l1_head, game_l2_block_number).await?;
+        let zk_artifact_hash =
+            verifier.proof_artifacts(config.game_address).await?.zk_artifact_hash();
+        let proof_bytes = checkpoint
+            .request_proof(&config, challenger, l1_head, game_l2_block_number, zk_artifact_hash)
+            .await?;
 
         let tx_hash = submitter
             .submit_dispute(

--- a/crates/proof/challenge/src/pending.rs
+++ b/crates/proof/challenge/src/pending.rs
@@ -368,6 +368,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
+                zk_artifact_hash: None,
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -7,7 +7,7 @@ use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest,
     SnarkPlonkProofRequest, TeeKind, TeeProofRequest,
 };
-use eyre::{Result, WrapErr, bail};
+use eyre::{Result, WrapErr, bail, eyre};
 
 /// Conversion helpers for challenger proof requests and dispute proof bytes.
 #[derive(Debug)]
@@ -46,16 +46,16 @@ impl ChallengerProofAdapter {
         game_address: Address,
         invalid_index: u64,
         request: SnarkPlonkProofRequest,
-    ) -> ProveBlockRangeRequest {
-        let session_id = Self::snark_plonk_session_id(
-            request.proof.zk_artifact_hash.unwrap_or_default(),
-            game_address,
-            invalid_index,
-        );
-        ProveBlockRangeRequest {
+    ) -> Result<ProveBlockRangeRequest> {
+        let artifact_hash = request
+            .proof
+            .zk_artifact_hash
+            .ok_or_else(|| eyre!("challenger ZK request is missing its artifact hash"))?;
+        let session_id = Self::snark_plonk_session_id(artifact_hash, game_address, invalid_index);
+        Ok(ProveBlockRangeRequest {
             proof: ProofRequest { session_id, request: ProofRequestKind::SnarkPlonk(request) },
             retry_failed: true,
-        }
+        })
     }
 
     /// Builds a prover-service request for a challenger TEE proof.
@@ -233,10 +233,37 @@ mod tests {
             game_address,
             invalid_index,
             request.clone(),
-        );
+        )
+        .expect("artifact-aware request should wrap");
 
         assert_eq!(wrapped.proof.session_id, session_id);
         assert_eq!(wrapped.proof.request, ProofRequestKind::SnarkPlonk(request));
+    }
+
+    #[test]
+    fn snark_plonk_prove_block_range_request_rejects_missing_artifact_hash() {
+        let request = SnarkPlonkProofRequest {
+            proof: ZkProofRequest {
+                start_block_number: 100,
+                number_of_blocks_to_prove: 300,
+                sequence_window: None,
+                l1_head: None,
+                intermediate_root_interval: None,
+                schedule_l2_block_number: None,
+                zk_artifact_hash: None,
+                zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
+            },
+            prover_address: Address::repeat_byte(0x11),
+        };
+
+        let error = ChallengerProofAdapter::snark_plonk_prove_block_range_request(
+            Address::repeat_byte(0xaa),
+            1,
+            request,
+        )
+        .expect_err("missing artifact hash should fail");
+        assert!(error.to_string().contains("missing its artifact hash"));
     }
 
     #[test]

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -18,22 +18,26 @@ impl ChallengerProofAdapter {
     const SESSION_NAMESPACE: &'static [u8] = b"base/challenger/proof-session/v2";
 
     /// Derives an idempotent challenger SNARK proof session ID.
-    pub fn snark_plonk_session_id(game_address: Address, invalid_index: u64) -> String {
+    pub fn snark_plonk_session_id(
+        artifact_hash: B256,
+        game_address: Address,
+        invalid_index: u64,
+    ) -> String {
         let invalid_index = invalid_index.to_be_bytes();
         ProofSessionId::derive_from_components(
             Self::SESSION_NAMESPACE,
             "zk/sp1/snark_plonk",
-            &[game_address.as_slice(), &invalid_index],
+            &[artifact_hash.as_slice(), game_address.as_slice(), &invalid_index],
         )
     }
 
     /// Derives an idempotent challenger TEE proof session ID.
-    pub fn tee_session_id(game_address: Address, invalid_index: u64) -> String {
+    pub fn tee_session_id(image_hash: B256, game_address: Address, invalid_index: u64) -> String {
         let invalid_index = invalid_index.to_be_bytes();
         ProofSessionId::derive_from_components(
             Self::SESSION_NAMESPACE,
             "tee/aws_nitro",
-            &[game_address.as_slice(), &invalid_index],
+            &[image_hash.as_slice(), game_address.as_slice(), &invalid_index],
         )
     }
 
@@ -43,7 +47,11 @@ impl ChallengerProofAdapter {
         invalid_index: u64,
         request: SnarkPlonkProofRequest,
     ) -> ProveBlockRangeRequest {
-        let session_id = Self::snark_plonk_session_id(game_address, invalid_index);
+        let session_id = Self::snark_plonk_session_id(
+            request.proof.zk_artifact_hash.unwrap_or_default(),
+            game_address,
+            invalid_index,
+        );
         ProveBlockRangeRequest {
             proof: ProofRequest { session_id, request: ProofRequestKind::SnarkPlonk(request) },
             retry_failed: true,
@@ -56,7 +64,7 @@ impl ChallengerProofAdapter {
         invalid_index: u64,
         request: PrimitiveProofRequest,
     ) -> ProveBlockRangeRequest {
-        let session_id = Self::tee_session_id(game_address, invalid_index);
+        let session_id = Self::tee_session_id(request.image_hash, game_address, invalid_index);
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id,
@@ -140,28 +148,59 @@ mod tests {
     fn challenger_session_ids_are_stable_and_type_separated() {
         let game_address = Address::repeat_byte(0xaa);
         let invalid_index = 1;
+        let artifact_hash = B256::repeat_byte(0x42);
 
         assert_eq!(
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, invalid_index),
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, invalid_index)
+            ChallengerProofAdapter::snark_plonk_session_id(
+                artifact_hash,
+                game_address,
+                invalid_index
+            ),
+            ChallengerProofAdapter::snark_plonk_session_id(
+                artifact_hash,
+                game_address,
+                invalid_index
+            )
         );
         assert_ne!(
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, invalid_index),
-            ChallengerProofAdapter::tee_session_id(game_address, invalid_index)
+            ChallengerProofAdapter::snark_plonk_session_id(
+                artifact_hash,
+                game_address,
+                invalid_index
+            ),
+            ChallengerProofAdapter::tee_session_id(artifact_hash, game_address, invalid_index)
         );
     }
 
     #[test]
     fn challenger_session_ids_separate_game_address_and_invalid_index() {
         let game_address = Address::repeat_byte(0xaa);
+        let artifact_hash = B256::repeat_byte(0x42);
 
         assert_ne!(
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, 1),
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, 2)
+            ChallengerProofAdapter::snark_plonk_session_id(artifact_hash, game_address, 1),
+            ChallengerProofAdapter::snark_plonk_session_id(artifact_hash, game_address, 2)
         );
         assert_ne!(
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, 1),
-            ChallengerProofAdapter::snark_plonk_session_id(Address::repeat_byte(0xbb), 1)
+            ChallengerProofAdapter::snark_plonk_session_id(artifact_hash, game_address, 1),
+            ChallengerProofAdapter::snark_plonk_session_id(
+                artifact_hash,
+                Address::repeat_byte(0xbb),
+                1
+            )
+        );
+    }
+
+    #[test]
+    fn challenger_session_ids_separate_artifact_hashes() {
+        let game_address = Address::repeat_byte(0xaa);
+        assert_ne!(
+            ChallengerProofAdapter::snark_plonk_session_id(B256::repeat_byte(1), game_address, 1),
+            ChallengerProofAdapter::snark_plonk_session_id(B256::repeat_byte(2), game_address, 1),
+        );
+        assert_ne!(
+            ChallengerProofAdapter::tee_session_id(B256::repeat_byte(1), game_address, 1),
+            ChallengerProofAdapter::tee_session_id(B256::repeat_byte(2), game_address, 1),
         );
     }
 
@@ -169,8 +208,12 @@ mod tests {
     fn snark_plonk_prove_block_range_request_converts_zk_request() {
         let game_address = Address::repeat_byte(0xaa);
         let invalid_index = 1;
-        let session_id =
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, invalid_index);
+        let artifact_hash = B256::repeat_byte(0x42);
+        let session_id = ChallengerProofAdapter::snark_plonk_session_id(
+            artifact_hash,
+            game_address,
+            invalid_index,
+        );
         let prover_address = Address::repeat_byte(0x11);
         let l1_head = B256::repeat_byte(0x22);
         let proof = ZkProofRequest {
@@ -180,6 +223,7 @@ mod tests {
             l1_head: Some(l1_head),
             intermediate_root_interval: Some(150),
             schedule_l2_block_number: None,
+            zk_artifact_hash: Some(artifact_hash),
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         };
@@ -209,9 +253,11 @@ mod tests {
             proposer: Address::repeat_byte(0x04),
             intermediate_block_interval: 300,
             l1_head_number: 1200,
+            image_hash: B256::repeat_byte(0x42),
             schedule_l2_block_number: None,
         };
-        let session_id = ChallengerProofAdapter::tee_session_id(game_address, invalid_index);
+        let session_id =
+            ChallengerProofAdapter::tee_session_id(request.image_hash, game_address, invalid_index);
 
         let wrapped = ChallengerProofAdapter::tee_prove_block_range_request(
             game_address,

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -241,7 +241,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             game_address,
             invalid_index,
             proof_request.clone(),
-        );
+        )?;
 
         let prove_response = self.proof_requester.prove_block_range(request).await?;
 
@@ -587,7 +587,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             game_address,
             invalid_index,
             request,
-        );
+        )?;
 
         match self.proof_requester.prove_block_range(prove_request).await {
             Ok(response) => {
@@ -649,7 +649,7 @@ mod tests {
                 l1_head: Some(B256::repeat_byte(0xAA)),
                 intermediate_root_interval: Some(10),
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x42)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -296,6 +296,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             proposer,
             intermediate_block_interval: candidate.intermediate_block_interval,
             l1_head_number,
+            image_hash: candidate.proof_artifacts.tee_image_hash,
             schedule_l2_block_number: Some(candidate.info.l2_block_number),
         })
     }
@@ -316,6 +317,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
                 l1_head: Some(candidate.l1_head),
                 intermediate_root_interval: Some(candidate.intermediate_block_interval),
                 schedule_l2_block_number: Some(candidate.info.l2_block_number),
+                zk_artifact_hash: Some(candidate.proof_artifacts.zk_artifact_hash()),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },
@@ -647,6 +649,7 @@ mod tests {
                 l1_head: Some(B256::repeat_byte(0xAA)),
                 intermediate_root_interval: Some(10),
                 schedule_l2_block_number: None,
+                zk_artifact_hash: None,
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -40,7 +40,7 @@ use std::{
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient, GameAtIndex,
-    GameInfo, GameStatus,
+    GameInfo, GameStatus, ProofArtifacts,
 };
 use eyre::Result;
 use futures::stream::{self, StreamExt};
@@ -102,6 +102,8 @@ pub struct CandidateGame {
     pub intermediate_block_interval: u64,
     /// The L1 head block hash stored at game creation time.
     pub l1_head: B256,
+    /// Proving artifacts committed by this game's verifier.
+    pub proof_artifacts: ProofArtifacts,
     /// Address of the TEE prover for this game (`Address::ZERO` if none registered).
     pub tee_prover: Address,
     /// Classification of this candidate and the action the driver should take.
@@ -393,17 +395,19 @@ impl GameScanner {
         };
 
         // Fetch remaining fields only for actionable games.
-        let ((info, starting_block_number, l1_head), intermediate_block_interval) = tokio::try_join!(
-            async {
-                tokio::try_join!(
-                    self.verifier_client.game_info(factory.proxy),
-                    self.verifier_client.starting_block_number(factory.proxy),
-                    self.verifier_client.l1_head(factory.proxy),
-                )
-                .map_err(Into::into)
-            },
-            self.resolve_intermediate_block_interval(factory.game_type),
-        )?;
+        let ((info, starting_block_number, l1_head, proof_artifacts), intermediate_block_interval) =
+            tokio::try_join!(
+                async {
+                    tokio::try_join!(
+                        self.verifier_client.game_info(factory.proxy),
+                        self.verifier_client.starting_block_number(factory.proxy),
+                        self.verifier_client.l1_head(factory.proxy),
+                        self.verifier_client.proof_artifacts(factory.proxy),
+                    )
+                    .map_err(Into::into)
+                },
+                self.resolve_intermediate_block_interval(factory.game_type),
+            )?;
 
         Ok(Some(CandidateGame {
             index,
@@ -412,6 +416,7 @@ impl GameScanner {
             starting_block_number,
             intermediate_block_interval,
             l1_head,
+            proof_artifacts,
             tee_prover,
             category,
         }))

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -20,7 +20,7 @@ use base_common_consensus::Predeploys;
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorPreflight, AnchorRoot, AnchorSnapshot,
     AnchorStateRegistryClient, ContractError, DisputeGameFactoryClient, GameAtIndex, GameInfo,
-    GameStatus,
+    GameStatus, ProofArtifacts,
 };
 use base_proof_rpc::{BaseHeader, L1Provider, L2Provider, RpcError, RpcResult};
 use base_prover_service_client::{ProofRequesterProvider, ProverServiceClientError};
@@ -49,6 +49,8 @@ pub struct MockGameState {
     pub starting_block_number: u64,
     /// L1 head block hash stored at game creation time.
     pub l1_head: B256,
+    /// Proving artifacts committed by this game.
+    pub proof_artifacts: ProofArtifacts,
     /// Intermediate output roots for this game.
     pub intermediate_output_roots: Vec<B256>,
     /// 1-based index of the challenged intermediate root (`0` = unchallenged).
@@ -86,6 +88,11 @@ impl Default for MockGameState {
             },
             starting_block_number: 0,
             l1_head: B256::ZERO,
+            proof_artifacts: ProofArtifacts {
+                tee_image_hash: B256::repeat_byte(0x11),
+                zk_range_hash: B256::repeat_byte(0x22),
+                zk_aggregate_hash: B256::repeat_byte(0x33),
+            },
             intermediate_output_roots: vec![],
             countered_index: 0,
             game_over: false,
@@ -311,6 +318,13 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError> {
         self.status_reads.lock().unwrap().push(game_address);
         self.get(game_address, |s| s.status)
+    }
+
+    async fn proof_artifacts(
+        &self,
+        game_address: Address,
+    ) -> Result<ProofArtifacts, ContractError> {
+        self.get(game_address, |s| s.proof_artifacts)
     }
 
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -17,7 +17,9 @@ use base_challenger::{
         mock_state, mock_state_with_tee, receipt_with_status,
     },
 };
-use base_proof_contracts::{AggregateVerifierClient, DisputeGameFactoryClient, GameStatus};
+use base_proof_contracts::{
+    AggregateVerifierClient, DisputeGameFactoryClient, GameStatus, ProofArtifacts,
+};
 use base_proof_primitives::Proposal;
 use base_proof_rpc::L1Provider;
 use base_proof_submission::test_utils::SnarkReceiptFixture;
@@ -153,6 +155,7 @@ fn default_ready_proof(intent: DisputeIntent) -> PendingProof {
             l1_head: Some(DEFAULT_L1_HEAD),
             intermediate_root_interval: None,
             schedule_l2_block_number: None,
+            zk_artifact_hash: None,
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         },
@@ -422,7 +425,16 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
     let tx_manager = default_tx_manager();
     let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
 
-    let expected_session_id = ChallengerProofAdapter::snark_plonk_session_id(addr(0), 1);
+    let expected_session_id = ChallengerProofAdapter::snark_plonk_session_id(
+        ProofArtifacts {
+            tee_image_hash: B256::repeat_byte(0x11),
+            zk_range_hash: B256::repeat_byte(0x22),
+            zk_aggregate_hash: B256::repeat_byte(0x33),
+        }
+        .zk_artifact_hash(),
+        addr(0),
+        1,
+    );
 
     // Step 1: initial proveBlockRange call from initiate_zk_proof.
     driver.step().await.unwrap();

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -7,7 +7,7 @@
 //! [`encode_nullify_calldata`] or `challenge` via
 //! [`encode_challenge_calldata`].
 
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256, keccak256};
 use alloy_provider::RootProvider;
 use alloy_sol_types::{SolCall, SolError, sol};
 use async_trait::async_trait;
@@ -59,6 +59,15 @@ sol! {
 
         /// Returns the intermediate block interval for intermediate output root checkpoints.
         function INTERMEDIATE_BLOCK_INTERVAL() external view returns (uint256);
+
+        /// Returns the Nitro enclave image hash committed by this game.
+        function TEE_IMAGE_HASH() external view returns (bytes32);
+
+        /// Returns the SP1 range verification-key commitment.
+        function ZK_RANGE_HASH() external view returns (bytes32);
+
+        /// Returns the SP1 aggregation verification-key commitment.
+        function ZK_AGGREGATE_HASH() external view returns (bytes32);
 
         /// Returns the game type.
         function gameType() external view returns (uint32);
@@ -183,6 +192,28 @@ pub enum GameStatus {
     DefenderWins = 2,
 }
 
+/// Proving artifacts committed by one historical game proxy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProofArtifacts {
+    /// Nitro enclave image hash accepted by this game.
+    pub tee_image_hash: B256,
+    /// SP1 range verification-key commitment.
+    pub zk_range_hash: B256,
+    /// SP1 aggregation verification-key commitment.
+    pub zk_aggregate_hash: B256,
+}
+
+impl ProofArtifacts {
+    /// Returns the composite ZK routing hash for this artifact generation.
+    #[must_use]
+    pub fn zk_artifact_hash(&self) -> B256 {
+        let mut artifacts = [0_u8; 64];
+        artifacts[..32].copy_from_slice(self.zk_range_hash.as_slice());
+        artifacts[32..].copy_from_slice(self.zk_aggregate_hash.as_slice());
+        keccak256(artifacts)
+    }
+}
+
 impl std::fmt::Display for GameStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -217,6 +248,10 @@ pub trait AggregateVerifierClient: Send + Sync {
 
     /// Returns the current game status.
     async fn status(&self, game_address: Address) -> Result<GameStatus, ContractError>;
+
+    /// Returns the proving artifacts committed by a historical game proxy.
+    async fn proof_artifacts(&self, game_address: Address)
+    -> Result<ProofArtifacts, ContractError>;
 
     /// Returns the address that provided a ZK proof for the given game.
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError>;
@@ -384,6 +419,23 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
                 "game {game_address} returned unrecognized status {unknown}"
             ))
         })
+    }
+
+    async fn proof_artifacts(
+        &self,
+        game_address: Address,
+    ) -> Result<ProofArtifacts, ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(game_address, &self.provider);
+        let (tee_image_hash, zk_range_hash, zk_aggregate_hash) = futures::try_join!(
+            async { contract_call!(contract.TEE_IMAGE_HASH().call(), "TEE_IMAGE_HASH failed") },
+            async { contract_call!(contract.ZK_RANGE_HASH().call(), "ZK_RANGE_HASH failed") },
+            async {
+                contract_call!(contract.ZK_AGGREGATE_HASH().call(), "ZK_AGGREGATE_HASH failed")
+            },
+        )?;
+
+        Ok(ProofArtifacts { tee_image_hash, zk_range_hash, zk_aggregate_hash })
     }
 
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {
@@ -819,6 +871,25 @@ mod tests {
             &resolve[..4],
             &claim[..4],
             "resolve and claimCredit must have different selectors"
+        );
+    }
+
+    #[test]
+    fn zk_artifact_hash_commits_to_both_verification_keys() {
+        let artifacts = ProofArtifacts {
+            tee_image_hash: B256::repeat_byte(1),
+            zk_range_hash: B256::repeat_byte(2),
+            zk_aggregate_hash: B256::repeat_byte(3),
+        };
+
+        assert_ne!(
+            artifacts.zk_artifact_hash(),
+            ProofArtifacts { zk_range_hash: B256::repeat_byte(4), ..artifacts }.zk_artifact_hash()
+        );
+        assert_ne!(
+            artifacts.zk_artifact_hash(),
+            ProofArtifacts { zk_aggregate_hash: B256::repeat_byte(5), ..artifacts }
+                .zk_artifact_hash()
         );
     }
 }

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -11,7 +11,7 @@ mod macros;
 
 mod aggregate_verifier;
 pub use aggregate_verifier::{
-    AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, GameStatus,
+    AggregateVerifierClient, AggregateVerifierContractClient, GameInfo, GameStatus, ProofArtifacts,
     already_proven_selector, encode_challenge_calldata, encode_claim_credit_calldata,
     encode_nullify_calldata, encode_resolve_calldata, encode_verify_proposal_proof_calldata,
     invalid_parent_game_selector, invalid_signer_selector, l1_origin_too_old_selector,

--- a/crates/proof/primitives/src/proof.rs
+++ b/crates/proof/primitives/src/proof.rs
@@ -72,6 +72,9 @@ pub struct ProofRequest {
     /// L1 head block number without an extra lookup.
     #[cfg_attr(feature = "serde", serde(default))]
     pub l1_head_number: u64,
+    /// Keccak256 hash of the enclave PCR0 measurement required by the verifier.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub image_hash: B256,
     /// L2 block used to pin the upgrade schedule; defaults to the claimed block.
     #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
     pub schedule_l2_block_number: Option<u64>,

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -2,7 +2,7 @@
 
 use std::{num::NonZeroUsize, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_cli_utils::CliStyles;
 use clap::{Args, Parser};
 use url::Url;
@@ -83,6 +83,10 @@ pub struct ProposerArgs {
     /// Game type ID for `AggregateVerifier` dispute games.
     #[arg(long = "game-type", env = cli_env!("GAME_TYPE"))]
     pub game_type: u32,
+
+    /// Nitro enclave image hash required for proposal proofs.
+    #[arg(long = "tee-image-hash", env = cli_env!("TEE_IMAGE_HASH"))]
+    pub tee_image_hash: B256,
 
     /// Polling interval for new blocks (e.g., "12s", "1m").
     #[arg(
@@ -195,6 +199,8 @@ mod tests {
             "0x2234567890123456789012345678901234567890",
             "--game-type",
             "1",
+            "--tee-image-hash",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
             "--rollup-rpc",
             "http://localhost:7545",
         ])
@@ -229,6 +235,8 @@ mod tests {
             "0x2234567890123456789012345678901234567890",
             "--game-type",
             "1",
+            "--tee-image-hash",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
             "--rollup-rpc",
             "http://localhost:7545",
             "--recovery-scan-concurrency",

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{net::SocketAddr, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_cli_utils::{LogConfig, MetricsConfig};
 use base_retry::RetryConfig;
 use eyre::{Result, WrapErr};
@@ -29,6 +29,8 @@ pub struct ProposerConfig {
     pub dispute_game_factory_addr: Address,
     /// Game type ID for `AggregateVerifier` dispute games.
     pub game_type: u32,
+    /// Nitro enclave image hash required for proposal proofs.
+    pub tee_image_hash: B256,
     /// Polling interval for new blocks.
     pub poll_interval: Duration,
     /// RPC request timeout.
@@ -123,6 +125,7 @@ impl ProposerConfig {
             anchor_state_registry_addr: proposer.anchor_state_registry_addr,
             dispute_game_factory_addr: proposer.dispute_game_factory_addr,
             game_type: proposer.game_type,
+            tee_image_hash: proposer.tee_image_hash,
             poll_interval: proposer.poll_interval,
             rpc_timeout: proposer.rpc_timeout,
             rollup_rpc: proposer.rollup_rpc,
@@ -169,6 +172,8 @@ mod tests {
             "0x2234567890123456789012345678901234567890",
             "--game-type",
             "1",
+            "--tee-image-hash",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
             "--rollup-rpc",
             "http://localhost:7545",
             "--private-key",

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -43,6 +43,8 @@ pub struct DriverConfig {
     pub intermediate_block_interval: u64,
     /// Game type ID for `AggregateVerifier` dispute games.
     pub game_type: u32,
+    /// Nitro enclave image hash required for proposal proofs.
+    pub tee_image_hash: B256,
     /// Address of the proposer that submits proof transactions onchain.
     /// Included in the proof journal so the enclave signs over the correct `msg.sender`.
     pub proposer_address: Address,
@@ -60,6 +62,7 @@ impl Default for DriverConfig {
             block_interval: 512,
             intermediate_block_interval: 512,
             game_type: 0,
+            tee_image_hash: B256::ZERO,
             proposer_address: Address::ZERO,
             anchor_state_registry_address: Address::ZERO,
         }
@@ -290,6 +293,7 @@ mod tests {
             Arc::clone(&rollup),
             proof_submitter,
             config.block_interval,
+            config.tee_image_hash,
             config.submit_timeout,
         );
         let pipeline =

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -328,6 +328,7 @@ mod tests {
             Arc::clone(&rollup),
             proof_submitter,
             config.block_interval,
+            config.tee_image_hash,
             config.submit_timeout,
         );
         ProvingPipeline::new(config, proof_dispatcher, proof_recovery, proof_collector)

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -18,14 +18,19 @@ impl ProposerProofAdapter {
 
     const TEE_SESSION_LABEL: &'static str = "tee/aws_nitro";
 
-    /// Derives an idempotent TEE proof session ID from proof subtype and claimed root.
-    pub fn tee_session_id_for_root(root: B256) -> String {
-        ProofSessionId::derive(Self::SESSION_NAMESPACE, Self::TEE_SESSION_LABEL, root)
+    /// Derives an idempotent TEE proof session ID from the image hash and claimed root.
+    pub fn tee_session_id_for_root(image_hash: B256, root: B256) -> String {
+        ProofSessionId::derive_from_components(
+            Self::SESSION_NAMESPACE,
+            Self::TEE_SESSION_LABEL,
+            &[image_hash.as_slice(), root.as_slice()],
+        )
     }
 
     /// Builds a prover-service request for a TEE proposal proof.
     pub fn tee_prove_block_range_request(request: PrimitiveProofRequest) -> ProveBlockRangeRequest {
-        let session_id = Self::tee_session_id_for_root(request.claimed_l2_output_root);
+        let session_id =
+            Self::tee_session_id_for_root(request.image_hash, request.claimed_l2_output_root);
         Self::tee_prove_block_range_request_with_session_id(request, session_id)
     }
 
@@ -93,6 +98,7 @@ mod tests {
             proposer: Address::repeat_byte(0x04),
             intermediate_block_interval: 300,
             l1_head_number: 1200,
+            image_hash: B256::repeat_byte(0x06),
             schedule_l2_block_number: None,
         }
     }
@@ -101,7 +107,8 @@ mod tests {
     fn tee_prove_block_range_request_wraps_primitive_request() {
         let root = B256::repeat_byte(0xaa);
         let request = test_request(root);
-        let expected_session_id = ProposerProofAdapter::tee_session_id_for_root(root);
+        let expected_session_id =
+            ProposerProofAdapter::tee_session_id_for_root(request.image_hash, root);
 
         let wrapped = ProposerProofAdapter::tee_prove_block_range_request(request.clone());
 
@@ -113,6 +120,15 @@ mod tests {
             }
             other => panic!("unexpected proof request kind: {other:?}"),
         }
+    }
+
+    #[test]
+    fn tee_session_id_changes_with_image_hash() {
+        let root = B256::repeat_byte(0xaa);
+        assert_ne!(
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(1), root),
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(2), root),
+        );
     }
 
     #[test]

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -2,7 +2,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_proof_rpc::RollupProvider;
 use base_proof_submission::ProofSubmissionError;
 use base_prover_service_client::ProofRequesterProvider;
@@ -34,6 +34,7 @@ where
     rollup_client: Arc<R>,
     submitter: ProofSubmitter,
     block_interval: u64,
+    tee_image_hash: B256,
     submit_timeout: Option<Duration>,
 }
 
@@ -59,9 +60,17 @@ where
         rollup_client: Arc<R>,
         submitter: ProofSubmitter,
         block_interval: u64,
+        tee_image_hash: B256,
         submit_timeout: Option<Duration>,
     ) -> Self {
-        Self { proof_requester, rollup_client, submitter, block_interval, submit_timeout }
+        Self {
+            proof_requester,
+            rollup_client,
+            submitter,
+            block_interval,
+            tee_image_hash,
+            submit_timeout,
+        }
     }
 
     /// Runs one collector tick.
@@ -109,7 +118,10 @@ where
                 return false;
             };
 
-            let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_l2_output_root);
+            let session_id = ProposerProofAdapter::tee_session_id_for_root(
+                self.tee_image_hash,
+                claimed_l2_output_root,
+            );
             let proof = match Self::poll_proof(
                 self.proof_requester.as_ref(),
                 target_block,
@@ -503,6 +515,7 @@ mod tests {
             rollup_client,
             submitter,
             BLOCK_INTERVAL,
+            B256::repeat_byte(0x42),
             Some(std::time::Duration::from_secs(60)),
         )
     }
@@ -552,6 +565,7 @@ mod tests {
             claimed_l2_block_number: target_block,
             intermediate_block_interval: BLOCK_INTERVAL,
             l1_head_number: 1000,
+            image_hash: B256::repeat_byte(0x42),
             ..Default::default()
         };
         requester
@@ -590,6 +604,7 @@ mod tests {
                 claimed_l2_block_number: target_block,
                 intermediate_block_interval: BLOCK_INTERVAL,
                 l1_head_number: 1000,
+                image_hash: B256::repeat_byte(0x42),
                 ..Default::default()
             };
             requester
@@ -648,12 +663,14 @@ mod tests {
         let requester = Arc::new(MockProofRequester::default());
         let target_block = 200;
         let claimed_root = B256::repeat_byte(target_block as u8);
-        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), claimed_root);
         let proof_request = ProofRequest {
             claimed_l2_output_root: claimed_root,
             claimed_l2_block_number: target_block,
             intermediate_block_interval: BLOCK_INTERVAL,
             l1_head_number: 1000,
+            image_hash: B256::repeat_byte(0x42),
             ..Default::default()
         };
         requester
@@ -661,13 +678,15 @@ mod tests {
             .await
             .expect("test setup should dispatch root session");
         let later_root = B256::repeat_byte(0xcc);
-        let later_session_id = ProposerProofAdapter::tee_session_id_for_root(later_root);
+        let later_session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), later_root);
         requester
             .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(ProofRequest {
                 claimed_l2_output_root: later_root,
                 claimed_l2_block_number: target_block + BLOCK_INTERVAL,
                 intermediate_block_interval: BLOCK_INTERVAL,
                 l1_head_number: 1000,
+                image_hash: B256::repeat_byte(0x42),
                 ..Default::default()
             }))
             .await
@@ -699,12 +718,14 @@ mod tests {
         let requester = Arc::new(MockProofRequester { reject_delete: true, ..Default::default() });
         let target_block = 200;
         let claimed_root = B256::repeat_byte(target_block as u8);
-        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), claimed_root);
         let proof_request = ProofRequest {
             claimed_l2_output_root: claimed_root,
             claimed_l2_block_number: target_block,
             intermediate_block_interval: BLOCK_INTERVAL,
             l1_head_number: 1000,
+            image_hash: B256::repeat_byte(0x42),
             ..Default::default()
         };
         requester
@@ -734,12 +755,14 @@ mod tests {
         let target_block = 200;
         let stale_root = B256::repeat_byte(0xaa);
         let fresh_root = B256::repeat_byte(0xbb);
-        let session_id = ProposerProofAdapter::tee_session_id_for_root(stale_root);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), stale_root);
         let proof_request = ProofRequest {
             claimed_l2_output_root: stale_root,
             claimed_l2_block_number: target_block,
             intermediate_block_interval: BLOCK_INTERVAL,
             l1_head_number: 1000,
+            image_hash: B256::repeat_byte(0x42),
             ..Default::default()
         };
         requester
@@ -778,7 +801,8 @@ mod tests {
         let requester = Arc::new(MockProofRequester::default());
         let target_block = 200;
         let claimed_root = B256::repeat_byte(0xaa);
-        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), claimed_root);
         requester
             .failed_sessions
             .lock()

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -27,6 +27,8 @@ pub struct ProofDispatcherConfig {
     pub proposer_address: Address,
     /// Number of L2 blocks between intermediate output root checkpoints.
     pub intermediate_block_interval: u64,
+    /// Nitro enclave image hash required for proposal proofs.
+    pub tee_image_hash: B256,
 }
 
 impl From<&DriverConfig> for ProofDispatcherConfig {
@@ -35,6 +37,7 @@ impl From<&DriverConfig> for ProofDispatcherConfig {
             block_interval: config.block_interval,
             proposer_address: config.proposer_address,
             intermediate_block_interval: config.intermediate_block_interval,
+            tee_image_hash: config.tee_image_hash,
         }
     }
 }
@@ -108,6 +111,7 @@ impl ProofDispatcher {
             proposer: self.config.proposer_address,
             intermediate_block_interval: self.config.intermediate_block_interval,
             l1_head_number: l1_header.number,
+            image_hash: self.config.tee_image_hash,
             schedule_l2_block_number: None,
         })
     }
@@ -306,6 +310,7 @@ mod tests {
                 block_interval: 100,
                 proposer_address: Address::repeat_byte(0x04),
                 intermediate_block_interval: 300,
+                tee_image_hash: B256::repeat_byte(0x42),
             },
         );
         let recovered = RecoveredState {

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -223,6 +223,7 @@ impl ProposerService {
             block_interval,
             intermediate_block_interval,
             game_type: config.game_type,
+            tee_image_hash: config.tee_image_hash,
             proposer_address: proposer_address.unwrap_or_default(),
             anchor_state_registry_address: config.anchor_state_registry_addr,
         };
@@ -257,6 +258,7 @@ impl ProposerService {
             Arc::clone(&rollup_client),
             proof_submitter,
             driver_config.block_interval,
+            driver_config.tee_image_hash,
             driver_config.submit_timeout,
         );
         let pipeline =

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -14,7 +14,7 @@ use base_optimism_rpc::{L1BlockId, L1BlockRef, L2BlockRef, OutputAtBlock, SyncSt
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorPreflight, AnchorRoot, AnchorSnapshot,
     AnchorStateRegistryClient, ContractError, DisputeGameFactoryClient, GameAtIndex, GameInfo,
-    GameStatus,
+    GameStatus, ProofArtifacts,
 };
 use base_proof_primitives::Proposal;
 use base_proof_rpc::{
@@ -254,6 +254,9 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         unimplemented!("unused in proposer tests")
     }
     async fn status(&self, _: Address) -> Result<GameStatus, ContractError> {
+        unimplemented!("unused in proposer tests")
+    }
+    async fn proof_artifacts(&self, _: Address) -> Result<ProofArtifacts, ContractError> {
         unimplemented!("unused in proposer tests")
     }
     async fn zk_prover(&self, _: Address) -> Result<Address, ContractError> {

--- a/crates/proof/prover-service/Cargo.toml
+++ b/crates/proof/prover-service/Cargo.toml
@@ -30,6 +30,7 @@ metrics.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+alloy-primitives.workspace = true
 rstest.workspace = true
 chrono.workspace = true
 jsonrpsee = { workspace = true, features = ["http-client"] }

--- a/crates/proof/prover-service/client/src/requester.rs
+++ b/crates/proof/prover-service/client/src/requester.rs
@@ -524,6 +524,7 @@ mod tests {
                     l1_head: None,
                     intermediate_root_interval: None,
                     schedule_l2_block_number: None,
+                    zk_artifact_hash: None,
                     zk_vm: ZkVm::Sp1,
                     zk_backend: ZkBackend::Cluster,
                 }),

--- a/crates/proof/prover-service/client/src/worker.rs
+++ b/crates/proof/prover-service/client/src/worker.rs
@@ -599,6 +599,7 @@ mod tests {
             tee_kinds: Vec::new(),
             zk_vms: vec![ZkVm::Sp1],
             zk_backends: vec![ZkBackend::Cluster],
+            supported_artifact_hash: None,
             lock_duration_seconds: 60,
         }
     }
@@ -674,6 +675,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
+                zk_artifact_hash: None,
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),
@@ -699,6 +701,7 @@ mod tests {
             tee_kinds: Vec::new(),
             zk_vms: vec![ZkVm::Sp1],
             zk_backends: vec![ZkBackend::Cluster],
+            supported_artifact_hash: None,
             lock_duration_seconds: 60,
         };
         let provider: &dyn ProverWorkerProvider = &server.client;

--- a/crates/proof/prover-service/db/Cargo.toml
+++ b/crates/proof/prover-service/db/Cargo.toml
@@ -8,6 +8,9 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+# primitives
+alloy-primitives.workspace = true
+
 # protocol
 base-prover-service-protocol.workspace = true
 
@@ -29,7 +32,6 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-alloy-primitives.workspace = true
 base-proof-primitives.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/proof/prover-service/db/migrations/018_add_artifact_hash.sql
+++ b/crates/proof/prover-service/db/migrations/018_add_artifact_hash.sql
@@ -1,0 +1,47 @@
+-- Persist the exact TEE image or ZK artifact hash used for worker routing.
+--
+-- Existing rows intentionally remain NULL and therefore cannot be claimed by
+-- artifact-aware workers. Operators must backfill deployed legacy artifact
+-- hashes before rolling out workers that require those jobs; this migration
+-- does not guess environment-specific constants.
+BEGIN;
+
+ALTER TABLE proof_requests
+ADD COLUMN IF NOT EXISTS artifact_hash BYTEA;
+
+ALTER TABLE proof_requests
+DROP CONSTRAINT IF EXISTS proof_requests_artifact_hash_length;
+
+ALTER TABLE proof_requests
+ADD CONSTRAINT proof_requests_artifact_hash_length
+CHECK (artifact_hash IS NULL OR octet_length(artifact_hash) = 32);
+
+DROP INDEX IF EXISTS idx_proof_requests_job_claim;
+CREATE INDEX idx_proof_requests_tee_job_claim
+ON proof_requests(
+    job_status,
+    api_proof_type,
+    tee_kind,
+    artifact_hash,
+    start_block_number,
+    created_at
+)
+WHERE api_proof_type = 'tee';
+
+DROP INDEX IF EXISTS idx_proof_requests_zk_job_claim;
+CREATE INDEX idx_proof_requests_zk_job_claim
+ON proof_requests(
+    job_status,
+    api_proof_type,
+    zk_vm,
+    (COALESCE(zk_backend, 'cluster')),
+    artifact_hash,
+    start_block_number,
+    created_at
+)
+WHERE api_proof_type IN ('compressed', 'snark_plonk');
+
+COMMENT ON COLUMN proof_requests.artifact_hash IS
+'Exact 32-byte TEE image or ZK artifact hash required for worker routing. NULL legacy rows are nonclaimable until operationally backfilled.';
+
+COMMIT;

--- a/crates/proof/prover-service/db/src/conversions.rs
+++ b/crates/proof/prover-service/db/src/conversions.rs
@@ -278,6 +278,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
+                zk_artifact_hash: Some(alloy_primitives::B256::repeat_byte(0x11)),
                 zk_vm: ProtocolZkVm::Sp1,
                 zk_backend: ProtocolZkBackend::Cluster,
             }),

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 
+use alloy_primitives::B256;
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
     ProofResult as ProtocolProofResult, TeeKind as ProtocolTeeKind, ZkBackend,
@@ -321,6 +322,9 @@ pub enum CreateProofRequestValidationError {
         /// Backend proof type supplied for the request.
         proof_type: ProofType,
     },
+    /// A ZK request omitted the artifact hash required for exact worker routing.
+    #[error("zk_artifact_hash is required for ZK proof requests")]
+    MissingZkArtifactHash,
 }
 
 /// Legacy SP1 proof-shape discriminator retained for receipt compatibility.
@@ -758,6 +762,8 @@ pub struct CreateProofRequest {
     pub tee_kind: Option<TeeKind>,
     /// Protocol-level ZK proving backend for ZK proofs.
     pub zk_backend: Option<ZkBackend>,
+    /// Exact TEE image or ZK artifact hash required to execute this request.
+    pub artifact_hash: B256,
     /// Backend-specific proof type for current OP Succinct backends.
     pub proof_type: Option<ProofType>,
     /// Starting L2 block number.
@@ -788,6 +794,7 @@ impl CreateProofRequest {
             zk_vm: fields.zk_vm,
             tee_kind: fields.tee_kind,
             zk_backend: fields.zk_backend,
+            artifact_hash: fields.artifact_hash,
             proof_type: fields.proof_type,
             start_block_number: fields.start_block_number,
             number_of_blocks_to_prove: fields.number_of_blocks_to_prove,
@@ -820,6 +827,11 @@ impl CreateProofRequest {
         }
         if self.zk_backend != expected.zk_backend {
             return Err(CreateProofRequestValidationError::FieldMismatch { field: "zk_backend" });
+        }
+        if self.artifact_hash != expected.artifact_hash {
+            return Err(CreateProofRequestValidationError::FieldMismatch {
+                field: "artifact_hash",
+            });
         }
         if self.proof_type != expected.proof_type {
             return Err(CreateProofRequestValidationError::FieldMismatch { field: "proof_type" });
@@ -868,6 +880,8 @@ pub struct DerivedProofRequestFields {
     pub tee_kind: Option<TeeKind>,
     /// Protocol-level ZK proving backend for ZK proofs.
     pub zk_backend: Option<ZkBackend>,
+    /// Exact TEE image or ZK artifact hash required to execute this request.
+    pub artifact_hash: B256,
     /// Backend-specific proof type for current OP Succinct backends.
     pub proof_type: Option<ProofType>,
     /// Starting L2 block number.
@@ -895,6 +909,9 @@ impl DerivedProofRequestFields {
                 zk_vm: Some(protocol_zk_vm(proof.zk_vm)),
                 tee_kind: None,
                 zk_backend: Some(proof.zk_backend),
+                artifact_hash: proof
+                    .zk_artifact_hash
+                    .ok_or(CreateProofRequestValidationError::MissingZkArtifactHash)?,
                 proof_type: Some(ProofType::OpSuccinctSp1ClusterCompressed),
                 start_block_number: proof.start_block_number,
                 number_of_blocks_to_prove: proof.number_of_blocks_to_prove,
@@ -908,6 +925,10 @@ impl DerivedProofRequestFields {
                 zk_vm: Some(protocol_zk_vm(request.proof.zk_vm)),
                 tee_kind: None,
                 zk_backend: Some(request.proof.zk_backend),
+                artifact_hash: request
+                    .proof
+                    .zk_artifact_hash
+                    .ok_or(CreateProofRequestValidationError::MissingZkArtifactHash)?,
                 proof_type: Some(ProofType::OpSuccinctSp1ClusterSnarkPlonk),
                 start_block_number: request.proof.start_block_number,
                 number_of_blocks_to_prove: request.proof.number_of_blocks_to_prove,
@@ -921,6 +942,7 @@ impl DerivedProofRequestFields {
                 zk_vm: None,
                 tee_kind: Some(protocol_tee_kind(request.tee_kind)),
                 zk_backend: None,
+                artifact_hash: request.proof.image_hash,
                 proof_type: None,
                 start_block_number: request.proof.claimed_l2_block_number,
                 number_of_blocks_to_prove: 1,
@@ -1011,6 +1033,8 @@ pub struct ClaimProofJob {
     pub zk_vms: Vec<ZkVmKind>,
     /// ZK proving backends this worker can execute (matched for ZK proofs).
     pub zk_backends: Vec<ZkBackend>,
+    /// Exact TEE image or ZK artifact hash supported by this worker.
+    pub supported_artifact_hash: B256,
     /// Lock duration in seconds. Callers must resolve the server default first.
     pub lock_duration_seconds: u32,
     /// Reclaim budget for expired claims.
@@ -1258,6 +1282,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),
@@ -1299,6 +1324,20 @@ mod tests {
         req.session_id = "other-session".to_owned();
 
         assert_eq!(req.validate(), Err(CreateProofRequestValidationError::SessionIdMismatch));
+    }
+
+    #[test]
+    fn create_rejects_missing_zk_artifact_hash() {
+        let mut request = compressed_protocol_request("session-1");
+        let ProtocolProofRequestKind::Compressed(proof) = &mut request.request else {
+            unreachable!("helper always builds compressed requests");
+        };
+        proof.zk_artifact_hash = None;
+
+        assert_eq!(
+            CreateProofRequest::new(request).unwrap_err(),
+            CreateProofRequestValidationError::MissingZkArtifactHash
+        );
     }
 
     #[test]

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use base_prover_service_protocol::{
     ProofResult as ProtocolProofResult, SnarkPlonkProofResult, ZkBackend, ZkProofResult, ZkVm,
 };
@@ -38,10 +39,11 @@ impl ProofRequestRepo {
             r#"
             INSERT INTO proof_requests (
                 id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                artifact_hash,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
             "#,
         )
         .bind(prepared.id)
@@ -51,6 +53,7 @@ impl ProofRequestRepo {
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
         .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
         .bind(prepared.zk_backend.map(|zk_backend| zk_backend.as_str()))
+        .bind(prepared.artifact_hash.as_slice().to_vec())
         .bind(prepared.start_block_number)
         .bind(prepared.number_of_blocks_to_prove)
         .bind(prepared.sequence_window)
@@ -80,10 +83,11 @@ impl ProofRequestRepo {
             r#"
             INSERT INTO proof_requests (
                 id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                artifact_hash,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
             ON CONFLICT ((COALESCE(session_id, id::text))) DO NOTHING
             "#,
         )
@@ -94,6 +98,7 @@ impl ProofRequestRepo {
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
         .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
         .bind(prepared.zk_backend.map(|zk_backend| zk_backend.as_str()))
+        .bind(prepared.artifact_hash.as_slice().to_vec())
         .bind(prepared.start_block_number)
         .bind(prepared.number_of_blocks_to_prove)
         .bind(prepared.sequence_window)
@@ -115,6 +120,7 @@ impl ProofRequestRepo {
             r#"
             SELECT id, COALESCE(session_id, id::text) AS session_id,
                    request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                   artifact_hash,
                    start_block_number, number_of_blocks_to_prove, sequence_window,
                    proof_type, status, prover_address, l1_head,
                    intermediate_root_interval, retry_count
@@ -141,6 +147,7 @@ impl ProofRequestRepo {
             zk_vm: prepared.zk_vm.map(|zk_vm| zk_vm.as_str()),
             tee_kind: prepared.tee_kind.map(|tee_kind| tee_kind.as_str()),
             zk_backend: prepared.zk_backend.map(|zk_backend| zk_backend.as_str()),
+            artifact_hash: prepared.artifact_hash.as_slice(),
             start_block_number: prepared.start_block_number,
             number_of_blocks_to_prove: prepared.number_of_blocks_to_prove,
             sequence_window: prepared.sequence_window,
@@ -586,12 +593,14 @@ impl ProofRequestRepo {
             ApiProofType::Tee => {
                 let tee_kinds: Vec<String> =
                     req.tee_kinds.iter().map(|kind| kind.as_str().to_owned()).collect();
+                let artifact_hash = req.supported_artifact_hash.as_slice().to_vec();
                 sqlx::query(&sql)
                     .bind(&req.worker_id)
                     .bind(lock_id)
                     .bind(i64::from(req.lock_duration_seconds))
                     .bind(req.api_proof_type.as_str())
                     .bind(&tee_kinds)
+                    .bind(artifact_hash)
                     .bind(i64::from(req.max_attempts))
                     .fetch_optional(&self.pool)
                     .await?
@@ -606,6 +615,7 @@ impl ProofRequestRepo {
                     .chain(req.zk_backends.is_empty().then_some(ZkBackend::Cluster))
                     .map(|backend| backend.as_str().to_owned())
                     .collect();
+                let artifact_hash = req.supported_artifact_hash.as_slice().to_vec();
                 sqlx::query(&sql)
                     .bind(&req.worker_id)
                     .bind(lock_id)
@@ -613,6 +623,7 @@ impl ProofRequestRepo {
                     .bind(req.api_proof_type.as_str())
                     .bind(&zk_vms)
                     .bind(&zk_backends)
+                    .bind(artifact_hash)
                     .bind(i64::from(req.max_attempts))
                     .fetch_optional(&self.pool)
                     .await?
@@ -1686,6 +1697,7 @@ struct PreparedProofRequest {
     zk_vm: Option<ZkVmKind>,
     tee_kind: Option<TeeKind>,
     zk_backend: Option<ZkBackend>,
+    artifact_hash: B256,
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
@@ -1741,6 +1753,7 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
             zk_vm: req.zk_vm,
             tee_kind: req.tee_kind,
             zk_backend: req.zk_backend,
+            artifact_hash: req.artifact_hash,
             start_block_number,
             number_of_blocks_to_prove,
             sequence_window,
@@ -2086,9 +2099,10 @@ fn claim_query(api_proof_type: ApiProofType) -> String {
                 SELECT id FROM proof_requests
                 WHERE api_proof_type = $4
                   AND tee_kind = ANY($5::text[])
+                  AND artifact_hash = $6
                   AND (
                       job_status = 'PENDING'
-                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $6)
+                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $7)
                   )
                 ORDER BY start_block_number ASC, created_at ASC, id ASC
                 FOR UPDATE SKIP LOCKED
@@ -2113,9 +2127,10 @@ fn claim_query(api_proof_type: ApiProofType) -> String {
                 WHERE api_proof_type = $4
                   AND zk_vm = ANY($5::text[])
                   AND COALESCE(zk_backend, 'cluster') = ANY($6::text[])
+                  AND artifact_hash = $7
                   AND (
                       job_status = 'PENDING'
-                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $7)
+                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $8)
                   )
                 ORDER BY start_block_number ASC, created_at ASC, id ASC
                 FOR UPDATE SKIP LOCKED
@@ -2192,6 +2207,7 @@ struct CreateRequestParams<'a> {
     zk_vm: Option<&'a str>,
     tee_kind: Option<&'a str>,
     zk_backend: Option<&'a str>,
+    artifact_hash: &'a [u8],
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
@@ -2228,6 +2244,9 @@ impl CreateRequestParams<'_> {
         }
         if row.get::<Option<i64>, _>("sequence_window") != self.sequence_window {
             return Some("sequence_window");
+        }
+        if row.get::<Option<Vec<u8>>, _>("artifact_hash").as_deref() != Some(self.artifact_hash) {
+            return Some("artifact_hash");
         }
         if row.get::<Option<&str>, _>("proof_type") != self.proof_type {
             return Some("proof_type");
@@ -2347,6 +2366,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: Some(5),
                 schedule_l2_block_number: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),
@@ -2384,6 +2404,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),
@@ -2443,7 +2464,10 @@ mod tests {
         let create = CreateProofRequest::new(ProtocolProofRequest {
             session_id: "tee-session".to_owned(),
             request: ProofRequestKind::Tee(TeeProofRequest {
-                proof: Default::default(),
+                proof: base_proof_primitives::ProofRequest {
+                    image_hash: B256::repeat_byte(0x22),
+                    ..Default::default()
+                },
                 tee_kind: ProtocolTeeKind::AwsNitro,
             }),
         })
@@ -2558,7 +2582,10 @@ mod tests {
         ProtocolProofRequest {
             session_id: session_id.to_owned(),
             request: ProofRequestKind::Tee(TeeProofRequest {
-                proof: Default::default(),
+                proof: base_proof_primitives::ProofRequest {
+                    image_hash: B256::repeat_byte(0x22),
+                    ..Default::default()
+                },
                 tee_kind: ProtocolTeeKind::AwsNitro,
             }),
         }
@@ -2574,7 +2601,10 @@ mod tests {
         let mut create = CreateProofRequest::new(ProtocolProofRequest {
             session_id: "bad-tee-session".to_owned(),
             request: ProofRequestKind::Tee(TeeProofRequest {
-                proof: Default::default(),
+                proof: base_proof_primitives::ProofRequest {
+                    image_hash: B256::repeat_byte(0x22),
+                    ..Default::default()
+                },
                 tee_kind: ProtocolTeeKind::AwsNitro,
             }),
         })
@@ -2598,6 +2628,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -15,7 +15,7 @@
 
 use std::time::Duration;
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_proof_primitives::Proposal;
 use base_prover_service_db::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
@@ -75,6 +75,7 @@ fn compressed_request_at_with_backend(
             l1_head: None,
             intermediate_root_interval: None,
             schedule_l2_block_number: None,
+            zk_artifact_hash: Some(B256::repeat_byte(0x11)),
             zk_vm: ZkVm::Sp1,
             zk_backend,
         }),
@@ -92,6 +93,7 @@ fn compressed_request_with_l1_head(l1_head: &str) -> CreateProofRequest {
             l1_head: Some(l1_head.parse().expect("valid hash")),
             intermediate_root_interval: None,
             schedule_l2_block_number: None,
+            zk_artifact_hash: Some(B256::repeat_byte(0x11)),
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         }),
@@ -114,6 +116,7 @@ fn snark_request() -> CreateProofRequest {
                 ),
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },
@@ -129,7 +132,10 @@ fn tee_request() -> CreateProofRequest {
     CreateProofRequest::new(ProtocolProofRequest {
         session_id: Uuid::new_v4().to_string(),
         request: ProtocolProofRequestKind::Tee(TeeProofRequest {
-            proof: Default::default(),
+            proof: base_proof_primitives::ProofRequest {
+                image_hash: B256::repeat_byte(0x22),
+                ..Default::default()
+            },
             tee_kind: ProtocolTeeKind::AwsNitro,
         }),
     })
@@ -1149,6 +1155,35 @@ async fn test_create_for_worker_queue_rejects_backend_collision() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_for_worker_queue_rejects_artifact_hash_collision() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut original = compressed_request();
+    set_request_session_id(&mut original, explicit_id.to_string());
+    repo.create_for_worker_queue(original, TEST_MAX_PROOF_RETRIES, true).await.unwrap();
+
+    let replacement_hash = B256::repeat_byte(0x33);
+    let mut conflicting = compressed_request();
+    set_request_session_id(&mut conflicting, explicit_id.to_string());
+    let ProtocolProofRequestKind::Compressed(proof) = &mut conflicting.request_payload.request
+    else {
+        unreachable!("helper always builds compressed requests");
+    };
+    proof.zk_artifact_hash = Some(replacement_hash);
+    conflicting.artifact_hash = replacement_hash;
+
+    assert!(matches!(
+        repo.create_for_worker_queue(conflicting, TEST_MAX_PROOF_RETRIES, true)
+            .await
+            .unwrap_err(),
+        CreateProofRequestError::IdCollision { id, field: "artifact_hash" } if id == explicit_id
+    ));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
 async fn test_create_for_worker_queue_requeues_failed_row() {
     let pool = test_pool().await;
     let repo = test_repo(pool.clone());
@@ -1564,6 +1599,11 @@ fn claim_job(
         } else {
             vec![ZkBackend::Cluster]
         },
+        supported_artifact_hash: if api_proof_type == ApiProofType::Tee {
+            B256::repeat_byte(0x22)
+        } else {
+            B256::repeat_byte(0x11)
+        },
         lock_duration_seconds: 3600,
         max_attempts,
     }
@@ -1674,6 +1714,34 @@ async fn test_claim_next_proof_job_claim_and_capabilities() {
         .expect("a compressed job should be claimable by a ZK worker");
     assert_eq!(job.api_proof_type, ApiProofType::Compressed);
     assert_eq!(job.job_status, ProofJobStatus::Claimed);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_claim_next_proof_job_requires_exact_artifact_hash() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    drain_claimable_compressed_jobs(&repo).await;
+    let id = repo.create(compressed_request()).await.unwrap();
+    let stored_hash =
+        sqlx::query_scalar::<_, Vec<u8>>("SELECT artifact_hash FROM proof_requests WHERE id = $1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(stored_hash, B256::repeat_byte(0x11).as_slice());
+
+    let mut wrong_hash = compressed_claim("wrong-artifact-worker", 3);
+    wrong_hash.supported_artifact_hash = B256::repeat_byte(0x33);
+    assert!(repo.claim_next_proof_job(wrong_hash).await.unwrap().is_none());
+
+    let claimed = repo
+        .claim_next_proof_job(compressed_claim("matching-artifact-worker", 3))
+        .await
+        .unwrap()
+        .expect("matching artifact hash should claim the job");
+    assert_eq!(claimed.id, id);
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/protocol/src/types.rs
+++ b/crates/proof/prover-service/protocol/src/types.rs
@@ -202,6 +202,9 @@ pub struct ZkProofRequest {
     /// L2 block used to pin the upgrade schedule; defaults to the claimed block.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schedule_l2_block_number: Option<u64>,
+    /// Composite hash of the range and aggregation verification-key commitments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zk_artifact_hash: Option<B256>,
     /// ZK virtual machine implementation to use.
     pub zk_vm: ZkVm,
     /// Proving backend that should execute this request.
@@ -405,6 +408,9 @@ pub struct GetNextProofRequest {
     /// ZK proving backends this worker can execute for ZK proofs.
     #[serde(default)]
     pub zk_backends: Vec<ZkBackend>,
+    /// Exact TEE or ZK artifact hash supported by this worker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supported_artifact_hash: Option<B256>,
     /// Requested lock duration in seconds. Zero uses the server default.
     pub lock_duration_seconds: u32,
 }
@@ -556,6 +562,7 @@ mod tests {
                     l1_head: Some(B256::repeat_byte(0xab)),
                     intermediate_root_interval: Some(128),
                     schedule_l2_block_number: None,
+                    zk_artifact_hash: None,
                     zk_vm: ZkVm::Sp1,
                     zk_backend: ZkBackend::Cluster,
                 }),
@@ -678,6 +685,7 @@ mod tests {
                 proposer: address!("0000000000000000000000000000000000000006"),
                 intermediate_block_interval: 7,
                 l1_head_number: 8,
+                image_hash: B256::repeat_byte(9),
                 schedule_l2_block_number: None,
             },
             tee_kind: TeeKind::AwsNitro,
@@ -697,6 +705,7 @@ mod tests {
                     "proposer": "0x0000000000000000000000000000000000000006",
                     "intermediate_block_interval": 7,
                     "l1_head_number": 8,
+                    "image_hash": format!("{:#x}", B256::repeat_byte(9)),
                 },
                 "tee_kind": "aws_nitro",
             })
@@ -839,6 +848,7 @@ mod tests {
             proposer: address!("0000000000000000000000000000000000000006"),
             intermediate_block_interval: 7,
             l1_head_number: 8,
+            image_hash: B256::repeat_byte(9),
             schedule_l2_block_number: None,
         };
 
@@ -855,6 +865,7 @@ mod tests {
                 "proposer": "0x0000000000000000000000000000000000000006",
                 "intermediate_block_interval": 7,
                 "l1_head_number": 8,
+                "image_hash": format!("{:#x}", B256::repeat_byte(9)),
             })
         );
     }
@@ -918,6 +929,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
+                zk_artifact_hash: None,
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }
@@ -933,6 +945,7 @@ mod tests {
             l1_head: None,
             intermediate_root_interval: None,
             schedule_l2_block_number: Some(42),
+            zk_artifact_hash: None,
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         };
@@ -965,6 +978,7 @@ mod tests {
             tee_kinds: Vec::new(),
             zk_vms: vec![ZkVm::Sp1],
             zk_backends: vec![ZkBackend::Cluster, ZkBackend::DryRun],
+            supported_artifact_hash: Some(B256::repeat_byte(0x42)),
             lock_duration_seconds: 30,
         };
 
@@ -978,6 +992,7 @@ mod tests {
                 "tee_kinds": [],
                 "zk_vms": ["sp1"],
                 "zk_backends": ["cluster", "dry_run"],
+                "supported_artifact_hash": format!("{:#x}", B256::repeat_byte(0x42)),
                 "lock_duration_seconds": 30
             })
         );
@@ -995,6 +1010,7 @@ mod tests {
         assert_eq!(request.tee_kinds, Vec::new());
         assert_eq!(request.zk_vms, Vec::new());
         assert_eq!(request.zk_backends, Vec::new());
+        assert_eq!(request.supported_artifact_hash, None);
     }
 
     #[test]

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -77,12 +77,16 @@ impl ProverServiceServer {
         &self,
         request: GetNextProofRequest,
     ) -> RpcResult<GetNextProofResponse> {
+        let Some(supported_artifact_hash) = request.supported_artifact_hash else {
+            return Ok(GetNextProofResponse { job: None });
+        };
         let claim = ClaimProofJob {
             worker_id: request.worker_id,
             api_proof_type: request.proof_type.into(),
             tee_kinds: request.tee_kinds.into_iter().map(Into::into).collect(),
             zk_vms: request.zk_vms.into_iter().map(Into::into).collect(),
             zk_backends: request.zk_backends,
+            supported_artifact_hash,
             lock_duration_seconds: resolve_lock_duration(
                 self.config.worker,
                 request.lock_duration_seconds,

--- a/crates/proof/prover-service/tests/idempotency.rs
+++ b/crates/proof/prover-service/tests/idempotency.rs
@@ -23,6 +23,7 @@ fn compressed_request(session_id: &str, start_block_number: u64) -> ProveBlockRa
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
+                zk_artifact_hash: None,
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),

--- a/crates/proof/prover-service/tests/idempotency.rs
+++ b/crates/proof/prover-service/tests/idempotency.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use alloy_primitives::B256;
 use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProverRequesterApiClient, ZkBackend,
     ZkProofRequest, ZkVm,
@@ -23,7 +24,7 @@ fn compressed_request(session_id: &str, start_block_number: u64) -> ProveBlockRa
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),

--- a/crates/proof/prover-service/tests/worker_api_e2e.rs
+++ b/crates/proof/prover-service/tests/worker_api_e2e.rs
@@ -13,6 +13,7 @@
 
 use std::{net::SocketAddr, time::Duration};
 
+use alloy_primitives::B256;
 use base_prover_service::{ProverServiceServer, ServerConfig, WorkerApiConfig, WorkerQueueConfig};
 use base_prover_service_db::{
     ApiProofType, ClaimProofJob, CreateProofRequest, DatabaseConfig, ProofRequestRepo,
@@ -107,6 +108,7 @@ async fn drain_claimable_compressed_jobs(repo: &ProofRequestRepo) {
         tee_kinds: Vec::new(),
         zk_vms: vec![ZkVmKind::Sp1],
         zk_backends: vec![ZkBackend::Cluster],
+        supported_artifact_hash: B256::repeat_byte(0x11),
         lock_duration_seconds: 3600,
         max_attempts: u32::MAX,
     };
@@ -129,6 +131,7 @@ fn compressed_request(session_id: &str, start_block_number: u64) -> CreateProofR
             l1_head: None,
             intermediate_root_interval: None,
             schedule_l2_block_number: None,
+            zk_artifact_hash: Some(B256::repeat_byte(0x11)),
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         }),
@@ -144,8 +147,30 @@ fn worker_claim(worker_id: &str) -> GetNextProofRequest {
         zk_vms: vec![ZkVm::Sp1],
         // Omitted by legacy workers; the server defaults this capability to cluster.
         zk_backends: Vec::new(),
+        supported_artifact_hash: Some(B256::repeat_byte(0x11)),
         lock_duration_seconds: 60,
     }
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL)"]
+async fn worker_without_artifact_hash_claims_nothing() {
+    let repo = test_repo().await;
+    drain_claimable_compressed_jobs(&repo).await;
+
+    let session_id = Uuid::new_v4().to_string();
+    repo.create_for_worker_queue(compressed_request(&session_id, 10), TEST_MAX_PROOF_RETRIES, true)
+        .await
+        .expect("seeding the worker queue should succeed");
+
+    let server = RunningServer::spawn(repo).await;
+    let mut claim = worker_claim("worker-without-artifact");
+    claim.supported_artifact_hash = None;
+
+    let response =
+        server.client.get_next_proof(claim).await.expect("get_next_proof should succeed");
+    assert!(response.job.is_none());
+    server.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/proof/tee/nitro-enclave/src/protocol.rs
+++ b/crates/proof/tee/nitro-enclave/src/protocol.rs
@@ -1,5 +1,6 @@
 //! Typed request/response protocol for host ↔ enclave communication over vsock.
 
+use alloy_primitives::B256;
 use base_proof_preimage::PreimageKey;
 use base_proof_primitives::ProofResult;
 use serde::{Deserialize, Serialize};
@@ -11,6 +12,8 @@ pub enum EnclaveRequest {
     Prove(Vec<(PreimageKey, Vec<u8>)>),
     /// Return the enclave's 65-byte uncompressed ECDSA public key.
     SignerPublicKey,
+    /// Return the enclave image hash derived from PCR0.
+    TeeImageHash,
     /// Return the raw Nitro attestation document (`COSE_Sign1` bytes).
     SignerAttestation {
         /// Optional application-specific data to bind into the attestation.
@@ -27,6 +30,8 @@ pub enum EnclaveResponse {
     Prove(Box<ProofResult>),
     /// 65-byte uncompressed ECDSA public key for [`EnclaveRequest::SignerPublicKey`].
     SignerPublicKey(Vec<u8>),
+    /// Enclave image hash for [`EnclaveRequest::TeeImageHash`].
+    TeeImageHash(B256),
     /// Raw Nitro attestation document (`COSE_Sign1` bytes) for [`EnclaveRequest::SignerAttestation`].
     SignerAttestation(Vec<u8>),
     /// An error occurred while handling the request.

--- a/crates/proof/tee/nitro-enclave/src/runtime.rs
+++ b/crates/proof/tee/nitro-enclave/src/runtime.rs
@@ -89,6 +89,14 @@ impl NitroEnclave {
                 let key = self.server.signer_public_key();
                 Frame::write(&mut stream, &EnclaveResponse::SignerPublicKey(key)).await?;
             }
+            EnclaveRequest::TeeImageHash => {
+                info!("received TEE image hash request");
+                Frame::write(
+                    &mut stream,
+                    &EnclaveResponse::TeeImageHash(self.server.tee_image_hash()),
+                )
+                .await?;
+            }
             EnclaveRequest::SignerAttestation { user_data, nonce } => {
                 info!(
                     has_nonce = nonce.is_some(),

--- a/crates/proof/tee/nitro-enclave/src/server.rs
+++ b/crates/proof/tee/nitro-enclave/src/server.rs
@@ -112,6 +112,12 @@ impl Server {
         self.pcr0.is_empty()
     }
 
+    /// Returns the enclave image hash derived from PCR0.
+    #[must_use]
+    pub const fn tee_image_hash(&self) -> B256 {
+        self.tee_image_hash
+    }
+
     /// Get the signer's public key as a 65-byte uncompressed EC point.
     #[must_use]
     pub fn signer_public_key(&self) -> Vec<u8> {

--- a/crates/proof/tee/nitro-host/src/error.rs
+++ b/crates/proof/tee/nitro-host/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for host-side TEE prover operations.
 
+use alloy_primitives::B256;
 use base_proof_tee_nitro_enclave::{NitroError, TransportError};
 use thiserror::Error;
 
@@ -33,6 +34,14 @@ pub enum NitroHostError {
     /// The signer public key returned by the enclave is malformed.
     #[error("invalid signer public key: expected 65-byte uncompressed SEC1 key")]
     InvalidSignerKey,
+    /// Enclaves in one worker pool advertise different image hashes.
+    #[error("enclave image hash mismatch: expected {expected}, got {actual}")]
+    ImageHashMismatch {
+        /// Image hash advertised by the first enclave.
+        expected: B256,
+        /// Different image hash advertised by another enclave.
+        actual: B256,
+    },
     /// A response-read timed out (distinct from connect timeout).
     #[error("{operation} timed out")]
     ResponseTimeout {

--- a/crates/proof/tee/nitro-host/src/host.rs
+++ b/crates/proof/tee/nitro-host/src/host.rs
@@ -6,6 +6,7 @@ use base_proof_worker::{JobDiscovery, JobDiscoveryConfig, ProofSubmitter};
 use base_prover_service_client::ProverWorkerProvider;
 use base_prover_service_protocol::TeeKind;
 use tokio_util::sync::CancellationToken;
+use tracing::error;
 
 use crate::{NitroEnclavePool, ProofGenerator, ProofGeneratorHeartbeatConfig};
 
@@ -62,12 +63,20 @@ where
 {
     /// Runs the host until cancellation is requested.
     pub async fn run_until_cancelled(self, cancel: CancellationToken) {
+        let artifact_hash = match self.pool.tee_image_hash().await {
+            Ok(hash) => hash,
+            Err(error) => {
+                error!(error = %error, "failed to read local Nitro artifact hash");
+                return;
+            }
+        };
+        let discovery_config = self.discovery.with_supported_artifact_hash(artifact_hash);
         let submitter = ProofSubmitter::new(self.client.clone());
         let proof_generator = Arc::new(
             ProofGenerator::new(self.pool, submitter, self.heartbeat)
-                .with_max_pending_submissions(self.discovery.normalized_max_concurrent_jobs()),
+                .with_max_pending_submissions(discovery_config.normalized_max_concurrent_jobs()),
         );
-        let discovery = JobDiscovery::new(self.client, proof_generator, self.discovery);
+        let discovery = JobDiscovery::new(self.client, proof_generator, discovery_config);
 
         discovery.run_until_cancelled(cancel).await;
     }

--- a/crates/proof/tee/nitro-host/src/pool.rs
+++ b/crates/proof/tee/nitro-host/src/pool.rs
@@ -2,6 +2,7 @@
 
 use std::{fmt, sync::Arc};
 
+use alloy_primitives::B256;
 use base_proof_host::{ProverConfig, ProverError, ProverService};
 use base_proof_primitives::{ProofRequest, ProofResult};
 use thiserror::Error;
@@ -9,7 +10,7 @@ use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tracing::warn;
 
 use super::{
-    NitroBackend,
+    NitroBackend, NitroHostError,
     registration::{RegistrationChecker, RegistrationError},
     transport::NitroTransport,
 };
@@ -95,6 +96,18 @@ impl NitroEnclavePool {
     /// Returns the configured enclave transports.
     pub fn transports(&self) -> Vec<Arc<NitroTransport>> {
         self.enclaves.iter().map(|enclave| Arc::clone(&enclave.transport)).collect()
+    }
+
+    /// Returns the single image hash supported by every enclave in this pool.
+    pub async fn tee_image_hash(&self) -> Result<B256, NitroHostError> {
+        let expected = self.enclaves[0].transport.tee_image_hash().await?;
+        for enclave in &self.enclaves[1..] {
+            let actual = enclave.transport.tee_image_hash().await?;
+            if actual != expected {
+                return Err(NitroHostError::ImageHashMismatch { expected, actual });
+            }
+        }
+        Ok(expected)
     }
 
     /// Returns the registration checker if one is configured.

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -554,6 +554,7 @@ mod tests {
                     l1_head: None,
                     intermediate_root_interval: None,
                     schedule_l2_block_number: None,
+                    zk_artifact_hash: None,
                     zk_vm: base_prover_service_protocol::ZkVm::Sp1,
                     zk_backend: base_prover_service_protocol::ZkBackend::Cluster,
                 })

--- a/crates/proof/tee/nitro-host/src/transport.rs
+++ b/crates/proof/tee/nitro-host/src/transport.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use alloy_signer::utils::public_key_to_address;
 #[cfg(feature = "metrics")]
 use base_proof_host::Metrics;
@@ -59,6 +59,15 @@ impl NitroTransport {
             #[cfg(target_os = "linux")]
             Self::Vsock(t) => t.signer_public_key().await,
             Self::Local(s) => Ok(s.signer_public_key()),
+        }
+    }
+
+    /// Return the enclave image hash derived from PCR0.
+    pub async fn tee_image_hash(&self) -> Result<B256, NitroHostError> {
+        match self {
+            #[cfg(target_os = "linux")]
+            Self::Vsock(t) => t.tee_image_hash().await,
+            Self::Local(s) => Ok(s.tee_image_hash()),
         }
     }
 

--- a/crates/proof/tee/nitro-host/src/vsock.rs
+++ b/crates/proof/tee/nitro-host/src/vsock.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use alloy_primitives::B256;
 use base_proof_preimage::PreimageKey;
 use base_proof_primitives::ProofResult;
 use base_proof_tee_nitro_enclave::{EnclaveRequest, EnclaveResponse, Frame};
@@ -64,7 +65,9 @@ impl VsockTransport {
         match response {
             EnclaveResponse::Prove(result) => Ok(*result),
             EnclaveResponse::Error(e) => Err(NitroHostError::EnclaveRemoteError(e)),
-            EnclaveResponse::SignerPublicKey(_) | EnclaveResponse::SignerAttestation(_) => {
+            EnclaveResponse::SignerPublicKey(_)
+            | EnclaveResponse::TeeImageHash(_)
+            | EnclaveResponse::SignerAttestation(_) => {
                 Err(NitroHostError::UnexpectedResponse { expected: "prove" })
             }
         }
@@ -92,8 +95,35 @@ impl VsockTransport {
                 Ok(key)
             }
             EnclaveResponse::Error(e) => Err(NitroHostError::EnclaveRemoteError(e)),
-            EnclaveResponse::Prove(_) | EnclaveResponse::SignerAttestation(_) => {
+            EnclaveResponse::Prove(_)
+            | EnclaveResponse::TeeImageHash(_)
+            | EnclaveResponse::SignerAttestation(_) => {
                 Err(NitroHostError::UnexpectedResponse { expected: "signer_public_key" })
+            }
+        }
+    }
+
+    /// Return the enclave image hash derived from PCR0.
+    pub async fn tee_image_hash(&self) -> Result<B256, NitroHostError> {
+        let mut stream = self.connect().await?;
+
+        Frame::write(&mut stream, &EnclaveRequest::TeeImageHash)
+            .await
+            .map_err(NitroHostError::FrameWrite)?;
+
+        let response: EnclaveResponse =
+            tokio::time::timeout(SIGNER_TIMEOUT, Frame::read(&mut stream))
+                .await
+                .map_err(|_| NitroHostError::ResponseTimeout { operation: "tee_image_hash" })?
+                .map_err(NitroHostError::FrameRead)?;
+
+        match response {
+            EnclaveResponse::TeeImageHash(hash) => Ok(hash),
+            EnclaveResponse::Error(e) => Err(NitroHostError::EnclaveRemoteError(e)),
+            EnclaveResponse::Prove(_)
+            | EnclaveResponse::SignerPublicKey(_)
+            | EnclaveResponse::SignerAttestation(_) => {
+                Err(NitroHostError::UnexpectedResponse { expected: "tee_image_hash" })
             }
         }
     }
@@ -119,7 +149,9 @@ impl VsockTransport {
         match response {
             EnclaveResponse::SignerAttestation(doc) => Ok(doc),
             EnclaveResponse::Error(e) => Err(NitroHostError::EnclaveRemoteError(e)),
-            EnclaveResponse::Prove(_) | EnclaveResponse::SignerPublicKey(_) => {
+            EnclaveResponse::Prove(_)
+            | EnclaveResponse::SignerPublicKey(_)
+            | EnclaveResponse::TeeImageHash(_) => {
                 Err(NitroHostError::UnexpectedResponse { expected: "signer_attestation" })
             }
         }

--- a/crates/proof/worker/Cargo.toml
+++ b/crates/proof/worker/Cargo.toml
@@ -23,6 +23,7 @@ async-trait.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 
 # misc
+alloy-primitives.workspace = true
 backon.workspace = true
 chrono.workspace = true
 tracing.workspace = true

--- a/crates/proof/worker/src/job_discovery.rs
+++ b/crates/proof/worker/src/job_discovery.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use alloy_primitives::B256;
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{
     GetNextProofRequest, ProofJob, ProofType, TeeKind, ZkBackend, ZkVm,
@@ -92,15 +93,22 @@ impl JobClaimFilter {
     pub fn get_next_proof_requests(
         &self,
         worker_id: String,
+        supported_artifact_hash: Option<B256>,
         lock_duration_seconds: u32,
     ) -> impl Iterator<Item = GetNextProofRequest> {
-        self.get_next_proof_requests_starting_at(worker_id, lock_duration_seconds, 0)
+        self.get_next_proof_requests_starting_at(
+            worker_id,
+            supported_artifact_hash,
+            lock_duration_seconds,
+            0,
+        )
     }
 
     /// Builds the worker claim requests for this filter with a proof-type rotation offset.
     pub fn get_next_proof_requests_starting_at(
         &self,
         worker_id: String,
+        supported_artifact_hash: Option<B256>,
         lock_duration_seconds: u32,
         proof_type_offset: usize,
     ) -> impl Iterator<Item = GetNextProofRequest> {
@@ -112,6 +120,7 @@ impl JobClaimFilter {
                     tee_kinds: tee_kinds.clone(),
                     zk_vms: Vec::new(),
                     zk_backends: Vec::new(),
+                    supported_artifact_hash,
                     lock_duration_seconds,
                 }),
                 None,
@@ -133,6 +142,7 @@ impl JobClaimFilter {
                         tee_kinds: Vec::new(),
                         zk_vms: zk_vms.clone(),
                         zk_backends: zk_backends.clone(),
+                        supported_artifact_hash,
                         lock_duration_seconds,
                     }),
                     Some(GetNextProofRequest {
@@ -141,6 +151,7 @@ impl JobClaimFilter {
                         tee_kinds: Vec::new(),
                         zk_vms,
                         zk_backends,
+                        supported_artifact_hash,
                         lock_duration_seconds,
                     }),
                 ]
@@ -156,6 +167,7 @@ impl JobClaimFilter {
 pub struct JobDiscoveryConfig {
     worker_id: String,
     claim_filter: JobClaimFilter,
+    supported_artifact_hash: Option<B256>,
     poll_interval: Duration,
     lock_duration_seconds: u32,
     max_concurrent_jobs: usize,
@@ -181,6 +193,7 @@ impl JobDiscoveryConfig {
         Self {
             worker_id: worker_id.into(),
             claim_filter,
+            supported_artifact_hash: None,
             poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
             lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
             max_concurrent_jobs: DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
@@ -220,6 +233,13 @@ impl JobDiscoveryConfig {
         self
     }
 
+    /// Sets the exact artifact hash advertised on every claim request.
+    #[must_use]
+    pub const fn with_supported_artifact_hash(mut self, artifact_hash: B256) -> Self {
+        self.supported_artifact_hash = Some(artifact_hash);
+        self
+    }
+
     /// Returns the configured poll interval clamped to the minimum allowed delay.
     pub fn normalized_poll_interval(&self) -> Duration {
         self.poll_interval.max(MIN_JOB_DISCOVERY_POLL_INTERVAL)
@@ -242,6 +262,7 @@ impl JobDiscoveryConfig {
     ) -> impl Iterator<Item = GetNextProofRequest> {
         self.claim_filter.get_next_proof_requests_starting_at(
             self.worker_id.clone(),
+            self.supported_artifact_hash,
             self.lock_duration_seconds,
             proof_type_offset,
         )
@@ -628,6 +649,7 @@ mod tests {
             l1_head: None,
             intermediate_root_interval: None,
             schedule_l2_block_number: None,
+            zk_artifact_hash: None,
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         }
@@ -667,6 +689,7 @@ mod tests {
             vec![ZkVm::Sp1],
             vec![ZkBackend::Cluster, ZkBackend::Network],
         )
+        .with_supported_artifact_hash(B256::repeat_byte(0x42))
         .with_lock_duration_seconds(30)
         .with_max_concurrent_jobs(0);
 
@@ -678,12 +701,14 @@ mod tests {
         assert!(requests[0].tee_kinds.is_empty());
         assert_eq!(requests[0].zk_vms, vec![ZkVm::Sp1]);
         assert_eq!(requests[0].zk_backends, vec![ZkBackend::Cluster, ZkBackend::Network]);
+        assert_eq!(requests[0].supported_artifact_hash, Some(B256::repeat_byte(0x42)));
         assert_eq!(requests[0].lock_duration_seconds, 30);
         assert_eq!(requests[1].worker_id, "worker-a");
         assert_eq!(requests[1].proof_type, ProofType::SnarkPlonk);
         assert!(requests[1].tee_kinds.is_empty());
         assert_eq!(requests[1].zk_vms, vec![ZkVm::Sp1]);
         assert_eq!(requests[1].zk_backends, vec![ZkBackend::Cluster, ZkBackend::Network]);
+        assert_eq!(requests[1].supported_artifact_hash, Some(B256::repeat_byte(0x42)));
         assert_eq!(requests[1].lock_duration_seconds, 30);
         assert_eq!(config.normalized_max_concurrent_jobs(), 1);
     }
@@ -691,6 +716,7 @@ mod tests {
     #[test]
     fn config_builds_nitro_claim_request() {
         let config = JobDiscoveryConfig::tee("worker-a", vec![TeeKind::AwsNitro])
+            .with_supported_artifact_hash(B256::repeat_byte(0x24))
             .with_lock_duration_seconds(45);
 
         let requests = config.get_next_proof_requests().collect::<Vec<_>>();
@@ -701,6 +727,7 @@ mod tests {
         assert_eq!(request.proof_type, ProofType::Tee);
         assert_eq!(request.tee_kinds, vec![TeeKind::AwsNitro]);
         assert!(request.zk_vms.is_empty());
+        assert_eq!(request.supported_artifact_hash, Some(B256::repeat_byte(0x24)));
         assert_eq!(request.lock_duration_seconds, 45);
     }
 

--- a/crates/proof/worker/src/proof_submitter.rs
+++ b/crates/proof/worker/src/proof_submitter.rs
@@ -448,6 +448,7 @@ mod tests {
                     l1_head: None,
                     intermediate_root_interval: None,
                     schedule_l2_block_number: None,
+                    zk_artifact_hash: None,
                     zk_vm: ZkVm::Sp1,
                     zk_backend: ZkBackend::Cluster,
                 }),

--- a/crates/proof/zk/backend/src/lib.rs
+++ b/crates/proof/zk/backend/src/lib.rs
@@ -16,4 +16,5 @@ pub use succinct::{
     cluster_setup_vkeys, cluster_submit_agg_proof, cluster_submit_range_proof, get_agg_proof_stdin,
     get_cache_dir, get_range_elf_embedded, get_sp1_stdin, get_stdin_cache_path, initialize_host,
     is_cluster_mode, load_stdin_from_cache, reconstruct_proof_request, save_stdin_to_cache,
+    zk_artifact_hash,
 };

--- a/crates/proof/zk/backend/src/succinct/mod.rs
+++ b/crates/proof/zk/backend/src/succinct/mod.rs
@@ -32,5 +32,5 @@ pub use utils::{
     cluster_range_proof, cluster_setup_keys, cluster_setup_range_key, cluster_setup_vkeys,
     cluster_submit_agg_proof, cluster_submit_range_proof, get_agg_proof_stdin, get_cache_dir,
     get_range_elf_embedded, get_sp1_stdin, get_stdin_cache_path, initialize_host, is_cluster_mode,
-    load_stdin_from_cache, reconstruct_proof_request, save_stdin_to_cache,
+    load_stdin_from_cache, reconstruct_proof_request, save_stdin_to_cache, zk_artifact_hash,
 };

--- a/crates/proof/zk/backend/src/succinct/utils/elf.rs
+++ b/crates/proof/zk/backend/src/succinct/utils/elf.rs
@@ -1,9 +1,11 @@
 //! Embedded SP1 program bytes and proving-key setup.
 
+use alloy_primitives::{B256, keccak256};
 use anyhow::{Context, Result};
 use base_proof_succinct_elfs::{AGGREGATION_ELF, RANGE_ELF_EMBEDDED};
+use base_proof_zk_utils::types::u32_to_u8;
 use sp1_sdk::{
-    Elf, ProvingKey, SP1ProvingKey, SP1VerifyingKey,
+    Elf, HashableKey, ProvingKey, SP1ProvingKey, SP1VerifyingKey,
     blocking::{CpuProver, LightProver, Prover as BlockingProver},
 };
 
@@ -62,4 +64,15 @@ pub async fn cluster_setup_vkeys() -> Result<(SP1VerifyingKey, SP1VerifyingKey)>
         anyhow::Ok((range_vk, agg_vk))
     })
     .await?
+}
+
+/// Computes the routing hash for the embedded range and aggregation programs.
+pub async fn zk_artifact_hash() -> Result<B256> {
+    let (range_vk, aggregate_vk) = cluster_setup_vkeys().await?;
+    let range_hash = B256::from(u32_to_u8(range_vk.hash_u32()));
+    let aggregate_hash = B256::from(u32_to_u8(aggregate_vk.hash_u32()));
+    let mut artifacts = [0_u8; 64];
+    artifacts[..32].copy_from_slice(range_hash.as_slice());
+    artifacts[32..].copy_from_slice(aggregate_hash.as_slice());
+    Ok(keccak256(artifacts))
 }

--- a/crates/proof/zk/backend/src/succinct/utils/mod.rs
+++ b/crates/proof/zk/backend/src/succinct/utils/mod.rs
@@ -6,6 +6,7 @@ pub use stdin::{get_agg_proof_stdin, get_sp1_stdin};
 mod elf;
 pub use elf::{
     cluster_setup_keys, cluster_setup_range_key, cluster_setup_vkeys, get_range_elf_embedded,
+    zk_artifact_hash,
 };
 
 mod cluster;

--- a/crates/proof/zk/host/Cargo.toml
+++ b/crates/proof/zk/host/Cargo.toml
@@ -23,11 +23,11 @@ async-trait.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 
 # misc
+alloy-primitives.workspace = true
 chrono.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-alloy-primitives.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 base-proof-primitives = { workspace = true, features = ["std", "serde"] }

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -17,7 +17,7 @@ use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkBackend, ZkProver, 
 pub struct ZkHostConfig {
     worker_id: String,
     zk_vms: Vec<ZkVm>,
-    supported_artifact_hash: Option<B256>,
+    supported_artifact_hash: B256,
     job_discovery_poll_interval: Duration,
     job_discovery_lock_duration_seconds: u32,
     job_discovery_max_concurrent_jobs: usize,
@@ -26,11 +26,15 @@ pub struct ZkHostConfig {
 
 impl ZkHostConfig {
     /// Creates a ZK host config with default timing settings.
-    pub fn new(worker_id: impl Into<String>, zk_vms: impl Into<Vec<ZkVm>>) -> Self {
+    pub fn new(
+        worker_id: impl Into<String>,
+        zk_vms: impl Into<Vec<ZkVm>>,
+        supported_artifact_hash: B256,
+    ) -> Self {
         Self {
             worker_id: worker_id.into(),
             zk_vms: zk_vms.into(),
-            supported_artifact_hash: None,
+            supported_artifact_hash,
             job_discovery_poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
             job_discovery_lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
             job_discovery_max_concurrent_jobs: DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
@@ -39,8 +43,8 @@ impl ZkHostConfig {
     }
 
     /// Creates an SP1 ZK host config with default timing settings.
-    pub fn sp1(worker_id: impl Into<String>) -> Self {
-        Self::new(worker_id, vec![ZkVm::Sp1])
+    pub fn sp1(worker_id: impl Into<String>, supported_artifact_hash: B256) -> Self {
+        Self::new(worker_id, vec![ZkVm::Sp1], supported_artifact_hash)
     }
 
     /// Returns the worker identifier used for prover-service claims.
@@ -112,13 +116,6 @@ impl ZkHostConfig {
         self.proof_generator_heartbeat = proof_generator_heartbeat;
         self
     }
-
-    /// Sets the composite hash of the embedded range and aggregation programs.
-    #[must_use]
-    pub const fn with_supported_artifact_hash(mut self, artifact_hash: B256) -> Self {
-        self.supported_artifact_hash = Some(artifact_hash);
-        self
-    }
 }
 
 /// Runs ZK proof generation jobs claimed from the prover service.
@@ -158,11 +155,8 @@ where
         let discovery_config = JobDiscoveryConfig::zk(config.worker_id, config.zk_vms, zk_backends)
             .with_poll_interval(config.job_discovery_poll_interval)
             .with_lock_duration_seconds(config.job_discovery_lock_duration_seconds)
-            .with_max_concurrent_jobs(config.job_discovery_max_concurrent_jobs);
-        let discovery_config = match config.supported_artifact_hash {
-            Some(hash) => discovery_config.with_supported_artifact_hash(hash),
-            None => discovery_config,
-        };
+            .with_max_concurrent_jobs(config.job_discovery_max_concurrent_jobs)
+            .with_supported_artifact_hash(config.supported_artifact_hash);
         let submitter = ProofSubmitter::new(client.clone());
         let proof_generator = Arc::new(
             ProofGenerator::new(provers, submitter, config.proof_generator_heartbeat)

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use alloy_primitives::B256;
 use base_proof_worker::{
     DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
     DEFAULT_JOB_DISCOVERY_POLL_INTERVAL, JobDiscovery, JobDiscoveryConfig, ProofSubmitter,
@@ -16,6 +17,7 @@ use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkBackend, ZkProver, 
 pub struct ZkHostConfig {
     worker_id: String,
     zk_vms: Vec<ZkVm>,
+    supported_artifact_hash: Option<B256>,
     job_discovery_poll_interval: Duration,
     job_discovery_lock_duration_seconds: u32,
     job_discovery_max_concurrent_jobs: usize,
@@ -28,6 +30,7 @@ impl ZkHostConfig {
         Self {
             worker_id: worker_id.into(),
             zk_vms: zk_vms.into(),
+            supported_artifact_hash: None,
             job_discovery_poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
             job_discovery_lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
             job_discovery_max_concurrent_jobs: DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
@@ -109,6 +112,13 @@ impl ZkHostConfig {
         self.proof_generator_heartbeat = proof_generator_heartbeat;
         self
     }
+
+    /// Sets the composite hash of the embedded range and aggregation programs.
+    #[must_use]
+    pub const fn with_supported_artifact_hash(mut self, artifact_hash: B256) -> Self {
+        self.supported_artifact_hash = Some(artifact_hash);
+        self
+    }
 }
 
 /// Runs ZK proof generation jobs claimed from the prover service.
@@ -149,6 +159,10 @@ where
             .with_poll_interval(config.job_discovery_poll_interval)
             .with_lock_duration_seconds(config.job_discovery_lock_duration_seconds)
             .with_max_concurrent_jobs(config.job_discovery_max_concurrent_jobs);
+        let discovery_config = match config.supported_artifact_hash {
+            Some(hash) => discovery_config.with_supported_artifact_hash(hash),
+            None => discovery_config,
+        };
         let submitter = ProofSubmitter::new(client.clone());
         let proof_generator = Arc::new(
             ProofGenerator::new(provers, submitter, config.proof_generator_heartbeat)

--- a/crates/proof/zk/host/src/prover.rs
+++ b/crates/proof/zk/host/src/prover.rs
@@ -140,6 +140,7 @@ mod tests {
             l1_head: None,
             intermediate_root_interval: None,
             schedule_l2_block_number: None,
+            zk_artifact_hash: None,
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         }

--- a/crates/proof/zk/witness/src/fetcher.rs
+++ b/crates/proof/zk/witness/src/fetcher.rs
@@ -810,6 +810,7 @@ impl OPSuccinctDataFetcher {
             claimed_l2_block_number: l2_end_block,
             intermediate_block_interval,
             l1_head_number,
+            image_hash: B256::ZERO,
             // We don't need to set the proposer for the range proof zk program
             proposer: Address::ZERO,
             schedule_l2_block_number,

--- a/etc/systems/benches/common/zk_proof.rs
+++ b/etc/systems/benches/common/zk_proof.rs
@@ -126,6 +126,7 @@ impl ZkProofBench {
                         l1_head: Some(l1_head),
                         intermediate_root_interval: None,
                         schedule_l2_block_number: None,
+                        zk_artifact_hash: None,
                         zk_vm: ZkVm::Sp1,
                         zk_backend: ZkBackend::DryRun,
                     }),


### PR DESCRIPTION
## What changed
- persist an exact 32-byte TEE image or composite ZK artifact hash on every new proof job
- require worker claims to advertise the same artifact hash before the database assigns work
- source TEE/ZK hashes from proposer configuration, game contracts, Nitro enclaves, and embedded ZK verification keys
- include artifact identity in deterministic proposer and challenger session IDs

## Why
Protocol upgrades can leave multiple prover artifact generations live at once. Capability-only routing can assign a job to a worker whose enclave image or verification keys are incompatible with the verifier that requested it. Exact hash matching fails closed and keeps each job on a compatible worker generation.

## Rollout notes
- migration 018 leaves pre-existing rows without a hash unclaimable
- pause the prover service and drain unfinished jobs before applying the migration
- deploy the related base-proofs worker-group PR before introducing another artifact generation

## How to test
```sh
cargo check -p base-prover-service-protocol -p base-prover-service-db -p base-prover-service -p base-proof-contracts -p base-proposer -p base-challenger -p base-proof-worker -p base-proof-tee-nitro-host -p base-proof-zk-host -p base-prover-zk-host
cargo test -p base-prover-service-protocol -p base-prover-service-db -p base-proof-contracts -p base-proof-worker -p base-proposer -p base-challenger --lib
cargo test -p base-proof-tee-nitro-host -p base-proof-zk-host --lib
cargo test -p base-prover-service --test worker_api_e2e --no-run
cargo test -p base-prover-service-db --test postgres_integration --no-run
cargo test -p base-challenger --test driver --no-run
```

PostgreSQL integration tests require a migrated test database and remain ignored by default.

Made with [Cursor](https://cursor.com)