### PR TITLE
fix(precompiles): stop aliased ABI double-decode (Cantina #16 / BOP-603)

### DIFF
--- a/crates/common/precompiles/src/b20_asset/abi/mod.rs
+++ b/crates/common/precompiles/src/b20_asset/abi/mod.rs
@@ -16,3 +16,59 @@ pub use v1::IB20Asset as IB20AssetV1;
 
 mod v2;
 pub use v2::{ERC165_INTERFACE_ID, ERC8056_INTERFACE_IDS, IB20Asset, IB20Asset as IB20AssetV2};
+
+/// Lifts a Beryl-frozen asset call into the canonical (Cobalt) enum without re-parsing calldata.
+///
+/// Every V1 selector exists on V2 with identical parameter layouts, so this is a move of owned
+/// fields — the second owned ABI materialization that Cantina #16 measured is avoided.
+impl From<IB20AssetV1::IB20AssetCalls> for IB20Asset::IB20AssetCalls {
+    fn from(call: IB20AssetV1::IB20AssetCalls) -> Self {
+        match call {
+            IB20AssetV1::IB20AssetCalls::OPERATOR_ROLE(_) => {
+                Self::OPERATOR_ROLE(IB20Asset::OPERATOR_ROLECall {})
+            }
+            IB20AssetV1::IB20AssetCalls::WAD_PRECISION(_) => {
+                Self::WAD_PRECISION(IB20Asset::WAD_PRECISIONCall {})
+            }
+            IB20AssetV1::IB20AssetCalls::announce(c) => Self::announce(IB20Asset::announceCall {
+                internalCalls: c.internalCalls,
+                id: c.id,
+                description: c.description,
+                uri: c.uri,
+            }),
+            IB20AssetV1::IB20AssetCalls::isAnnouncementIdUsed(c) => {
+                Self::isAnnouncementIdUsed(IB20Asset::isAnnouncementIdUsedCall { id: c.id })
+            }
+            IB20AssetV1::IB20AssetCalls::multiplier(_) => {
+                Self::multiplier(IB20Asset::multiplierCall {})
+            }
+            IB20AssetV1::IB20AssetCalls::toScaledBalance(c) => {
+                Self::toScaledBalance(IB20Asset::toScaledBalanceCall { rawBalance: c.rawBalance })
+            }
+            IB20AssetV1::IB20AssetCalls::toRawBalance(c) => {
+                Self::toRawBalance(IB20Asset::toRawBalanceCall { scaledBalance: c.scaledBalance })
+            }
+            IB20AssetV1::IB20AssetCalls::scaledBalanceOf(c) => {
+                Self::scaledBalanceOf(IB20Asset::scaledBalanceOfCall { account: c.account })
+            }
+            IB20AssetV1::IB20AssetCalls::updateMultiplier(c) => {
+                Self::updateMultiplier(IB20Asset::updateMultiplierCall {
+                    newMultiplier: c.newMultiplier,
+                })
+            }
+            IB20AssetV1::IB20AssetCalls::batchMint(c) => Self::batchMint(IB20Asset::batchMintCall {
+                recipients: c.recipients,
+                amounts: c.amounts,
+            }),
+            IB20AssetV1::IB20AssetCalls::extraMetadata(c) => {
+                Self::extraMetadata(IB20Asset::extraMetadataCall { key: c.key })
+            }
+            IB20AssetV1::IB20AssetCalls::updateExtraMetadata(c) => {
+                Self::updateExtraMetadata(IB20Asset::updateExtraMetadataCall {
+                    key: c.key,
+                    value: c.value,
+                })
+            }
+        }
+    }
+}

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -8,8 +8,10 @@
 //! internal-call loop stays here because re-dispatching arbitrary sub-calls is a
 //! routing responsibility; its version-defined business steps live on [`Asset`].
 
+use alloc::string::String;
+
 use alloy_primitives::{Bytes, U256};
-use alloy_sol_types::{SolCall, SolValue};
+use alloy_sol_types::{abi, SolCall, SolType, SolValue};
 use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, StorageCtx};
 use revm::precompile::PrecompileResult;
