### PR TITLE
chore(reth): Bump Pin And Fix Squash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6792,7 +6792,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -6812,7 +6812,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -9958,8 +9958,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -10864,7 +10864,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -10895,7 +10895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
 dependencies = [
  "bincode 1.3.3",
- "derive_more 2.1.1",
+ "derive_more 1.0.0",
  "iai-callgrind-macros",
  "iai-callgrind-runner",
 ]
@@ -10906,7 +10906,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
 dependencies = [
- "derive_more 2.1.1",
+ "derive_more 1.0.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -10936,7 +10936,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -13433,7 +13433,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15173,7 +15173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -15206,7 +15206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15219,7 +15219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15332,7 +15332,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -15372,7 +15372,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -15965,7 +15965,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15992,7 +15992,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16023,7 +16023,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16043,7 +16043,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -16056,7 +16056,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16145,7 +16145,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -16155,7 +16155,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16206,7 +16206,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -16223,7 +16223,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16237,7 +16237,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16250,7 +16250,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16275,7 +16275,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16304,7 +16304,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16330,7 +16330,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16360,7 +16360,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16375,7 +16375,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16400,7 +16400,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16424,7 +16424,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16448,7 +16448,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16483,7 +16483,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16540,7 +16540,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16567,7 +16567,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16590,7 +16590,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16617,7 +16617,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16673,7 +16673,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16703,7 +16703,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16721,7 +16721,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16737,7 +16737,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16761,7 +16761,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16772,7 +16772,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16801,7 +16801,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16827,7 +16827,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16843,7 +16843,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16859,7 +16859,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -16873,7 +16873,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16903,7 +16903,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16917,7 +16917,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16927,7 +16927,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16953,7 +16953,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16973,7 +16973,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -16991,7 +16991,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -17004,7 +17004,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17023,7 +17023,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17061,7 +17061,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -17093,7 +17093,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17107,7 +17107,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "serde",
  "serde_json",
@@ -17117,7 +17117,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17143,7 +17143,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "bytes",
  "futures",
@@ -17163,7 +17163,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -17180,7 +17180,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -17189,7 +17189,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "futures",
  "libc",
@@ -17203,7 +17203,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -17212,7 +17212,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -17226,7 +17226,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17285,7 +17285,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17310,7 +17310,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17334,7 +17334,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17349,7 +17349,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17363,7 +17363,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17380,7 +17380,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17404,7 +17404,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17472,7 +17472,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17527,7 +17527,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17576,7 +17576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17600,7 +17600,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17624,7 +17624,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "bytes",
  "eyre",
@@ -17653,7 +17653,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17665,7 +17665,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17689,7 +17689,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17701,7 +17701,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17724,7 +17724,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17734,7 +17734,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17777,7 +17777,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17826,7 +17826,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17853,7 +17853,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17869,7 +17869,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17884,7 +17884,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17960,7 +17960,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -17990,7 +17990,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -18033,7 +18033,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -18053,7 +18053,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18084,7 +18084,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -18131,7 +18131,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -18182,7 +18182,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -18196,7 +18196,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18227,7 +18227,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18278,7 +18278,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18306,7 +18306,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18320,7 +18320,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18340,7 +18340,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18355,7 +18355,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18381,7 +18381,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18398,7 +18398,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18425,7 +18425,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18446,7 +18446,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18462,7 +18462,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18472,7 +18472,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "clap",
  "eyre",
@@ -18492,7 +18492,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18511,7 +18511,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18554,7 +18554,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18580,7 +18580,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18607,7 +18607,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18623,7 +18623,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18647,7 +18647,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.1#d80b19e5b597f047268c6593300cbbe1f235631b"
+source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -23148,7 +23148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -24053,7 +24053,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -330,72 +330,72 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-network-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
-reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
-reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
-reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
-reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1", default-features = false }
-reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.1.1" }
+reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-network-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
+reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
+reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
+reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
+reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
 
 # tokio
 tokio = "1.53.1"

--- a/etc/scripts/local/reth_release.py
+++ b/etc/scripts/local/reth_release.py
@@ -170,7 +170,12 @@ def gh_json(args: list[str]) -> object:
 
 
 def fetch_pr(repo: str, number: int) -> PatchPr:
-    """Load PR metadata and the ordered non-merge commit list."""
+    """Load PR metadata and the ordered commit list.
+
+    The list is every commit GitHub attributes to the PR, in order. It may
+    include merge commits when the author merged the base branch in;
+    `squash_pr` drops those before cherry-picking.
+    """
     data = gh_json(
         [
             "pr",
@@ -249,8 +254,23 @@ def already_squashed(clone: Path, upstream_tag: str, pr: PatchPr) -> bool:
     return any(line.startswith(needle) for line in log.splitlines())
 
 
+def non_merge_commits(clone: Path, commits: tuple[str, ...]) -> list[str]:
+    """Return the given commits that are not merge commits, preserving order.
+
+    A merge commit (e.g. from merging the base branch into the PR) cannot be
+    cherry-picked without `-m`, and its diff is just the base changes we are
+    already building on, so it is dropped from the squash.
+    """
+    kept: list[str] = []
+    for commit in commits:
+        parents = git(clone, "show", "-s", "--format=%P", commit).split()
+        if len(parents) <= 1:
+            kept.append(commit)
+    return kept
+
+
 def squash_pr(clone: Path, pr: PatchPr, env: dict[str, str]) -> None:
-    """Cherry-pick every PR commit and squash them into one commit."""
+    """Cherry-pick every non-merge PR commit and squash them into one commit."""
     source = f"https://github.com/{pr.repo}"
     local_ref = f"refs/reths/{pr.repo.replace('/', '-')}-{pr.number}"
     git(
@@ -260,8 +280,13 @@ def squash_pr(clone: Path, pr: PatchPr, env: dict[str, str]) -> None:
         f"pull/{pr.number}/head:{local_ref}",
         "--force",
     )
+    picks = non_merge_commits(clone, pr.commits)
+    if not picks:
+        raise ReleaseError(
+            f"{pr.repo}#{pr.number} has no non-merge commits to squash"
+        )
     result = run(
-        ["git", "cherry-pick", "-n", *pr.commits],
+        ["git", "cherry-pick", "-n", *picks],
         cwd=clone,
         env=env,
         check=False,

--- a/etc/upstream-pins/reth.toml
+++ b/etc/upstream-pins/reth.toml
@@ -7,8 +7,8 @@
 # To return to an official Reth tag, edit this file and run `just pin-reth`.
 
 repository = "https://github.com/base/reth"
-reference = "base-v2.5.1.1"
-rev = "d80b19e5b597f047268c6593300cbbe1f235631b"
+reference = "base-v2.5.1.2"
+rev = "78658a84600d7d0567f6626f39a76bc7d8e8290c"
 
 [upstream_base]
 tag = "v2.5.1"
@@ -21,3 +21,7 @@ head = "f213ff930925e0912a2f6907cec0c62d473bc330"
 [[patches]]
 pr = "https://github.com/paradigmxyz/reth/pull/26766"
 head = "f47fd63a3762d8add2e07f1d4afa9363e60d0853"
+
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26794"
+head = "70f22cbb8a0a385135c58a57648f1bbf7bd55bee"


### PR DESCRIPTION
## Summary

Bumps the workspace Reth pin to `base-v2.5.1.2`, which adds the runtime fork-filter update backport (paradigmxyz/reth#26794) on top of the existing squashed PRs. The fork tag and `backport/v2.5.1/main` branch on base/reth were regenerated to include this PR. This lets us drop the old PR that manually merged into the 2.5.1 backport branch.

It also fixes `reth_release.py`, which previously passed every PR commit to `git cherry-pick` and failed when a PR head was a merge commit. The script now skips merge commits before squashing, so PRs that merged `main` in apply cleanly.