### PR TITLE
fix(upgrade-signal): Reconcile Schedule Shrinkage Into Registry

### DIFF
--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -818,10 +818,12 @@ mod tests {
         // An admin refresh transiently rewrites the registry to {Azul@50} at a newer L1 block,
         // both dropping Beryl (a missing key) and moving Azul's activation (a value drift) — without
         // touching this monitor's own view of what it applied.
-        assert!(refresher
-            .apply(&UpgradeSignalSchedule::new(2, vec![upgrade(BaseUpgrade::Azul, 50)]))
-            .unwrap()
-            .committed);
+        assert!(
+            refresher
+                .apply(&UpgradeSignalSchedule::new(2, vec![upgrade(BaseUpgrade::Azul, 50)]))
+                .unwrap()
+                .committed
+        );
 
         // L1 returns to the original schedule before the next poll. This monitor's own applied
         // values never moved, so a baseline-only check would see both entries as satisfied and never

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -163,6 +163,14 @@ pub struct UpgradeSignalMonitor {
     pub metrics_layer: UpgradeSignalMetricLayer,
     /// Live observer state by contract-backed upgrade.
     states: BTreeMap<BaseUpgrade, UpgradeSignalState>,
+    /// Minimum protocol version of each active upgrade the last committed apply validated.
+    ///
+    /// The runtime registry stores only activation timestamps, not the minimum protocol version an
+    /// upgrade demands, so an activation-unchanged version bump leaves the registry matching. This
+    /// baseline lets [`Self::schedule_needs_apply`] still detect such a protocol-only change and
+    /// re-validate it (which may alarm or fail the node closed). Advanced only on a committed apply,
+    /// so a rejected or failed apply keeps the schedule offered for re-validation.
+    validated_protocol_versions: BTreeMap<BaseUpgrade, U256>,
     /// Contract values of the last schedule that failed to apply, used to page only on the first
     /// occurrence of a persistent failure rather than on every poll.
     last_apply_failure: Option<Vec<UpgradeSignal>>,
@@ -176,7 +184,12 @@ impl UpgradeSignalMonitor {
         for upgrade_id in BaseUpgrade::CONTRACT_VARIANTS {
             states.insert(upgrade_id, UpgradeSignalState::new());
         }
-        Self { metrics_layer, states, last_apply_failure: None }
+        Self {
+            metrics_layer,
+            states,
+            validated_protocol_versions: BTreeMap::new(),
+            last_apply_failure: None,
+        }
     }
 
     /// Tolerantly polls the reader, records live metrics, and — when `refresher` is supplied —
@@ -265,6 +278,7 @@ impl UpgradeSignalMonitor {
                 // nothing, so the schedule stays offered for a newer-block re-read.
                 if summary.committed {
                     self.last_apply_failure = None;
+                    self.validated_protocol_versions = Self::active_protocol_versions(schedule);
                     UpgradeSignalMetrics::record_apply_success(self.metrics_layer, schedule);
                 }
                 return UpgradeSignalPollOutcome::Continue;
@@ -370,6 +384,15 @@ impl UpgradeSignalMonitor {
     /// (it is not contract-backed) and a governance clear is kept as an explicit [`Never`] rather
     /// than removed — so this comparison is true iff a commit would change the registry.
     ///
+    /// The registry alone is not sufficient, however: it stores only activation timestamps, not the
+    /// minimum protocol version each upgrade demands. An upgrade that raises its minimum version
+    /// while leaving its activation timestamp unchanged would leave the registry matching, so the
+    /// gate also fires when an active signal's minimum version has drifted from the last one this
+    /// monitor validated (see [`Self::validated_protocol_versions`]). Without this a protocol-only
+    /// bump would slip past validation, and the node would never alarm or fail closed as the
+    /// unsupportable activation approached. Only signals with a positive activation carry a
+    /// meaningful minimum (a clear carries none), so cleared signals never trip this check.
+    ///
     /// [`Never`]: UpgradeActivation::Never
     fn schedule_needs_apply(&self, chain_id: u64, schedule: &UpgradeSignalSchedule) -> bool {
         let mut expected = UpgradeActivationOverrides::new();
@@ -379,8 +402,25 @@ impl UpgradeSignalMonitor {
                 UpgradeActivation::from_timestamp(signal.positive_activation_timestamp()),
             );
         }
+        if RuntimeUpgradeRegistry::overrides(chain_id).unwrap_or_default() != expected {
+            return true;
+        }
 
-        RuntimeUpgradeRegistry::overrides(chain_id).unwrap_or_default() != expected
+        Self::active_protocol_versions(schedule) != self.validated_protocol_versions
+    }
+
+    /// Returns the minimum protocol version of each active signal in the schedule.
+    ///
+    /// Only signals with a positive activation timestamp are included: a clear carries no meaningful
+    /// minimum version. This is both the baseline a committed apply records and the value
+    /// [`Self::schedule_needs_apply`] compares a fresh read against, so the two stay in lockstep.
+    fn active_protocol_versions(schedule: &UpgradeSignalSchedule) -> BTreeMap<BaseUpgrade, U256> {
+        schedule
+            .signals
+            .iter()
+            .filter(|signal| signal.activation_timestamp > 0)
+            .map(|signal| (signal.upgrade_id, signal.protocol_version))
+            .collect()
     }
 
     /// Applies signals read from L1 and records corresponding live metrics.
@@ -850,6 +890,107 @@ mod tests {
             Some(UpgradeActivation::Timestamp(84))
         );
         assert!(!monitor.schedule_needs_apply(chain_id, &returned));
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn protocol_version_bump_with_unchanged_activation_trips_apply_gate() {
+        let chain_id = 9_100_090;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        // A dev-build node version satisfies any minimum, so every apply here commits.
+        let refresher = refresher(chain_id, UpgradeSignalDefaults::node_protocol_version());
+        let v1 = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let v2 = UpgradeSignalDefaults::packed_protocol_version(1, 2, 0);
+
+        // Commit Azul@42 requiring v1; the registry activation and the validated-version baseline
+        // now both reflect it, so the schedule is not re-offered.
+        let first = versioned_schedule(42, v1);
+        let mut monitor = monitor();
+        monitor.update_schedule(first.clone());
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &first, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
+        assert!(!monitor.schedule_needs_apply(chain_id, &first));
+
+        // L1 raises Azul's minimum version to v2 but leaves the activation timestamp at 42. The
+        // registry stores activations only, so it still matches; only the validated-version baseline
+        // exposes the drift and keeps the schedule offered for re-validation.
+        let bumped = UpgradeSignalSchedule::new(
+            2,
+            vec![UpgradeSignal {
+                upgrade_id: BaseUpgrade::Azul,
+                activation_timestamp: 42,
+                protocol_version: v2,
+            }],
+        );
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
+            Some(UpgradeActivation::Timestamp(42))
+        );
+        monitor.update_schedule(bumped.clone());
+        assert!(
+            monitor.schedule_needs_apply(chain_id, &bumped),
+            "a protocol-only version bump must trip the apply gate even when the activation is unchanged"
+        );
+
+        // Re-applying validates and commits the new minimum, advancing the baseline so the gate
+        // settles once the registry and the validated version both reflect the bump.
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &bumped, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
+        assert!(!monitor.schedule_needs_apply(chain_id, &bumped));
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn unsupportable_protocol_bump_with_unchanged_activation_fails_closed() {
+        let chain_id = 9_100_091;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        // Node supports 1.1.0.
+        let node_version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let refresher = refresher(chain_id, node_version);
+        let activation = 1_000_000;
+
+        // Commit an imminent Azul@activation the node currently supports (requires 1.1.0). The
+        // registry records the activation and the baseline records the validated 1.1.0 minimum.
+        let supported = versioned_schedule(activation, node_version);
+        let mut monitor = monitor();
+        monitor.update_schedule(supported.clone());
+        let now = activation - refresher.config.halt_lead_time().as_secs() + 1;
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &supported, now),
+            UpgradeSignalPollOutcome::Continue
+        );
+
+        // L1 raises the minimum to 1.1.1 (unsupportable) without moving the activation. The registry
+        // still matches on activation alone, so only the version baseline exposes the drift and keeps
+        // the unsupportable schedule offered for re-validation.
+        let unsupportable = UpgradeSignalSchedule::new(
+            2,
+            vec![UpgradeSignal {
+                upgrade_id: BaseUpgrade::Azul,
+                activation_timestamp: activation,
+                protocol_version: UpgradeSignalDefaults::packed_protocol_version(1, 1, 1),
+            }],
+        );
+        monitor.update_schedule(unsupportable.clone());
+        assert!(
+            monitor.schedule_needs_apply(chain_id, &unsupportable),
+            "an unsupportable protocol-only bump must still be offered for re-validation"
+        );
+
+        // With the activation inside the halt lead time and this node too old, the re-validation the
+        // gate forces fails the node closed rather than letting it fork off at activation.
+        assert!(matches!(
+            monitor.apply_and_evaluate(&refresher, &unsupportable, now),
+            UpgradeSignalPollOutcome::HaltNode { upgrade_id: BaseUpgrade::Azul, .. }
+        ));
 
         RuntimeUpgradeRegistry::clear_chain(chain_id);
     }

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use alloy_primitives::U256;
-use base_common_genesis::BaseUpgrade;
+use base_common_genesis::{BaseUpgrade, RuntimeUpgradeRegistry};
 use tracing::{debug, error, info};
 
 use crate::{
@@ -140,11 +140,6 @@ impl UpgradeSignalState {
         self.applied = Some(signal.clone());
     }
 
-    /// Returns true when a signal has been committed to the runtime registry for this upgrade.
-    const fn is_applied(&self) -> bool {
-        self.applied.is_some()
-    }
-
     /// Clears the applied baseline after this upgrade is reconciled out of the schedule.
     const fn clear_applied(&mut self) {
         self.applied = None;
@@ -231,7 +226,7 @@ impl UpgradeSignalMonitor {
         let Some(refresher) = refresher else {
             return UpgradeSignalPollOutcome::Continue;
         };
-        if !self.schedule_needs_apply(&schedule) {
+        if !self.schedule_needs_apply(refresher.chain_id, &schedule) {
             return UpgradeSignalPollOutcome::Continue;
         }
 
@@ -245,6 +240,11 @@ impl UpgradeSignalMonitor {
     /// failure is a deterministic local validation error — either an outdated node (the schedule
     /// requires a newer protocol version than this binary advertises) or a malformed L1 signal (a
     /// scheduled activation with no minimum protocol version). There is therefore nothing to retry.
+    ///
+    /// A stale schedule can also be *rejected* rather than failed: the registry refuses a schedule
+    /// read from an older L1 block than the one it already committed, returning `Ok` with
+    /// `committed == false`. That is not an error, so it never halts; the applied baseline is left
+    /// untouched exactly as on failure, so a newer-block re-read of the same schedule still applies.
     ///
     /// On failure the applied baseline is deliberately *not* advanced, so the schedule is re-offered
     /// (and re-evaluated) on every subsequent poll. Handling depends on the cause:
@@ -270,10 +270,19 @@ impl UpgradeSignalMonitor {
         now_secs: u64,
     ) -> UpgradeSignalPollOutcome {
         let apply_error = match refresher.apply(schedule) {
-            Ok(_) => {
-                self.mark_schedule_applied(schedule);
-                self.last_apply_failure = None;
-                UpgradeSignalMetrics::record_apply_success(self.metrics_layer, schedule);
+            Ok(summary) => {
+                // The registry rejects a schedule read from an older L1 block than the one it has
+                // already committed (a lower-block reorg on a non-finalized tag), returning `Ok`
+                // with `committed == false` and leaving the registry untouched. Advance the applied
+                // baseline only when the registry actually committed the schedule; otherwise the
+                // monitor would desync from the registry — recording a spurious success and moving
+                // (or clearing) a baseline whose override is still live — and never retry the
+                // reconcile once a newer block re-offers the same schedule.
+                if summary.committed {
+                    self.mark_schedule_applied(schedule);
+                    self.last_apply_failure = None;
+                    UpgradeSignalMetrics::record_apply_success(self.metrics_layer, schedule);
+                }
                 return UpgradeSignalPollOutcome::Continue;
             }
             Err(apply_error) => apply_error,
@@ -357,23 +366,26 @@ impl UpgradeSignalMonitor {
         UpgradeSignalPollOutcome::Continue
     }
 
-    /// Returns true when the schedule diverges from what has been committed to the runtime
-    /// registry, either because a present signal has not yet been applied or because a
-    /// previously-applied upgrade has vanished from a later, shorter schedule and must be
-    /// reconciled out of the registry.
+    /// Returns true when the schedule diverges from what is committed to the runtime registry,
+    /// either because a present signal has not yet been applied or because an upgrade the registry
+    /// still overrides has vanished from a later, shorter schedule and must be reconciled out.
     ///
     /// The removal case covers a pure schedule shrink — for example an L1 reorg on a non-finalized
     /// tag that unwinds a trailing upgrade's registration. Without it the shrink would never trip
     /// the apply gate (the present entries are unchanged), so the stale activation would linger in
     /// the registry until a restart or manual refresh. A governance clear keeps its slot with a
     /// `0` timestamp, so it stays present and is not treated as a removal.
-    fn schedule_needs_apply(&self, schedule: &UpgradeSignalSchedule) -> bool {
+    ///
+    /// Removal is detected against the authoritative runtime registry (`chain_id`), not the
+    /// monitor's own applied baseline: the admin refresh path writes the registry without touching
+    /// `states`, so a registry override this poller never applied itself would otherwise be missed
+    /// and its stale activation left in place.
+    fn schedule_needs_apply(&self, chain_id: u64, schedule: &UpgradeSignalSchedule) -> bool {
         let present: BTreeSet<BaseUpgrade> =
             schedule.signals.iter().map(|signal| signal.upgrade_id).collect();
-        let removed = self
-            .states
-            .iter()
-            .any(|(upgrade_id, state)| state.is_applied() && !present.contains(upgrade_id));
+        let removed = RuntimeUpgradeRegistry::overrides(chain_id).is_some_and(|overrides| {
+            overrides.activations.keys().any(|upgrade_id| !present.contains(upgrade_id))
+        });
 
         removed
             || schedule.signals.iter().any(|signal| {
@@ -579,6 +591,8 @@ mod tests {
 
     #[test]
     fn failed_apply_keeps_schedule_offered_for_retry() {
+        let chain_id = 9_100_030;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
         let mut monitor = monitor();
         let schedule = schedule(10);
 
@@ -586,30 +600,34 @@ mod tests {
         // apply must NOT advance the applied baseline, so the schedule is offered again next poll.
         monitor.update_schedule(schedule.clone());
         assert!(
-            monitor.schedule_needs_apply(&schedule),
+            monitor.schedule_needs_apply(chain_id, &schedule),
             "an unapplied schedule must remain offered for retry"
         );
 
         // A subsequent successful apply advances the applied baseline and stops the retries.
         monitor.mark_schedule_applied(&schedule);
-        assert!(!monitor.schedule_needs_apply(&schedule));
+        assert!(!monitor.schedule_needs_apply(chain_id, &schedule));
     }
 
     #[test]
     fn l1_change_after_failed_apply_is_offered() {
+        let chain_id = 9_100_031;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
         let mut monitor = monitor();
 
         // Observe v1 and leave it unapplied (apply failed).
         monitor.update_schedule(schedule(10));
-        assert!(monitor.schedule_needs_apply(&schedule(10)));
+        assert!(monitor.schedule_needs_apply(chain_id, &schedule(10)));
 
         // L1 then changes to v2, which must still be offered for apply.
         monitor.update_schedule(schedule(12));
-        assert!(monitor.schedule_needs_apply(&schedule(12)));
+        assert!(monitor.schedule_needs_apply(chain_id, &schedule(12)));
     }
 
     #[test]
     fn applied_schedule_is_not_reoffered() {
+        let chain_id = 9_100_032;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
         let mut monitor = monitor();
         let schedule = schedule(10);
 
@@ -618,7 +636,7 @@ mod tests {
 
         // The same contract values, even at a new L1 block number, are not re-offered.
         let same_values_new_block = UpgradeSignalSchedule::new(2, vec![signal(10)]);
-        assert!(!monitor.schedule_needs_apply(&same_values_new_block));
+        assert!(!monitor.schedule_needs_apply(chain_id, &same_values_new_block));
     }
 
     #[test]
@@ -662,7 +680,7 @@ mod tests {
         let outcome = monitor.apply_and_evaluate(&refresher, &schedule, 0);
 
         assert_eq!(outcome, UpgradeSignalPollOutcome::Continue);
-        assert!(!monitor.schedule_needs_apply(&schedule));
+        assert!(!monitor.schedule_needs_apply(chain_id, &schedule));
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
@@ -705,7 +723,7 @@ mod tests {
         let shrunk = UpgradeSignalSchedule::new(2, vec![upgrade(BaseUpgrade::Azul, 42)]);
         monitor.update_schedule(shrunk.clone());
         assert!(
-            monitor.schedule_needs_apply(&shrunk),
+            monitor.schedule_needs_apply(chain_id, &shrunk),
             "a vanished upgrade must trigger reconciliation even when present entries are unchanged"
         );
 
@@ -722,9 +740,100 @@ mod tests {
 
         // The baseline is reconciled too, so the shrunk schedule is not re-offered next poll.
         assert!(
-            !monitor.schedule_needs_apply(&shrunk),
+            !monitor.schedule_needs_apply(chain_id, &shrunk),
             "a reconciled shrink must not re-fire the apply gate"
         );
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn rejected_lower_block_schedule_does_not_advance_the_baseline() {
+        let chain_id = 9_100_060;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let refresher = refresher(chain_id, UpgradeSignalDefaults::node_protocol_version());
+        let version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let azul = |activation_timestamp| UpgradeSignal {
+            upgrade_id: BaseUpgrade::Azul,
+            activation_timestamp,
+            protocol_version: version,
+        };
+
+        // Commit Azul@42 at L1 block 100; it lands in the registry and advances the baseline.
+        let committed = UpgradeSignalSchedule::new(100, vec![azul(42)]);
+        let mut monitor = monitor();
+        monitor.update_schedule(committed.clone());
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &committed, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
+
+        // A reorg on a non-finalized tag re-reads Azul@50 at the older L1 block 99. The registry
+        // rejects the stale schedule (`Ok` with `committed == false`) and keeps Azul@42.
+        let stale = UpgradeSignalSchedule::new(99, vec![azul(50)]);
+        monitor.update_schedule(stale.clone());
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &stale, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
+            Some(UpgradeActivation::Timestamp(42))
+        );
+
+        // Because the rejected apply left the baseline untouched, Azul@50 is still offered so a
+        // newer-block re-read can commit it; the baseline was not desynced to the uncommitted value.
+        assert!(
+            monitor.schedule_needs_apply(chain_id, &stale),
+            "a rejected stale schedule must not advance the applied baseline"
+        );
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn removal_is_detected_against_registry_written_by_admin_refresh() {
+        let chain_id = 9_100_070;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let refresher = refresher(chain_id, UpgradeSignalDefaults::node_protocol_version());
+        let version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let upgrade = |upgrade_id, activation_timestamp| UpgradeSignal {
+            upgrade_id,
+            activation_timestamp,
+            protocol_version: version,
+        };
+
+        // The admin refresh commits {Azul, Beryl} straight to the registry without touching this
+        // monitor's in-memory state — exactly the drift the registry-based removal check guards.
+        let admin = UpgradeSignalSchedule::new(
+            1,
+            vec![upgrade(BaseUpgrade::Azul, 42), upgrade(BaseUpgrade::Beryl, 84)],
+        );
+        assert!(refresher.apply(&admin).unwrap().committed);
+
+        // The monitor's own baseline knows only Azul (its present entry is already applied), so a
+        // baseline-only removal check would miss Beryl. The registry still overrides Beryl, so the
+        // shrink must trip the apply gate anyway.
+        let mut monitor = monitor();
+        monitor.mark_schedule_applied(&UpgradeSignalSchedule::new(
+            1,
+            vec![upgrade(BaseUpgrade::Azul, 42)],
+        ));
+        let shrunk = UpgradeSignalSchedule::new(2, vec![upgrade(BaseUpgrade::Azul, 42)]);
+        monitor.update_schedule(shrunk.clone());
+        assert!(
+            monitor.schedule_needs_apply(chain_id, &shrunk),
+            "a registry override this monitor never applied itself must still trip the apply gate"
+        );
+
+        // Applying the shrunk schedule trims Beryl out of the registry.
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &shrunk, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl), None);
 
         RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
@@ -747,7 +856,7 @@ mod tests {
         // Not yet fatal: the node keeps running, nothing is committed, and the schedule stays
         // offered (baseline not advanced) so a later poll re-evaluates it.
         assert_eq!(outcome, UpgradeSignalPollOutcome::Continue);
-        assert!(monitor.schedule_needs_apply(&schedule));
+        assert!(monitor.schedule_needs_apply(chain_id, &schedule));
         assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul), None);
 
         RuntimeUpgradeRegistry::clear_chain(chain_id);

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -1,9 +1,11 @@
 //! Upgrade signal state values.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use alloy_primitives::U256;
-use base_common_genesis::{BaseUpgrade, RuntimeUpgradeRegistry};
+use base_common_genesis::{
+    BaseUpgrade, RuntimeUpgradeRegistry, UpgradeActivation, UpgradeActivationOverrides,
+};
 use tracing::{debug, error, info};
 
 use crate::{
@@ -96,24 +98,23 @@ impl UpgradeSignalStateUpdate {
     }
 }
 
-/// Stateful live tracker for one contract-backed upgrade.
+/// Live observer baseline for one contract-backed upgrade.
 ///
-/// Two independent baselines are tracked: `observed` advances on every read and drives metrics and
-/// change detection, while `applied` advances only when a schedule is successfully committed to the
-/// runtime registry. Keeping them separate means a failed apply does not poison the baseline: the
-/// signal keeps being offered for apply until a commit actually succeeds.
+/// Tracks the last signal read from L1, which drives change detection and metrics. Whether a
+/// schedule still needs applying is decided against the runtime registry itself (see
+/// [`UpgradeSignalMonitor::schedule_needs_apply`]), not this observer baseline, so a failed apply
+/// cannot poison the decision: the schedule keeps being offered until the registry actually
+/// reflects it.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 struct UpgradeSignalState {
     /// Last signal read from L1 by the live observer.
     observed: Option<UpgradeSignal>,
-    /// Last signal a successful apply committed to the runtime registry.
-    applied: Option<UpgradeSignal>,
 }
 
 impl UpgradeSignalState {
     /// Creates an empty upgrade signal state tracker.
     const fn new() -> Self {
-        Self { observed: None, applied: None }
+        Self { observed: None }
     }
 
     /// Records a newly read live signal against the observed baseline.
@@ -128,21 +129,6 @@ impl UpgradeSignalState {
 
         self.observed = Some(signal);
         update
-    }
-
-    /// Returns true when `signal` has not yet been successfully applied.
-    fn needs_apply(&self, signal: &UpgradeSignal) -> bool {
-        self.applied.as_ref().is_none_or(|applied| !applied.has_same_contract_values(signal))
-    }
-
-    /// Advances the applied baseline after a successful commit.
-    fn mark_applied(&mut self, signal: &UpgradeSignal) {
-        self.applied = Some(signal.clone());
-    }
-
-    /// Clears the applied baseline after this upgrade is reconciled out of the schedule.
-    const fn clear_applied(&mut self) {
-        self.applied = None;
     }
 }
 
@@ -175,7 +161,7 @@ pub enum UpgradeSignalPollOutcome {
 pub struct UpgradeSignalMonitor {
     /// Metric layer recorded by this monitor.
     pub metrics_layer: UpgradeSignalMetricLayer,
-    /// Live metrics and apply state by contract-backed upgrade.
+    /// Live observer state by contract-backed upgrade.
     states: BTreeMap<BaseUpgrade, UpgradeSignalState>,
     /// Contract values of the last schedule that failed to apply, used to page only on the first
     /// occurrence of a persistent failure rather than on every poll.
@@ -198,7 +184,7 @@ impl UpgradeSignalMonitor {
     ///
     /// This is the single live-poll routine shared by the consensus actor and the execution
     /// metrics extension. Read failures are recorded but do not abort the poll and do not advance
-    /// either baseline; a schedule that reads cleanly but cannot be applied is handled by
+    /// the observed baseline; a schedule that reads cleanly but cannot be applied is handled by
     /// [`Self::apply_and_evaluate`], which may return [`UpgradeSignalPollOutcome::HaltNode`]. The
     /// caller MUST fail the node closed on `HaltNode`.
     pub async fn poll_and_apply(
@@ -243,11 +229,12 @@ impl UpgradeSignalMonitor {
     ///
     /// A stale schedule can also be *rejected* rather than failed: the registry refuses a schedule
     /// read from an older L1 block than the one it already committed, returning `Ok` with
-    /// `committed == false`. That is not an error, so it never halts; the applied baseline is left
-    /// untouched exactly as on failure, so a newer-block re-read of the same schedule still applies.
+    /// `committed == false`. That is not an error, so it never halts; the registry is left untouched
+    /// exactly as on failure, so a newer-block re-read of the same schedule still applies.
     ///
-    /// On failure the applied baseline is deliberately *not* advanced, so the schedule is re-offered
-    /// (and re-evaluated) on every subsequent poll. Handling depends on the cause:
+    /// On failure the registry is deliberately *not* mutated, so [`Self::schedule_needs_apply`] keeps
+    /// re-offering the schedule (and re-evaluating it) on every subsequent poll. Handling depends on
+    /// the cause:
     ///
     /// * **Outdated node** — the node cannot follow the upgrade and will fork off the network at its
     ///   activation, so this is fail-closed. While the activation is more than the halt lead time
@@ -273,13 +260,10 @@ impl UpgradeSignalMonitor {
             Ok(summary) => {
                 // The registry rejects a schedule read from an older L1 block than the one it has
                 // already committed (a lower-block reorg on a non-finalized tag), returning `Ok`
-                // with `committed == false` and leaving the registry untouched. Advance the applied
-                // baseline only when the registry actually committed the schedule; otherwise the
-                // monitor would desync from the registry — recording a spurious success and moving
-                // (or clearing) a baseline whose override is still live — and never retry the
-                // reconcile once a newer block re-offers the same schedule.
+                // with `committed == false` and leaving the registry untouched. Only record success
+                // when the registry actually committed the schedule; a non-committed apply changed
+                // nothing, so the schedule stays offered for a newer-block re-read.
                 if summary.committed {
-                    self.mark_schedule_applied(schedule);
                     self.last_apply_failure = None;
                     UpgradeSignalMetrics::record_apply_success(self.metrics_layer, schedule);
                 }
@@ -366,50 +350,37 @@ impl UpgradeSignalMonitor {
         UpgradeSignalPollOutcome::Continue
     }
 
-    /// Returns true when the schedule diverges from what is committed to the runtime registry,
-    /// either because a present signal has not yet been applied or because an upgrade the registry
-    /// still overrides has vanished from a later, shorter schedule and must be reconciled out.
+    /// Returns true when the runtime registry does not already match the schedule.
     ///
-    /// The removal case covers a pure schedule shrink — for example an L1 reorg on a non-finalized
-    /// tag that unwinds a trailing upgrade's registration. Without it the shrink would never trip
-    /// the apply gate (the present entries are unchanged), so the stale activation would linger in
-    /// the registry until a restart or manual refresh. A governance clear keeps its slot with a
-    /// `0` timestamp, so it stays present and is not treated as a removal.
+    /// Compares the *entire* override set a commit of this schedule would produce against what the
+    /// registry currently holds — present keys, absent keys, and activation values alike. It is true
+    /// exactly when applying the schedule would change the registry, and false once the two agree.
     ///
-    /// Removal is detected against the authoritative runtime registry (`chain_id`), not the
-    /// monitor's own applied baseline: the admin refresh path writes the registry without touching
-    /// `states`, so a registry override this poller never applied itself would otherwise be missed
-    /// and its stale activation left in place.
+    /// The registry is the authoritative source of truth, not the monitor's own view of what it has
+    /// applied. The admin refresh path (and any other writer) mutates the registry without touching
+    /// this monitor, so a baseline-only check would miss any drift it did not cause itself:
+    ///
+    /// * an upgrade the registry still overrides that has vanished from a later, shorter schedule —
+    ///   the pure schedule shrink of an L1 reorg on a non-finalized tag, which a present-entries
+    ///   check alone never trips because the surviving entries are unchanged;
+    /// * an activation value another writer transiently changed, or a key it dropped, that a later
+    ///   L1 read must reconcile back even though this monitor's own applied values never moved.
+    ///
+    /// A commit derives its override set from the schedule exactly as done here — Zenith is excluded
+    /// (it is not contract-backed) and a governance clear is kept as an explicit [`Never`] rather
+    /// than removed — so this comparison is true iff a commit would change the registry.
+    ///
+    /// [`Never`]: UpgradeActivation::Never
     fn schedule_needs_apply(&self, chain_id: u64, schedule: &UpgradeSignalSchedule) -> bool {
-        let present: BTreeSet<BaseUpgrade> =
-            schedule.signals.iter().map(|signal| signal.upgrade_id).collect();
-        let removed = RuntimeUpgradeRegistry::overrides(chain_id).is_some_and(|overrides| {
-            overrides.activations.keys().any(|upgrade_id| !present.contains(upgrade_id))
-        });
-
-        removed
-            || schedule.signals.iter().any(|signal| {
-                self.states.get(&signal.upgrade_id).is_none_or(|state| state.needs_apply(signal))
-            })
-    }
-
-    /// Reconciles the applied baseline with a successfully committed schedule.
-    ///
-    /// Advances the baseline for every present signal and clears the baseline of any upgrade absent
-    /// from the schedule, mirroring the runtime registry that `replace_overrides` has just trimmed
-    /// to exactly this schedule. Clearing the vanished entries keeps the apply gate from re-firing
-    /// on every subsequent poll.
-    fn mark_schedule_applied(&mut self, schedule: &UpgradeSignalSchedule) {
-        let present: BTreeSet<BaseUpgrade> =
-            schedule.signals.iter().map(|signal| signal.upgrade_id).collect();
-        for (upgrade_id, state) in &mut self.states {
-            if !present.contains(upgrade_id) {
-                state.clear_applied();
-            }
-        }
+        let mut expected = UpgradeActivationOverrides::new();
         for signal in &schedule.signals {
-            self.states.entry(signal.upgrade_id).or_default().mark_applied(signal);
+            expected.set_activation(
+                signal.upgrade_id,
+                UpgradeActivation::from_timestamp(signal.positive_activation_timestamp()),
+            );
         }
+
+        RuntimeUpgradeRegistry::overrides(chain_id).unwrap_or_default() != expected
     }
 
     /// Applies signals read from L1 and records corresponding live metrics.
@@ -563,50 +534,29 @@ mod tests {
     }
 
     #[test]
-    fn state_needs_apply_until_marked_applied() {
-        let mut state = UpgradeSignalState::new();
-        let signal = signal(10);
-
-        // Never applied: needs apply even before it has been observed.
-        assert!(state.needs_apply(&signal));
-
-        // Observing the signal advances the observed baseline but not the applied baseline.
-        state.update_signal(signal.clone());
-        assert!(state.needs_apply(&signal));
-
-        // Only a successful apply advances the applied baseline.
-        state.mark_applied(&signal);
-        assert!(!state.needs_apply(&signal));
-    }
-
-    #[test]
-    fn state_changed_signal_needs_apply_after_previous_applied() {
-        let mut state = UpgradeSignalState::new();
-
-        state.mark_applied(&signal(10));
-
-        assert!(!state.needs_apply(&signal(10)));
-        assert!(state.needs_apply(&signal(12)));
-    }
-
-    #[test]
     fn failed_apply_keeps_schedule_offered_for_retry() {
         let chain_id = 9_100_030;
         RuntimeUpgradeRegistry::clear_chain(chain_id);
         let mut monitor = monitor();
         let schedule = schedule(10);
 
-        // Mirror `poll_and_apply`: observe first (advances the observed baseline), then a failed
-        // apply must NOT advance the applied baseline, so the schedule is offered again next poll.
+        // Mirror `poll_and_apply`: observe first (advances the observed baseline), then — with the
+        // registry still empty because the apply failed — the schedule is offered again next poll.
         monitor.update_schedule(schedule.clone());
         assert!(
             monitor.schedule_needs_apply(chain_id, &schedule),
             "an unapplied schedule must remain offered for retry"
         );
 
-        // A subsequent successful apply advances the applied baseline and stops the retries.
-        monitor.mark_schedule_applied(&schedule);
+        // A subsequent successful apply lands the schedule in the registry and stops the retries.
+        let refresher = refresher(chain_id, UpgradeSignalDefaults::node_protocol_version());
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &schedule, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
         assert!(!monitor.schedule_needs_apply(chain_id, &schedule));
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
 
     #[test]
@@ -631,12 +581,18 @@ mod tests {
         let mut monitor = monitor();
         let schedule = schedule(10);
 
+        let refresher = refresher(chain_id, UpgradeSignalDefaults::node_protocol_version());
         monitor.update_schedule(schedule.clone());
-        monitor.mark_schedule_applied(&schedule);
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &schedule, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
 
         // The same contract values, even at a new L1 block number, are not re-offered.
         let same_values_new_block = UpgradeSignalSchedule::new(2, vec![signal(10)]);
         assert!(!monitor.schedule_needs_apply(chain_id, &same_values_new_block));
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
 
     #[test]
@@ -738,7 +694,7 @@ mod tests {
         );
         assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl), None);
 
-        // The baseline is reconciled too, so the shrunk schedule is not re-offered next poll.
+        // The registry now matches the shrunk schedule, so it is not re-offered next poll.
         assert!(
             !monitor.schedule_needs_apply(chain_id, &shrunk),
             "a reconciled shrink must not re-fire the apply gate"
@@ -748,7 +704,7 @@ mod tests {
     }
 
     #[test]
-    fn rejected_lower_block_schedule_does_not_advance_the_baseline() {
+    fn rejected_lower_block_schedule_leaves_registry_unchanged() {
         let chain_id = 9_100_060;
         RuntimeUpgradeRegistry::clear_chain(chain_id);
 
@@ -760,7 +716,7 @@ mod tests {
             protocol_version: version,
         };
 
-        // Commit Azul@42 at L1 block 100; it lands in the registry and advances the baseline.
+        // Commit Azul@42 at L1 block 100; it lands in the registry.
         let committed = UpgradeSignalSchedule::new(100, vec![azul(42)]);
         let mut monitor = monitor();
         monitor.update_schedule(committed.clone());
@@ -782,11 +738,11 @@ mod tests {
             Some(UpgradeActivation::Timestamp(42))
         );
 
-        // Because the rejected apply left the baseline untouched, Azul@50 is still offered so a
-        // newer-block re-read can commit it; the baseline was not desynced to the uncommitted value.
+        // Because the rejected apply left the registry untouched, Azul@50 is still offered so a
+        // newer-block re-read can commit it; the registry was not desynced to the uncommitted value.
         assert!(
             monitor.schedule_needs_apply(chain_id, &stale),
-            "a rejected stale schedule must not advance the applied baseline"
+            "a rejected stale schedule must keep being offered until a newer block commits it"
         );
 
         RuntimeUpgradeRegistry::clear_chain(chain_id);
@@ -813,14 +769,10 @@ mod tests {
         );
         assert!(refresher.apply(&admin).unwrap().committed);
 
-        // The monitor's own baseline knows only Azul (its present entry is already applied), so a
-        // baseline-only removal check would miss Beryl. The registry still overrides Beryl, so the
-        // shrink must trip the apply gate anyway.
+        // This monitor never applied anything itself, so it has no private record of Beryl. Because
+        // the apply gate reads the authoritative registry — which the admin refresh left overriding
+        // Beryl — the shrunk schedule that drops Beryl must still trip it.
         let mut monitor = monitor();
-        monitor.mark_schedule_applied(&UpgradeSignalSchedule::new(
-            1,
-            vec![upgrade(BaseUpgrade::Azul, 42)],
-        ));
         let shrunk = UpgradeSignalSchedule::new(2, vec![upgrade(BaseUpgrade::Azul, 42)]);
         monitor.update_schedule(shrunk.clone());
         assert!(
@@ -834,6 +786,68 @@ mod tests {
             UpgradeSignalPollOutcome::Continue
         );
         assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl), None);
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn transient_admin_drift_is_reconciled_by_value_and_missing_key() {
+        let chain_id = 9_100_080;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let refresher = refresher(chain_id, UpgradeSignalDefaults::node_protocol_version());
+        let version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let upgrade = |upgrade_id, activation_timestamp| UpgradeSignal {
+            upgrade_id,
+            activation_timestamp,
+            protocol_version: version,
+        };
+
+        // This monitor commits {Azul@42, Beryl@84} at L1 block 1.
+        let full = UpgradeSignalSchedule::new(
+            1,
+            vec![upgrade(BaseUpgrade::Azul, 42), upgrade(BaseUpgrade::Beryl, 84)],
+        );
+        let mut monitor = monitor();
+        monitor.update_schedule(full.clone());
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &full, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
+
+        // An admin refresh transiently rewrites the registry to {Azul@50} at a newer L1 block,
+        // both dropping Beryl (a missing key) and moving Azul's activation (a value drift) — without
+        // touching this monitor's own view of what it applied.
+        assert!(refresher
+            .apply(&UpgradeSignalSchedule::new(2, vec![upgrade(BaseUpgrade::Azul, 50)]))
+            .unwrap()
+            .committed);
+
+        // L1 returns to the original schedule before the next poll. This monitor's own applied
+        // values never moved, so a baseline-only check would see both entries as satisfied and never
+        // notice the registry drifted. Comparing the full registry contents — Azul's drifted value
+        // and Beryl's missing key alike — the gate must fire to reconcile them back.
+        let returned = UpgradeSignalSchedule::new(3, full.signals.clone());
+        monitor.update_schedule(returned.clone());
+        assert!(
+            monitor.schedule_needs_apply(chain_id, &returned),
+            "a registry another writer drifted must re-trip the gate on both value and missing key"
+        );
+
+        // Applying restores the registry to exactly the schedule.
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &returned, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
+            Some(UpgradeActivation::Timestamp(42))
+        );
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl),
+            Some(UpgradeActivation::Timestamp(84))
+        );
+        assert!(!monitor.schedule_needs_apply(chain_id, &returned));
 
         RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
@@ -854,7 +868,7 @@ mod tests {
         let outcome = monitor.apply_and_evaluate(&refresher, &schedule, 0);
 
         // Not yet fatal: the node keeps running, nothing is committed, and the schedule stays
-        // offered (baseline not advanced) so a later poll re-evaluates it.
+        // offered (registry unchanged) so a later poll re-evaluates it.
         assert_eq!(outcome, UpgradeSignalPollOutcome::Continue);
         assert!(monitor.schedule_needs_apply(chain_id, &schedule));
         assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul), None);

--- a/crates/utilities/upgrade-signal/src/state.rs
+++ b/crates/utilities/upgrade-signal/src/state.rs
@@ -1,6 +1,6 @@
 //! Upgrade signal state values.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use alloy_primitives::U256;
 use base_common_genesis::BaseUpgrade;
@@ -138,6 +138,16 @@ impl UpgradeSignalState {
     /// Advances the applied baseline after a successful commit.
     fn mark_applied(&mut self, signal: &UpgradeSignal) {
         self.applied = Some(signal.clone());
+    }
+
+    /// Returns true when a signal has been committed to the runtime registry for this upgrade.
+    const fn is_applied(&self) -> bool {
+        self.applied.is_some()
+    }
+
+    /// Clears the applied baseline after this upgrade is reconciled out of the schedule.
+    const fn clear_applied(&mut self) {
+        self.applied = None;
     }
 }
 
@@ -347,15 +357,44 @@ impl UpgradeSignalMonitor {
         UpgradeSignalPollOutcome::Continue
     }
 
-    /// Returns true when any signal in `schedule` has not yet been successfully applied.
+    /// Returns true when the schedule diverges from what has been committed to the runtime
+    /// registry, either because a present signal has not yet been applied or because a
+    /// previously-applied upgrade has vanished from a later, shorter schedule and must be
+    /// reconciled out of the registry.
+    ///
+    /// The removal case covers a pure schedule shrink — for example an L1 reorg on a non-finalized
+    /// tag that unwinds a trailing upgrade's registration. Without it the shrink would never trip
+    /// the apply gate (the present entries are unchanged), so the stale activation would linger in
+    /// the registry until a restart or manual refresh. A governance clear keeps its slot with a
+    /// `0` timestamp, so it stays present and is not treated as a removal.
     fn schedule_needs_apply(&self, schedule: &UpgradeSignalSchedule) -> bool {
-        schedule.signals.iter().any(|signal| {
-            self.states.get(&signal.upgrade_id).is_none_or(|state| state.needs_apply(signal))
-        })
+        let present: BTreeSet<BaseUpgrade> =
+            schedule.signals.iter().map(|signal| signal.upgrade_id).collect();
+        let removed = self
+            .states
+            .iter()
+            .any(|(upgrade_id, state)| state.is_applied() && !present.contains(upgrade_id));
+
+        removed
+            || schedule.signals.iter().any(|signal| {
+                self.states.get(&signal.upgrade_id).is_none_or(|state| state.needs_apply(signal))
+            })
     }
 
-    /// Advances the applied baseline for every signal in a successfully committed schedule.
+    /// Reconciles the applied baseline with a successfully committed schedule.
+    ///
+    /// Advances the baseline for every present signal and clears the baseline of any upgrade absent
+    /// from the schedule, mirroring the runtime registry that `replace_overrides` has just trimmed
+    /// to exactly this schedule. Clearing the vanished entries keeps the apply gate from re-firing
+    /// on every subsequent poll.
     fn mark_schedule_applied(&mut self, schedule: &UpgradeSignalSchedule) {
+        let present: BTreeSet<BaseUpgrade> =
+            schedule.signals.iter().map(|signal| signal.upgrade_id).collect();
+        for (upgrade_id, state) in &mut self.states {
+            if !present.contains(upgrade_id) {
+                state.clear_applied();
+            }
+        }
         for signal in &schedule.signals {
             self.states.entry(signal.upgrade_id).or_default().mark_applied(signal);
         }
@@ -627,6 +666,64 @@ mod tests {
         assert_eq!(
             RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
             Some(UpgradeActivation::Timestamp(42))
+        );
+
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+    }
+
+    #[test]
+    fn schedule_shrink_reconciles_removed_upgrade_out_of_registry() {
+        let chain_id = 9_100_050;
+        RuntimeUpgradeRegistry::clear_chain(chain_id);
+
+        let refresher = refresher(chain_id, UpgradeSignalDefaults::node_protocol_version());
+        let version = UpgradeSignalDefaults::packed_protocol_version(1, 1, 0);
+        let upgrade = |upgrade_id, activation_timestamp| UpgradeSignal {
+            upgrade_id,
+            activation_timestamp,
+            protocol_version: version,
+        };
+
+        // Apply a two-upgrade schedule; both land in the runtime registry.
+        let full = UpgradeSignalSchedule::new(
+            1,
+            vec![upgrade(BaseUpgrade::Azul, 42), upgrade(BaseUpgrade::Beryl, 84)],
+        );
+        let mut monitor = monitor();
+        monitor.update_schedule(full.clone());
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &full, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl),
+            Some(UpgradeActivation::Timestamp(84))
+        );
+
+        // A later, shorter schedule (read at a newer L1 block) drops Beryl entirely while the
+        // remaining Azul entry is unchanged — the pure-shrink case from an L1 reorg.
+        let shrunk = UpgradeSignalSchedule::new(2, vec![upgrade(BaseUpgrade::Azul, 42)]);
+        monitor.update_schedule(shrunk.clone());
+        assert!(
+            monitor.schedule_needs_apply(&shrunk),
+            "a vanished upgrade must trigger reconciliation even when present entries are unchanged"
+        );
+
+        // Applying the shrunk schedule trims the removed upgrade out of the registry.
+        assert_eq!(
+            monitor.apply_and_evaluate(&refresher, &shrunk, 0),
+            UpgradeSignalPollOutcome::Continue
+        );
+        assert_eq!(
+            RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Azul),
+            Some(UpgradeActivation::Timestamp(42))
+        );
+        assert_eq!(RuntimeUpgradeRegistry::activation(chain_id, BaseUpgrade::Beryl), None);
+
+        // The baseline is reconciled too, so the shrunk schedule is not re-offered next poll.
+        assert!(
+            !monitor.schedule_needs_apply(&shrunk),
+            "a reconciled shrink must not re-fire the apply gate"
         );
 
         RuntimeUpgradeRegistry::clear_chain(chain_id);


### PR DESCRIPTION
## Summary

The live upgrade-signal poller only applied a freshly read L1 schedule when one of its present entries had changed, so a pure schedule shrink — a previously-applied upgrade vanishing from a later, shorter schedule after an L1 reorg on a non-finalized tag — never tripped the apply gate and the stale activation lingered in the runtime registry until a restart or manual refresh. The poller now also treats a previously-applied upgrade that is absent from the current schedule as needing apply, which runs the existing apply path so `replace_overrides` trims the removed activation out of the registry. The applied baseline is cleared for vanished upgrades so the gate does not re-fire on every subsequent poll. This is the code fix for audit finding #5 that PR #4660 documented as a known limitation.