### PR TITLE
feat(shadow-indexer): emit ExEx producer timing metrics

### DIFF
--- a/crates/execution/shadow-indexer/src/exex.rs
+++ b/crates/execution/shadow-indexer/src/exex.rs
@@ -11,6 +11,8 @@ use reth_primitives_traits::{AlloyBlockHeader, RecoveredBlock};
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
+use crate::ShadowExExMetrics;
+
 /// Shadow indexer `ExEx` handler.
 #[derive(Debug)]
 pub struct ShadowIndexerExEx {
@@ -31,35 +33,40 @@ impl ShadowIndexerExEx {
     {
         while let Some(notification) = ctx.notifications.try_next().await? {
             let is_syncing = ctx.network().is_syncing();
-            let fully_processed = match &notification {
-                ExExNotification::ChainCommitted { new } => {
-                    debug!(
-                        target: "base::shadow-indexer",
-                        block_number = new.tip().header().number(),
-                        block_hash = ?new.tip().hash(),
-                        "Committed chain notification received"
-                    );
-                    self.resolve_canonical_heights(new).await?
-                }
-                ExExNotification::ChainReorged { old, new } => {
-                    info!(
-                        target: "base::shadow-indexer",
-                        old_block_number = old.tip().header().number(),
-                        old_block_hash = ?old.tip().hash(),
-                        new_block_number = new.tip().header().number(),
-                        new_block_hash = ?new.tip().hash(),
-                        "ChainReorged notification received"
-                    );
-                    self.handle_chain_reorged(old, new).await?
-                }
-                ExExNotification::ChainReverted { old } => {
-                    info!(
-                        target: "base::shadow-indexer",
-                        old_block_number = old.tip().header().number(),
-                        old_block_hash = ?old.tip().hash(),
-                        "ChainReverted notification received"
-                    );
-                    self.handle_chain_reverted(old).await?
+            let kind = Self::notification_kind(&notification);
+            let fully_processed = {
+                let _timer =
+                    base_metrics::timed!(ShadowExExMetrics::notification_duration_seconds(kind));
+                match &notification {
+                    ExExNotification::ChainCommitted { new } => {
+                        debug!(
+                            target: "base::shadow-indexer",
+                            block_number = new.tip().header().number(),
+                            block_hash = ?new.tip().hash(),
+                            "Committed chain notification received"
+                        );
+                        self.resolve_canonical_heights(new).await?
+                    }
+                    ExExNotification::ChainReorged { old, new } => {
+                        info!(
+                            target: "base::shadow-indexer",
+                            old_block_number = old.tip().header().number(),
+                            old_block_hash = ?old.tip().hash(),
+                            new_block_number = new.tip().header().number(),
+                            new_block_hash = ?new.tip().hash(),
+                            "ChainReorged notification received"
+                        );
+                        self.handle_chain_reorged(old, new).await?
+                    }
+                    ExExNotification::ChainReverted { old } => {
+                        info!(
+                            target: "base::shadow-indexer",
+                            old_block_number = old.tip().header().number(),
+                            old_block_hash = ?old.tip().hash(),
+                            "ChainReverted notification received"
+                        );
+                        self.handle_chain_reverted(old).await?
+                    }
                 }
             };
 
@@ -107,12 +114,22 @@ impl ShadowIndexerExEx {
         }
     }
 
+    const fn notification_kind(notification: &ExExNotification<BasePrimitives>) -> &'static str {
+        match notification {
+            ExExNotification::ChainCommitted { .. } => "committed",
+            ExExNotification::ChainReorged { .. } => "reorged",
+            ExExNotification::ChainReverted { .. } => "reverted",
+        }
+    }
+
     fn build_row(
         &self,
         block: &RecoveredBlock<BaseBlock>,
         receipts: &[BaseReceipt],
         canonical_hash: Option<Vec<u8>>,
     ) -> Result<ShadowBlockRow> {
+        let _timer = base_metrics::timed!(ShadowExExMetrics::build_row_duration_seconds());
+
         let number = i64::try_from(block.header().number()).map_err(|error| {
             eyre::eyre!("block number overflow for shadow indexer row: {error}")
         })?;
@@ -200,6 +217,8 @@ impl ShadowIndexerExEx {
     }
 
     async fn send_write(&self, write: ShadowWrite) -> Result<bool> {
+        let _timer = base_metrics::timed!(ShadowExExMetrics::send_blocked_seconds());
+
         match self.tx.send(write).await {
             Ok(()) => Ok(true),
             Err(error) => {

--- a/crates/execution/shadow-indexer/src/lib.rs
+++ b/crates/execution/shadow-indexer/src/lib.rs
@@ -7,7 +7,7 @@ mod exex;
 pub use exex::ShadowIndexerExEx;
 
 mod metrics;
-pub use metrics::ShadowWriterMetrics;
+pub use metrics::{ShadowExExMetrics, ShadowWriterMetrics};
 
 mod writer;
 pub use writer::ShadowWriter;

--- a/crates/execution/shadow-indexer/src/metrics.rs
+++ b/crates/execution/shadow-indexer/src/metrics.rs
@@ -1,4 +1,4 @@
-//! Backpressure and throughput metrics for the shadow indexer writer.
+//! Backpressure and throughput metrics for the shadow indexer writer and `ExEx`.
 
 base_metrics::define_metrics! {
     shadow_indexer.writer, struct = ShadowWriterMetrics,
@@ -17,4 +17,15 @@ base_metrics::define_metrics! {
     #[describe("Total flushes performed, labeled by trigger reason")]
     #[label(trigger)]
     flushes: counter,
+}
+
+base_metrics::define_metrics! {
+    shadow_indexer.exex, struct = ShadowExExMetrics,
+    #[describe("Duration in seconds to handle one ExEx notification, labeled by kind")]
+    #[label(kind)]
+    notification_duration_seconds: histogram,
+    #[describe("Duration in seconds to build one shadow block row (block clone + receipts copy)")]
+    build_row_duration_seconds: histogram,
+    #[describe("Duration in seconds spent awaiting the writer channel send (backpressure wait)")]
+    send_blocked_seconds: histogram,
 }


### PR DESCRIPTION
Adds ShadowExExMetrics (scope shadow_indexer.exex) with three histograms to localize where per-notification time is spent on the producer side, which reth's built-in exex_manager metrics do not cover:

- notification_duration_seconds{kind}: total handler time per notification
- build_row_duration_seconds: block clone + receipts copy cost
- send_blocked_seconds: time awaiting the writer channel send (backpressure wait)

Instrumented via base_metrics::timed! on the notification dispatch, build_row, and send_write, matching the existing writer-metrics and base ExEx conventions.