### PR TITLE
chore(shadow-indexer): drop unused index

### DIFF
--- a/crates/execution/shadow-indexer-db/migrations/0008_drop_tx_hashes_index.sql
+++ b/crates/execution/shadow-indexer-db/migrations/0008_drop_tx_hashes_index.sql
@@ -1,0 +1,13 @@
+-- Drops the unused transaction-hash GIN index added in migration 0004. The
+-- `@> to_jsonb($hash)` explorer lookup it was built for was never wired up:
+-- pg_stat_user_indexes reports idx_scan = 0 and no query in the tree references
+-- it. At ~4.5 GB it was the costliest index to maintain on the batch-insert
+-- path (one GIN entry per transaction per block, plus fastupdate pending-list
+-- flushes that stall inserts).
+--
+-- Plain DROP INDEX (not CONCURRENTLY): sqlx wraps each migration in a
+-- transaction. This runs at shadow-indexer startup; the brief ACCESS EXCLUSIVE
+-- mirrors the index drops already performed in migration 0007.
+SET LOCAL lock_timeout = '5s';
+
+DROP INDEX IF EXISTS idx_shadow_blocks_tx_hashes;


### PR DESCRIPTION
## Summary

Drops `idx_shadow_blocks_tx_hashes`, the ~4.5 GB transaction-hash GIN index added
in migration 0004. The `@> to_jsonb($hash)` explorer lookup it was built for was
never wired up, so it is pure write-path overhead.

## Motivation

While profiling the slow batch-insert path on `shadow_blocks`, index-usage stats
showed this index is dead and expensive:

- `pg_stat_user_indexes`: `idx_scan = 0`, `idx_tup_read = 0` — never read since stats were last reset.
- No query in the tree references it (`jsonb_path_query_array` / `@> to_jsonb(...)` against `shadow_blocks` appears only in migration 0004 and test comments).
- At ~4.5 GB it is the costliest index to maintain on insert: one GIN entry per
  transaction per block, plus `fastupdate` pending-list flushes that stall the writer.

Dropping it removes the largest per-row maintenance cost on the priority insert
path and reclaims ~4.5 GB.

## Changes

- Add migration `0008_drop_tx_hashes_index.sql`: `DROP INDEX IF EXISTS idx_shadow_blocks_tx_hashes`.
- Plain (non-`CONCURRENTLY`) drop: sqlx wraps each migration in a transaction, and
  the brief `ACCESS EXCLUSIVE` mirrors the index drops already performed in migration 0007.
