### PR TITLE
ci: use Depot cache for Docker builds

### DIFF
--- a/.depot/workflows/ci-core.yml
+++ b/.depot/workflows/ci-core.yml
@@ -237,7 +237,6 @@ jobs:
         run: >-
           depot bake --project "${{ vars.DEPOT_PROJECT_ID }}"
           -f etc/docker/docker-bake.hcl base --load
-          --set base.cache-from=
   test-musl-sigsegv:
     name: Test SIGSEGV (musl)
     if: inputs.run_sigsegv

--- a/.depot/workflows/docker.yml
+++ b/.depot/workflows/docker.yml
@@ -60,7 +60,6 @@ jobs:
             --set "${TARGET}.platform=linux/amd64" \
             --set "${TARGET}.platform=linux/arm64" \
             --set "${TARGET}.output=type=image,push=true" \
-            --set "${TARGET}.cache-from=" \
             --set "${TARGET}.labels.org.opencontainers.image.source=${{ steps.image-labels.outputs.source }}" \
             --set "${TARGET}.labels.org.opencontainers.image.revision=${{ steps.image-labels.outputs.revision }}" \
             --set "${TARGET}.labels.org.opencontainers.image.created=${{ steps.image-labels.outputs.created }}"
@@ -85,7 +84,6 @@ jobs:
           for target in "${targets[@]}"; do
             set_args+=(--set "$target.platform=linux/amd64")
             set_args+=(--set "$target.output=type=cacheonly")
-            set_args+=(--set "$target.cache-from=")
           done
 
           depot bake --project "${{ vars.DEPOT_PROJECT_ID }}" -f etc/docker/docker-bake.hcl \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -197,7 +197,6 @@ jobs:
             --set "${TARGET}.tags=${IMAGE}" \
             --set "${TARGET}.platform=${{ matrix.settings.arch }}" \
             --set "${TARGET}.output=type=image,push-by-digest=true,name-canonical=true,push=true" \
-            --set "${TARGET}.cache-from=" \
             --set "${TARGET}.labels.org.opencontainers.image.source=${{ steps.image-labels.outputs.source }}" \
             --set "${TARGET}.labels.org.opencontainers.image.revision=${{ steps.image-labels.outputs.revision }}" \
             --set "${TARGET}.labels.org.opencontainers.image.created=${{ steps.image-labels.outputs.created }}" \

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -152,11 +152,6 @@ ingress-logs *containers:
 build-image target='base' profile='dev':
     #!/usr/bin/env bash
     set -euo pipefail
-    case "$(uname -m)" in
-      x86_64)       platform_pair="linux-amd64" ;;
-      arm64|aarch64) platform_pair="linux-arm64" ;;
-      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-    esac
     elf_require=1
     case "{{ profile }}" in
       dev|profiling)
@@ -165,7 +160,7 @@ build-image target='base' profile='dev':
         esac
         ;;
     esac
-    PROFILE="{{ profile }}" ZK_HOST_PROFILE=release BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ target }}" --load
+    PROFILE="{{ profile }}" ZK_HOST_PROFILE=release BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ target }}" --load
 
 # Prepares Docker images needed for system tests
 pull-images:
@@ -202,11 +197,6 @@ _build-setup-image:
 _build-rust-images group profile='dev':
     #!/usr/bin/env bash
     set -euo pipefail
-    case "$(uname -m)" in
-      x86_64)       platform_pair="linux-amd64" ;;
-      arm64|aarch64) platform_pair="linux-arm64" ;;
-      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-    esac
     elf_require=1
     case "{{ profile }}" in
       dev|profiling)
@@ -215,7 +205,7 @@ _build-rust-images group profile='dev':
         esac
         ;;
     esac
-    PROFILE="{{ profile }}" ZK_HOST_PROFILE=release BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" PLATFORM_PAIR="${platform_pair}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ group }}" --load
+    PROFILE="{{ profile }}" ZK_HOST_PROFILE=release BASE_SUCCINCT_ELF_REQUIRE="${elf_require}" docker buildx bake -f etc/docker/docker-bake.hcl "{{ group }}" --load
 
 [private]
 _up-devnet compose_profile mode:

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -14,14 +14,6 @@ variable "ZK_HOST_PROFILE" {
   default = "release"
 }
 
-variable "REGISTRY_IMAGE" {
-  default = "ghcr.io/base/node"
-}
-
-variable "PLATFORM_PAIR" {
-  default = "linux-amd64"
-}
-
 variable "DEVNET_TARGETS" {
   default = ["base", "batcher"]
 }
@@ -68,7 +60,6 @@ target "_rust-service-common" {
     PROFILE = "${PROFILE}"
     RUST_VERSION = "${RUST_VERSION}"
   }
