### PR TITLE
ci: reduce Depot Docker build contention

### DIFF
--- a/.depot/workflows/docker.yml
+++ b/.depot/workflows/docker.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
   workflow_dispatch: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/node
 permissions:
@@ -64,6 +67,7 @@ jobs:
             --set "${TARGET}.labels.org.opencontainers.image.revision=${{ steps.image-labels.outputs.revision }}" \
             --set "${TARGET}.labels.org.opencontainers.image.created=${{ steps.image-labels.outputs.created }}"
   warm-devnet-cache:
+    needs: build-and-push
     runs-on: depot-ubuntu-24.04
     env:
       PROFILE: dev

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -1,10 +1,18 @@
-ARG RUST_VERSION=1.95.0
+# syntax=docker/dockerfile:1
+ARG RUST_VERSION=1.96.0
 FROM public.ecr.aws/docker/library/rust:${RUST_VERSION}-trixie AS rust-builder-base
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev libssl-dev pkg-config curl build-essential cmake && \
+      git libclang-dev libssl-dev pkg-config curl build-essential cmake \
+      protobuf-compiler libprotobuf-dev && \
     rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo install cargo-chef sccache --locked
+ENV RUSTC_WRAPPER=sccache
+ENV SCCACHE_DIR=/sccache
+ENV CARGO_INCREMENTAL=0
 
 FROM rust-builder-base AS zk-builder-base
 RUN apt-get update && \
@@ -35,110 +43,155 @@ RUN set -eux; \
     unzip /tmp/protoc.zip -d /usr/local; \
     rm /tmp/protoc.zip
 
-FROM rust-builder-base AS source
+FROM rust-builder-base AS planner
 COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM rust-builder-base AS rust-deps
+ARG PROFILE=release
+ARG CARGO_CHEF_ARGS=""
+ARG SCCACHE_CACHE_ID=rust-services-sccache
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
+    cargo chef cook --profile "$PROFILE" --recipe-path recipe.json ${CARGO_CHEF_ARGS}
+
+FROM rust-deps AS source
+COPY . .
+
+FROM source AS base-image-builder
+ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
+    set -eux; \
+    cargo build --profile "$PROFILE" \
+      --package base --bin base \
+      --package base-reth-node --bin base-reth-node \
+      --package base-consensus --bin base-consensus \
+      --package base-snapshotter-bin --bin snapshotter; \
+    profile_dir="$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")"; \
+    cp "/app/target/${profile_dir}/base" /app/base; \
+    cp "/app/target/${profile_dir}/base-reth-node" /app/base-reth-node; \
+    cp "/app/target/${profile_dir}/base-consensus" /app/base-consensus; \
+    cp "/app/target/${profile_dir}/snapshotter" /app/snapshotter
 
 FROM source AS base-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=base-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base --bin base && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base /app/base
 
 FROM source AS execution-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=execution-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base-reth-node --bin base-reth-node && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-reth-node /app/base-reth-node
 
 FROM source AS consensus-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=consensus-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base-consensus --bin base-consensus && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-consensus /app/base-consensus
 
 FROM source AS builder-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=builder-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base-builder-bin --bin base-builder && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-builder /app/base-builder
 
 FROM source AS basectl-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=basectl-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package basectl --bin basectl && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/basectl /app/basectl
 
 FROM source AS snapshotter-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=snapshotter-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base-snapshotter-bin --bin snapshotter && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/snapshotter /app/snapshotter
 
 FROM source AS proposer-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=proposer-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base-proposer-bin --bin base-proposer && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-proposer /app/base-proposer
 
 FROM source AS websocket-proxy-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=websocket-proxy-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package websocket-proxy-bin --bin websocket-proxy && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/websocket-proxy /app/websocket-proxy
 
 FROM source AS ingress-rpc-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=ingress-rpc-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package ingress-rpc --bin ingress-rpc && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/ingress-rpc /app/ingress-rpc
 
 FROM source AS audit-archiver-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=audit-archiver-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package audit-archiver --bin audit-archiver && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/audit-archiver /app/audit-archiver
 
 FROM source AS batcher-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=batcher-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base-batcher-bin --bin base-batcher && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-batcher /app/base-batcher
 
 FROM source AS sidecrush-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=sidecrush-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base-sidecrush-bin --bin sidecrush && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/sidecrush /app/sidecrush
 
 FROM source AS prover-service-builder
 ARG PROFILE=release
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=prover-service-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base-prover-service-bin --bin base-prover-service && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-prover-service /app/base-prover-service
 
@@ -148,9 +201,10 @@ COPY . .
 FROM zk-source AS zk-host-builder
 ARG PROFILE=release
 ARG BASE_SUCCINCT_ELF_REQUIRE=1
+ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/app/target,id=zk-host-target,sharing=locked \
+    --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     cargo build --profile $PROFILE --package base-prover-zk-host --bin base-prover-zk-host && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-prover-zk-host /app/base-prover-zk-host
 
@@ -165,16 +219,16 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends supervisor && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/log/supervisor
-COPY --from=base-builder /app/base ./base
+COPY --from=base-image-builder /app/base ./base
 # Compose uses this wrapper to source generated devnet upgrade-signal env before /app/base.
 COPY etc/scripts/devnet/base-entrypoint.sh ./base-entrypoint.sh
 # Keep split binaries here for now, needed for bare metal work
 # Remove only when there is an alternative available
 # e.g. when we publish independent separate Docker images for each
 # via the CI
-COPY --from=execution-builder /app/base-reth-node ./base-reth-node
-COPY --from=consensus-builder /app/base-consensus ./base-consensus
-COPY --from=snapshotter-builder /app/snapshotter ./snapshotter
+COPY --from=base-image-builder /app/base-reth-node ./base-reth-node
+COPY --from=base-image-builder /app/base-consensus ./base-consensus
+COPY --from=base-image-builder /app/snapshotter ./snapshotter
 COPY etc/scripts/node/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY etc/scripts/node/execution-entrypoint .
 COPY etc/scripts/node/consensus-entrypoint .

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -3,7 +3,7 @@ variable "PROFILE" {
 }
 
 variable "RUST_VERSION" {
-  default = "1.95.0"
+  default = "1.96.0"
 }
 
 variable "BASE_SUCCINCT_ELF_REQUIRE" {
@@ -62,81 +62,137 @@ target "_rust-service-common" {
   }
 }
 
+# Keep SCCACHE_CACHE_ID stable for a target so repeated builds reuse cached Rust
+# compiler outputs. Use a different ID when targets normally run concurrently,
+# otherwise BuildKit's locked sccache mount will serialize those builds.
+
 target "base" {
   inherits = ["_rust-service-common"]
   target = "base"
+  args = {
+    CARGO_CHEF_ARGS = "--package base --package base-reth-node --package base-consensus --package base-snapshotter-bin"
+    SCCACHE_CACHE_ID = "rust-services-base-sccache"
+  }
   tags = ["base:local"]
 }
 
 target "execution" {
   inherits = ["_rust-service-common"]
   target = "execution"
+  args = {
+    CARGO_CHEF_ARGS = "--package base-reth-node"
+    SCCACHE_CACHE_ID = "rust-services-execution-sccache"
+  }
   tags = ["base-execution:local"]
 }
 
 target "consensus" {
   inherits = ["_rust-service-common"]
   target = "consensus"
+  args = {
+    CARGO_CHEF_ARGS = "--package base-consensus"
+    SCCACHE_CACHE_ID = "rust-services-consensus-sccache"
+  }
   tags = ["base-consensus:local"]
 }
 
 target "builder" {
   inherits = ["_rust-service-common"]
   target = "builder"
+  args = {
+    CARGO_CHEF_ARGS = "--package base-builder-bin"
+    SCCACHE_CACHE_ID = "rust-services-builder-sccache"
+  }
   tags = ["base-builder:local"]
 }
 
 target "basectl" {
   inherits = ["_rust-service-common"]
   target = "basectl"
+  args = {
+    CARGO_CHEF_ARGS = "--package basectl"
+    SCCACHE_CACHE_ID = "rust-services-basectl-sccache"
+  }
   tags = ["base-basectl:local"]
 }
 
 target "snapshotter" {
   inherits = ["_rust-service-common"]
   target = "snapshotter"
+  args = {
+    CARGO_CHEF_ARGS = "--package base-snapshotter-bin"
+    SCCACHE_CACHE_ID = "rust-services-snapshotter-sccache"
+  }
   tags = ["base-snapshotter:local"]
 }
 
 target "proposer" {
   inherits = ["_rust-service-common"]
   target = "proposer"
+  args = {
+    CARGO_CHEF_ARGS = "--package base-proposer-bin"
+    SCCACHE_CACHE_ID = "rust-services-proposer-sccache"
+  }
   tags = ["base-proposer:local"]
 }
 
 target "websocket-proxy" {
   inherits = ["_rust-service-common"]
   target = "websocket-proxy"
+  args = {
+    CARGO_CHEF_ARGS = "--package websocket-proxy-bin"
+    SCCACHE_CACHE_ID = "rust-services-websocket-proxy-sccache"
+  }
   tags = ["websocket-proxy:local"]
 }
 
 target "ingress-rpc" {
   inherits = ["_rust-service-common"]
   target = "ingress-rpc"
+  args = {
+    CARGO_CHEF_ARGS = "--package ingress-rpc"
+    SCCACHE_CACHE_ID = "rust-services-ingress-rpc-sccache"
+  }
   tags = ["ingress-rpc:local"]
 }
 
 target "audit-archiver" {
   inherits = ["_rust-service-common"]
   target = "audit-archiver"
+  args = {
+    CARGO_CHEF_ARGS = "--package audit-archiver"
+    SCCACHE_CACHE_ID = "rust-services-audit-archiver-sccache"
+  }
   tags = ["audit-archiver:local"]
 }
 
 target "batcher" {
   inherits = ["_rust-service-common"]
   target = "batcher"
+  args = {
+    CARGO_CHEF_ARGS = "--package base-batcher-bin"
+    SCCACHE_CACHE_ID = "rust-services-batcher-sccache"
+  }
   tags = ["base-batcher:local"]
 }
 
 target "sidecrush" {
   inherits = ["_rust-service-common"]
   target = "sidecrush"
+  args = {
+    CARGO_CHEF_ARGS = "--package base-sidecrush-bin"
+    SCCACHE_CACHE_ID = "rust-services-sidecrush-sccache"
+  }
   tags = ["sidecrush:local"]
 }
 
 target "prover-service" {
   inherits = ["_rust-service-common"]
   target = "prover-service"
+  args = {
+    CARGO_CHEF_ARGS = "--package base-prover-service-bin"
+    SCCACHE_CACHE_ID = "rust-services-prover-service-sccache"
+  }
   tags = ["base-prover-service:local"]
 }
 
