### PR TITLE
docs: disallow tautological tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,8 @@ Use structured tracing instead of interpolated strings. Always use key=value fie
 
 Keep unit tests colocated with their implementation. Do not introduce standalone `tests.rs` modules for unit tests; define tests in the same `.rs` implementation file/module inside a `#[cfg(test)] mod tests { ... }` block.
 
+Do not create tautological tests. Tests that merely restate the implementation without independently validating behavior are considered bad tests.
+
 `#[cfg(test)] mod tests { ... }` must always be placed at the end of the file, after all non-test code.
 
 Do not destructure a type into its fields with `let Self { .. } = self` (or similar `let T { .. } = value`) just to read fields. Access fields directly via `self.field` for readability.


### PR DESCRIPTION
## Summary

- document that tautological tests should not be created
- clarify that tests must independently validate behavior