-  cache-from = ["type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}"]
 }
 
 target "base" {
@@ -81,30 +72,18 @@ target "execution" {
   inherits = ["_rust-service-common"]
   target = "execution"
   tags = ["base-execution:local"]
-  cache-from = [
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-execution-${PLATFORM_PAIR}",
-  ]
 }
 
 target "consensus" {
   inherits = ["_rust-service-common"]
   target = "consensus"
   tags = ["base-consensus:local"]
-  cache-from = [
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-consensus-${PLATFORM_PAIR}",
-  ]
 }
 
 target "builder" {
   inherits = ["_rust-service-common"]
   target = "builder"
   tags = ["base-builder:local"]
-  cache-from = [
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-builder-${PLATFORM_PAIR}",
-  ]
 }
 
 target "basectl" {
@@ -147,30 +126,18 @@ target "batcher" {
   inherits = ["_rust-service-common"]
   target = "batcher"
   tags = ["base-batcher:local"]
-  cache-from = [
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-batcher-${PLATFORM_PAIR}",
-  ]
 }
 
 target "sidecrush" {
   inherits = ["_rust-service-common"]
   target = "sidecrush"
   tags = ["sidecrush:local"]
-  cache-from = [
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-sidecrush-${PLATFORM_PAIR}",
-  ]
 }
 
 target "prover-service" {
   inherits = ["_rust-service-common"]
   target = "prover-service"
   tags = ["base-prover-service:local"]
-  cache-from = [
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-prover-service-${PLATFORM_PAIR}",
-  ]
 }
 
 target "zk-host" {
@@ -181,8 +148,4 @@ target "zk-host" {
     BASE_SUCCINCT_ELF_REQUIRE = "${BASE_SUCCINCT_ELF_REQUIRE}"
   }
   tags = ["base-prover-zk-host:local"]
-  cache-from = [
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-${PLATFORM_PAIR}",
-    "type=registry,ref=${REGISTRY_IMAGE}:cache-zk-host-${PLATFORM_PAIR}",
-  ]
 }

--- a/etc/just/prover.just
+++ b/etc/just/prover.just
@@ -47,12 +47,7 @@ up network:
       fi
     done
 
-    case "$(uname -m)" in
-      x86_64)        platform_pair="linux-amd64" ;;
-      arm64|aarch64) platform_pair="linux-arm64" ;;
-      *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
-    esac
-    PROFILE=dev ZK_HOST_PROFILE=release BASE_SUCCINCT_ELF_REQUIRE=1 PLATFORM_PAIR="${platform_pair}" \
+    PROFILE=dev ZK_HOST_PROFILE=release BASE_SUCCINCT_ELF_REQUIRE=1 \
       docker buildx bake -f etc/docker/docker-bake.hcl prover-service zk-host --load
 
     PROVER_NETWORK="$network" docker compose -p "base-prover-${network}" \


### PR DESCRIPTION
## Summary

- remove registry `cache-from` entries from the shared Docker bake file
- remove now-unneeded `cache-from` overrides from Depot CI Docker builds and GitHub release Docker builds
- remove dead local `PLATFORM_PAIR` plumbing from Just recipes now that the bake file no longer consumes it
- leave the GitHub `pull_request` fork fallback on local `docker buildx bake`, since Depot OIDC is not available for untrusted fork PRs

## Why

Depot's container build docs say `depot bake` is the drop-in replacement for `docker bake`, and that Depot automatically persists Docker layer cache in the project cache for subsequent builds. Keeping the old registry cache refs in the bake file means we still pay for external cache lookup/pull plumbing that Depot is meant to replace.

The in-repo PR Docker workflow and Docker publication workflow already run on Depot. This removes the legacy cache config so those builds rely on Depot's persistent project cache directly.

## Validation

- `depot --version`
- `depot list projects`
- `depot bake -f etc/docker/docker-bake.hcl base --print`
- `depot bake -f etc/docker/docker-bake.hcl rust-services --print`
- `rg -n "cache-from|cache-to|type=gha|type=registry,ref=.*cache" .depot/workflows .github/workflows etc/docker/docker-bake.hcl`
- `git diff --check`

## CI timing

The affected `CI / Docker` check passed on the prior revision of this PR, which already had the shared bake-file cache removal:

- GitHub check wall time: `2026-08-27T19:10:44Z` to `2026-08-27T19:31:21Z` = 20m37s
- Depot build ID: `5bxt04dcn1`
- Depot build duration: 1,230s

For context, recent non-trivial finished builds in the same Depot project history were 2,714s, 3,202s, 3,380s, 4,283s, 4,797s, 5,266s, 5,820s, 6,191s, 6,222s, 6,480s, and 6,810s. This PR's Docker build is below that range and ~77% lower than that sample's 5,266s median. This is not a perfectly controlled A/B because other builds may target different images/platforms, but it confirms the PR path is using Depot caching successfully and the observed Docker CI time is lower than recent large builds in the same project.