@@ -104,6 +106,21 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
     where
         O: PrecompileCallObserver,
     {
+        // `announce` is intercepted before the generic decode so its `bytes[] internalCalls` is
+        // decoded borrowed (never materialized into an owned `Vec<Bytes>`). Routing it through the
+        // canonical enum would force that owned expansion, which an aliased payload can amplify into
+        // a heap-exhaustion DoS. Gated on `valid_selector` so a future fork that drops `announce`
+        // from the asset surface falls through to the generic unknown-selector path.
+        if let Some(selector) = calldata.first_chunk::<4>().copied()
+            && selector == IB20Asset::announceCall::SELECTOR
+            && version.abi().asset.valid_selector(selector)
+        {
+            return observer.observe("precompile-b20-asset-announce", || {
+                self.announce(ctx, calldata, version, privileged, &observer)?;
+                Ok(Bytes::new())
+            });
+        }
+
         let call = version.abi().decode(calldata)?;
         let label = call.as_label();
         match call {
@@ -397,11 +414,8 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
                 Bytes::new()
             }
 
-            // --- Announcement ---
-            SC::announce(c) => {
-                self.announce(ctx, c, version, privileged, &observer)?;
-                Bytes::new()
-            }
+            // `announce` is intercepted in `route` (borrowed decode) and never reaches this enum.
+            SC::announce(_) => return Err(BasePrecompileError::Revert(Bytes::new())),
 
             // --- Batched mint ---
             SC::batchMint(c) => {
@@ -424,14 +438,23 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
 
     /// Posts an announcement and atomically executes `internalCalls` via self-dispatch.
     ///
-    /// Re-dispatching arbitrary sub-calls is a routing responsibility, so it stays in the
-    /// dispatcher; the version's [`Asset::begin_announce`]/[`Asset::end_announce`] bracket the loop
-    /// with the version-defined business steps. Each internal call routes at the same `version`.
-    /// The selector check in the inner loop prevents recursive invocation.
+    /// `calldata` is the full `announce` calldata (selector included); `route` only enters here
+    /// after matching the 4-byte `announce` selector. The `bytes[] internalCalls` vector is decoded
+    /// **borrowed** — each entry is a slice into `calldata`, never an owned copy — so an aliased
+    /// payload (many element offsets pointing at one tail) cannot amplify a small calldata into a
+    /// large heap allocation. Only the three strings are materialized, and they do not fan out.
+    ///
+    /// The borrowed decode runs the same `decode_sequence` + `type_check` as the canonical
+    /// `abi_decode_validate`, skipping only the infallible `detokenize`, so it accepts and rejects
+    /// exactly the same inputs. On any rejection it defers to the existing version-aware decode
+    /// ([`AssetAbiPair::decode`](crate::AssetAbiPair)) so the revert carries byte-identical consensus
+    /// error bytes (frozen surface for V1, canonical for V2).
+    ///
+    /// Cobalt (V2) additionally meters the expanded dynamic byte length before the body runs.
     fn announce<O>(
         &mut self,
         ctx: StorageCtx<'_>,
-        call: IB20Asset::announceCall,
+        calldata: &[u8],
         version: AssetVersion,
         privileged: bool,
         observer: &O,
@@ -439,10 +462,113 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
     where
         O: PrecompileCallObserver,
     {
-        let caller = ctx.caller();
-        let internal_calls = call.internalCalls;
-        let internal_call_count = internal_calls.len();
-        let internal_call_bytes = internal_calls.iter().map(|call| call.len()).sum();
+        match Self::decode_announce_borrowed(&calldata[4..]) {
+            Ok((internal_calls, id, description, uri)) => {
+                let expanded_bytes: usize =
+                    internal_calls.0.iter().map(|call| call.as_slice().len()).sum();
+                Self::deduct_announce_expanded_gas(ctx, version, expanded_bytes)?;
+                self.run_announce(
+                    ctx,
+                    version,
+                    privileged,
+                    observer,
+                    String::from_utf8_lossy(id.as_slice()).into_owned(),
+                    String::from_utf8_lossy(description.as_slice()).into_owned(),
+                    String::from_utf8_lossy(uri.as_slice()).into_owned(),
+                    internal_calls.0.len(),
+                    expanded_bytes,
+                    internal_calls.0.iter().map(|call| call.as_slice()),
+                )
+            }
+            // Borrowed decode rejected. By the accept-set equality above, the existing decode also
+            // rejects, so `?` returns its exact error bytes. The `Ok` arm is unreachable by that
+            // equality; running the owned announce there is a total-function safety net (never a
+            // valid amplifying payload) that avoids a consensus-crashing panic if the equality were
+            // ever to not hold.
+            Err(()) => match version.abi().decode(calldata)? {
+                AssetCall::Asset(IB20Asset::IB20AssetCalls::announce(call)) => {
+                    let expanded_bytes: usize =
+                        call.internalCalls.iter().map(|call| call.len()).sum();
+                    Self::deduct_announce_expanded_gas(ctx, version, expanded_bytes)?;
+                    self.run_announce(
+                        ctx,
+                        version,
+                        privileged,
+                        observer,
+                        call.id,
+                        call.description,
+                        call.uri,
+                        call.internalCalls.len(),
+                        expanded_bytes,
+                        call.internalCalls.iter().map(|call| &call[..]),
+                    )
+                }
+                _ => Err(BasePrecompileError::Revert(Bytes::new())),
+            },
+        }
+    }
+
+    /// Decodes `announce`'s parameters **borrowed** — each `bytes` is a slice into `rest`, not an
+    /// owned copy. `rest` is the calldata with the 4-byte selector already stripped.
+    ///
+    /// This mirrors alloy's `abi_decode_validate` (`decode_sequence` then `type_check`) and omits
+    /// only the infallible `detokenize`, so it accepts and rejects exactly the same inputs. Running
+    /// `type_check` is mandatory, not optional: `string` validation rejects non-UTF-8 while
+    /// `detokenize` is lossy, so skipping it would accept an `id`/`description`/`uri` the canonical
+    /// path rejects — an accept-side divergence the caller's error fallback could not catch.
+    fn decode_announce_borrowed(
+        rest: &[u8],
+    ) -> core::result::Result<<IB20Asset::announceCall as SolCall>::Token<'_>, ()> {
+        let token = abi::decode_sequence::<<IB20Asset::announceCall as SolCall>::Token<'_>>(rest)
+            .map_err(|_| ())?;
+        <<IB20Asset::announceCall as SolCall>::Parameters<'_> as SolType>::type_check(&token)
+            .map_err(|_| ())?;
+        Ok(token)
+    }
+
+    /// Charges Cobalt expanded-dynamic gas for announce's `bytes[]` payload. Beryl is unchanged.
+    fn deduct_announce_expanded_gas(
+        ctx: StorageCtx<'_>,
+        version: AssetVersion,
+        expanded_bytes: usize,
+    ) -> base_precompile_storage::Result<()> {
+        if !matches!(version, AssetVersion::V2) || expanded_bytes == 0 {
+            return Ok(());
+        }
+        ctx.deduct_gas(BerylCallRecorder::<NoopPrecompileCallObserver>::expanded_gas_cost(
+            expanded_bytes,
+        ))
+    }
+
+    /// Runs the announcement body shared by the borrowed fast path and the owned safety net:
+    /// records metrics, brackets the internal-call loop with the version's
+    /// [`Asset::begin_announce`]/[`Asset::end_announce`], and self-dispatches each entry.
+    ///
+    /// Each internal call is dispatched via `route`, a direct Rust function call. Unlike the
+    /// base-std Solidity reference which routes each `internalCalls` entry through a DELEGATECALL
+    /// (~100 gas opcode overhead + memory expansion), the native precompile replaces the entire
+    /// EVM execution path so per-opcode call overhead does not apply. The cheaper batched cost is
+    /// intentional: the native precompile pays for the storage work of each sub-call (the same
+    /// SLOAD/SSTORE operations as the Solidity reference) but not for EVM call-frame overhead
+    /// that exists only in the interpreter.
+    #[allow(clippy::too_many_arguments)]
+    fn run_announce<'c, O, I>(
+        &mut self,
+        ctx: StorageCtx<'_>,
+        version: AssetVersion,
+        privileged: bool,
+        observer: &O,
+        id: String,
+        description: String,
+        uri: String,
+        internal_call_count: usize,
+        internal_call_bytes: usize,
+        internal_calls: I,
+    ) -> base_precompile_storage::Result<()>
+    where
+        O: PrecompileCallObserver,
+        I: Iterator<Item = &'c [u8]>,
+    {
         observer.record_internal_calls(
             &BerylAuxiliaryMetrics::b20("asset", "announce"),
             internal_call_count,
@@ -450,21 +576,13 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
         );
 
         let logic = version.implementation();
-        let id = call.id;
-        logic.begin_announce(self, caller, id.clone(), call.description, call.uri, privileged)?;
+        let caller = ctx.caller();
+        logic.begin_announce(self, caller, id.clone(), description, uri, privileged)?;
 
-        // Each internal call is dispatched via `route`, a direct Rust function call. Unlike the
-        // base-std Solidity reference which routes each `internalCalls` entry through a DELEGATECALL
-        // (~100 gas opcode overhead + memory expansion), the native precompile replaces the entire
-        // EVM execution path so per-opcode call overhead does not apply. The cheaper batched cost is
-        // intentional: the native precompile pays for the storage work of each sub-call (the same
-        // SLOAD/SSTORE operations as the Solidity reference) but not for EVM call-frame overhead
-        // that exists only in the interpreter.
-        for call in &internal_calls {
-            let call_bytes: &[u8] = call.as_ref();
+        for call_bytes in internal_calls {
             if call_bytes.len() < 4 {
                 return Err(BasePrecompileError::revert(IB20Asset::InternalCallMalformed {
-                    call: call.clone(),
+                    call: Bytes::copy_from_slice(call_bytes),
                 }));
             }
             if call_bytes[..4] == IB20Asset::announceCall::SELECTOR {
@@ -476,7 +594,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
                         err
                     } else {
                         BasePrecompileError::revert(IB20Asset::InternalCallFailed {
-                            call: call.clone(),
+                            call: Bytes::copy_from_slice(call_bytes),
                         })
                     }
                 },
@@ -499,10 +617,10 @@ mod tests {
 
     use crate::{
         ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, AssetAccounting,
-        AssetV1, AssetVersion, B20AssetStorage, B20AssetToken, B20TokenRole, BerylErrorKind,
-        FakePolicyAccounting, IB20, IB20Asset, InMemoryTokenAccounting, NoopPrecompileCallObserver,
-        PolicyVersion, PrecompileCallMetric, PrecompileCallObserver, PrecompileCallOutcome,
-        PrecompileCallStatus, Token, TokenAccounting,
+        AssetV1, AssetVersion, B20AssetStorage, B20AssetToken, B20TokenRole, BerylCallRecorder,
+        BerylErrorKind, FakePolicyAccounting, IB20, IB20Asset, InMemoryTokenAccounting,
+        NoopPrecompileCallObserver, PolicyVersion, PrecompileCallMetric, PrecompileCallObserver,
+        PrecompileCallOutcome, PrecompileCallStatus, Token, TokenAccounting,
     };
 
     type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, FakePolicyAccounting>;
@@ -839,5 +957,126 @@ mod tests {
 
         assert!(out.is_revert());
         assert_eq!(out.bytes, Bytes::from(IB20::NonPayable {}.abi_encode()));
+    }
+
+    /// Builds `announce` calldata where `n` `bytes[]` offsets all reference one shared `tail`.
+    ///
+    /// Starts from a valid one-element alloy encoding, then expands the array header so every
+    /// element offset points at the same tail blob and rewrites the trailing string offsets.
+    fn aliased_announce_calldata(n: usize, tail: &[u8]) -> Vec<u8> {
+        assert!(n >= 1, "need at least one aliased entry");
+        let base = IB20Asset::announceCall {
+            internalCalls: alloc::vec![Bytes::copy_from_slice(tail)],
+            id: String::from("aliased-id"),
+            description: String::from("desc"),
+            uri: String::new(),
+        }
+        .abi_encode();
+
+        // Args layout after selector:
+        //   [off_calls][off_id][off_desc][off_uri][len=1][off0=0x40][bytes blob][id][desc][uri]
+        let args = &base[4..];
+        let read_u256 = |at: usize| -> usize {
+            let mut buf = [0u8; 8];
+            buf.copy_from_slice(&args[at + 24..at + 32]);
+            u64::from_be_bytes(buf) as usize
+        };
+        let write_u256 = |out: &mut [u8], at: usize, v: usize| {
+            out[at..at + 32].fill(0);
+            out[at + 24..at + 32].copy_from_slice(&(v as u64).to_be_bytes());
+        };
+
+        let off_calls = read_u256(0);
+        let off_id = read_u256(32);
+        let off_desc = read_u256(64);
+        let off_uri = read_u256(96);
+        assert_eq!(read_u256(off_calls), 1, "base encode must be one-element");
+
+        let bytes_blob = &args[off_calls + 64..off_id]; // after len+off0
+        let strings = &args[off_id..];
+
+        // New array section: length + n offsets + shared blob.
+        let extra_offsets = (n - 1) * 32;
+        let new_off_id = off_id + extra_offsets;
+        let new_off_desc = off_desc + extra_offsets;
+        let new_off_uri = off_uri + extra_offsets;
+        let shared_elem_off = n * 32;
+
+        let mut out = base[..4].to_vec();
+        out.resize(4 + 128 + 32 + n * 32 + bytes_blob.len() + strings.len(), 0);
+        let args_out = &mut out[4..];
+        write_u256(args_out, 0, off_calls);
+        write_u256(args_out, 32, new_off_id);
+        write_u256(args_out, 64, new_off_desc);
+        write_u256(args_out, 96, new_off_uri);
+        write_u256(args_out, off_calls, n);
+        for i in 0..n {
+            write_u256(args_out, off_calls + 32 + i * 32, shared_elem_off);
+        }
+        let blob_at = off_calls + 32 + n * 32;
+        args_out[blob_at..blob_at + bytes_blob.len()].copy_from_slice(bytes_blob);
+        args_out[new_off_id..new_off_id + strings.len()].copy_from_slice(strings);
+        out
+    }
+
+
+
+    #[test]
+    fn aliased_announce_succeeds_on_beryl_without_expanded_gas() {
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((AssetV1::OPERATOR_ROLE, ALICE), true);
+
+        let n = 1_024usize;
+        // Valid zero-arg view: each aliased entry re-dispatches successfully.
+        let tail = IB20Asset::multiplierCall {}.abi_encode();
+        let calldata = aliased_announce_calldata(n, &tail);
+        let owned_style = IB20Asset::announceCall {
+            internalCalls: alloc::vec![Bytes::copy_from_slice(&tail); n],
+            id: String::from("aliased-id"),
+            description: String::from("desc"),
+            uri: String::new(),
+        }
+        .abi_encode();
+        assert!(
+            calldata.len() < owned_style.len(),
+            "aliased wire {} must be smaller than owned-style {}",
+            calldata.len(),
+            owned_style.len()
+        );
+        let mut storage = storage_with_caller(ALICE);
+
+        StorageCtx::enter(&mut storage, |ctx| {
+            token.route(ctx, &calldata, AssetVersion::V1, false, NoopPrecompileCallObserver)
+        })
+        .expect("borrowed aliased announce must succeed on Beryl");
+
+        assert!(token.accounting().is_announcement_id_used("aliased-id").unwrap());
+    }
+
+    #[test]
+    fn aliased_announce_charges_expanded_gas_on_cobalt() {
+        let mut token = make_token();
+        token.accounting_mut().roles.insert((AssetV1::OPERATOR_ROLE, ALICE), true);
+
+        let n = 1_024usize;
+        let tail = IB20Asset::multiplierCall {}.abi_encode();
+        let calldata = aliased_announce_calldata(n, &tail);
+        let expanded = n * tail.len();
+        let expected =
+            BerylCallRecorder::<NoopPrecompileCallObserver>::expanded_gas_cost(expanded);
+
+        let mut storage = storage_with_caller(ALICE);
+        StorageCtx::enter(&mut storage, |ctx| {
+            token.route(ctx, &calldata, AssetVersion::V2, false, NoopPrecompileCallObserver)
+        })
+        .expect("borrowed aliased announce must succeed when gas is uncapped");
+
+        // Body work also deducts gas; Cobalt must at least charge the expanded schedule.
+        assert!(
+            storage.gas_deducted() >= expected,
+            "gas_deducted {} must cover expanded cost {}",
+            storage.gas_deducted(),
+            expected
+        );
     }
 }

--- a/crates/common/precompiles/src/b20_asset/versions.rs
+++ b/crates/common/precompiles/src/b20_asset/versions.rs
@@ -86,24 +86,10 @@ impl AssetAbi {
         }
     }
 
-    /// Validates `calldata` against this version's asset surface, mapping failures to
-    /// `AbiDecodeFailed`.
-    fn abi_decode_validate(self, calldata: &[u8], selector: [u8; 4]) -> Result<()> {
-        match self {
-            Self::V1 => IB20AssetV1::IB20AssetCalls::abi_decode_validate(calldata).map(|_| ()),
-            Self::V2 => IB20AssetV2::IB20AssetCalls::abi_decode_validate(calldata).map(|_| ()),
-        }
-        .map_err(|error| BasePrecompileError::AbiDecodeFailed {
-            selector,
-            error: error.to_string(),
-        })
-    }
-
     /// Decodes `calldata` into a routable asset call, gated on this extension surface.
     ///
-    /// Where the frozen surface differs from canonical (`V1`), the calldata is validated against the
-    /// frozen surface first so a rejection carries that version's consensus error bytes, then
-    /// re-decoded into the canonical enum for routing.
+    /// On V1 the frozen surface is decoded once and lifted into the canonical enum (no second ABI
+    /// parse), so reject bytes stay V1's and successful calls avoid the double owned materialization
     fn decode(self, calldata: &[u8]) -> Result<IB20Asset::IB20AssetCalls> {
         let Some(selector) = calldata.first_chunk::<4>().copied() else {
             return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
@@ -112,13 +98,16 @@ impl AssetAbi {
             return Err(BasePrecompileError::UnknownFunctionSelector(selector));
         }
         match self {
-            Self::V1 => self.abi_decode_validate(calldata, selector)?,
-            Self::V2 => {}
+            Self::V1 => IB20AssetV1::IB20AssetCalls::abi_decode_validate(calldata)
+                .map(Into::into)
+                .map_err(|error| BasePrecompileError::AbiDecodeFailed {
+                    selector,
+                    error: error.to_string(),
+                }),
+            Self::V2 => IB20Asset::IB20AssetCalls::abi_decode_validate(calldata).map_err(|error| {
+                BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
+            }),
         }
-
-        IB20Asset::IB20AssetCalls::abi_decode_validate(calldata).map_err(|error| {
-            BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
-        })
     }
 }
 
@@ -202,9 +191,10 @@ impl AssetVersions {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::ToString;
     use alloc::vec::Vec;
 
-    use alloy_primitives::{Address, U256};
+    use alloy_primitives::{Address, Bytes, U256};
     use alloy_sol_types::{SolCall, SolInterface};
     use base_common_genesis::BaseUpgrade;
     use base_precompile_storage::BasePrecompileError;
@@ -271,10 +261,10 @@ mod tests {
         );
     }
 
-    /// The dispatcher re-decodes against the canonical surface after a frozen surface accepts, so
-    /// every frozen selector must exist on canonical. The difference is the 8 ERC-8056
-    /// scheduled-multiplier selectors Cobalt introduced plus the `toUIAmount` / `fromUIAmount`
-    /// aliases and the `MAX_UI_MULTIPLIER` getter added by the interface review (11 total).
+    /// The dispatcher lifts a frozen V1 decode into the canonical enum, so every frozen selector
+    /// must exist on canonical. The difference is the 8 ERC-8056 scheduled-multiplier selectors
+    /// Cobalt introduced plus the `toUIAmount` / `fromUIAmount` aliases and the
+    /// `MAX_UI_MULTIPLIER` getter added by the interface review (11 total).
     #[test]
     fn v1_selectors_are_a_subset_of_v2() {
         let v1: Vec<[u8; 4]> = IB20AssetV1::IB20AssetCalls::selectors().collect();
@@ -412,6 +402,56 @@ mod tests {
             AssetVersion::V1.abi().decode(&[]),
             Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]))
         );
