### PR TITLE
fix base-anvil package Rust toolchain

### DIFF
--- a/.depot/workflows/base-anvil-package.yml
+++ b/.depot/workflows/base-anvil-package.yml
@@ -133,6 +133,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          RUSTUP_TOOLCHAIN="$(rustup show active-toolchain | cut -d' ' -f1)"
+          export RUSTUP_TOOLCHAIN
           cd "$BASE_ANVIL_DIR"
           rustup show active-toolchain
           cargo \


### PR DESCRIPTION
## Summary
- build patched base-anvil binaries with Base's active Rust toolchain
- avoid the external base-anvil checkout downgrading the build to its Rust 1.95 pin

## Context
The post-merge Base Anvil Package workflow failed on both architectures because the patched Base crates require Rust 1.96, while the pinned base-anvil checkout selects Rust 1.95.
