### PR TITLE
test(builder): cover validity transactions on native blocks

### DIFF
--- a/actions/harness/src/engine.rs
+++ b/actions/harness/src/engine.rs
@@ -36,7 +36,7 @@ use base_consensus_node::{
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_evm::BaseEvmConfig;
 use base_execution_payload_builder::{
-    BaseBuiltPayload, BasePayloadBuilder, BasePayloadBuilderAttributes,
+    BaseBuiltPayload, BasePayloadBuilder, BasePayloadBuilderAttributes, NoopPayloadTransactions,
 };
 use base_execution_txpool::BasePooledTransaction;
 use base_node_core::BaseNode;
@@ -415,7 +415,10 @@ impl ActionEngineClient {
             pool,
             inner.blockchain_provider.clone(),
             inner.evm_config.clone(),
-        );
+        )
+        .with_transactions(|_pool: TestPool, _attrs| {
+            NoopPayloadTransactions::<BasePooledTransaction>::default()
+        });
         let outcome = RethPayloadBuilder::try_build(&payload_builder, args).map_err(|e| {
             TransportError::from(TransportErrorKind::custom_str(&format!(
                 "payload builder failed: {e}"

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -28,7 +28,7 @@ use base_execution_rpc::{
 };
 use base_execution_txpool::{
     BaseOrdering, BasePooledTransaction, BasePooledTx, BaseTransactionPool,
-    BaseTransactionValidator, GuardLimits, TimestampedTransaction,
+    BaseTransactionValidator, GuardLimits, ParkableTransactionPool, TimestampedTransaction,
     maintain_state_diff_invalidation,
 };
 use reth_chain_state::CanonStateSubscriptions;
@@ -1119,8 +1119,9 @@ where
                 <Node::Types as NodeTypes>::ChainSpec,
             >,
         > + 'static,
-    Pool:
-        TransactionPool<Transaction: BasePooledTx<Consensus = TxTy<Node::Types>>> + Unpin + 'static,
+    Pool: ParkableTransactionPool<Transaction: BasePooledTx<Consensus = TxTy<Node::Types>>>
+        + Unpin
+        + 'static,
     Txs: BasePayloadTransactions<Pool::Transaction>,
     Attrs: Attributes<Transaction = TxTy<Node::Types>> + Unpin,
 {

--- a/crates/execution/node/src/node.rs
+++ b/crates/execution/node/src/node.rs
@@ -28,7 +28,7 @@ use base_execution_rpc::{
 };
 use base_execution_txpool::{
     BaseOrdering, BasePooledTransaction, BasePooledTx, BaseTransactionPool,
-    BaseTransactionValidator, GuardLimits, ParkableTransactionPool, TimestampedTransaction,
+    BaseTransactionValidator, GuardLimits, TimestampedTransaction,
     maintain_state_diff_invalidation,
 };
 use reth_chain_state::CanonStateSubscriptions;
@@ -1119,10 +1119,9 @@ where
                 <Node::Types as NodeTypes>::ChainSpec,
             >,
         > + 'static,
-    Pool: ParkableTransactionPool<Transaction: BasePooledTx<Consensus = TxTy<Node::Types>>>
-        + Unpin
-        + 'static,
-    Txs: BasePayloadTransactions<Pool::Transaction>,
+    Pool:
+        TransactionPool<Transaction: BasePooledTx<Consensus = TxTy<Node::Types>>> + Unpin + 'static,
+    Txs: BasePayloadTransactions<Pool>,
     Attrs: Attributes<Transaction = TxTy<Node::Types>> + Unpin,
 {
     type PayloadBuilder =

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -7,7 +7,9 @@ use alloy_genesis::Genesis;
 use alloy_network::TxSignerSync;
 use alloy_primitives::{Address, ChainId, TxKind};
 use base_execution_chainspec::BaseChainSpecBuilder;
-use base_execution_payload_builder::builder::BasePayloadTransactions;
+use base_execution_payload_builder::{
+    NonParkablePayloadTransactions, ParkablePayloadTransactions, builder::BasePayloadTransactions,
+};
 use base_execution_txpool::BasePooledTransaction;
 use base_node_core::{
     BaseNode,
@@ -29,8 +31,7 @@ use reth_node_builder::{
 };
 use reth_node_core::args::DatadirArgs;
 use reth_payload_util::{
-    BestPayloadTransactions, PayloadTransactions, PayloadTransactionsChain,
-    PayloadTransactionsFixed,
+    BestPayloadTransactions, PayloadTransactionsChain, PayloadTransactionsFixed,
 };
 use reth_provider::providers::BlockchainProvider;
 use reth_tasks::Runtime;
@@ -47,9 +48,9 @@ impl BasePayloadTransactions<BasePooledTransaction> for CustomTxPriority {
         &self,
         pool: Pool,
         attr: reth_transaction_pool::BestTransactionsAttributes,
-    ) -> impl PayloadTransactions<Transaction = BasePooledTransaction>
+    ) -> impl ParkablePayloadTransactions<Transaction = BasePooledTransaction>
     where
-        Pool: reth_transaction_pool::TransactionPool<Transaction = BasePooledTransaction>,
+        Pool: base_execution_txpool::ParkableTransactionPool<Transaction = BasePooledTransaction>,
     {
         // Block composition:
         // 1. Best transactions from the pool (up to 250k gas)
@@ -74,14 +75,14 @@ impl BasePayloadTransactions<BasePooledTransaction> for CustomTxPriority {
             sender.address(),
         ));
 
-        PayloadTransactionsChain::new(
+        NonParkablePayloadTransactions::new(PayloadTransactionsChain::new(
             BestPayloadTransactions::new(pool.best_transactions_with_attributes(attr)),
             // Allow 250k gas for the transactions from the pool
             Some(250_000),
             PayloadTransactionsFixed::single(end_of_block_tx),
             // Allow 100k gas for the end-of-block transaction
             Some(100_000),
-        )
+        ))
     }
 }
 

--- a/crates/execution/node/tests/it/priority.rs
+++ b/crates/execution/node/tests/it/priority.rs
@@ -43,15 +43,15 @@ struct CustomTxPriority {
     chain_id: ChainId,
 }
 
-impl BasePayloadTransactions<BasePooledTransaction> for CustomTxPriority {
-    fn best_transactions<Pool>(
+impl<Pool> BasePayloadTransactions<Pool> for CustomTxPriority
+where
+    Pool: base_execution_txpool::ParkableTransactionPool<Transaction = BasePooledTransaction>,
+{
+    fn best_transactions(
         &self,
         pool: Pool,
         attr: reth_transaction_pool::BestTransactionsAttributes,
-    ) -> impl ParkablePayloadTransactions<Transaction = BasePooledTransaction>
-    where
-        Pool: base_execution_txpool::ParkableTransactionPool<Transaction = BasePooledTransaction>,
-    {
+    ) -> impl ParkablePayloadTransactions<Transaction = BasePooledTransaction> {
         // Block composition:
         // 1. Best transactions from the pool (up to 250k gas)
         // 2. End-of-block transaction created by the node (up to 100k gas)

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -246,12 +246,12 @@ impl<Pool, Client, Evm, N, Txs, Attrs> PayloadBuilder
 where
     N: PayloadPrimitives,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: Upgrades> + BlockReader + Clone,
-    Pool: ParkableTransactionPool<Transaction: BasePooledTx<Consensus = N::SignedTx>>,
+    Pool: TransactionPool<Transaction: BasePooledTx<Consensus = N::SignedTx>>,
     Evm: ConfigureEvm<
             Primitives = N,
             NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
         >,
-    Txs: BasePayloadTransactions<Pool::Transaction>,
+    Txs: BasePayloadTransactions<Pool>,
     Attrs: Attributes<Transaction = N::SignedTx>,
 {
     type Attributes = Attrs;
@@ -499,30 +499,52 @@ impl<Txs> Builder<'_, Txs> {
     }
 }
 
-/// A type that returns the [`PayloadTransactions`] that should be included in the pool.
-pub trait BasePayloadTransactions<Transaction: BasePooledTx>:
-    Clone + Send + Sync + Unpin + 'static
+/// A type that returns the [`PayloadTransactions`] that should be included in the payload.
+pub trait BasePayloadTransactions<Pool>: Clone + Send + Sync + Unpin + 'static
+where
+    Pool: TransactionPool,
+    Pool::Transaction: BasePooledTx,
 {
     /// Returns an iterator that yields the transaction in the order they should get included in the
     /// new payload.
     ///
     /// Custom iterators without lane-aware parking can use [`NonParkablePayloadTransactions`].
-    fn best_transactions<Pool: ParkableTransactionPool<Transaction = Transaction>>(
+    fn best_transactions(
         &self,
         pool: Pool,
         attr: BestTransactionsAttributes,
-    ) -> impl ParkablePayloadTransactions<Transaction = Transaction>;
+    ) -> impl ParkablePayloadTransactions<Transaction = Pool::Transaction>;
 }
 
-impl<T: BasePooledTx> BasePayloadTransactions<T> for () {
-    fn best_transactions<Pool: ParkableTransactionPool<Transaction = T>>(
+impl<Pool> BasePayloadTransactions<Pool> for ()
+where
+    Pool: ParkableTransactionPool,
+    Pool::Transaction: BasePooledTx,
+{
+    fn best_transactions(
         &self,
         pool: Pool,
         attr: BestTransactionsAttributes,
-    ) -> impl ParkablePayloadTransactions<Transaction = T> {
+    ) -> impl ParkablePayloadTransactions<Transaction = Pool::Transaction> {
         ParkableBestPayloadTransactions::new(
             pool.best_transactions_with_attributes_and_parking(attr),
         )
+    }
+}
+
+impl<Pool, F, Transactions> BasePayloadTransactions<Pool> for F
+where
+    Pool: TransactionPool,
+    Pool::Transaction: BasePooledTx,
+    F: Fn(Pool, BestTransactionsAttributes) -> Transactions + Clone + Send + Sync + Unpin + 'static,
+    Transactions: ParkablePayloadTransactions<Transaction = Pool::Transaction>,
+{
+    fn best_transactions(
+        &self,
+        pool: Pool,
+        attr: BestTransactionsAttributes,
+    ) -> impl ParkablePayloadTransactions<Transaction = Pool::Transaction> {
+        self(pool, attr)
     }
 }
 
@@ -794,7 +816,11 @@ where
                     tx_hash = ?tx_hash,
                     "skipping transaction with unsupported flashblock-index predicate"
                 );
-                best_txs.mark_invalid(tx.sender(), tx.nonce());
+                if tx.eip8130_replay_id().is_none() {
+                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                } else {
+                    best_txs.mark_current_committed();
+                }
                 continue;
             }
 
@@ -811,7 +837,11 @@ where
                             tx_hash = ?tx_hash,
                             "skipping transaction with expired validity predicate"
                         );
-                        best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        if tx.eip8130_replay_id().is_none() {
+                            best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        } else {
+                            best_txs.mark_current_committed();
+                        }
                         continue;
                     }
                     Ok(ValidityPredicateEvaluation::Unsatisfied { blocker, expired: false }) => {
@@ -824,7 +854,11 @@ where
                         if best_txs.park_current() {
                             predicate_index.park(tx_hash, tx, blocker);
                         } else {
-                            best_txs.mark_invalid(tx.sender(), tx.nonce());
+                            if tx.eip8130_replay_id().is_none() {
+                                best_txs.mark_invalid(tx.sender(), tx.nonce());
+                            } else {
+                                best_txs.mark_current_committed();
+                            }
                         }
                         continue;
                     }
@@ -835,7 +869,11 @@ where
                             error = ?error,
                             "failed to read validity predicate state"
                         );
-                        best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        if tx.eip8130_replay_id().is_none() {
+                            best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        } else {
+                            best_txs.mark_current_committed();
+                        }
                         continue;
                     }
                 }

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -2,7 +2,7 @@
 use std::{marker::PhantomData, sync::Arc};
 
 use alloy_consensus::{BlockHeader, Transaction, Typed2718};
-use alloy_evm::Evm as AlloyEvm;
+use alloy_evm::{Evm as AlloyEvm, block::TxResult};
 use alloy_primitives::{B256, U256};
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_engine::PayloadId;
@@ -10,7 +10,10 @@ use base_common_chains::Upgrades;
 use base_common_consensus::{BaseTransaction, Predeploys};
 use base_common_evm::L1BlockInfo;
 use base_execution_eip8130::IntrinsicGas;
-use base_execution_txpool::{BasePooledTx, GuardMetrics, estimated_da_size::DataAvailabilitySized};
+use base_execution_txpool::{
+    BasePooledTx, GuardMetrics, ParkableTransactionPool, PredicateContext, ValidityPredicate,
+    estimated_da_size::DataAvailabilitySized,
+};
 use reth_basic_payload_builder::{
     BuildArguments, BuildOutcome, BuildOutcomeKind, MissingPayloadBehaviour, PayloadBuilder,
     PayloadConfig, is_better_payload,
@@ -26,7 +29,7 @@ use reth_execution_cache::{CachedStateMetrics, CachedStateMetricsSource, CachedS
 use reth_execution_types::BlockExecutionOutput;
 use reth_payload_builder_primitives::PayloadBuilderError;
 use reth_payload_primitives::{BuildNextEnv, BuiltPayloadExecutedBlock};
-use reth_payload_util::{BestPayloadTransactions, NoopPayloadTransactions, PayloadTransactions};
+use reth_payload_util::{NoopPayloadTransactions, PayloadTransactions};
 use reth_primitives_traits::{
     HeaderTy, NodePrimitives, SealedHeader, SealedHeaderFor, SignedTransaction, TxTy,
 };
@@ -42,8 +45,10 @@ use revm::context::{Block, BlockEnv};
 use tracing::{debug, debug_span, instrument, trace, warn};
 
 use crate::{
-    Attributes, BasePayloadBuilderAttributes, PayloadPrimitives, config::BaseBuilderConfig,
-    error::BasePayloadBuilderError, payload::BaseBuiltPayload,
+    Attributes, BasePayloadBuilderAttributes, ParkableBestPayloadTransactions,
+    ParkablePayloadTransactions, ParkedPredicateIndex, PayloadPrimitives, StateChangeEffects,
+    ValidityPredicateEvaluation, config::BaseBuilderConfig, error::BasePayloadBuilderError,
+    payload::BaseBuiltPayload,
 };
 
 /// Base payload builder
@@ -155,7 +160,7 @@ where
         best: impl FnOnce(BestTransactionsAttributes) -> Txs + Send + Sync + 'a,
     ) -> Result<BuildOutcome<BaseBuiltPayload<N>>, PayloadBuilderError>
     where
-        Txs: PayloadTransactions<
+        Txs: ParkablePayloadTransactions<
             Transaction: PoolTransaction<Consensus = N::SignedTx> + BasePooledTx,
         >,
     {
@@ -241,7 +246,7 @@ impl<Pool, Client, Evm, N, Txs, Attrs> PayloadBuilder
 where
     N: PayloadPrimitives,
     Client: StateProviderFactory + ChainSpecProvider<ChainSpec: Upgrades> + BlockReader + Clone,
-    Pool: TransactionPool<Transaction: BasePooledTx<Consensus = N::SignedTx>>,
+    Pool: ParkableTransactionPool<Transaction: BasePooledTx<Consensus = N::SignedTx>>,
     Evm: ConfigureEvm<
             Primitives = N,
             NextBlockEnvCtx: BuildNextEnv<Attrs, N::BlockHeader, Client::ChainSpec>,
@@ -334,7 +339,7 @@ impl<Txs> Builder<'_, Txs> {
             >,
         ChainSpec: EthChainSpec + Upgrades,
         N: PayloadPrimitives,
-        Txs: PayloadTransactions<
+        Txs: ParkablePayloadTransactions<
             Transaction: PoolTransaction<Consensus = N::SignedTx> + BasePooledTx,
         >,
         Attrs: Attributes<Transaction = N::SignedTx>,
@@ -495,23 +500,29 @@ impl<Txs> Builder<'_, Txs> {
 }
 
 /// A type that returns the [`PayloadTransactions`] that should be included in the pool.
-pub trait BasePayloadTransactions<Transaction>: Clone + Send + Sync + Unpin + 'static {
+pub trait BasePayloadTransactions<Transaction: BasePooledTx>:
+    Clone + Send + Sync + Unpin + 'static
+{
     /// Returns an iterator that yields the transaction in the order they should get included in the
     /// new payload.
-    fn best_transactions<Pool: TransactionPool<Transaction = Transaction>>(
+    ///
+    /// Custom iterators without lane-aware parking can use [`NonParkablePayloadTransactions`].
+    fn best_transactions<Pool: ParkableTransactionPool<Transaction = Transaction>>(
         &self,
         pool: Pool,
         attr: BestTransactionsAttributes,
-    ) -> impl PayloadTransactions<Transaction = Transaction>;
+    ) -> impl ParkablePayloadTransactions<Transaction = Transaction>;
 }
 
-impl<T: PoolTransaction> BasePayloadTransactions<T> for () {
-    fn best_transactions<Pool: TransactionPool<Transaction = T>>(
+impl<T: BasePooledTx> BasePayloadTransactions<T> for () {
+    fn best_transactions<Pool: ParkableTransactionPool<Transaction = T>>(
         &self,
         pool: Pool,
         attr: BestTransactionsAttributes,
-    ) -> impl PayloadTransactions<Transaction = T> {
-        BestPayloadTransactions::new(pool.best_transactions_with_attributes(attr))
+    ) -> impl ParkablePayloadTransactions<Transaction = T> {
+        ParkableBestPayloadTransactions::new(
+            pool.best_transactions_with_attributes_and_parking(attr),
+        )
     }
 }
 
@@ -738,7 +749,7 @@ where
         &self,
         info: &mut ExecutionInfo,
         builder: &mut Builder,
-        mut best_txs: impl PayloadTransactions<
+        mut best_txs: impl ParkablePayloadTransactions<
             Transaction: PoolTransaction<Consensus = TxTy<Evm::Primitives>> + BasePooledTx,
         >,
     ) -> Result<Option<()>, PayloadBuilderError>
@@ -757,6 +768,10 @@ where
         let block_da_limit = self.builder_config.da_config.max_da_block_size();
         let tx_da_limit = self.builder_config.da_config.max_da_tx_size();
         let base_fee = builder.evm_mut().block().basefee();
+        let block_number =
+            builder.evm_mut().block().number().try_into().expect("block number must fit in u64");
+        let predicate_context = PredicateContext { block_number, flashblock_index: 0 };
+        let mut predicate_index = ParkedPredicateIndex::default();
 
         let block_timestamp = self.attributes().timestamp();
         let can_finalize_early = self.is_denim_active();
@@ -766,6 +781,64 @@ where
             }
             if can_finalize_early && self.cancel.is_finalization_requested() {
                 break;
+            }
+
+            let tx_hash = *tx.hash();
+            if tx
+                .validity_predicates()
+                .iter()
+                .any(|predicate| matches!(predicate, ValidityPredicate::FlashblockIndex { .. }))
+            {
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx_hash,
+                    "skipping transaction with unsupported flashblock-index predicate"
+                );
+                best_txs.mark_invalid(tx.sender(), tx.nonce());
+                continue;
+            }
+
+            if !tx.validity_predicates().is_empty() {
+                match ValidityPredicateEvaluation::evaluate(
+                    tx.validity_predicates(),
+                    builder.evm_mut().db_mut(),
+                    &predicate_context,
+                ) {
+                    Ok(ValidityPredicateEvaluation::Matched) => {}
+                    Ok(ValidityPredicateEvaluation::Unsatisfied { expired: true, .. }) => {
+                        trace!(
+                            target: "payload_builder",
+                            tx_hash = ?tx_hash,
+                            "skipping transaction with expired validity predicate"
+                        );
+                        best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        continue;
+                    }
+                    Ok(ValidityPredicateEvaluation::Unsatisfied { blocker, expired: false }) => {
+                        trace!(
+                            target: "payload_builder",
+                            tx_hash = ?tx_hash,
+                            ?blocker,
+                            "parking transaction with unsatisfied validity predicate"
+                        );
+                        if best_txs.park_current() {
+                            predicate_index.park(tx_hash, tx, blocker);
+                        } else {
+                            best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        }
+                        continue;
+                    }
+                    Err(error) => {
+                        warn!(
+                            target: "payload_builder",
+                            tx_hash = ?tx_hash,
+                            error = ?error,
+                            "failed to read validity predicate state"
+                        );
+                        best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        continue;
+                    }
+                }
             }
 
             if self.builder_config.manifest_precheck_enabled
@@ -785,6 +858,8 @@ where
                 // This transaction has already been consumed from the iterator.
                 if tx.eip8130_replay_id().is_none() {
                     best_txs.mark_invalid(tx.sender(), tx.nonce());
+                } else {
+                    best_txs.mark_current_committed();
                 }
                 continue;
             }
@@ -809,6 +884,8 @@ where
                         // independent, so invalidating by sender would suppress unrelated entries.
                         if tx.eip8130_replay_id().is_none() {
                             best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        } else {
+                            best_txs.mark_current_committed();
                         }
                         continue;
                     }
@@ -848,7 +925,16 @@ where
                 continue;
             }
 