@@ -146,6 +202,7 @@ target "zk-host" {
   args = {
     PROFILE                   = "${ZK_HOST_PROFILE}"
     BASE_SUCCINCT_ELF_REQUIRE = "${BASE_SUCCINCT_ELF_REQUIRE}"
+    SCCACHE_CACHE_ID          = "rust-services-zk-host-sccache"
   }
   tags = ["base-prover-zk-host:local"]
 }


### PR DESCRIPTION
## Summary
- cancel superseded Depot Docker push workflows for the same ref
- run the devnet cache warmer after the publish build instead of concurrently with it
- follow Depot's Rust Dockerfile guidance by using cargo-chef plus sccache with BuildKit cache mounts
- replace mutable `/app/target` cache mounts with Cargo registry/git and `SCCACHE_DIR` cache mounts
- scope `cargo chef cook` to the packages needed by each Docker bake target
- give each Rust service target a stable sccache cache ID so normally concurrent image builds do not all serialize on one locked cache
- build the `base` runtime image's four Rust binaries in one Cargo invocation instead of four parallel builder stages
- align the Docker Rust image default with `rust-toolchain.toml` to avoid rustup installing 1.96.0 inside 1.95.0 images

## Reasoning
Depot build `3441khb2vq` was slow because the Docker workflow had multiple heavyweight Rust image builds overlapping in the same Depot project. The logs showed long waits around shared BuildKit work and cache mounts before relatively short Cargo build work.

Depot's Rust guidance is to keep Cargo registry/git caches and an sccache directory as BuildKit cache mounts, with cargo-chef used for dependency cooking. This PR moves the Rust services Dockerfile to that shape and removes the previous full Cargo target-directory cache mounts.

The important cache behavior is:
- `cargo chef prepare` isolates dependency metadata before source is copied into the final build stages.
- `cargo chef cook` is package-scoped per bake target, so building `base` does not prebuild unrelated workspace packages such as prover-only dependencies.
- `SCCACHE_CACHE_ID` is stable for repeated builds of the same target, which preserves warm Rust compiler artifacts across Depot builds.
- Different targets get different sccache IDs because BuildKit cache mounts use `sharing=locked`; using one global sccache cache would make unrelated image targets contend on the same lock.
- The `base` image still shares one stable cache ID across profiles, so this does not split dev/maxperf cache reuse. The expected concurrency reduction comes from workflow ordering and fewer jobs per worker.
- The composite `base-image-builder` avoids the old intra-image behavior where `base-builder`, `execution-builder`, `consensus-builder`, and `snapshotter-builder` could run concurrently just to assemble one `base` image.

## Validation
- `docker buildx bake -f etc/docker/docker-bake.hcl base --print`
- `docker buildx build --call=outline -f etc/docker/Dockerfile.rust-services --target base --build-arg PROFILE=dev --build-arg RUST_VERSION=1.96.0 .`
- `git diff --check`
- Depot smoke build `tbr33m6hvs`: `base` dev cache-only build completed in 129s after the Dockerfile fixes.
- Depot smoke build `wnwlk06vwz`: completed after introducing target-scoped sccache IDs; this was expected to warm the new `rust-services-base-sccache` namespace.
