### PR TITLE
refactor(systems): support caller-owned in-process L2 datadirs

### DIFF
--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -18,18 +18,18 @@ use base_execution_txpool::{
 use base_node_core::{args::RollupArgs, node::BasePoolBuilder};
 use base_node_runner::{BaseNode, BaseNodeExtension, NodeHooks};
 use eyre::{Result, WrapErr, eyre};
-use nanoid::nanoid;
 use reth_db::{
     ClientVersion, DatabaseEnv, init_db,
     mdbx::{DatabaseArguments, KILOBYTE, MEGABYTE, MaxReadTransactionDuration},
 };
 use reth_node_builder::{NodeBuilder, NodeConfig, NodeHandle};
 use reth_node_core::{
-    args::{DatadirArgs, NetworkArgs, RpcServerArgs},
+    args::{DatadirArgs, MetricArgs, NetworkArgs, RpcServerArgs},
     dirs::{DataDirPath, MaybePlatformPath},
     exit::NodeExitFuture,
 };
-use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
+use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig, TokioConfig};
+use tempfile::TempDir;
 use tracing::warn;
 use url::Url;
 
@@ -38,8 +38,10 @@ use crate::{config::BUILDER, setup::BUILDER_ENODE_ID};
 /// Configuration for starting an in-process builder.
 #[derive(Debug)]
 pub struct InProcessBuilderConfig {
-    /// L2 genesis JSON content.
-    pub genesis_json: Vec<u8>,
+    /// Pre-built chain specification.
+    pub chain_spec: Arc<BaseChainSpec>,
+    /// Existing caller-owned datadir. A temporary datadir is created when omitted.
+    pub datadir: Option<PathBuf>,
     /// JWT secret hex for Engine API authentication.
     pub jwt_secret: JwtSecret,
     /// Optional fixed HTTP RPC port (uses random if None).
@@ -52,6 +54,8 @@ pub struct InProcessBuilderConfig {
     pub p2p_port: Option<u16>,
     /// Optional fixed Flashblocks port (uses random if None).
     pub flashblocks_port: Option<u16>,
+    /// Optional fixed Prometheus metrics port (uses random if None).
+    pub metrics_port: Option<u16>,
     /// Whether to accept experimental validity-bearing transactions.
     pub enable_experimental_validity_transactions: bool,
     /// Whether to run both payload builders and cut over to basic at Denim.
@@ -61,6 +65,27 @@ pub struct InProcessBuilderConfig {
     /// Lets downstream consumers layer their own [`BaseNodeExtension`] onto the standard
     /// in-process builder wiring without forking this crate.
     pub extra_extensions: Vec<Box<dyn BaseNodeExtension>>,
+    /// Interval used by the payload builder.
+    pub block_time: Duration,
+    /// Optional canonical block persistence threshold.
+    pub persistence_threshold: Option<u64>,
+    /// Optional pending/basefee/queued transaction count limit for benchmark workloads.
+    pub txpool_max_transactions: Option<usize>,
+    /// Optional pending/basefee/queued transaction size limit in megabytes.
+    pub txpool_max_size_mb: Option<usize>,
+    /// Optional maximum number of transaction slots retained per sender.
+    pub txpool_max_account_slots: Option<usize>,
+}
+
+impl InProcessBuilderConfig {
+    /// Parses L2 genesis JSON into a chain specification.
+    pub fn chain_spec_from_genesis_json(genesis_json: &[u8]) -> Result<Arc<BaseChainSpec>> {
+        let genesis: alloy_genesis::Genesis =
+            serde_json::from_slice(genesis_json).wrap_err("Invalid genesis JSON")?;
+        Ok(Arc::new(
+            BaseChainSpec::try_from_genesis(genesis).wrap_err("Invalid genesis chain spec")?,
+        ))
+    }
 }
 
 /// An in-process builder node that replaces Docker-based `BuilderContainer`.
@@ -71,20 +96,14 @@ pub struct InProcessBuilder {
     http_api_addr: SocketAddr,
     ws_api_addr: SocketAddr,
     engine_addr: SocketAddr,
+    metrics_addr: SocketAddr,
     flashblocks_port: u16,
     p2p_port: u16,
     data_dir: PathBuf,
     _node_exit_future: NodeExitFuture,
     _node: Box<dyn Any + Sync + Send>,
     _runtime: Runtime,
-}
-
-impl Drop for InProcessBuilder {
-    fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_dir_all(&self.data_dir) {
-            warn!(dir = ?self.data_dir, error = %e, "Failed to remove temp data directory");
-        }
-    }
+    _temp_dir: Option<TempDir>,
 }
 
 impl std::fmt::Debug for InProcessBuilder {
@@ -93,6 +112,7 @@ impl std::fmt::Debug for InProcessBuilder {
             .field("http_api_addr", &self.http_api_addr)
             .field("ws_api_addr", &self.ws_api_addr)
             .field("engine_addr", &self.engine_addr)
+            .field("metrics_addr", &self.metrics_addr)
             .field("flashblocks_port", &self.flashblocks_port)
             .field("p2p_port", &self.p2p_port)
             .finish_non_exhaustive()
@@ -104,22 +124,28 @@ impl InProcessBuilder {
     pub async fn start(config: InProcessBuilderConfig) -> Result<Self> {
         clear_otel_env_vars();
 
-        let tempdir = std::env::temp_dir();
-        let random_id = nanoid!();
-        let data_path = tempdir.join(format!("in-process-builder.{random_id}"));
+        let (data_path, temp_dir) = Self::prepare_datadir(config.datadir.clone())?;
         let jwt_path = data_path.join("jwt.hex");
 
         std::fs::create_dir_all(&data_path).wrap_err("Failed to create data directory")?;
         std::fs::write(&jwt_path, config.jwt_secret.as_bytes().encode_hex().as_bytes())
             .wrap_err("Failed to write JWT secret")?;
 
-        let runtime = RuntimeBuilder::new(RuntimeConfig::default()).build()?;
+        let runtime = RuntimeBuilder::new(
+            RuntimeConfig::default()
+                .with_tokio(TokioConfig::existing_handle(tokio::runtime::Handle::current())),
+        )
+        .build()?;
 
-        let chain_spec = parse_genesis(&config.genesis_json)?;
+        let chain_spec = Arc::clone(&config.chain_spec);
 
         let flashblocks_port = config.flashblocks_port.unwrap_or_else(get_available_port);
+        let metrics_addr = SocketAddr::new(
+            Ipv4Addr::LOCALHOST.into(),
+            config.metrics_port.unwrap_or_else(get_available_port),
+        );
         let builder_config = BuilderConfig {
-            block_time: Duration::from_millis(2000),
+            block_time: config.block_time,
             flashblocks_ws_addr: SocketAddr::new(Ipv4Addr::LOCALHOST.into(), flashblocks_port),
             flashblocks_interval: Duration::from_millis(200),
             ..Default::default()
@@ -145,46 +171,52 @@ impl InProcessBuilder {
             .with_gas_limit_config(gas_limit_config)
             .build();
 
-        let (db, _db_path) = create_test_db(&data_path)?;
-
-        let node_config = create_node_config(chain_spec, &data_path, &jwt_path, &config)?;
+        let mut node_config = create_node_config(chain_spec, &data_path, &jwt_path, &config)?;
+        node_config.metrics = MetricArgs { prometheus: Some(metrics_addr), ..Default::default() };
+        let db_path = node_config.datadir().db();
+        let db = if config.datadir.is_some() {
+            init_db(db_path, node_config.db.database_args())
+                .wrap_err("Failed to open builder database")?
+        } else {
+            create_test_db(&db_path)?
+        };
         let p2p_port = node_config.network.port;
 
         let accept_validity_transactions = config.enable_experimental_validity_transactions;
         let node_builder = NodeBuilder::new(node_config.clone())
             .with_database(db)
             .with_launch_context(runtime.clone())
-            .with_types::<BaseNode>()
-            .with_components(
-                base_node
-                    .components()
-                    .pool(pool_component(&rollup_args))
-                    .payload(
-                        MultiplexingServiceBuilder::new(builder_config)
-                            .with_cutover_enabled(config.payload_builder_cutover),
-                    ),
-            )
-            .with_add_ons(addons)
-            .on_component_initialized(move |_ctx| Ok(()))
-            // Register the builder API RPC module (base_insertValidatedTransaction)
-            .extend_rpc_modules(move |ctx| {
-                let api = BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
-                    ctx.pool().clone(),
-                    accept_validity_transactions,
-                    DEFAULT_MAX_VALIDITY_PREDICATES,
-                );
-                ctx.modules.merge_configured(api.into_rpc())?;
-                Ok(())
-            });
+            .with_types::<BaseNode>();
 
-        let NodeHandle { node: node_handle, node_exit_future } = config
+        let launched = config
             .extra_extensions
             .into_iter()
             .fold(NodeHooks::new(), |hooks, ext| ext.apply(hooks))
-            .apply_to(node_builder)
+            .apply_to(
+                node_builder
+                    .with_components(
+                        base_node.components().pool(pool_component(&rollup_args)).payload(
+                            MultiplexingServiceBuilder::new(builder_config)
+                                .with_cutover_enabled(config.payload_builder_cutover),
+                        ),
+                    )
+                    .with_add_ons(addons)
+                    .on_component_initialized(move |_ctx| Ok(()))
+                    .extend_rpc_modules(move |ctx| {
+                        let api = BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
+                            ctx.pool().clone(),
+                            accept_validity_transactions,
+                            DEFAULT_MAX_VALIDITY_PREDICATES,
+                        );
+                        ctx.modules.merge_configured(api.into_rpc())?;
+                        Ok(())
+                    }),
+            )
             .launch()
-            .await
-            .wrap_err("Failed to launch builder node")?;
+            .await;
+
+        let NodeHandle { node: node_handle, node_exit_future } =
+            launched.wrap_err("Failed to launch builder node")?;
 
         let http_api_addr = node_handle
             .rpc_server_handle()
@@ -202,13 +234,30 @@ impl InProcessBuilder {
             http_api_addr,
             ws_api_addr,
             engine_addr,
+            metrics_addr,
             flashblocks_port: flashblocks_ws_addr.port(),
             p2p_port,
             data_dir: data_path,
             _node_exit_future: node_exit_future,
             _node: Box::new(node_handle),
             _runtime: runtime,
+            _temp_dir: temp_dir,
         })
+    }
+
+    fn prepare_datadir(datadir: Option<PathBuf>) -> Result<(PathBuf, Option<TempDir>)> {
+        if let Some(path) = datadir {
+            eyre::ensure!(path.is_dir(), "caller-owned builder datadir does not exist");
+            eyre::ensure!(
+                path.join("db/mdbx.dat").is_file(),
+                "caller-owned builder datadir does not contain an existing database"
+            );
+            return Ok((path, None));
+        }
+
+        let temp_dir = TempDir::new().wrap_err("Failed to create temporary builder datadir")?;
+        let path = temp_dir.path().into();
+        Ok((path, Some(temp_dir)))
     }
 
     /// Returns the HTTP RPC URL (`localhost:actual_port`).
@@ -231,9 +280,41 @@ impl InProcessBuilder {
         format!("ws://127.0.0.1:{}/", self.flashblocks_port)
     }
 
+    /// Returns the Prometheus metrics URL.
+    pub fn metrics_url(&self) -> Result<Url> {
+        Url::parse(&format!("http://{}/metrics", self.metrics_addr))
+            .wrap_err("Failed to parse metrics URL")
+    }
+
     /// Returns the P2P enode URL with actual bound port.
     pub fn p2p_enode(&self) -> String {
         format!("enode://{BUILDER_ENODE_ID}@127.0.0.1:{}", self.p2p_port)
+    }
+
+    /// Returns the execution datadir used by this builder.
+    pub fn datadir(&self) -> &std::path::Path {
+        &self.data_dir
+    }
+
+    /// Requests graceful node shutdown before releasing the private runtime.
+    pub async fn shutdown(self) -> Result<()> {
+        let shutdown = self
+            ._runtime
+            .initiate_graceful_shutdown()
+            .map_err(|_| eyre!("builder runtime shutdown channel closed"))?;
+        shutdown.ignore_guard().await;
+        match tokio::time::timeout(Duration::from_secs(60), self._node_exit_future).await {
+            Ok(result) => result?,
+            Err(error) => {
+                warn!(error = %error, "forcing builder runtime shutdown after graceful timeout");
+            }
+        }
+        drop(self._node);
+        let runtime = self._runtime;
+        tokio::task::spawn_blocking(move || drop(runtime))
+            .await
+            .wrap_err("failed to release builder runtime")?;
+        Ok(())
     }
 
     /// Returns the Engine URL for Docker containers using testcontainers host port exposure.
@@ -280,12 +361,6 @@ fn clear_otel_env_vars() {
         // SAFETY: We're in a test environment where env var mutation is acceptable
         unsafe { std::env::remove_var(key) };
     }
-}
-
-fn parse_genesis(genesis_json: &[u8]) -> Result<Arc<BaseChainSpec>> {
-    let genesis: alloy_genesis::Genesis =
-        serde_json::from_slice(genesis_json).wrap_err("Invalid genesis JSON")?;
-    Ok(Arc::new(BaseChainSpec::try_from_genesis(genesis).wrap_err("Invalid genesis chain spec")?))
 }
 
 fn create_node_config(
@@ -349,6 +424,23 @@ fn create_node_config(
         .with_rpc(rpc)
         .with_network(network);
 
+    if let Some(persistence_threshold) = config.persistence_threshold {
+        node_config.engine.persistence_threshold = persistence_threshold;
+    }
+    if let Some(max_transactions) = config.txpool_max_transactions {
+        node_config.txpool.pending_max_count = max_transactions;
+        node_config.txpool.basefee_max_count = max_transactions;
+        node_config.txpool.queued_max_count = max_transactions;
+    }
+    if let Some(max_size_mb) = config.txpool_max_size_mb {
+        node_config.txpool.pending_max_size = max_size_mb;
+        node_config.txpool.basefee_max_size = max_size_mb;
+        node_config.txpool.queued_max_size = max_size_mb;
+    }
+    if let Some(max_account_slots) = config.txpool_max_account_slots {
+        node_config.txpool.max_account_slots = max_account_slots;
+    }
+
     if config.http_port.is_none()
         && config.ws_port.is_none()
         && config.auth_port.is_none()
@@ -360,12 +452,11 @@ fn create_node_config(
     Ok(node_config)
 }
 
-fn create_test_db(data_path: &std::path::Path) -> Result<(DatabaseEnv, PathBuf)> {
-    let db_path = data_path.join("db");
-    std::fs::create_dir_all(&db_path).wrap_err("Failed to create db directory")?;
+fn create_test_db(db_path: &std::path::Path) -> Result<DatabaseEnv> {
+    std::fs::create_dir_all(db_path).wrap_err("Failed to create db directory")?;
 
     let db = init_db(
-        db_path.as_path(),
+        db_path,
         DatabaseArguments::new(ClientVersion::default())
             .with_max_read_transaction_duration(Some(MaxReadTransactionDuration::Unbounded))
             .with_geometry_max_size(Some(4 * MEGABYTE))
@@ -373,9 +464,53 @@ fn create_test_db(data_path: &std::path::Path) -> Result<(DatabaseEnv, PathBuf)>
     )
     .wrap_err("Failed to initialize database")?;
 
-    Ok((db, db_path))
+    Ok(db)
 }
 
 fn pool_component(_rollup_args: &RollupArgs) -> BasePoolBuilder<BasePooledTransaction> {
     BasePoolBuilder::<BasePooledTransaction>::default()
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::InProcessBuilder;
+
+    #[test]
+    fn retains_caller_owned_datadir() {
+        let parent = TempDir::new().unwrap();
+        let datadir = parent.path().join("builder");
+        std::fs::create_dir_all(datadir.join("db")).unwrap();
+        std::fs::write(datadir.join("db/mdbx.dat"), []).unwrap();
+        let sentinel = datadir.join("caller-owned");
+        std::fs::write(&sentinel, []).unwrap();
+
+        let (actual, owner) = InProcessBuilder::prepare_datadir(Some(datadir.clone())).unwrap();
+        assert_eq!(actual, datadir);
+        assert!(owner.is_none());
+        drop(owner);
+
+        assert!(sentinel.exists());
+    }
+
+    #[test]
+    fn rejects_empty_caller_owned_datadir() {
+        let datadir = TempDir::new().unwrap();
+
+        let error = InProcessBuilder::prepare_datadir(Some(datadir.path().to_path_buf()))
+            .expect_err("empty caller-owned datadir should be rejected");
+
+        assert!(error.to_string().contains("does not contain an existing database"));
+    }
+
+    #[test]
+    fn removes_temporary_datadir() {
+        let (datadir, owner) = InProcessBuilder::prepare_datadir(None).unwrap();
+        assert!(datadir.exists());
+
+        drop(owner);
+
+        assert!(!datadir.exists());
+    }
 }

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -2,10 +2,11 @@
 //!
 //! Replaces Docker-based `ClientContainer` with an in-process node for faster tests.
 
-use std::{any::Any, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{any::Any, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use alloy_primitives::hex::ToHexExt;
 use alloy_rpc_types_engine::JwtSecret;
+use base_builder_core::test_utils::get_available_port;
 use base_bundle_extension::BundleExtension;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_cli::{
@@ -20,30 +21,43 @@ use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
 use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 use eyre::{Context, Result, eyre};
-use reth_db::{
-    ClientVersion, DatabaseEnv, init_db, mdbx::DatabaseArguments, test_utils::tempdir_path,
-};
+use reth_db::{ClientVersion, DatabaseEnv, init_db, mdbx::DatabaseArguments};
 use reth_node_builder::{Node, NodeBuilder, NodeConfig, NodeHandle};
 use reth_node_core::{
-    args::{DatadirArgs, DiscoveryArgs, NetworkArgs, RpcServerArgs},
+    args::{DatadirArgs, DiscoveryArgs, MetricArgs, NetworkArgs, RpcServerArgs},
     dirs::{DataDirPath, MaybePlatformPath},
     exit::NodeExitFuture,
 };
 use reth_provider::providers::BlockchainProvider;
-use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig};
+use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig, TokioConfig};
+use tempfile::TempDir;
+use tracing::warn;
 use url::Url;
+
+type BuiltExtensions = (Vec<Box<dyn BaseNodeExtension>>, Option<FlashblocksConfig>);
+
+/// Source for the chain spec used to start an in-process client node.
+#[derive(Debug, Clone)]
+pub enum ChainSpecSource {
+    /// Parse the chain spec from L2 genesis JSON content.
+    GenesisJson(Vec<u8>),
+    /// Use a pre-built chain specification.
+    Parsed(Arc<BaseChainSpec>),
+}
 
 /// Configuration for starting an in-process client node.
 #[derive(Debug)]
 pub struct InProcessClientConfig {
-    /// L2 genesis JSON content.
-    pub genesis_json: Vec<u8>,
+    /// Chain specification source.
+    pub chain_spec: ChainSpecSource,
+    /// Existing caller-owned datadir. A temporary datadir is created when omitted.
+    pub datadir: Option<PathBuf>,
     /// JWT secret for Engine API authentication.
     pub jwt_secret: JwtSecret,
     /// Builder HTTP RPC URL for rollup.sequencer.
     pub builder_rpc_url: String,
-    /// Builder flashblocks WebSocket URL.
-    pub builder_flashblocks_url: String,
+    /// Optional builder Flashblocks WebSocket URL.
+    pub builder_flashblocks_url: Option<String>,
     /// Builder P2P enode for trusted-peers.
     pub builder_p2p_enode: String,
     /// Optional fixed HTTP RPC port (uses random if None).
@@ -54,6 +68,10 @@ pub struct InProcessClientConfig {
     pub auth_port: Option<u16>,
     /// Optional fixed P2P port (uses random if None).
     pub p2p_port: Option<u16>,
+    /// Optional fixed Prometheus metrics port (uses random if None).
+    pub metrics_port: Option<u16>,
+    /// Optional canonical block persistence threshold.
+    pub persistence_threshold: Option<u64>,
     /// Optional transaction forwarding configuration.
     /// When set, the client will forward transactions to builder RPC endpoints.
     pub tx_forwarding_config: Option<TxForwardingConfig>,
@@ -80,18 +98,13 @@ pub struct InProcessClient {
     http_api_addr: SocketAddr,
     ws_api_addr: SocketAddr,
     engine_addr: SocketAddr,
+    metrics_addr: SocketAddr,
     chain_spec: Arc<BaseChainSpec>,
     _node_exit_future: NodeExitFuture,
     _node: Box<dyn Any + Sync + Send>,
     _runtime: Runtime,
-    _db_path: PathBuf,
-}
-
-impl Drop for InProcessClient {
-    fn drop(&mut self) {
-        // Clean up the temporary database directory
-        let _ = std::fs::remove_dir_all(&self._db_path);
-    }
+    data_dir: PathBuf,
+    _temp_dir: Option<TempDir>,
 }
 
 impl std::fmt::Debug for InProcessClient {
@@ -100,6 +113,7 @@ impl std::fmt::Debug for InProcessClient {
             .field("http_api_addr", &self.http_api_addr)
             .field("ws_api_addr", &self.ws_api_addr)
             .field("engine_addr", &self.engine_addr)
+            .field("metrics_addr", &self.metrics_addr)
             .finish_non_exhaustive()
     }
 }
@@ -107,27 +121,43 @@ impl std::fmt::Debug for InProcessClient {
 impl InProcessClient {
     /// Starts an in-process client node with the provided configuration.
     pub async fn start(config: InProcessClientConfig) -> Result<Self> {
-        let runtime = RuntimeBuilder::new(RuntimeConfig::default()).build()?;
+        eyre::ensure!(
+            config.upgrade_signal.is_none()
+                || matches!(&config.chain_spec, ChainSpecSource::GenesisJson(_)),
+            "upgrade_signal requires GenesisJson chain spec source"
+        );
 
-        // Parse genesis JSON to chain spec
-        let genesis: alloy_genesis::Genesis = serde_json::from_slice(&config.genesis_json)
-            .map_err(|e| eyre!("Failed to parse genesis JSON: {}", e))?;
-        let mut chain_spec =
-            BaseChainSpec::try_from_genesis(genesis).wrap_err("Invalid genesis chain spec")?;
+        let (data_dir, temp_dir) = Self::prepare_datadir(config.datadir.clone())?;
+        let runtime = RuntimeBuilder::new(
+            RuntimeConfig::default()
+                .with_tokio(TokioConfig::existing_handle(tokio::runtime::Handle::current())),
+        )
+        .build()?;
 
-        // Mirror the standalone execution CLI: apply the L1 upgrade signal schedule to the
-        // chain spec before startup when the configured mode applies at startup.
-        if let Some(signal_config) = &config.upgrade_signal
-            && signal_config.signal_config.mode.applies_at_startup()
-        {
-            ExecutionUpgradeSignal::apply_initial_signal_to_chain_spec(
-                signal_config,
-                &mut chain_spec,
-            )
-            .await
-            .wrap_err("Failed to apply upgrade signal to client chain spec")?;
-        }
-        let chain_spec = Arc::new(chain_spec);
+        let chain_spec = match &config.chain_spec {
+            ChainSpecSource::Parsed(chain_spec) => Arc::clone(chain_spec),
+            ChainSpecSource::GenesisJson(genesis_json) => {
+                let genesis: alloy_genesis::Genesis = serde_json::from_slice(genesis_json)
+                    .map_err(|e| eyre!("Failed to parse genesis JSON: {}", e))?;
+                let mut chain_spec = BaseChainSpec::try_from_genesis(genesis)
+                    .wrap_err("Invalid genesis chain spec")?;
+
+                // Mirror the standalone execution CLI: apply the L1 upgrade signal schedule to
+                // the chain spec before startup when the configured mode applies at startup.
+                if let Some(signal_config) = &config.upgrade_signal
+                    && signal_config.signal_config.mode.applies_at_startup()
+                {
+                    ExecutionUpgradeSignal::apply_initial_signal_to_chain_spec(
+                        signal_config,
+                        &mut chain_spec,
+                    )
+                    .await
+                    .wrap_err("Failed to apply upgrade signal to client chain spec")?;
+                }
+
+                Arc::new(chain_spec)
+            }
+        };
 
         let mut network_config = NetworkArgs {
             discovery: DiscoveryArgs { disable_discovery: true, ..DiscoveryArgs::default() },
@@ -138,8 +168,8 @@ impl InProcessClient {
             network_config.port = port;
         }
 
-        let (db, db_path) = Self::create_test_database()?;
-        let jwt_path = db_path.join("jwt.hex");
+        std::fs::create_dir_all(&data_dir).wrap_err("Failed to create client datadir")?;
+        let jwt_path = data_dir.join("jwt.hex");
         std::fs::write(&jwt_path, config.jwt_secret.as_bytes().encode_hex().as_bytes())
             .wrap_err("Failed to write JWT secret")?;
 
@@ -178,7 +208,11 @@ impl InProcessClient {
         let mut node_config = NodeConfig::new(Arc::clone(&chain_spec))
             .with_network(network_config)
             .with_rpc(rpc_args);
-
+        let metrics_addr = SocketAddr::new(
+            std::net::Ipv4Addr::LOCALHOST.into(),
+            config.metrics_port.unwrap_or_else(get_available_port),
+        );
+        node_config.metrics = MetricArgs { prometheus: Some(metrics_addr), ..Default::default() };
         if config.http_port.is_none()
             && config.ws_port.is_none()
             && config.auth_port.is_none()
@@ -186,10 +220,21 @@ impl InProcessClient {
         {
             node_config = node_config.with_unused_ports();
         }
+        if let Some(persistence_threshold) = config.persistence_threshold {
+            node_config.engine.persistence_threshold = persistence_threshold;
+        }
 
-        let datadir_path = MaybePlatformPath::<DataDirPath>::from(db_path.clone());
+        let datadir_path = MaybePlatformPath::<DataDirPath>::from(data_dir.clone());
         node_config = node_config
             .with_datadir_args(DatadirArgs { datadir: datadir_path, ..Default::default() });
+
+        let db_path = node_config.datadir().db();
+        let db = if config.datadir.is_some() {
+            init_db(db_path, node_config.db.database_args())
+                .wrap_err("Failed to open client database")?
+        } else {
+            Self::create_test_database(&db_path)?
+        };
 
         let builder = NodeBuilder::new(node_config.clone())
             .with_database(db)
@@ -204,7 +249,7 @@ impl InProcessClient {
         // Flashblocks extension must be installed last: it uses `replace_configured`, which
         // overwrites RPC methods (e.g. `eth_getTransactionCount`, `eth_subscribe`) that
         // built-in and caller-supplied extensions alike may register.
-        extensions.push(Box::new(FlashblocksExtension::new(Some(flashblocks_config))));
+        extensions.push(Box::new(FlashblocksExtension::new(flashblocks_config)));
         let NodeHandle { node: node_handle, node_exit_future } = extensions
             .into_iter()
             .fold(NodeHooks::new(), |b, ext| ext.apply(b))
@@ -228,11 +273,13 @@ impl InProcessClient {
             http_api_addr,
             ws_api_addr,
             engine_addr,
+            metrics_addr,
             chain_spec,
             _node_exit_future: node_exit_future,
             _node: Box::new(node_handle),
             _runtime: runtime,
-            _db_path: db_path,
+            data_dir,
+            _temp_dir: temp_dir,
         })
     }
 
@@ -240,6 +287,21 @@ impl InProcessClient {
     /// schedule applied at startup.
     pub const fn chain_spec(&self) -> &Arc<BaseChainSpec> {
         &self.chain_spec
+    }
+
+    fn prepare_datadir(datadir: Option<PathBuf>) -> Result<(PathBuf, Option<TempDir>)> {
+        if let Some(path) = datadir {
+            eyre::ensure!(path.is_dir(), "caller-owned client datadir does not exist");
+            eyre::ensure!(
+                path.join("db/mdbx.dat").is_file(),
+                "caller-owned client datadir does not contain an existing database"
+            );
+            return Ok((path, None));
+        }
+
+        let temp_dir = TempDir::new().wrap_err("Failed to create temporary client datadir")?;
+        let path = temp_dir.path().into();
+        Ok((path, Some(temp_dir)))
     }
 
     /// Returns the HTTP RPC URL for the client.
@@ -262,6 +324,38 @@ impl InProcessClient {
             .map_err(|e| eyre!("Failed to build Engine URL: {}", e))
     }
 
+    /// Returns the Prometheus metrics URL.
+    pub fn metrics_url(&self) -> Result<Url> {
+        Url::parse(&format!("http://{}/metrics", self.metrics_addr))
+            .map_err(|e| eyre!("Failed to build metrics URL: {}", e))
+    }
+
+    /// Returns the execution datadir used by this client.
+    pub fn datadir(&self) -> &std::path::Path {
+        &self.data_dir
+    }
+
+    /// Requests graceful node shutdown before releasing the private runtime.
+    pub async fn shutdown(self) -> Result<()> {
+        let shutdown = self
+            ._runtime
+            .initiate_graceful_shutdown()
+            .map_err(|_| eyre!("client runtime shutdown channel closed"))?;
+        shutdown.ignore_guard().await;
+        match tokio::time::timeout(Duration::from_secs(60), self._node_exit_future).await {
+            Ok(result) => result?,
+            Err(error) => {
+                warn!(error = %error, "forcing client runtime shutdown after graceful timeout");
+            }
+        }
+        drop(self._node);
+        let runtime = self._runtime;
+        tokio::task::spawn_blocking(move || drop(runtime))
+            .await
+            .wrap_err("failed to release client runtime")?;
+        Ok(())
+    }
+
     /// Returns the Engine API URL for Docker containers using testcontainers host port exposure.
     pub fn host_engine_url(&self) -> String {
         format!("http://{}:{}", crate::host::host_address(), self.engine_addr.port())
@@ -273,30 +367,31 @@ impl InProcessClient {
     }
 
     /// Creates a test database with a 100 MB map size.
-    fn create_test_database() -> Result<(DatabaseEnv, PathBuf)> {
-        let path = tempdir_path();
+    fn create_test_database(path: &std::path::Path) -> Result<DatabaseEnv> {
+        std::fs::create_dir_all(path).wrap_err("Failed to create client database directory")?;
         let args = DatabaseArguments::new(ClientVersion::default())
             .with_geometry_max_size(Some(100 * 1024 * 1024));
-        let db = init_db(&path, args).expect("Failed to create test database");
-        Ok((db, path))
+        init_db(path, args).wrap_err("Failed to create test database")
     }
 
     /// Builds the client node's built-in extensions, excluding [`FlashblocksExtension`].
     ///
     /// [`FlashblocksExtension`] must be installed last (see [`Self::start`]), since it uses
     /// `replace_configured` to overwrite RPC methods that other extensions may register.
-    fn build_extensions(
-        config: &InProcessClientConfig,
-    ) -> Result<(Vec<Box<dyn BaseNodeExtension>>, FlashblocksConfig)> {
+    fn build_extensions(config: &InProcessClientConfig) -> Result<BuiltExtensions> {
         let mut extensions: Vec<Box<dyn BaseNodeExtension>> = Vec::new();
 
         // TxPool extension (tracing disabled for client)
-        let flashblocks_url: Url = config
+        let flashblocks_config = config
             .builder_flashblocks_url
-            .parse()
-            .map_err(|e| eyre!("Failed to parse flashblocks URL: {}", e))?;
-
-        let flashblocks_config = FlashblocksConfig::new(flashblocks_url, 3);
+            .as_ref()
+            .map(|value| {
+                value
+                    .parse::<Url>()
+                    .map(|url| FlashblocksConfig::new(url, 3))
+                    .map_err(|e| eyre!("Failed to parse flashblocks URL: {}", e))
+            })
+            .transpose()?;
 
         // TxPool RPC extension (management + status APIs)
         let txpool_rpc_config =
@@ -311,7 +406,7 @@ impl InProcessClient {
             tracing_enabled: false,
             tracing_logs_enabled: false,
             transaction_event_node_role: None,
-            flashblocks_config: Some(flashblocks_config.clone()),
+            flashblocks_config: flashblocks_config.clone(),
         };
         extensions.push(Box::new(TxPoolExtension::new(txpool_config)));
 
@@ -336,5 +431,22 @@ impl InProcessClient {
         }
 
         Ok((extensions, flashblocks_config))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::InProcessClient;
+
+    #[test]
+    fn rejects_empty_caller_owned_datadir() {
+        let datadir = TempDir::new().unwrap();
+
+        let error = InProcessClient::prepare_datadir(Some(datadir.path().to_path_buf()))
+            .expect_err("empty caller-owned datadir should be rejected");
+
+        assert!(error.to_string().contains("does not contain an existing database"));
     }
 }

--- a/etc/systems/src/l2/mod.rs
+++ b/etc/systems/src/l2/mod.rs
@@ -10,7 +10,7 @@ mod in_process_builder;
 pub use in_process_builder::{InProcessBuilder, InProcessBuilderConfig};
 
 mod in_process_client;
-pub use in_process_client::{InProcessClient, InProcessClientConfig};
+pub use in_process_client::{ChainSpecSource, InProcessClient, InProcessClientConfig};
 
 mod in_process_consensus;
 pub use in_process_consensus::{InProcessConsensus, InProcessConsensusConfig};

--- a/etc/systems/src/l2/shadow_sequencer.rs
+++ b/etc/systems/src/l2/shadow_sequencer.rs
@@ -15,7 +15,7 @@
 //! the next cycle. Accepting the canonical gossip requires the shadow's
 //! `unsafe_block_signer` to match the active sequencer's address.
 
-use std::num::NonZeroU64;
+use std::{num::NonZeroU64, time::Duration};
 
 use alloy_genesis::ChainConfig;
 use alloy_primitives::{Address, B256};
@@ -80,17 +80,26 @@ impl ShadowSequencer {
     /// address so it accepts the canonical payloads gossiped by the active
     /// sequencer. Those buffered canonical payloads drive reconciliation.
     pub async fn start(config: ShadowSequencerConfig) -> Result<Self> {
+        let chain_spec = InProcessBuilderConfig::chain_spec_from_genesis_json(&config.l2_genesis)
+            .wrap_err("Failed to parse shadow builder L2 chain spec")?;
         let builder = InProcessBuilder::start(InProcessBuilderConfig {
-            genesis_json: config.l2_genesis,
+            chain_spec,
+            datadir: None,
             jwt_secret: config.jwt_secret,
             http_port: None,
             ws_port: None,
             auth_port: None,
             p2p_port: None,
             flashblocks_port: None,
+            metrics_port: None,
             enable_experimental_validity_transactions: false,
             payload_builder_cutover: false,
             extra_extensions: Vec::new(),
+            block_time: Duration::from_secs(config.rollup_config.block_time),
+            persistence_threshold: None,
+            txpool_max_transactions: None,
+            txpool_max_size_mb: None,
+            txpool_max_account_slots: None,
         })
         .await
         .wrap_err("Failed to start shadow builder")?;

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -6,7 +6,7 @@
 //! - Batcher (in-process, submits L2 transaction batches to L1)
 //! - Client execution layer (in-process, follows the L2 and builds pending state using Flashblocks)
 
-use std::{num::NonZeroU64, time::Duration};
+use std::{num::NonZeroU64, path::PathBuf, time::Duration};
 
 use alloy_consensus::SignableTransaction;
 use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
@@ -30,10 +30,10 @@ use tokio::time::{sleep, timeout};
 use url::Url;
 
 use super::{
-    InProcessBatcher, InProcessBatcherConfig, InProcessBuilder, InProcessBuilderConfig,
-    InProcessClient, InProcessClientConfig, InProcessConsensus, InProcessConsensusConfig,
-    InProcessFollowConsensus, InProcessFollowConsensusConfig, L2ContainerConfig, ShadowSequencer,
-    ShadowSequencerConfig,
+    ChainSpecSource, InProcessBatcher, InProcessBatcherConfig, InProcessBuilder,
+    InProcessBuilderConfig, InProcessClient, InProcessClientConfig, InProcessConsensus,
+    InProcessConsensusConfig, InProcessFollowConsensus, InProcessFollowConsensusConfig,
+    L2ContainerConfig, ShadowSequencer, ShadowSequencerConfig,
 };
 use crate::config::{ANVIL_ACCOUNT_1, BATCHER, SEQUENCER};
 
@@ -52,6 +52,10 @@ pub enum L2ClientConsensusMode {
 pub struct L2StackConfig {
     /// L2 genesis JSON content.
     pub l2_genesis: Vec<u8>,
+    /// Optional caller-owned builder datadir.
+    pub builder_datadir: Option<PathBuf>,
+    /// Optional caller-owned client datadir.
+    pub client_datadir: Option<PathBuf>,
     /// Rollup configuration JSON.
     pub rollup_config: Vec<u8>,
     /// L1 genesis JSON (for consensus chain spec).
@@ -191,20 +195,30 @@ impl L2Stack {
         }
         let l1_chain_config: ChainConfig = serde_json::from_slice(&config.l1_genesis)
             .wrap_err("Failed to parse L1 chain config")?;
+        let builder_chain_spec =
+            InProcessBuilderConfig::chain_spec_from_genesis_json(&config.l2_genesis)
+                .wrap_err("Failed to parse builder L2 chain spec")?;
 
         // 1. Start the builder (in-process EL).
         let builder_config = InProcessBuilderConfig {
-            genesis_json: config.l2_genesis.clone(),
+            chain_spec: builder_chain_spec,
+            datadir: config.builder_datadir,
             jwt_secret: config.jwt_secret,
             http_port: container_config.and_then(|c| c.builder_http_port),
             ws_port: container_config.and_then(|c| c.builder_ws_port),
             auth_port: container_config.and_then(|c| c.builder_auth_port),
             p2p_port: container_config.and_then(|c| c.builder_p2p_port),
             flashblocks_port: container_config.and_then(|c| c.builder_flashblocks_port),
+            metrics_port: None,
             enable_experimental_validity_transactions: config
                 .enable_experimental_validity_transactions,
             payload_builder_cutover: config.payload_builder_cutover,
             extra_extensions: config.extra_builder_extensions,
+            block_time: Duration::from_secs(rollup_config.block_time),
+            persistence_threshold: None,
+            txpool_max_transactions: None,
+            txpool_max_size_mb: None,
+            txpool_max_account_slots: None,
         };
         let builder = InProcessBuilder::start(builder_config)
             .await
@@ -272,15 +286,18 @@ impl L2Stack {
         };
 
         let client_config = InProcessClientConfig {
-            genesis_json: config.l2_genesis.clone(),
+            chain_spec: ChainSpecSource::GenesisJson(config.l2_genesis.clone()),
+            datadir: config.client_datadir,
             jwt_secret: config.jwt_secret,
             builder_rpc_url: builder.rpc_url()?.to_string(),
-            builder_flashblocks_url: builder.flashblocks_url(),
+            builder_flashblocks_url: Some(builder.flashblocks_url()),
             builder_p2p_enode: builder.p2p_enode(),
             http_port: container_config.and_then(|c| c.client_http_port),
             ws_port: container_config.and_then(|c| c.client_ws_port),
             auth_port: container_config.and_then(|c| c.client_auth_port),
             p2p_port: container_config.and_then(|c| c.client_p2p_port),
+            metrics_port: None,
+            persistence_threshold: None,
             tx_forwarding_config,
             enable_experimental_validity_transactions: config
                 .enable_experimental_validity_transactions,

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -47,11 +47,11 @@ pub use l1::{
 
 mod l2;
 pub use l2::{
-    InProcessBatcher, InProcessBatcherConfig, InProcessBuilder, InProcessBuilderConfig,
-    InProcessClient, InProcessClientConfig, InProcessConsensus, InProcessConsensusConfig,
-    InProcessFollowConsensus, InProcessFollowConsensusConfig, L2ClientConsensus,
-    L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig, ShadowSequencer,
-    ShadowSequencerConfig, ShadowSequencersConfig,
+    ChainSpecSource, InProcessBatcher, InProcessBatcherConfig, InProcessBuilder,
+    InProcessBuilderConfig, InProcessClient, InProcessClientConfig, InProcessConsensus,
+    InProcessConsensusConfig, InProcessFollowConsensus, InProcessFollowConsensusConfig,
+    L2ClientConsensus, L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig,
+    ShadowSequencer, ShadowSequencerConfig, ShadowSequencersConfig,
 };
 
 mod network;

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -680,6 +680,8 @@ impl SystemTestStackBuilder {
 
         let l2_config = L2StackConfig {
             l2_genesis: l2_genesis_bytes,
+            builder_datadir: None,
+            client_datadir: None,
             rollup_config: rollup_config_bytes,
             l1_genesis: l1_genesis_bytes,
             jwt_secret,


### PR DESCRIPTION
## Summary

Foundation PR for the snapshot devnet stack. Refactors the in-process L2 execution wrappers so they can be reused with caller-owned datadirs while preserving existing system-test behavior.

## Changes

- Let in-process builder/client use caller-owned datadirs or temporary datadirs.
- Add metrics URLs, datadir accessors, graceful shutdown, and runtime reuse support.
- Add configurable builder block time, persistence threshold, and txpool sizing knobs.
- Update existing L2 stack and shadow sequencer call sites to preserve current behavior.

## Verification

- cargo check -p base-system-tests --all-targets
- cargo test -p base-system-tests --lib