-            let gas_output = match builder.execute_transaction(tx.clone()) {
+            let mut state_change_effects = StateChangeEffects::default();
+            let gas_output = match builder.execute_transaction_with_result_closure(
+                tx.clone(),
+                |result| {
+                    if !predicate_index.is_empty() {
+                        state_change_effects =
+                            predicate_index.affected_by_state(&result.result().state);
+                    }
+                },
+            ) {
                 Ok(gas_output) => gas_output,
                 Err(BlockExecutionError::Validation(BlockValidationError::InvalidTx {
                     error,
@@ -856,6 +942,7 @@ where
                 })) => {
                     if error.is_nonce_too_low() {
                         trace!(target: "payload_builder", %error, ?tx, "skipping nonce too low transaction");
+                        best_txs.mark_current_committed();
                     } else {
                         trace!(target: "payload_builder", %error, ?tx, "skipping invalid transaction and its descendants");
                         best_txs.mark_invalid(tx.signer(), tx.nonce());
@@ -869,6 +956,36 @@ where
 
             info.cumulative_gas_used += gas_output.tx_gas_used();
             info.cumulative_da_bytes_used += tx_da_size;
+
+            best_txs.mark_current_committed();
+            for parked_hash in state_change_effects.affected_transactions {
+                let Some(parked_transaction) = predicate_index.transaction(parked_hash) else {
+                    continue;
+                };
+                match ValidityPredicateEvaluation::evaluate(
+                    parked_transaction.validity_predicates(),
+                    builder.evm_mut().db_mut(),
+                    &predicate_context,
+                ) {
+                    Ok(ValidityPredicateEvaluation::Matched) => {
+                        predicate_index.remove(parked_hash);
+                        best_txs.promote(parked_hash);
+                    }
+                    Ok(ValidityPredicateEvaluation::Unsatisfied { blocker, .. }) => {
+                        predicate_index.reindex(parked_hash, blocker);
+                    }
+                    Err(error) => {
+                        warn!(
+                            target: "payload_builder",
+                            tx_hash = ?parked_hash,
+                            error = ?error,
+                            "failed to re-read validity predicate state"
+                        );
+                        predicate_index.remove(parked_hash);
+                        best_txs.discard_parked(parked_hash);
+                    }
+                }
+            }
 
             let miner_fee = tx
                 .effective_tip_per_gas(base_fee)
@@ -889,7 +1006,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, mem::ManuallyDrop, sync::Arc};
+    use std::{
+        collections::{HashMap, VecDeque},
+        mem::ManuallyDrop,
+        sync::Arc,
+    };
 
     use alloy_consensus::{Header, SignableTransaction, TxEip1559};
     use alloy_eips::eip2718::Encodable2718;
@@ -899,7 +1020,7 @@ mod tests {
     use base_common_evm::BaseTime;
     use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
     use base_execution_evm::BaseEvmConfig;
-    use base_execution_txpool::BasePooledTransaction;
+    use base_execution_txpool::{BasePooledTransaction, ValidityOperator, ValidityPredicate};
     use reth_basic_payload_builder::{BuildOutcomeKind, PayloadConfig};
     use reth_chainspec::ChainSpec;
     use reth_ethereum_forks::ForkCondition;
@@ -922,8 +1043,8 @@ mod tests {
 
     use super::{BasePayloadBuilderCtx, Builder, ExecutionInfo};
     use crate::{
-        BasePayloadBuilderAttributes, config::BaseBuilderConfig,
-        payload::EthPayloadBuilderAttributes,
+        BasePayloadBuilderAttributes, NonParkablePayloadTransactions, ParkablePayloadTransactions,
+        config::BaseBuilderConfig, payload::EthPayloadBuilderAttributes,
     };
 
     #[derive(Debug)]
@@ -1052,6 +1173,22 @@ mod tests {
     where
         Txs: PayloadTransactions<Transaction = BasePooledTransaction> + Send + Sync,
     {
+        let funded_sender = pool_transaction(0).sender();
+        build_parkable_pool_payload(
+            ctx,
+            NonParkablePayloadTransactions::new(transactions),
+            &[funded_sender],
+        )
+    }
+
+    fn build_parkable_pool_payload<Txs>(
+        ctx: BasePayloadBuilderCtx<BaseEvmConfig, BaseChainSpec>,
+        transactions: Txs,
+        funded_senders: &[Address],
+    ) -> BuildOutcomeKind<crate::BaseBuiltPayload<BasePrimitives>>
+    where
+        Txs: ParkablePayloadTransactions<Transaction = BasePooledTransaction> + Send + Sync,
+    {
         let mut storage = HashMap::default();
         storage.insert(
             StorageKey::from(BaseTime::ADMIN_SLOT.to_be_bytes::<32>()),
@@ -1064,18 +1201,24 @@ mod tests {
             Some(BaseTime::proxy_bytecode()),
             storage,
         );
-        provider.insert_account(
-            pool_transaction(0).sender(),
-            Account { balance: U256::MAX, ..Default::default() },
-            None,
-            HashMap::default(),
-        );
+        for sender in funded_senders {
+            provider.insert_account(
+                *sender,
+                Account { balance: U256::MAX, ..Default::default() },
+                None,
+                HashMap::default(),
+            );
+        }
         Builder::new(|_| transactions)
             .build(StateProviderDatabase::new(&provider), &provider, Some(state_root_handle()), ctx)
             .expect("payload must build")
     }
 
     fn pool_transaction(nonce: u64) -> BasePooledTransaction {
+        pool_transaction_to(nonce, Address::repeat_byte(0x11), U256::ZERO)
+    }
+
+    fn pool_transaction_to(nonce: u64, to: Address, value: U256) -> BasePooledTransaction {
         let envelope = BaseTxEnvelope::Eip1559(
             TxEip1559 {
                 chain_id: 8_453,
@@ -1083,7 +1226,8 @@ mod tests {
                 gas_limit: 100_000,
                 max_fee_per_gas: 2_000_000_000,
                 max_priority_fee_per_gas: 1,
-                to: TxKind::Call(Address::repeat_byte(0x11)),
+                to: TxKind::Call(to),
+                value,
                 ..Default::default()
             }
             .into_signed(Signature::test_signature()),
@@ -1093,6 +1237,67 @@ mod tests {
             envelope.try_into_recovered().expect("test signature must recover"),
             encoded_len,
         )
+    }
+
+    /// Scripted iterator is required here because predicate promotion mutates which transaction
+    /// `next` returns while the build is in flight, which a static mock cannot express.
+    struct TestParkableTransactions {
+        queued: VecDeque<BasePooledTransaction>,
+        ready: VecDeque<BasePooledTransaction>,
+        parked: HashMap<B256, BasePooledTransaction>,
+        current: Option<BasePooledTransaction>,
+    }
+
+    impl TestParkableTransactions {
+        fn new(transactions: Vec<BasePooledTransaction>) -> Self {
+            Self {
+                queued: transactions.into(),
+                ready: VecDeque::new(),
+                parked: HashMap::default(),
+                current: None,
+            }
+        }
+    }
+
+    impl PayloadTransactions for TestParkableTransactions {
+        type Transaction = BasePooledTransaction;
+
+        fn next(&mut self, _ctx: ()) -> Option<Self::Transaction> {
+            assert!(self.current.is_none(), "current transaction was not lifecycle-managed");
+            let transaction = self.ready.pop_front().or_else(|| self.queued.pop_front())?;
+            self.current = Some(transaction.clone());
+            Some(transaction)
+        }
+
+        fn mark_invalid(&mut self, _sender: Address, _nonce: u64) {
+            self.current = None;
+        }
+    }
+
+    impl ParkablePayloadTransactions for TestParkableTransactions {
+        fn park_current(&mut self) -> bool {
+            let Some(transaction) = self.current.take() else {
+                return false;
+            };
+            self.parked.insert(*transaction.hash(), transaction);
+            true
+        }
+
+        fn mark_current_committed(&mut self) {
+            self.current = None;
+        }
+
+        fn promote(&mut self, transaction_hash: B256) -> bool {
+            let Some(transaction) = self.parked.remove(&transaction_hash) else {
+                return false;
+            };
+            self.ready.push_back(transaction);
+            true
+        }
+
+        fn discard_parked(&mut self, transaction_hash: B256) -> bool {
+            self.parked.remove(&transaction_hash).is_some()
+        }
     }
 
     struct FinalizeAfterFirstTransaction {
@@ -1145,6 +1350,98 @@ mod tests {
             panic!("Denim payload must freeze")
         };
         assert_eq!(payload.block().body().transactions.len(), 1);
+    }
+
+    #[test]
+    fn native_builder_includes_transaction_with_matching_block_predicate() {
+        let transaction =
+            pool_transaction(0).with_validity_predicates(vec![ValidityPredicate::BlockNumber {
+                op: ValidityOperator::Equal,
+                value: U256::ONE,
+            }]);
+        let sender = transaction.sender();
+        let transaction_hash = *transaction.hash();
+
+        let BuildOutcomeKind::Freeze(payload) = build_parkable_pool_payload(
+            pool_payload_context(DENIM_TIMESTAMP),
+            TestParkableTransactions::new(vec![transaction]),
+            &[sender],
+        ) else {
+            panic!("Denim payload must freeze")
+        };
+
+        assert_eq!(payload.block().body().transactions.len(), 1);
+        assert_eq!(*payload.block().body().transactions[0].tx_hash(), transaction_hash);
+    }
+
+    #[test]
+    fn native_builder_rejects_flashblock_index_predicates() {
+        let transaction = pool_transaction(0).with_validity_predicates(vec![
+            ValidityPredicate::FlashblockIndex { op: ValidityOperator::Equal, value: U256::ZERO },
+        ]);
+        let sender = transaction.sender();
+
+        let BuildOutcomeKind::Freeze(payload) = build_parkable_pool_payload(
+            pool_payload_context(DENIM_TIMESTAMP),
+            TestParkableTransactions::new(vec![transaction]),
+            &[sender],
+        ) else {
+            panic!("Denim payload must freeze")
+        };
+
+        assert!(payload.block().body().transactions.is_empty());
+    }
+
+    #[test]
+    fn native_builder_skips_expired_block_predicates() {
+        let transaction =
+            pool_transaction(0).with_validity_predicates(vec![ValidityPredicate::BlockNumber {
+                op: ValidityOperator::Equal,
+                value: U256::ZERO,
+            }]);
+        let sender = transaction.sender();
+
+        let BuildOutcomeKind::Freeze(payload) = build_parkable_pool_payload(
+            pool_payload_context(DENIM_TIMESTAMP),
+            TestParkableTransactions::new(vec![transaction]),
+            &[sender],
+        ) else {
+            panic!("Denim payload must freeze")
+        };
+
+        assert!(payload.block().body().transactions.is_empty());
+    }
+
+    #[test]
+    fn native_builder_promotes_transaction_after_predicate_state_changes() {
+        let watched_address = Address::repeat_byte(0x44);
+        let gated = pool_transaction_to(0, Address::repeat_byte(0x55), U256::ZERO)
+            .with_validity_predicates(vec![ValidityPredicate::Balance {
+                address: watched_address,
+                op: ValidityOperator::Equal,
+                value: U256::ONE,
+            }]);
+        let trigger = pool_transaction_to(0, watched_address, U256::ONE);
+        let funded_senders = [gated.sender(), trigger.sender()];
+        let gated_hash = *gated.hash();
+        let trigger_hash = *trigger.hash();
+
+        let BuildOutcomeKind::Freeze(payload) = build_parkable_pool_payload(
+            pool_payload_context(DENIM_TIMESTAMP),
+            TestParkableTransactions::new(vec![gated, trigger]),
+            &funded_senders,
+        ) else {
+            panic!("Denim payload must freeze")
+        };
+
+        let included_hashes = payload
+            .block()
+            .body()
+            .transactions
+            .iter()
+            .map(|transaction| *transaction.tx_hash())
+            .collect::<Vec<_>>();
+        assert_eq!(included_hashes, vec![trigger_hash, gated_hash]);
     }
 
     #[test]

--- a/crates/execution/payload/src/lib.rs
+++ b/crates/execution/payload/src/lib.rs
@@ -18,7 +18,8 @@ pub use payload::{BaseBuiltPayload, BasePayloadBuilderAttributes};
 
 mod parkable;
 pub use parkable::{
-    ParkableBestPayloadTransactions, ParkablePayloadTransactions, PayloadTransactionInvalidated,
+    NonParkablePayloadTransactions, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
+    PayloadTransactionInvalidated,
 };
 
 mod predicate_loads;

--- a/crates/execution/payload/src/lib.rs
+++ b/crates/execution/payload/src/lib.rs
@@ -18,8 +18,8 @@ pub use payload::{BaseBuiltPayload, BasePayloadBuilderAttributes};
 
 mod parkable;
 pub use parkable::{
-    NonParkablePayloadTransactions, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
-    PayloadTransactionInvalidated,
+    NonParkablePayloadTransactions, NoopPayloadTransactions, ParkableBestPayloadTransactions,
+    ParkablePayloadTransactions, PayloadTransactionInvalidated,
 };
 
 mod predicate_loads;

--- a/crates/execution/payload/src/parkable.rs
+++ b/crates/execution/payload/src/parkable.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use alloy_primitives::{Address, TxHash};
 use base_execution_txpool::{BasePooledTx, ParkableBestTransactions};
+pub use reth_payload_util::NoopPayloadTransactions;
 use reth_payload_util::PayloadTransactions;
 use reth_transaction_pool::{
     BestTransactions, PoolTransaction, ValidPoolTransaction,

--- a/crates/execution/payload/src/parkable.rs
+++ b/crates/execution/payload/src/parkable.rs
@@ -69,6 +69,76 @@ where
     }
 }
 
+impl<T> ParkablePayloadTransactions for reth_payload_util::NoopPayloadTransactions<T>
+where
+    T: PoolTransaction,
+{
+    fn park_current(&mut self) -> bool {
+        false
+    }
+
+    fn mark_current_committed(&mut self) {}
+
+    fn promote(&mut self, _transaction_hash: TxHash) -> bool {
+        false
+    }
+
+    fn discard_parked(&mut self, _transaction_hash: TxHash) -> bool {
+        false
+    }
+}
+
+/// Adds no-op parking lifecycle methods to a payload iterator that cannot park transactions.
+///
+/// The payload builder skips transactions with unsatisfied predicates when this adapter reports
+/// that parking is unavailable.
+#[derive(Debug, Clone)]
+pub struct NonParkablePayloadTransactions<I> {
+    inner: I,
+}
+
+impl<I> NonParkablePayloadTransactions<I> {
+    /// Wraps a payload iterator without adding parking support.
+    pub const fn new(inner: I) -> Self {
+        Self { inner }
+    }
+}
+
+impl<I> PayloadTransactions for NonParkablePayloadTransactions<I>
+where
+    I: PayloadTransactions,
+{
+    type Transaction = I::Transaction;
+
+    fn next(&mut self, ctx: ()) -> Option<Self::Transaction> {
+        self.inner.next(ctx)
+    }
+
+    fn mark_invalid(&mut self, sender: Address, nonce: u64) {
+        self.inner.mark_invalid(sender, nonce);
+    }
+}
+
+impl<I> ParkablePayloadTransactions for NonParkablePayloadTransactions<I>
+where
+    I: PayloadTransactions,
+    I::Transaction: PoolTransaction,
+{
+    fn park_current(&mut self) -> bool {
+        false
+    }
+
+    fn mark_current_committed(&mut self) {}
+
+    fn promote(&mut self, _transaction_hash: TxHash) -> bool {
+        false
+    }
+
+    fn discard_parked(&mut self, _transaction_hash: TxHash) -> bool {
+        false
+    }
+}
+
 /// Converts a parkable best iterator into the payload-transaction interface used by the builder.
 pub struct ParkableBestPayloadTransactions<T>
 where

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -30,6 +30,8 @@ use tokio::time::{sleep, timeout};
 
 const L1_CHAIN_ID: u64 = 1337;
 const L2_CHAIN_ID: u64 = 84538453;
+const COBALT_ACTIVATION_BLOCK: u64 = 0;
+const DENIM_ACTIVATION_BLOCK: u64 = 1;
 const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 const PENDING_TX_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -47,15 +49,19 @@ async fn wait_for_pending_transaction(provider: &RootProvider<Base>, tx_hash: B2
     .wrap_err("transaction did not become pending on the builder")?
 }
 
-/// Starts a separate mempool and builder pair with validity transport enabled on both nodes.
+/// Starts a separate mempool and builder pair using the native Denim payload builder with validity
+/// transport enabled on both nodes.
 async fn start_validity_system() -> Result<SystemTestStack> {
     let system = SystemTestStackBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
+        .with_base_cobalt_activation_block(COBALT_ACTIVATION_BLOCK)
+        .with_base_denim_activation_block(DENIM_ACTIVATION_BLOCK)
         .with_tx_forwarding(
             TxForwardingConfig::new(vec![]).with_resend_after_ms(2000).with_max_batch_size(100),
         )
         .with_experimental_validity_transactions()
+        .with_payload_builder_cutover()
         .build()
         .await?;
 
@@ -288,7 +294,8 @@ async fn test_tx_forwarding_pipeline_system() -> Result<()> {
     Ok(())
 }
 
-/// Exercises every predicate kind through mempool ingress, forwarding, and builder inclusion.
+/// Exercises every native-builder predicate kind through mempool ingress, forwarding, and builder
+/// inclusion.
 #[tokio::test]
 async fn test_matching_validity_predicates_are_forwarded_and_included() -> Result<()> {
     let system = start_validity_system().await?;
@@ -322,10 +329,6 @@ async fn test_matching_validity_predicates_are_forwarded_and_included() -> Resul
         ValidityPredicate::BlockNumber {
             op: ValidityOperator::GreaterThan,
             value: U256::from(current_block),
-        },
-        ValidityPredicate::FlashblockIndex {
-            op: ValidityOperator::GreaterThanOrEqual,
-            value: U256::ZERO,
         },
     ];
     let rpc_client = RpcClient::builder().http(system.l2_client_rpc_url()?);
@@ -435,7 +438,9 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
     client_provider.wait_for_balance(storage_signer.address(), Duration::from_secs(15)).await?;
 
     let current_block = builder_provider.get_block_number().await?;
-    let target_block = current_block + 5;
+    // Native Denim blocks advance every 200 ms, so leave enough time to submit and observe all
+    // three transactions before the future predicate becomes true.
+    let target_block = current_block + 50;
     let recipient: Address = "0x000000000000000000000000000000000000dEaD".parse()?;
     let future_nonce = client_provider.get_transaction_count(future_signer.address()).await?;
     let (_, raw_future_tx, future_tx_hash) =
@@ -502,11 +507,6 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
     wait_for_pending_transaction(&builder_provider, future_tx_hash).await?;
     wait_for_pending_transaction(&builder_provider, expiring_tx_hash).await?;
     wait_for_pending_transaction(&builder_provider, storage_tx_hash).await?;
-    builder_provider.wait_for_block(target_block - 1, Duration::from_secs(20)).await?;
-    assert!(
-        builder_provider.get_transaction_receipt(future_tx_hash).await?.is_none(),
-        "future-gated transaction landed before its target block"
-    );
 
     let future_receipt =
         builder_provider.wait_for_receipt(future_tx_hash, TX_RECEIPT_TIMEOUT).await?;


### PR DESCRIPTION
## Summary

- run the validity transaction system-test stack with Cobalt and Denim activated
- enable payload-builder cutover so validity ingress, forwarding, predicate evaluation, and inclusion exercise the native 200 ms builder
- limit the matching-predicate case to predicates supported by the native builder
- make block-predicate timing assertions robust at Denim's 200 ms cadence

Stacked on #4731.