+    }
+
+    /// Frozen V1 decode + [`From`] lift must equal a direct canonical decode for every shared
+    /// selector. Proves Layer 1 of Cantina #16 does not change the accept set or payload.
+    #[test]
+    fn v1_decode_lift_matches_canonical_for_shared_calls() {
+        let samples: Vec<Vec<u8>> = alloc::vec![
+            IB20Asset::multiplierCall {}.abi_encode(),
+            IB20Asset::OPERATOR_ROLECall {}.abi_encode(),
+            IB20Asset::WAD_PRECISIONCall {}.abi_encode(),
+            IB20Asset::toScaledBalanceCall { rawBalance: U256::from(7u64) }.abi_encode(),
+            IB20Asset::batchMintCall {
+                recipients: alloc::vec![Address::repeat_byte(0x11)],
+                amounts: alloc::vec![U256::from(9u64)],
+            }
+            .abi_encode(),
+            IB20Asset::announceCall {
+                internalCalls: alloc::vec![Bytes::from_static(&[0xde, 0xad])],
+                id: alloc::string::String::from("id"),
+                description: alloc::string::String::from("desc"),
+                uri: alloc::string::String::from("uri"),
+            }
+            .abi_encode(),
+            IB20Asset::updateExtraMetadataCall {
+                key: alloc::string::String::from("k"),
+                value: alloc::string::String::from("v"),
+            }
+            .abi_encode(),
+        ];
+
+        for calldata in samples {
+            let lifted = AssetAbi::V1.decode(&calldata).expect("V1 must accept shared call");
+            let canonical =
+                IB20Asset::IB20AssetCalls::abi_decode_validate(&calldata).expect("canonical");
+            assert_eq!(lifted, canonical);
+        }
+    }
+
+    /// Truncated known asset selector: V1 error bytes come from the frozen surface, not canonical.
+    #[test]
+    fn v1_malformed_announce_keeps_frozen_error_bytes() {
+        let calldata = IB20Asset::announceCall::SELECTOR.to_vec();
+        let err = AssetAbi::V1.decode(&calldata).unwrap_err();
+        let BasePrecompileError::AbiDecodeFailed { selector, error } = err else {
+            panic!("expected AbiDecodeFailed, got {err:?}");
+        };
+        assert_eq!(selector, IB20Asset::announceCall::SELECTOR);
+        let frozen_err =
+            IB20AssetV1::IB20AssetCalls::abi_decode_validate(&calldata).unwrap_err().to_string();
+        assert_eq!(error, frozen_err);
     }
 
     #[test]

