### PR TITLE
refactor(builder): share validity predicate machinery

### DIFF
--- a/crates/builder/core/src/flashblocks/best_txs.rs
+++ b/crates/builder/core/src/flashblocks/best_txs.rs
@@ -1,169 +1,13 @@
 //! Flashblocks adapters for parkable best-transaction iterators.
 
-use std::{collections::HashSet, marker::PhantomData, sync::Arc};
+use std::{collections::HashSet, marker::PhantomData};
 
 use alloy_primitives::{Address, TxHash};
-use base_execution_txpool::{BasePooledTx, ParkableBestTransactions};
+use base_execution_payload_builder::ParkablePayloadTransactions;
 use reth_payload_util::PayloadTransactions;
-use reth_transaction_pool::{
-    BestTransactions, PoolTransaction, ValidPoolTransaction,
-    error::{InvalidPoolTransactionError, PoolTransactionError},
-};
+use reth_transaction_pool::PoolTransaction;
 
 use crate::{BuilderMetrics, RejectionCache};
-
-/// Indicates that the payload builder excluded a transaction from the current candidate iterator.
-#[derive(Debug, thiserror::Error)]
-#[error("transaction invalidated during payload construction")]
-pub struct PayloadTransactionInvalidated;
-
-impl PoolTransactionError for PayloadTransactionInvalidated {
-    fn is_bad_transaction(&self) -> bool {
-        false
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-}
-
-/// Parking lifecycle callbacks used in addition to payload iteration.
-///
-/// A transaction returned by [`PayloadTransactions::next`] becomes current until the caller parks,
-/// commits, or invalidates it. Current-transaction callbacks use the exact validated pool
-/// transaction retained by the adapter rather than reconstructing its identity from a hash.
-pub trait ParkablePayloadTransactions: PayloadTransactions
-where
-    Self::Transaction: PoolTransaction,
-{
-    /// Parks and clears the current transaction.
-    ///
-    /// Returns `false` when this iterator does not support parking or has no current transaction.
-    fn park_current(&mut self) -> bool;
-
-    /// Commits and clears the current transaction, if any.
-    fn mark_current_committed(&mut self);
-
-    /// Promotes a predicate-parked transaction back into priority competition.
-    fn promote(&mut self, transaction_hash: TxHash) -> bool;
-
-    /// Excludes a predicate-parked transaction for the remainder of this iterator.
-    fn discard_parked(&mut self, transaction_hash: TxHash) -> bool;
-}
-
-impl<T, I> ParkablePayloadTransactions for reth_payload_util::BestPayloadTransactions<T, I>
-where
-    T: PoolTransaction,
-    I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
-{
-    fn park_current(&mut self) -> bool {
-        false
-    }
-
-    fn mark_current_committed(&mut self) {}
-
-    fn promote(&mut self, _transaction_hash: TxHash) -> bool {
-        false
-    }
-
-    fn discard_parked(&mut self, _transaction_hash: TxHash) -> bool {
-        false
-    }
-}
-
-/// Converts a parkable best iterator into the payload-transaction interface used by the builder.
-pub struct ParkableBestPayloadTransactions<T>
-where
-    T: BasePooledTx,
-{
-    inner: Box<dyn ParkableBestTransactions<T>>,
-    current: Option<Arc<ValidPoolTransaction<T>>>,
-}
-
-impl<T> std::fmt::Debug for ParkableBestPayloadTransactions<T>
-where
-    T: BasePooledTx,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ParkableBestPayloadTransactions")
-            .field("has_current", &self.current.is_some())
-            .finish_non_exhaustive()
-    }
-}
-
-impl<T> ParkableBestPayloadTransactions<T>
-where
-    T: BasePooledTx,
-{
-    /// Creates a payload adapter over a parkable best iterator.
-    pub fn new(inner: Box<dyn ParkableBestTransactions<T>>) -> Self {
-        Self { inner, current: None }
-    }
-}
-
-impl<T> PayloadTransactions for ParkableBestPayloadTransactions<T>
-where
-    T: BasePooledTx,
-{
-    type Transaction = T;
-
-    fn next(&mut self, _ctx: ()) -> Option<Self::Transaction> {
-        debug_assert!(
-            self.current.is_none(),
-            "previous transaction must be lifecycle-managed before next"
-        );
-        let transaction = self.inner.next()?;
-        self.current = Some(Arc::clone(&transaction));
-        Some(transaction.transaction.clone())
-    }
-
-    fn mark_invalid(&mut self, sender: Address, nonce: u64) {
-        let Some(transaction) = self.current.as_ref() else {
-            return;
-        };
-        let matches_current =
-            transaction.sender() == sender && transaction.transaction.nonce() == nonce;
-        debug_assert!(matches_current, "mark_invalid must identify the current transaction");
-        if !matches_current {
-            return;
-        }
-        let transaction = self.current.take().expect("current transaction was checked above");
-        self.inner.mark_invalid(
-            &transaction,
-            InvalidPoolTransactionError::other(PayloadTransactionInvalidated),
-        );
-    }
-}
-
-impl<T> ParkablePayloadTransactions for ParkableBestPayloadTransactions<T>
-where
-    T: BasePooledTx,
-{
-    fn park_current(&mut self) -> bool {
-        let Some(transaction) = self.current.take() else {
-            return false;
-        };
-        self.inner.park(&transaction);
-        true
-    }
-
-    fn mark_current_committed(&mut self) {
-        if let Some(transaction) = self.current.take() {
-            self.inner.mark_committed(&transaction);
-        }
-    }
-
-    fn promote(&mut self, transaction_hash: TxHash) -> bool {
-        self.inner.promote(transaction_hash)
-    }
-
-    fn discard_parked(&mut self, transaction_hash: TxHash) -> bool {
-        self.inner.discard_parked(
-            transaction_hash,
-            InvalidPoolTransactionError::other(PayloadTransactionInvalidated),
-        )
-    }
-}
 
 /// An adapter that skips transactions already committed or permanently rejected by flashblocks.
 pub struct BestFlashblocksTxs<T, I>
