### PR TITLE
fix(precompiles): remove incomplete PrecompileProvider impl (Cantina #19 / BOP-606)

### DIFF
--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -1060,9 +1060,7 @@ impl Eip8130Executor {
                     let current_nonce = read.current();
                     NonceValidator::validate_sequence(tx, current_nonce, NonceMode::Inclusion)
                         .map_err(BaseTransactionError::eip8130)?;
-                    nonce_mgr
-                        .increment_from_read(read)
-                        .map_err(BaseTransactionError::eip8130)?;
+                    nonce_mgr.increment_from_read(read).map_err(BaseTransactionError::eip8130)?;
                     (current_nonce == 0, false)
                 };
 

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -1,17 +1,12 @@
-use alloc::string::String;
-
 use alloy_evm::precompiles::PrecompilesMap;
 use alloy_primitives::Address;
 use base_common_chains::BaseUpgradeExt;
 use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::StorageFeatures;
 use revm::{
-    context::Cfg,
-    context_interface::ContextTr,
-    handler::{EthPrecompiles, PrecompileProvider},
-    interpreter::{CallInputs, InterpreterResult},
+    handler::EthPrecompiles,
     precompile::{self, Precompiles, bn254, modexp, secp256r1},
-    primitives::{AddressSet, OnceLock, hardfork::SpecId},
+    primitives::{OnceLock, hardfork::SpecId},
 };
 
 use crate::{
@@ -20,7 +15,14 @@ use crate::{
     TxContext, UpgradeGatedStorageFeatures, bls12_381, bn254_pair,
 };
 
-/// Base precompile provider.
+/// Builder for the complete Base precompile set for a given [`BasePrecompileSpec`].
+///
+/// Call [`Self::install`] or [`Self::install_with_observer`] to obtain a
+/// [`PrecompilesMap`] that includes the dynamic fork-installed precompiles
+/// (`B20Factory`, `BerylLookup`, `PolicyRegistryPrecompile`, `ActivationRegistry`
+/// at Beryl+, plus `TxContext` and `NonceManager` at Cobalt+). Only the resulting
+/// [`PrecompilesMap`] implements [`revm::handler::PrecompileProvider`]; using
+/// this builder directly as a provider would silently omit the dynamic entries.
 #[derive(Debug, Clone)]
 pub struct BasePrecompiles<S = BaseUpgrade> {
     /// Inner precompile provider is the same as Ethereum's.
@@ -239,43 +241,6 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
     }
 }
 
-impl<CTX, S> PrecompileProvider<CTX> for BasePrecompiles<S>
-where
-    S: BasePrecompileSpec,
-    CTX: ContextTr<Cfg: Cfg<Spec = S>>,
-{
-    type Output = InterpreterResult;
-
-    #[inline]
-    fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool {
-        if spec == self.spec {
-            return false;
-        }
-        *self =
-            Self::new_with_spec(spec).with_activation_admin_address(self.activation_admin_address);
-        true
-    }
-
-    #[inline]
-    fn run(
-        &mut self,
-        context: &mut CTX,
-        inputs: &CallInputs,
-    ) -> Result<Option<Self::Output>, String> {
-        self.inner.run(context, inputs)
-    }
-
-    #[inline]
-    fn warm_addresses(&self) -> &AddressSet {
-        self.inner.warm_addresses()
-    }
-
-    #[inline]
-    fn contains(&self, address: &Address) -> bool {
-        self.inner.contains(address)
-    }
-}
-
 impl<S: BasePrecompileSpec> Default for BasePrecompiles<S> {
     fn default() -> Self {
         Self::new_with_spec(S::default_precompile_spec())
@@ -297,7 +262,7 @@ mod tests {
 
     use crate::{
         ActivationRegistryStorage, B20FactoryStorage, B20Variant, BasePrecompiles,
-        NonceManagerStorage, TxContextStorage, bls12_381, bn254_pair,
+        NonceManagerStorage, PolicyRegistryStorage, TxContextStorage, bls12_381, bn254_pair,
     };
 
     type TestPrecompiles = BasePrecompiles<BaseUpgrade>;
@@ -627,5 +592,24 @@ mod tests {
         let precompiles = BasePrecompiles::new_with_spec(spec).install();
 
         assert_eq!(precompiles.get(&NonceManagerStorage::ADDRESS).is_some(), expected);
+    }
+
+    /// Cantina #19 (BOP-606) trait-boundary regression: every fork-installed precompile
+    /// must be reachable through `.install()` on the `BasePrecompiles` builder. If a
+    /// future refactor reintroduces a partial provider that skips these entries, this
+    /// test fails.
+    #[test]
+    fn cobalt_install_exposes_every_fork_installed_precompile() {
+        let precompiles = BasePrecompiles::new_with_spec(BaseUpgrade::Cobalt).install();
+
+        assert!(precompiles.get(&B20FactoryStorage::ADDRESS).is_some());
+        assert!(precompiles.get(&PolicyRegistryStorage::ADDRESS).is_some());
+        assert!(precompiles.get(&ActivationRegistryStorage::ADDRESS).is_some());
+        assert!(precompiles.get(&TxContextStorage::ADDRESS).is_some());
+        assert!(precompiles.get(&NonceManagerStorage::ADDRESS).is_some());
+
+        let (token, _) =
+            B20Variant::Asset.compute_address(Address::repeat_byte(0x11), B256::repeat_byte(0x22));
+        assert!(precompiles.get(&token).is_some());
     }
 }


### PR DESCRIPTION
## Summary

- Removes `impl PrecompileProvider for BasePrecompiles` from `crates/common/precompiles/src/provider.rs`. `BasePrecompiles::new_with_spec` builds an inner `EthPrecompiles` holding only the static per-hardfork set; the dynamic fork-installed entries (`B20Factory`, `BerylLookup`, `PolicyRegistryPrecompile`, `ActivationRegistry` at Beryl+, plus `TxContext` and `NonceManager` at Cobalt+) are only injected by `install_with_observer`. The former trait impl silently omitted them.
- Retargets the struct doc to name `BasePrecompiles` a builder that must be finalized via `.install()` / `.install_with_observer()` → `PrecompilesMap` (which already `impl PrecompileProvider` upstream in `alloy_evm`).
- Adds a Cobalt boundary regression test `cobalt_install_exposes_every_fork_installed_precompile` that asserts all six fork-installed addresses are reachable via `.install()`.

First-party builders (`api/builder.rs::precompiles_for_node`, `zk/utils/precompiles/mod.rs::installed_precompiles`) already go through `.install_with_observer(...)`, so there is no runtime behavioral change — this is a Cantina-flagged Informational integration hazard.

Cantina finding #19 (severity Informational, reporter slowfi) — [link](https://cantina.xyz/code/3a3e0d24-1cb7-474c-87ef-f0ad2350b5c4/findings/19). Linear: [BOP-606](https://linear.app/coinbase/issue/BOP-606/cantina-19-direct-provider-use-can-omit-fork-installed-precompiles).

**Base:** stacked on top of #4748 (BOP-605); will auto-retarget to `main` once that merges. My change is independent — rebase onto `main` is trivial if reviewers prefer.

## Test plan

- [x] `cargo check -p base-common-precompiles -p base-common-evm -p base-proof-zk-utils --all-targets` — clean.
- [x] `cargo test -p base-common-precompiles` — 662 tests pass, including the new `cobalt_install_exposes_every_fork_installed_precompile`.
- [x] `cargo test -p base-common-evm` — 122 tests pass, including `build_base_installs_dynamic_beryl_precompiles` (end-to-end coverage that the builder still produces a complete provider).
- [x] `cargo clippy -p base-common-precompiles -p base-common-evm --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)