--- a/crates/common/precompiles/src/common/abi/b20_abi.rs
+++ b/crates/common/precompiles/src/common/abi/b20_abi.rs
@@ -43,8 +43,8 @@ impl B20Abi {
 
     /// Decodes `calldata` into a routable call, gated on this wire surface.
     ///
-    /// The frozen surface decides what is dialable and owns any error bytes; the canonical surface
-    /// then produces the value the dispatcher matches on.
+    /// On V1 the frozen surface is decoded once and lifted into the canonical enum (no second ABI
+    /// parse), so reject bytes stay V1's. V2 is already canonical and decodes once.
     pub fn decode(self, calldata: &[u8]) -> Result<IB20::IB20Calls> {
         let Some(selector) = calldata.first_chunk::<4>().copied() else {
             return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
@@ -53,13 +53,16 @@ impl B20Abi {
             return Err(BasePrecompileError::UnknownFunctionSelector(selector));
         }
         match self {
-            Self::V1 => self.abi_decode_validate(calldata, selector)?,
-            Self::V2 => {}
+            Self::V1 => IB20V1::IB20Calls::abi_decode_validate(calldata).map(Into::into).map_err(
+                |error| BasePrecompileError::AbiDecodeFailed {
+                    selector,
+                    error: error.to_string(),
+                },
+            ),
+            Self::V2 => IB20::IB20Calls::abi_decode_validate(calldata).map_err(|error| {
+                BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
+            }),
         }
-
-        IB20::IB20Calls::abi_decode_validate(calldata).map_err(|error| {
-            BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
-        })
     }
 }
 

--- a/crates/common/precompiles/src/common/abi/mod.rs
+++ b/crates/common/precompiles/src/common/abi/mod.rs
@@ -20,3 +20,163 @@ pub use v2::{IB20, IB20 as IB20V2};
 
 mod b20_abi;
 pub use b20_abi::B20Abi;
+
+/// Lifts a Beryl-frozen common B-20 call into the canonical (Cobalt) enum without re-parsing.
+///
+/// V1 selectors are a subset of V2. Shared parameter layouts move; `PausableFeature` values are
+/// remapped by name (V1 never carried `SEIZE`).
+impl From<IB20V1::IB20Calls> for IB20::IB20Calls {
+    fn from(call: IB20V1::IB20Calls) -> Self {
+        match call {
+            IB20V1::IB20Calls::DEFAULT_ADMIN_ROLE(_) => {
+                Self::DEFAULT_ADMIN_ROLE(IB20::DEFAULT_ADMIN_ROLECall {})
+            }
+            IB20V1::IB20Calls::MINT_ROLE(_) => Self::MINT_ROLE(IB20::MINT_ROLECall {}),
+            IB20V1::IB20Calls::BURN_ROLE(_) => Self::BURN_ROLE(IB20::BURN_ROLECall {}),
+            IB20V1::IB20Calls::BURN_BLOCKED_ROLE(_) => {
+                Self::BURN_BLOCKED_ROLE(IB20::BURN_BLOCKED_ROLECall {})
+            }
+            IB20V1::IB20Calls::PAUSE_ROLE(_) => Self::PAUSE_ROLE(IB20::PAUSE_ROLECall {}),
+            IB20V1::IB20Calls::UNPAUSE_ROLE(_) => Self::UNPAUSE_ROLE(IB20::UNPAUSE_ROLECall {}),
+            IB20V1::IB20Calls::METADATA_ROLE(_) => Self::METADATA_ROLE(IB20::METADATA_ROLECall {}),
+            IB20V1::IB20Calls::TRANSFER_SENDER_POLICY(_) => {
+                Self::TRANSFER_SENDER_POLICY(IB20::TRANSFER_SENDER_POLICYCall {})
+            }
+            IB20V1::IB20Calls::TRANSFER_RECEIVER_POLICY(_) => {
+                Self::TRANSFER_RECEIVER_POLICY(IB20::TRANSFER_RECEIVER_POLICYCall {})
+            }
+            IB20V1::IB20Calls::TRANSFER_EXECUTOR_POLICY(_) => {
+                Self::TRANSFER_EXECUTOR_POLICY(IB20::TRANSFER_EXECUTOR_POLICYCall {})
+            }
+            IB20V1::IB20Calls::MINT_RECEIVER_POLICY(_) => {
+                Self::MINT_RECEIVER_POLICY(IB20::MINT_RECEIVER_POLICYCall {})
+            }
+            IB20V1::IB20Calls::name(_) => Self::name(IB20::nameCall {}),
+            IB20V1::IB20Calls::symbol(_) => Self::symbol(IB20::symbolCall {}),
+            IB20V1::IB20Calls::decimals(_) => Self::decimals(IB20::decimalsCall {}),
+            IB20V1::IB20Calls::totalSupply(_) => Self::totalSupply(IB20::totalSupplyCall {}),
+            IB20V1::IB20Calls::balanceOf(c) => {
+                Self::balanceOf(IB20::balanceOfCall { account: c.account })
+            }
+            IB20V1::IB20Calls::allowance(c) => {
+                Self::allowance(IB20::allowanceCall { owner: c.owner, spender: c.spender })
+            }
+            IB20V1::IB20Calls::transfer(c) => {
+                Self::transfer(IB20::transferCall { to: c.to, amount: c.amount })
+            }
+            IB20V1::IB20Calls::transferFrom(c) => Self::transferFrom(IB20::transferFromCall {
+                from: c.from,
+                to: c.to,
+                amount: c.amount,
+            }),
+            IB20V1::IB20Calls::approve(c) => {
+                Self::approve(IB20::approveCall { spender: c.spender, amount: c.amount })
+            }
+            IB20V1::IB20Calls::updateName(c) => {
+                Self::updateName(IB20::updateNameCall { newName: c.newName })
+            }
+            IB20V1::IB20Calls::updateSymbol(c) => {
+                Self::updateSymbol(IB20::updateSymbolCall { newSymbol: c.newSymbol })
+            }
+            IB20V1::IB20Calls::transferWithMemo(c) => {
+                Self::transferWithMemo(IB20::transferWithMemoCall {
+                    to: c.to,
+                    amount: c.amount,
+                    memo: c.memo,
+                })
+            }
+            IB20V1::IB20Calls::transferFromWithMemo(c) => {
+                Self::transferFromWithMemo(IB20::transferFromWithMemoCall {
+                    from: c.from,
+                    to: c.to,
+                    amount: c.amount,
+                    memo: c.memo,
+                })
+            }
+            IB20V1::IB20Calls::mint(c) => {
+                Self::mint(IB20::mintCall { to: c.to, amount: c.amount })
+            }
+            IB20V1::IB20Calls::mintWithMemo(c) => Self::mintWithMemo(IB20::mintWithMemoCall {
+                to: c.to,
+                amount: c.amount,
+                memo: c.memo,
+            }),
+            IB20V1::IB20Calls::burn(c) => Self::burn(IB20::burnCall { amount: c.amount }),
+            IB20V1::IB20Calls::burnWithMemo(c) => {
+                Self::burnWithMemo(IB20::burnWithMemoCall { amount: c.amount, memo: c.memo })
+            }
+            IB20V1::IB20Calls::burnBlocked(c) => {
+                Self::burnBlocked(IB20::burnBlockedCall { from: c.from, amount: c.amount })
+            }
+            IB20V1::IB20Calls::hasRole(c) => {
+                Self::hasRole(IB20::hasRoleCall { role: c.role, account: c.account })
+            }
+            IB20V1::IB20Calls::getRoleAdmin(c) => {
+                Self::getRoleAdmin(IB20::getRoleAdminCall { role: c.role })
+            }
+            IB20V1::IB20Calls::grantRole(c) => {
+                Self::grantRole(IB20::grantRoleCall { role: c.role, account: c.account })
+            }
+            IB20V1::IB20Calls::revokeRole(c) => {
+                Self::revokeRole(IB20::revokeRoleCall { role: c.role, account: c.account })
+            }
+            IB20V1::IB20Calls::renounceRole(c) => Self::renounceRole(IB20::renounceRoleCall {
+                role: c.role,
+                callerConfirmation: c.callerConfirmation,
+            }),
+            IB20V1::IB20Calls::renounceLastAdmin(_) => {
+                Self::renounceLastAdmin(IB20::renounceLastAdminCall {})
+            }
+            IB20V1::IB20Calls::setRoleAdmin(c) => Self::setRoleAdmin(IB20::setRoleAdminCall {
+                role: c.role,
+                newAdminRole: c.newAdminRole,
+            }),
+            IB20V1::IB20Calls::pausedFeatures(_) => {
+                Self::pausedFeatures(IB20::pausedFeaturesCall {})
+            }
+            IB20V1::IB20Calls::isPaused(c) => {
+                Self::isPaused(IB20::isPausedCall { feature: lift_pausable_feature(c.feature) })
+            }
+            IB20V1::IB20Calls::pause(c) => Self::pause(IB20::pauseCall {
+                features: c.features.into_iter().map(lift_pausable_feature).collect(),
+            }),
+            IB20V1::IB20Calls::unpause(c) => Self::unpause(IB20::unpauseCall {
+                features: c.features.into_iter().map(lift_pausable_feature).collect(),
+            }),
+            IB20V1::IB20Calls::policyId(c) => {
+                Self::policyId(IB20::policyIdCall { policyScope: c.policyScope })
+            }
+            IB20V1::IB20Calls::updatePolicy(c) => Self::updatePolicy(IB20::updatePolicyCall {
+                policyScope: c.policyScope,
+                newPolicyId: c.newPolicyId,
+            }),
+            IB20V1::IB20Calls::supplyCap(_) => Self::supplyCap(IB20::supplyCapCall {}),
+            IB20V1::IB20Calls::updateSupplyCap(c) => {
+                Self::updateSupplyCap(IB20::updateSupplyCapCall { newSupplyCap: c.newSupplyCap })
+            }
+            IB20V1::IB20Calls::DOMAIN_SEPARATOR(_) => {
+                Self::DOMAIN_SEPARATOR(IB20::DOMAIN_SEPARATORCall {})
+            }
+            IB20V1::IB20Calls::nonces(c) => Self::nonces(IB20::noncesCall { owner: c.owner }),
+            IB20V1::IB20Calls::permit(c) => Self::permit(IB20::permitCall {
+                owner: c.owner,
+                spender: c.spender,
+                value: c.value,
+                deadline: c.deadline,
+                v: c.v,
+                r: c.r,
+                s: c.s,
+            }),
+            IB20V1::IB20Calls::eip712Domain(_) => Self::eip712Domain(IB20::eip712DomainCall {}),
+            IB20V1::IB20Calls::contractURI(_) => Self::contractURI(IB20::contractURICall {}),
+            IB20V1::IB20Calls::updateContractURI(c) => {
+                Self::updateContractURI(IB20::updateContractURICall { newURI: c.newURI })
+            }
+        }
+    }
+}
+
+fn lift_pausable_feature(feature: IB20V1::PausableFeature) -> IB20::PausableFeature {
+    IB20::PausableFeature::try_from(feature as u8)
+        .expect("V1 PausableFeature discriminant must lift into V2")
+}

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -55,6 +55,7 @@ mod metrics;
 pub use metrics::{
     BerylAuxiliaryMetrics, BerylCallOutcome, BerylCallRecorder, BerylCallTimer,
     BerylErrorClassifier, BerylErrorKind, BerylMetricLabels, BerylSelector, CALLDATA_WORD_GAS,
+    EXPANDED_WORD_GAS,
     PrecompileCallMetric, PrecompileCallOutcome, PrecompileCallStatus,
 };
 

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -552,6 +552,13 @@ impl BerylCallTimer {
 /// Part of the receipts/gas-used commitment: must be identical across all Base execution clients.
 pub const CALLDATA_WORD_GAS: u64 = 6;
 
+/// Per-word cost for expanded dynamic ABI payload, charged from Cobalt onward.
+///
+/// Same `G_copy + G_memory` schedule as [`CALLDATA_WORD_GAS`], applied to the *expanded*
+/// length of dynamic data (for example `sum(bytes[i].len())` for an aliased `bytes[]`) rather
+/// than wire calldata length. Beryl does not charge this; changing Beryl gas would break replay.
+pub const EXPANDED_WORD_GAS: u64 = 6;
+
 /// Per-call recorder for Beryl precompile observations.
 #[derive(Debug)]
 pub struct BerylCallRecorder<O> {
@@ -592,9 +599,22 @@ where
         (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS)
     }
 
+    /// Computes the Cobalt expanded-dynamic gas cost for `expanded_bytes`.
+    pub const fn expanded_gas_cost(expanded_bytes: usize) -> u64 {
+        (expanded_bytes as u64).div_ceil(32).saturating_mul(EXPANDED_WORD_GAS)
+    }
+
     /// Deducts the common calldata gas charged by Beryl precompile dispatch.
     pub fn deduct_calldata_gas(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<()> {
         ctx.deduct_gas(Self::calldata_gas_cost(calldata))
+    }
+
+    /// Deducts Cobalt expanded-dynamic gas. No-op when `expanded_bytes` is zero.
+    pub fn deduct_expanded_gas(&self, ctx: StorageCtx<'_>, expanded_bytes: usize) -> Result<()> {
+        if expanded_bytes == 0 {
+            return Ok(());
+        }
+        ctx.deduct_gas(Self::expanded_gas_cost(expanded_bytes))
     }
 
     /// Records a Base precompile error before it is converted to a [`PrecompileResult`].
@@ -661,7 +681,7 @@ mod tests {
 
     use crate::{
         BerylCallOutcome, BerylCallRecorder, BerylErrorKind, BerylMetricLabels, BerylSelector,
-        CALLDATA_WORD_GAS, IActivationRegistry, IB20, IB20Factory, IPolicyRegistry,
+        CALLDATA_WORD_GAS, EXPANDED_WORD_GAS, IActivationRegistry, IB20, IB20Factory, IPolicyRegistry,
         NoopPrecompileCallObserver,
     };
 
@@ -748,5 +768,21 @@ mod tests {
 
         // 36 bytes (4-byte selector + 32-byte arg) = ceil(36/32) = 2 words => 2 * CALLDATA_WORD_GAS
         assert_eq!(Recorder::calldata_gas_cost(&[0u8; 36]), 2 * CALLDATA_WORD_GAS);
+    }
+
+    #[test]
+    fn expanded_dynamic_gas_formula() {
+        type Recorder = BerylCallRecorder<NoopPrecompileCallObserver>;
+
+        assert_eq!(Recorder::expanded_gas_cost(0), 0);
+        assert_eq!(Recorder::expanded_gas_cost(1), EXPANDED_WORD_GAS);
+        assert_eq!(Recorder::expanded_gas_cost(32), EXPANDED_WORD_GAS);
+        assert_eq!(Recorder::expanded_gas_cost(33), 2 * EXPANDED_WORD_GAS);
+        // Cantina-shaped alias: 1024 × 64 KiB expanded words.
+        let expanded = 1_024usize * 65_536;
+        assert_eq!(
+            Recorder::expanded_gas_cost(expanded),
+            (expanded as u64).div_ceil(32) * EXPANDED_WORD_GAS
+        );
     }
 }

--- a/crates/common/precompiles/src/policy/abi/mod.rs
+++ b/crates/common/precompiles/src/policy/abi/mod.rs
@@ -11,6 +11,80 @@ pub use v1::IPolicyRegistry as IPolicyRegistryV1;
 mod v2;
 pub use v2::{IPolicyRegistry, IPolicyRegistry as IPolicyRegistryV2};
 
+/// Lifts a Beryl-frozen policy call into the canonical (Cobalt) enum without re-parsing calldata.
+///
+/// V1 selectors are a subset of V2. Shared layouts move; `PolicyType` is remapped by name (V1
+/// never carried `UNION` / `INTERSECT`).
+impl From<IPolicyRegistryV1::IPolicyRegistryCalls> for IPolicyRegistry::IPolicyRegistryCalls {
+    fn from(call: IPolicyRegistryV1::IPolicyRegistryCalls) -> Self {
+        match call {
+            IPolicyRegistryV1::IPolicyRegistryCalls::createPolicy(c) => {
+                Self::createPolicy(IPolicyRegistry::createPolicyCall {
+                    admin: c.admin,
+                    policyType: lift_policy_type(c.policyType),
+                })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::createPolicyWithAccounts(c) => {
+                Self::createPolicyWithAccounts(IPolicyRegistry::createPolicyWithAccountsCall {
+                    admin: c.admin,
+                    policyType: lift_policy_type(c.policyType),
+                    accounts: c.accounts,
+                })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::stageUpdateAdmin(c) => {
+                Self::stageUpdateAdmin(IPolicyRegistry::stageUpdateAdminCall {
+                    policyId: c.policyId,
+                    newAdmin: c.newAdmin,
+                })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::finalizeUpdateAdmin(c) => {
+                Self::finalizeUpdateAdmin(IPolicyRegistry::finalizeUpdateAdminCall {
+                    policyId: c.policyId,
+                })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::renounceAdmin(c) => {
+                Self::renounceAdmin(IPolicyRegistry::renounceAdminCall { policyId: c.policyId })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::updateAllowlist(c) => {
+                Self::updateAllowlist(IPolicyRegistry::updateAllowlistCall {
+                    policyId: c.policyId,
+                    allowed: c.allowed,
+                    accounts: c.accounts,
+                })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::updateBlocklist(c) => {
+                Self::updateBlocklist(IPolicyRegistry::updateBlocklistCall {
+                    policyId: c.policyId,
+                    blocked: c.blocked,
+                    accounts: c.accounts,
+                })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::isAuthorized(c) => {
+                Self::isAuthorized(IPolicyRegistry::isAuthorizedCall {
+                    policyId: c.policyId,
+                    account: c.account,
+                })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::policyExists(c) => {
+                Self::policyExists(IPolicyRegistry::policyExistsCall { policyId: c.policyId })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::policyAdmin(c) => {
+                Self::policyAdmin(IPolicyRegistry::policyAdminCall { policyId: c.policyId })
+            }
+            IPolicyRegistryV1::IPolicyRegistryCalls::pendingPolicyAdmin(c) => {
+                Self::pendingPolicyAdmin(IPolicyRegistry::pendingPolicyAdminCall {
+                    policyId: c.policyId,
+                })
+            }
+        }
+    }
+}
+
+fn lift_policy_type(policy_type: IPolicyRegistryV1::PolicyType) -> IPolicyRegistry::PolicyType {
+    IPolicyRegistry::PolicyType::try_from(policy_type as u8)
+        .expect("V1 PolicyType discriminant must lift into V2")
+}
+
 impl IPolicyRegistry::IPolicyRegistryCalls {
     /// Returns the stable metric label for this decoded policy-registry call.
     pub const fn as_label(&self) -> &'static str {

--- a/crates/common/precompiles/src/policy/versions.rs
+++ b/crates/common/precompiles/src/policy/versions.rs
@@ -70,7 +70,7 @@ impl PolicyAbi {
     }
 
     /// Validates `calldata` against this wire surface via alloy's `abi_decode_validate`, discarding
-    /// the decoded call.
+    /// the decoded call. Used by the activation gate so malformed args fail before activation.
     pub fn abi_decode_validate(self, calldata: &[u8], selector: [u8; 4]) -> Result<()> {
         match self {
             Self::V1 => {
@@ -88,9 +88,8 @@ impl PolicyAbi {
 
     /// Decodes `calldata` into a routable call via alloy's `abi_decode`, gated on this wire surface.
     ///
-    /// Where the frozen surface differs from canonical (`V1`), the calldata is validated against the
-    /// frozen surface first so a rejection carries that version's consensus error bytes, then
-    /// re-decoded into the canonical enum for routing.
+    /// On V1 the frozen surface is decoded once and lifted into the canonical enum (no second ABI
+    /// parse), so reject bytes stay V1's. V2 is already canonical and decodes once.
     pub fn decode(self, calldata: &[u8]) -> Result<IPolicyRegistry::IPolicyRegistryCalls> {
         let Some(selector) = calldata.first_chunk::<4>().copied() else {
             return Err(BasePrecompileError::UnknownFunctionSelector([0u8; 4]));
@@ -99,13 +98,18 @@ impl PolicyAbi {
             return Err(BasePrecompileError::UnknownFunctionSelector(selector));
         }
         match self {
-            Self::V1 => self.abi_decode_validate(calldata, selector)?,
-            Self::V2 => {}
+            Self::V1 => IPolicyRegistryV1::IPolicyRegistryCalls::abi_decode_validate(calldata)
+                .map(Into::into)
+                .map_err(|error| BasePrecompileError::AbiDecodeFailed {
+                    selector,
+                    error: error.to_string(),
+                }),
+            Self::V2 => IPolicyRegistry::IPolicyRegistryCalls::abi_decode_validate(calldata)
+                .map_err(|error| BasePrecompileError::AbiDecodeFailed {
+                    selector,
+                    error: error.to_string(),
+                }),
         }
-
-        IPolicyRegistry::IPolicyRegistryCalls::abi_decode_validate(calldata).map_err(|error| {
-            BasePrecompileError::AbiDecodeFailed { selector, error: error.to_string() }
-        })
     }
 }
 


### PR DESCRIPTION
## Summary
- Decode frozen V1 ABI surfaces once and `From`-lift into the canonical enum (asset, common B-20, policy), removing the second owned materialization Cantina #16 measured.
- Borrow-decode `announce`’s `bytes[]` so aliased offsets stay slices into calldata; reject path still uses decode-once for consensus `AbiDecodeFailed` bytes.
- From Cobalt, meter expanded dynamic bytes (`ceil(expanded/32) * 6`) for announce so the 1024×aliased-tail payload is no longer under-metered; Beryl gas and revert strings stay unchanged.

## Test plan
- [x] `cargo test -p base-common-precompiles --lib -- aliased_announce v1_decode_lift v1_malformed_announce expanded_dynamic`
- [x] `cargo clippy -p base-common-precompiles --all-targets -- -D warnings`
- [ ] Confirm Beryl golden / calldata-gas suites still match prior gas and revert payloads
- [ ] Review Cobalt-only expanded gas on aliased announce (uncapped test charges schedule; real tx caps OOG)


Made with [Cursor](https://cursor.com)