@@ -326,10 +170,7 @@ mod tests {
         test_utils::{MockTransaction, MockTransactionFactory},
     };
 
-    use crate::{
-        RejectionCache,
-        flashblocks::best_txs::{BestFlashblocksTxs, ParkablePayloadTransactions},
-    };
+    use crate::{BestFlashblocksTxs, ParkablePayloadTransactions, RejectionCache};
 
     fn test_rejection_cache() -> RejectionCache {
         RejectionCache::new(1000, Duration::from_secs(60))

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -23,7 +23,7 @@ use base_execution_payload_builder::{
 };
 use base_execution_txpool::{
     BasePooledTx, BundleTransaction, GuardMetrics, PredicateContext, TimestampedTransaction,
-    ValidityPredicate, estimated_da_size::DataAvailabilitySized,
+    estimated_da_size::DataAvailabilitySized,
 };
 use base_observability_events::TransactionEventType;
 use reth_basic_payload_builder::PayloadConfig;
@@ -46,7 +46,7 @@ use tracing::{Level, debug, span, trace, warn};
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, ExecutionMeteringLimitExceeded,
     ParkedPredicateIndex, PayloadTxsBounds, PredicateReadRecorder, ResourceLimits,
-    StateChangeEffects, TxResources, TxnExecutionError, TxnOutcome, ValidityPredicateKey,
+    StateChangeEffects, TxResources, TxnExecutionError, TxnOutcome, ValidityPredicateEvaluation,
     transaction_events::{
         BuilderAcceptedEventData, BuilderConsideredEventData, BuilderDeferredEventData,
         BuilderExpiredEventData, BuilderRejectedEventData, BuilderTransactionEventContext,
@@ -913,17 +913,22 @@ impl BasePayloadBuilderCtx {
             }
 
             let mut predicate_read_failed = false;
+            let mut predicate_expired = false;
             let blocking_predicate = if has_validity_predicates {
                 match Self::accumulate_elapsed(&mut predicate_eval_total, || {
                     let mut recorder =
                         PredicateReadRecorder::new(&mut **evm.db_mut(), &mut info.predicate_loads);
-                    ValidityPredicateKey::first_unsatisfied(
+                    ValidityPredicateEvaluation::evaluate(
                         tx.validity_predicates(),
                         &mut recorder,
                         &predicate_context,
                     )
                 }) {
-                    Ok(blocking_predicate) => blocking_predicate,
+                    Ok(ValidityPredicateEvaluation::Matched) => None,
+                    Ok(ValidityPredicateEvaluation::Unsatisfied { blocker, expired }) => {
+                        predicate_expired = expired;
+                        Some(blocker)
+                    }
                     Err(error) => {
                         warn!(
                             target: "payload_builder",
@@ -951,14 +956,6 @@ impl BasePayloadBuilderCtx {
             if predicate_read_failed || blocking_predicate.is_some() {
                 num_txs_considered += 1;
                 let ordering_position = num_txs_considered;
-                // A position predicate (block_number / flashblock_index) whose
-                // upper bound the build has passed can never be satisfied again,
-                // so the transaction is expired rather than merely unsatisfied.
-                let predicate_expired = !predicate_read_failed
-                    && ValidityPredicate::is_batch_expired(
-                        tx.validity_predicates(),
-                        &predicate_context,
-                    );
                 let (decision_reason, decision_detail) = if predicate_read_failed {
                     (
                         "validity_predicate_read_failed",
@@ -1567,13 +1564,16 @@ impl BasePayloadBuilderCtx {
                             &mut **evm.db_mut(),
                             &mut info.predicate_loads,
                         );
-                        ValidityPredicateKey::first_unsatisfied(
+                        ValidityPredicateEvaluation::evaluate(
                             parked_transaction.validity_predicates(),
                             &mut recorder,
                             &predicate_context,
                         )
                     }) {
-                        Ok(blocking_predicate) => blocking_predicate,
+                        Ok(ValidityPredicateEvaluation::Matched) => None,
+                        Ok(ValidityPredicateEvaluation::Unsatisfied { blocker, .. }) => {
+                            Some(blocker)
+                        }
                         Err(error) => {
                             warn!(
                                 target: "payload_builder",

--- a/crates/builder/core/src/flashblocks/mod.rs
+++ b/crates/builder/core/src/flashblocks/mod.rs
@@ -1,16 +1,12 @@
 //! Flashblocks builder types.
 
 mod best_txs;
-pub use best_txs::{
-    BestFlashblocksTxs, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
-    PayloadTransactionInvalidated,
+pub use base_execution_payload_builder::{
+    ParkableBestPayloadTransactions, ParkablePayloadTransactions, ParkedPredicateIndex,
+    PayloadTransactionInvalidated, PredicateLoadTracker, PredicateReadRecorder, StateChangeEffects,
+    ValidityPredicateEvaluation, ValidityPredicateKey,
 };
-
-mod predicate_index;
-pub use predicate_index::{ParkedPredicateIndex, StateChangeEffects, ValidityPredicateKey};
-
-mod predicate_loads;
-pub use predicate_loads::{PredicateLoadTracker, PredicateReadRecorder};
+pub use best_txs::BestFlashblocksTxs;
 
 mod inclusion;
 pub use inclusion::{FLOW_STANDARD, FLOW_VALIDITY, InclusionFlow, InclusionTracker};

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -55,10 +55,8 @@ use tracing::{debug, error, info, metadata::Level, span, warn};
 use crate::{
     BuilderConfig, BuilderMetrics, ExecutionInfo, PayloadBuilder, ResourceLimits,
     flashblocks::{
-        FlashblocksExtraCtx,
-        best_txs::{BestFlashblocksTxs, ParkableBestPayloadTransactions},
-        context::BasePayloadBuilderCtx,
-        generator::BuildArguments,
+        BasePayloadBuilderCtx, BestFlashblocksTxs, FlashblocksExtraCtx,
+        ParkableBestPayloadTransactions, generator::BuildArguments,
     },
     traits::{ClientBounds, PoolBounds},
     transaction_events::{

--- a/crates/builder/core/src/lib.rs
+++ b/crates/builder/core/src/lib.rs
@@ -47,7 +47,7 @@ pub use flashblocks::{
     InclusionTracker, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
     ParkedPredicateIndex, PayloadBuilder, PayloadHandler, PayloadJobDeadline,
     PayloadTransactionInvalidated, PredicateLoadTracker, PredicateReadRecorder, ResolvePayload,
-    StateChangeEffects, ValidityPredicateKey,
+    StateChangeEffects, ValidityPredicateEvaluation, ValidityPredicateKey,
 };
 
 mod extension;

--- a/crates/execution/payload/src/lib.rs
+++ b/crates/execution/payload/src/lib.rs
@@ -15,9 +15,24 @@ pub mod config;
 pub mod error;
 pub mod payload;
 pub use payload::{BaseBuiltPayload, BasePayloadBuilderAttributes};
+
+mod parkable;
+pub use parkable::{
+    ParkableBestPayloadTransactions, ParkablePayloadTransactions, PayloadTransactionInvalidated,
+};
+
+mod predicate_loads;
+pub use predicate_loads::{PredicateLoadTracker, PredicateReadRecorder};
+
 mod traits;
 pub use traits::*;
 mod types;
 pub use types::BasePayloadTypes;
+
+mod validity;
+pub use validity::{
+    ParkedPredicateIndex, StateChangeEffects, ValidityPredicateEvaluation, ValidityPredicateKey,
+};
+
 pub mod validator;
 pub use validator::BaseExecutionPayloadValidator;

--- a/crates/execution/payload/src/parkable.rs
+++ b/crates/execution/payload/src/parkable.rs
@@ -1,0 +1,164 @@
+//! Payload transaction adapters with lane-aware parking support.
+
+use std::sync::Arc;
+
+use alloy_primitives::{Address, TxHash};
+use base_execution_txpool::{BasePooledTx, ParkableBestTransactions};
+use reth_payload_util::PayloadTransactions;
+use reth_transaction_pool::{
+    BestTransactions, PoolTransaction, ValidPoolTransaction,
+    error::{InvalidPoolTransactionError, PoolTransactionError},
+};
+
+/// Indicates that the payload builder excluded a transaction from the current candidate iterator.
+#[derive(Debug, thiserror::Error)]
+#[error("transaction invalidated during payload construction")]
+pub struct PayloadTransactionInvalidated;
+
+impl PoolTransactionError for PayloadTransactionInvalidated {
+    fn is_bad_transaction(&self) -> bool {
+        false
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+/// Parking lifecycle callbacks used in addition to payload iteration.
+///
+/// A transaction returned by [`PayloadTransactions::next`] becomes current until the caller parks,
+/// commits, or invalidates it. Current-transaction callbacks use the exact validated pool
+/// transaction retained by the adapter rather than reconstructing its identity from a hash.
+pub trait ParkablePayloadTransactions: PayloadTransactions
+where
+    Self::Transaction: PoolTransaction,
+{
+    /// Parks and clears the current transaction.
+    ///
+    /// Returns `false` when this iterator does not support parking or has no current transaction.
+    fn park_current(&mut self) -> bool;
+
+    /// Commits and clears the current transaction, if any.
+    fn mark_current_committed(&mut self);
+
+    /// Promotes a predicate-parked transaction back into priority competition.
+    fn promote(&mut self, transaction_hash: TxHash) -> bool;
+
+    /// Excludes a predicate-parked transaction for the remainder of this iterator.
+    fn discard_parked(&mut self, transaction_hash: TxHash) -> bool;
+}
+
+impl<T, I> ParkablePayloadTransactions for reth_payload_util::BestPayloadTransactions<T, I>
+where
+    T: PoolTransaction,
+    I: Iterator<Item = Arc<ValidPoolTransaction<T>>>,
+{
+    fn park_current(&mut self) -> bool {
+        false
+    }
+
+    fn mark_current_committed(&mut self) {}
+
+    fn promote(&mut self, _transaction_hash: TxHash) -> bool {
+        false
+    }
+
+    fn discard_parked(&mut self, _transaction_hash: TxHash) -> bool {
+        false
+    }
+}
+
+/// Converts a parkable best iterator into the payload-transaction interface used by the builder.
+pub struct ParkableBestPayloadTransactions<T>
+where
+    T: BasePooledTx,
+{
+    inner: Box<dyn ParkableBestTransactions<T>>,
+    current: Option<Arc<ValidPoolTransaction<T>>>,
+}
+
+impl<T> std::fmt::Debug for ParkableBestPayloadTransactions<T>
+where
+    T: BasePooledTx,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParkableBestPayloadTransactions")
+            .field("has_current", &self.current.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> ParkableBestPayloadTransactions<T>
+where
+    T: BasePooledTx,
+{
+    /// Creates a payload adapter over a parkable best iterator.
+    pub fn new(inner: Box<dyn ParkableBestTransactions<T>>) -> Self {
+        Self { inner, current: None }
+    }
+}
+
+impl<T> PayloadTransactions for ParkableBestPayloadTransactions<T>
+where
+    T: BasePooledTx,
+{
+    type Transaction = T;
+
+    fn next(&mut self, _ctx: ()) -> Option<Self::Transaction> {
+        debug_assert!(
+            self.current.is_none(),
+            "previous transaction must be lifecycle-managed before next"
+        );
+        let transaction = self.inner.next()?;
+        self.current = Some(Arc::clone(&transaction));
+        Some(transaction.transaction.clone())
+    }
+
+    fn mark_invalid(&mut self, sender: Address, nonce: u64) {
+        let Some(transaction) = self.current.as_ref() else {
+            return;
+        };
+        let matches_current =
+            transaction.sender() == sender && transaction.transaction.nonce() == nonce;
+        debug_assert!(matches_current, "mark_invalid must identify the current transaction");
+        if !matches_current {
+            return;
+        }
+        let transaction = self.current.take().expect("current transaction was checked above");
+        self.inner.mark_invalid(
+            &transaction,
+            InvalidPoolTransactionError::other(PayloadTransactionInvalidated),
+        );
+    }
+}
+
+impl<T> ParkablePayloadTransactions for ParkableBestPayloadTransactions<T>
+where
+    T: BasePooledTx,
+{
+    fn park_current(&mut self) -> bool {
+        let Some(transaction) = self.current.take() else {
+            return false;
+        };
+        self.inner.park(&transaction);
+        true
+    }
+
+    fn mark_current_committed(&mut self) {
+        if let Some(transaction) = self.current.take() {
+            self.inner.mark_committed(&transaction);
+        }
+    }
+
+    fn promote(&mut self, transaction_hash: TxHash) -> bool {
+        self.inner.promote(transaction_hash)
+    }
+
+    fn discard_parked(&mut self, transaction_hash: TxHash) -> bool {
+        self.inner.discard_parked(
+            transaction_hash,
+            InvalidPoolTransactionError::other(PayloadTransactionInvalidated),
+        )
+    }
+}

--- a/crates/execution/payload/src/predicate_loads.rs
+++ b/crates/execution/payload/src/predicate_loads.rs
@@ -1,4 +1,4 @@
-//! Per-block accounting of validity-predicate state loads.
+//! Per-block accounting of payload validity-predicate state loads.
 //!
 //! Evaluating a transaction's validity predicates reads account balances and
 //! contract storage slots from the state the builder is building on. This module
@@ -30,9 +30,9 @@ use revm::{
 /// Per-block accumulator for validity-predicate state loads.
 ///
 /// Totals count every read: a slot re-read (e.g. after it is written, or when a
-/// parked transaction is re-evaluated on a later flashblock) counts again, so
-/// the total captures raw read volume. The unique sets count distinct locations
-/// touched across the block, i.e. the predicate state footprint.
+/// parked transaction is re-evaluated after a state change) counts again, so the
+/// total captures raw read volume. The unique sets count distinct locations touched
+/// across the block, i.e. the predicate state footprint.
 #[derive(Debug, Default)]
 pub struct PredicateLoadTracker {
     /// Total account (balance) reads.

--- a/crates/execution/payload/src/validity.rs
+++ b/crates/execution/payload/src/validity.rs
@@ -1,4 +1,4 @@
-//! State-key index for predicate-parked payload transactions.
+//! Validity-predicate evaluation and indexing for payload transactions.
 
 use alloy_primitives::{
     Address, TxHash, U256,
@@ -11,8 +11,8 @@ use revm::{Database, state::EvmState};
 ///
 /// State keys ([`Self::Balance`], [`Self::Storage`]) are woken by
 /// [`ParkedPredicateIndex::affected_by_state`]. Context keys
-/// ([`Self::BlockNumber`], [`Self::FlashblockIndex`]) do not change during a
-/// flashblock, so they stay parked until the next iterator refresh.
+/// ([`Self::BlockNumber`], [`Self::FlashblockIndex`]) stay parked until the
+/// iterator is rebuilt with an updated context.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ValidityPredicateKey {
     /// Account balance.
@@ -53,6 +53,40 @@ impl ValidityPredicateKey {
             }
         }
         Ok(None)
+    }
+}
+
+/// Result of evaluating a transaction's validity predicates at one build position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValidityPredicateEvaluation {
+    /// Every predicate is satisfied.
+    Matched,
+    /// The transaction is blocked by its first unsatisfied predicate.
+    Unsatisfied {
+        /// State or position key that currently blocks the transaction.
+        blocker: ValidityPredicateKey,
+        /// Whether the predicate batch can never be satisfied at a later build position.
+        expired: bool,
+    },
+}
+
+impl ValidityPredicateEvaluation {
+    /// Evaluates predicates against the current state and build position.
+    ///
+    /// Returns a database error when a state-reading predicate cannot be verified.
+    pub fn evaluate<DB: Database>(
+        predicates: &[ValidityPredicate],
+        db: &mut DB,
+        context: &PredicateContext,
+    ) -> Result<Self, DB::Error> {
+        let Some(blocker) = ValidityPredicateKey::first_unsatisfied(predicates, db, context)?
+        else {
+            return Ok(Self::Matched);
+        };
+        Ok(Self::Unsatisfied {
+            blocker,
+            expired: ValidityPredicate::is_batch_expired(predicates, context),
+        })
     }
 }
 
@@ -365,6 +399,22 @@ mod tests {
         assert_eq!(
             ValidityPredicateKey::first_unsatisfied(&predicates, &mut db, &context).unwrap(),
             Some(ValidityPredicateKey::Balance(Address::with_last_byte(2)))
+        );
+    }
+
+    #[test]
+    fn evaluation_classifies_expired_position_predicates() {
+        let mut db = InMemoryDB::default();
+        let context = PredicateContext { block_number: 2, flashblock_index: 1 };
+        let predicates =
+            [ValidityPredicate::BlockNumber { op: ValidityOperator::Equal, value: U256::from(1) }];
+
+        assert_eq!(
+            super::ValidityPredicateEvaluation::evaluate(&predicates, &mut db, &context).unwrap(),
+            super::ValidityPredicateEvaluation::Unsatisfied {
+                blocker: ValidityPredicateKey::BlockNumber,
+                expired: true,
+            }
         );
     }
 


### PR DESCRIPTION
## Summary

- move predicate evaluation, indexing, and read tracking from the Flashblocks builder into the shared execution payload crate
- move lane-aware payload transaction parking adapters into the shared crate
- keep Flashblocks-specific lifecycle, rejection caching, events, and metrics in builder core
- preserve the builder-core re-exports and existing Flashblocks behavior
