### PR TITLE
feat(evm2): Implement Deposit Execution Semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,7 +3594,6 @@ dependencies = [
  "base-common-genesis",
  "base-common-l1-fees",
  "evm2",
- "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3591,9 +3591,11 @@ dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
  "base-common-consensus",
+ "base-common-evm",
  "base-common-genesis",
  "base-common-l1-fees",
  "evm2",
+ "revm",
 ]
 
 [[package]]

--- a/crates/common/evm2/Cargo.toml
+++ b/crates/common/evm2/Cargo.toml
@@ -25,6 +25,3 @@ evm2 = { workspace = true, features = ["std"] }
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
-
-# misc
-thiserror.workspace = true

--- a/crates/common/evm2/Cargo.toml
+++ b/crates/common/evm2/Cargo.toml
@@ -25,3 +25,17 @@ evm2 = { workspace = true, features = ["std"] }
 alloy-eips.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
+
+[dev-dependencies]
+# base — the revm execution path, for the differential deposit-parity harness
+base-common-genesis.workspace = true
+base-common-evm = { workspace = true, features = ["blst", "c-kzg", "portable", "secp256k1", "std"] }
+
+# evm2
+evm2 = { workspace = true, features = ["std"] }
+
+# revm
+revm = { workspace = true, features = ["std"] }
+
+# alloy
+alloy-primitives.workspace = true

--- a/crates/common/evm2/src/lib.rs
+++ b/crates/common/evm2/src/lib.rs
@@ -7,7 +7,6 @@ mod handler;
 pub use handler::BaseTxHandlerHooks;
 
 mod registry;
-pub use registry::CreateDepositUnsupported;
 
 mod types;
 pub use types::{BaseEvmExt, BaseEvmTypes, BaseTxResultExt};

--- a/crates/common/evm2/src/registry.rs
+++ b/crates/common/evm2/src/registry.rs
@@ -7,6 +7,7 @@ use evm2::{
     ethereum::{
         TxEnvelope, eip1559, eip2930, eip7702, execute_initial_frame, finalize_gas,
         initial_gas_and_reservoir, intrinsic_gas, legacy, prepare_initial_frame,
+        warm_base_accounts,
     },
     handler::GasSettlement,
     interpreter::{GasTracker, InstrStop},
@@ -80,6 +81,10 @@ impl BaseEvmTypes {
         if tx.is_system_transaction {
             return Ok(Self::failed_deposit(tx));
         }
+
+        // Pre-warm the sender, destination, coinbase, and precompiles, matching the standard
+        // transaction handlers so warm/cold (EIP-2929) access gas agrees with the reference.
+        warm_base_accounts(host, tx.from, tx.to);
 
         // Meter the deposit like a standard transaction: charge intrinsic gas up front, then
         // run the call/create frame with the remaining gas. A deposit that cannot afford its

--- a/crates/common/evm2/src/registry.rs
+++ b/crates/common/evm2/src/registry.rs
@@ -92,8 +92,24 @@ impl BaseEvmTypes {
             initial_gas_and_reservoir(host.version(), tx.gas_limit, intrinsic, 0);
         let mut tx_gas =
             GasTracker::new_with_execution_gas_and_reservoir(execution_gas_limit, reservoir);
-        let frame =
-            prepare_initial_frame(host, tx.from, nonce, tx.to, &tx.input, tx.value, &mut tx_gas)?;
+        // Deposits cannot fail fatally per the OP-stack spec (the revm reference catches every
+        // transaction-level error in `catch_error` and returns a failed deposit); only a database
+        // error is genuinely fatal. `prepare_initial_frame` only produces `Fatal` errors today,
+        // but matching on the variant future-proofs against evm2 introducing typed frame errors:
+        // a `Fatal` propagates, anything else settles as a failed deposit.
+        let frame = match prepare_initial_frame(
+            host,
+            tx.from,
+            nonce,
+            tx.to,
+            &tx.input,
+            tx.value,
+            &mut tx_gas,
+        ) {
+            Ok(frame) => frame,
+            Err(err @ HandlerError::Fatal(_)) => return Err(err),
+            Err(_) => return Ok(Self::failed_deposit(tx)),
+        };
         let tx_env = TxEnvExt {
             origin: tx.from,
             gas_price: U256::ZERO,
@@ -116,8 +132,11 @@ impl BaseEvmTypes {
         }
 
         // Success or revert: finalize gas like a standard transaction, but skip the fee charge
-        // and beneficiary reward (deposits are funded on L1).
-        finalize_gas(
+        // and beneficiary reward (deposits are funded on L1). As with prepare_initial_frame, a
+        // database error propagates as fatal while any other error settles as a failed deposit —
+        // deposits never fail fatally per the OP-stack spec. finalize_gas only surfaces `Fatal`
+        // errors today; the match makes the invariant explicit and future-proofs it.
+        match finalize_gas(
             host,
             GasSettlement {
                 caller: tx.from,
@@ -128,7 +147,11 @@ impl BaseEvmTypes {
                 state_refund: 0,
                 result,
             },
-        )
+        ) {
+            Ok(result) => Ok(result),
+            Err(err @ HandlerError::Fatal(_)) => Err(err),
+            Err(_) => Ok(Self::failed_deposit(tx)),
+        }
     }
 
     /// Credits a deposit's minted value to the sender and bumps its nonce, returning the
@@ -299,6 +322,38 @@ mod tests {
         let result = run(&mut evm, tx);
         assert!(!result.status);
         assert_eq!(result.total_gas_spent, gas_limit);
+        assert_eq!(balance(&mut evm, SENDER), U256::from(1_000));
+    }
+
+    #[test]
+    fn halted_call_deposit_rolls_back_value_transfer() {
+        // Deploy `INVALID` at the target so a call to it halts *after* the value transfer,
+        // exercising that the transfer is unwound (relied on for parity with the revm reference).
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            &TARGET,
+            evm2::AccountInfo {
+                code: Some(evm2::bytecode::Bytecode::new_legacy(Bytes::from_static(&[0xfe]))),
+                ..Default::default()
+            },
+        );
+        let mut evm = Evm::new(
+            SPEC,
+            BlockEnv::<BaseEvmTypes>::default(),
+            BaseEvmTypes::tx_registry(),
+            db,
+            Precompiles::base(SPEC),
+        );
+
+        let tx = deposit(TxKind::Call(TARGET), 1_000, U256::from(500), Bytes::new(), false);
+        let gas_limit = tx.gas_limit;
+        let result = run(&mut evm, tx);
+
+        assert!(!result.status);
+        assert_eq!(result.total_gas_spent, gas_limit);
+        // The value transfer was rolled back with the halted execution: the target keeps nothing,
+        // and the sender retains the full mint (value returned).
+        assert_eq!(balance(&mut evm, TARGET), U256::ZERO);
         assert_eq!(balance(&mut evm, SENDER), U256::from(1_000));
     }
 }

--- a/crates/common/evm2/src/registry.rs
+++ b/crates/common/evm2/src/registry.rs
@@ -1,11 +1,15 @@
 //! Base transaction registry.
 
-use alloy_primitives::TxKind;
+use alloy_primitives::U256;
 use evm2::{
-    TxResult,
+    Evm, TxResult,
     env::TxEnvExt,
-    ethereum::{TxEnvelope, eip1559, eip2930, eip7702, legacy},
-    interpreter::{Host, MessageExt},
+    ethereum::{
+        TxEnvelope, eip1559, eip2930, eip7702, execute_initial_frame, finalize_gas,
+        initial_gas_and_reservoir, intrinsic_gas, legacy, prepare_initial_frame,
+    },
+    handler::GasSettlement,
+    interpreter::{GasTracker, InstrStop},
     registry::{HandlerError, HandlerResult, TxRegistry, TxRequest},
 };
 
@@ -13,14 +17,6 @@ use crate::{
     BaseEvmTypes, BaseTxHandlerHooks,
     transaction::{BaseTxEnvelope, DEPOSIT_TX_TYPE, TxDeposit},
 };
-
-/// Error returned when a create-kind deposit transaction is encountered.
-///
-/// Create-kind deposits require contract-address derivation and a create message
-/// frame, which are follow-up work; until then they are rejected explicitly.
-#[derive(Debug, thiserror::Error)]
-#[error("create-kind deposit transactions are not yet supported")]
-pub struct CreateDepositUnsupported;
 
 impl BaseEvmTypes {
     /// Builds the Base transaction registry.
@@ -61,64 +57,165 @@ impl BaseEvmTypes {
         registry
     }
 
-    /// Executes a deposit transaction.
+    /// Executes a deposit transaction, mirroring the OP-stack deposit rules of the revm
+    /// execution path (`base-common-evm`), for which Base is always Regolith-active.
     ///
-    /// Deposits mint value on L2 and execute exempt from the L1 data fee and
-    /// standard gas payment. This currently runs the deposit as a plain call and
-    /// is the anchor for the remaining deposit semantics: crediting `mint`,
-    /// honoring `is_system_transaction`, resolving the destination's (possibly
-    /// delegated) code, and handling create-kind deposits.
+    /// The minted value is credited to the sender before execution and kept regardless of the
+    /// outcome. System-transaction deposits are rejected (post-Regolith) and settled as failed
+    /// deposits. Deposits are exempt from the L1 data fee, the operator fee, and the
+    /// beneficiary reward, so gas is finalized without charging any fee. A halted deposit is
+    /// charged the full gas limit — there is no L2 fee payer to refund — while a reverted
+    /// deposit reports its actual gas, like any transaction.
     pub fn handle_deposit(
         req: TxRequest<'_, '_, Self, TxDeposit>,
     ) -> HandlerResult<TxResult<Self>> {
-        let destination = match req.tx.to {
-            TxKind::Call(address) => address,
-            // Create-kind deposits require contract-address derivation and a create
-            // message frame (follow-up work). Reject explicitly rather than silently
-            // misrouting the call to the zero address.
-            TxKind::Create => return Err(HandlerError::external(CreateDepositUnsupported)),
+        let host = req.host;
+        let tx: &TxDeposit = *req.tx;
+
+        // Credit the mint and bump the sender nonce, capturing the pre-bump nonce for a create
+        // deposit's contract-address derivation.
+        let nonce = Self::prepare_deposit_sender(host, tx)?;
+
+        // System-transaction deposits are rejected post-Regolith (always active on Base).
+        if tx.is_system_transaction {
+            return Ok(Self::failed_deposit(tx));
+        }
+
+        // Meter the deposit like a standard transaction: charge intrinsic gas up front, then
+        // run the call/create frame with the remaining gas. A deposit that cannot afford its
+        // intrinsic cost is settled as a failed deposit.
+        let intrinsic = intrinsic_gas(host.version(), tx.from, tx.to, &tx.input, 0, 0, tx.value);
+        if tx.gas_limit < intrinsic {
+            return Ok(Self::failed_deposit(tx));
+        }
+        let (execution_gas_limit, reservoir) =
+            initial_gas_and_reservoir(host.version(), tx.gas_limit, intrinsic, 0);
+        let mut tx_gas =
+            GasTracker::new_with_execution_gas_and_reservoir(execution_gas_limit, reservoir);
+        let frame =
+            prepare_initial_frame(host, tx.from, nonce, tx.to, &tx.input, tx.value, &mut tx_gas)?;
+        let tx_env = TxEnvExt {
+            origin: tx.from,
+            gas_price: U256::ZERO,
+            chain_id: U256::from(host.version().chain_id),
+            ..TxEnvExt::default()
         };
-        // `mint` is not yet credited to the sender and `is_system_transaction`
-        // gas-metering exemption is not yet honored (both follow-up work, see the
-        // doc comment above). Guard against silently mis-executing a deposit that
-        // relies on either before support lands — these assertions catch unintended
-        // use in tests without changing release behavior for the currently
-        // exercised (mint-free, non-system) deposits.
-        debug_assert_eq!(req.tx.mint, 0, "deposit mint is not yet credited before execution");
-        debug_assert!(
-            !req.tx.is_system_transaction,
-            "system-transaction gas exemption is not yet honored"
+        let result = execute_initial_frame(
+            host,
+            &tx_env,
+            frame,
+            &mut tx_gas,
+            execution_gas_limit,
+            reservoir,
         );
-        let mut message = MessageExt {
-            gas_limit: req.tx.gas_limit,
-            destination,
-            caller: req.tx.from,
-            input: req.tx.input.clone(),
-            value: req.tx.value,
-            ..MessageExt::default()
-        };
-        let tx_env = TxEnvExt::default();
-        let result = req.host.execute_message(&tx_env, &mut message);
-        Ok(TxResult::<Self> {
-            status: result.stop.is_success(),
-            // TODO: this gas accounting is incomplete per the deposit
-            // rules and will be finished alongside mint/system-transaction support:
-            // system transactions (`is_system_transaction`) must report zero gas
-            // spent, and failed (reverted) deposits are charged the full
-            // `gas_limit` since there is no L2 fee payer to refund. Both directly
-            // feed receipt `gasUsed` and the state root, so this must be exact
-            // before the handler is wired into the node.
-            total_gas_spent: req.tx.gas_limit.saturating_sub(result.gas.remaining()),
-            stop: result.stop,
-            output: result.output,
+
+        // A halt has no L2 fee payer to refund, so it is charged the full gas limit. evm2 has
+        // already rolled back the execution state; the mint and nonce bump are retained.
+        if result.stop.is_halt() {
+            return Ok(Self::failed_deposit(tx));
+        }
+
+        // Success or revert: finalize gas like a standard transaction, but skip the fee charge
+        // and beneficiary reward (deposits are funded on L1).
+        finalize_gas(
+            host,
+            GasSettlement {
+                caller: tx.from,
+                gas_price: U256::ZERO,
+                gas_limit: tx.gas_limit,
+                floor_gas: 0,
+                initial_state_gas: 0,
+                state_refund: 0,
+                result,
+            },
+        )
+    }
+
+    /// Credits a deposit's minted value to the sender and bumps its nonce, returning the
+    /// sender's pre-bump nonce (used to derive a create deposit's contract address).
+    ///
+    /// The mint is added before execution and retained regardless of the deposit's outcome.
+    /// The nonce is bumped once here (mirroring the standard-transaction handlers; evm2 only
+    /// bumps automatically for nested creates).
+    pub fn prepare_deposit_sender(host: &mut Evm<'_, Self>, tx: &TxDeposit) -> HandlerResult<u64> {
+        let mut account = host.state_mut().account(&tx.from, false).map_err(HandlerError::Fatal)?;
+        account.add_balance(U256::from(tx.mint));
+        let nonce = account.nonce();
+        account.bump_nonce();
+        Ok(nonce)
+    }
+
+    /// Builds the result for a failed deposit: status `false`, the full gas limit charged, and
+    /// no output.
+    ///
+    /// The sender's mint and nonce bump are applied by
+    /// [`prepare_deposit_sender`](Self::prepare_deposit_sender) and any execution state has
+    /// already been rolled back, so only the result is assembled here. The halt reason is
+    /// reported uniformly as [`InstrStop::OutOfGas`] since the full gas limit is consumed.
+    pub fn failed_deposit(tx: &TxDeposit) -> TxResult<Self> {
+        TxResult::<Self> {
+            status: false,
+            total_gas_spent: tx.gas_limit,
+            stop: InstrStop::OutOfGas,
             ..Default::default()
-        })
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::transaction::Recovered;
+    use alloy_primitives::{Address, Bytes, TxKind, U256};
+    use evm2::{Evm, Precompiles, SpecId, env::BlockEnv, evm::InMemoryDB};
+
     use super::*;
+
+    const SENDER: Address = Address::repeat_byte(0x11);
+    const TARGET: Address = Address::repeat_byte(0x22);
+    const SPEC: SpecId = SpecId::OSAKA;
+
+    /// Builds an in-memory EVM wired with the Base transaction registry.
+    fn new_evm() -> Evm<'static, BaseEvmTypes> {
+        Evm::new(
+            SPEC,
+            BlockEnv::<BaseEvmTypes>::default(),
+            BaseEvmTypes::tx_registry(),
+            InMemoryDB::default(),
+            Precompiles::base(SPEC),
+        )
+    }
+
+    /// Builds a deposit with the shared `SENDER`, a 100k gas limit, and the given fields.
+    fn deposit(to: TxKind, mint: u128, value: U256, input: Bytes, is_system: bool) -> TxDeposit {
+        TxDeposit {
+            from: SENDER,
+            to,
+            mint,
+            value,
+            gas_limit: 100_000,
+            input,
+            is_system_transaction: is_system,
+            ..Default::default()
+        }
+    }
+
+    /// Routes `tx` through the registry and commits the resulting state changes.
+    fn run(evm: &mut Evm<'static, BaseEvmTypes>, tx: TxDeposit) -> TxResult<BaseEvmTypes> {
+        let recovered = Recovered::new_unchecked(BaseTxEnvelope::Deposit(tx), SENDER);
+        evm.transact(&recovered).expect("deposit must not fatally error").commit()
+    }
+
+    fn balance(evm: &mut Evm<'static, BaseEvmTypes>, addr: Address) -> U256 {
+        evm.state_mut()
+            .account_info_untracked(&addr)
+            .unwrap()
+            .map(|i| i.balance)
+            .unwrap_or_default()
+    }
+
+    fn nonce(evm: &mut Evm<'static, BaseEvmTypes>, addr: Address) -> u64 {
+        evm.state_mut().account_info_untracked(&addr).unwrap().map(|i| i.nonce).unwrap_or_default()
+    }
 
     #[test]
     fn registry_registers_deposit_and_standard_handlers() {
@@ -130,5 +227,78 @@ mod tests {
             assert!(registry.contains(ty), "standard handler {ty} must be registered");
         }
         assert!(!registry.contains(3), "EIP-4844 blob handler must not be registered");
+    }
+
+    #[test]
+    fn mint_is_credited_and_nonce_bumped() {
+        let mut evm = new_evm();
+        let result =
+            run(&mut evm, deposit(TxKind::Call(TARGET), 1_000, U256::ZERO, Bytes::new(), false));
+        assert!(result.status);
+        assert_eq!(balance(&mut evm, SENDER), U256::from(1_000));
+        assert_eq!(nonce(&mut evm, SENDER), 1);
+    }
+
+    #[test]
+    fn value_is_transferred_to_target() {
+        let mut evm = new_evm();
+        let result = run(
+            &mut evm,
+            deposit(TxKind::Call(TARGET), 1_000, U256::from(300), Bytes::new(), false),
+        );
+        assert!(result.status);
+        assert_eq!(balance(&mut evm, SENDER), U256::from(700));
+        assert_eq!(balance(&mut evm, TARGET), U256::from(300));
+    }
+
+    #[test]
+    fn system_transaction_is_rejected_with_full_gas() {
+        let mut evm = new_evm();
+        let tx = deposit(TxKind::Call(TARGET), 1_000, U256::ZERO, Bytes::new(), true);
+        let gas_limit = tx.gas_limit;
+        let result = run(&mut evm, tx);
+        assert!(!result.status);
+        assert_eq!(result.total_gas_spent, gas_limit);
+        // The mint is credited and the nonce bumped even though execution is skipped.
+        assert_eq!(balance(&mut evm, SENDER), U256::from(1_000));
+        assert_eq!(nonce(&mut evm, SENDER), 1);
+    }
+
+    #[test]
+    fn create_deposit_deploys_contract() {
+        let mut evm = new_evm();
+        // Init code `STOP` deploys empty runtime code and succeeds.
+        let init = Bytes::from_static(&[0x00]);
+        let result = run(&mut evm, deposit(TxKind::Create, 1_000, U256::ZERO, init, false));
+        assert!(result.status);
+        assert_eq!(result.created_address, Some(SENDER.create(0)));
+        assert_eq!(nonce(&mut evm, SENDER), 1);
+    }
+
+    #[test]
+    fn reverted_deposit_reports_actual_gas_and_keeps_mint() {
+        let mut evm = new_evm();
+        // Init code `PUSH1 0, PUSH1 0, REVERT` reverts during contract creation.
+        let init = Bytes::from_static(&[0x60, 0x00, 0x60, 0x00, 0xfd]);
+        let tx = deposit(TxKind::Create, 1_000, U256::ZERO, init, false);
+        let gas_limit = tx.gas_limit;
+        let result = run(&mut evm, tx);
+        assert!(!result.status);
+        // A revert is metered like any transaction, not charged the full limit.
+        assert!(result.total_gas_spent < gas_limit);
+        assert_eq!(balance(&mut evm, SENDER), U256::from(1_000));
+    }
+
+    #[test]
+    fn halted_deposit_is_charged_full_gas_and_keeps_mint() {
+        let mut evm = new_evm();
+        // Init code `INVALID` halts during contract creation, consuming all gas.
+        let init = Bytes::from_static(&[0xfe]);
+        let tx = deposit(TxKind::Create, 1_000, U256::ZERO, init, false);
+        let gas_limit = tx.gas_limit;
+        let result = run(&mut evm, tx);
+        assert!(!result.status);
+        assert_eq!(result.total_gas_spent, gas_limit);
+        assert_eq!(balance(&mut evm, SENDER), U256::from(1_000));
     }
 }

--- a/crates/common/evm2/tests/deposit_parity.rs
+++ b/crates/common/evm2/tests/deposit_parity.rs
@@ -1,0 +1,328 @@
+//! Differential parity harness for deposit execution.
+//!
+//! Runs the same OP-stack deposit through the `base-common-evm2` handler and the revm-based
+//! `base-common-evm` reference, then asserts the two engines agree on the observable outcome:
+//! success, gas used, the created contract address, and the post-state (balance, nonce,
+//! code hash, and storage) of every account the fixture cares about.
+//!
+//! Both engines run at the same fork — evm2 [`SpecId::MERGE`] and revm
+//! [`BaseUpgrade::Regolith`] (which maps to `MERGE`) — so gas is comparable, and both take the
+//! same `base_common_consensus::TxDeposit` fields (shared thanks to the type dedup).
+
+use std::collections::BTreeMap;
+
+use alloy_consensus::transaction::Recovered;
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
+// revm reference side.
+use base_common_evm::{BaseSpecId, BaseTransaction, Builder, DefaultBase, L1BlockInfo};
+// evm2 side.
+use base_common_evm2::{BaseEvmTypes, BaseTxEnvelope, TxDeposit};
+use base_common_genesis::BaseUpgrade;
+use evm2::{
+    Evm, Precompiles, SpecId, bytecode::Bytecode as Evm2Bytecode, env::BlockEnv, evm::InMemoryDB,
+};
+use revm::{
+    ExecuteEvm,
+    bytecode::Bytecode as RevmBytecode,
+    context::{CfgEnv, Context, TxEnv},
+    context_interface::result::{ExecutionResult, Output, ResultAndState},
+    database::InMemoryDB as RevmDb,
+    primitives::TxKind as RevmTxKind,
+    state::AccountInfo as RevmAccountInfo,
+};
+
+const SENDER: Address = Address::repeat_byte(0x11);
+const SOURCE_HASH: B256 = B256::repeat_byte(0xab);
+
+/// An account to seed into both engines before execution.
+#[derive(Clone)]
+struct Seed {
+    address: Address,
+    balance: U256,
+    nonce: u64,
+    code: Vec<u8>,
+}
+
+/// A deposit scenario plus the accounts/slots whose post-state to compare.
+struct Fixture {
+    seed: Vec<Seed>,
+    to: TxKind,
+    mint: u128,
+    value: U256,
+    gas_limit: u64,
+    input: Vec<u8>,
+    is_system: bool,
+    /// Addresses (with the storage slots) whose post-state is compared across engines.
+    compare: Vec<(Address, Vec<U256>)>,
+}
+
+/// The normalized post-state of a single account.
+#[derive(Debug, PartialEq, Eq)]
+struct AccountState {
+    balance: U256,
+    nonce: u64,
+    code_hash: B256,
+    storage: BTreeMap<U256, U256>,
+}
+
+/// The normalized observable outcome of executing a deposit.
+#[derive(Debug, PartialEq, Eq)]
+struct Outcome {
+    success: bool,
+    gas_used: u64,
+    created: Option<Address>,
+    accounts: BTreeMap<Address, AccountState>,
+}
+
+/// Normalizes an empty/zero code hash to the canonical empty-code keccak so the two engines'
+/// representations of a code-less account compare equal.
+fn norm_code_hash(hash: B256) -> B256 {
+    if hash == B256::ZERO { keccak256([]) } else { hash }
+}
+
+/// Executes `fixture` through the evm2 deposit handler and captures its outcome.
+fn run_evm2(fixture: &Fixture) -> Outcome {
+    let mut db = InMemoryDB::default();
+    for seed in &fixture.seed {
+        let mut info =
+            evm2::AccountInfo { balance: seed.balance, nonce: seed.nonce, ..Default::default() };
+        if !seed.code.is_empty() {
+            info.code = Some(Evm2Bytecode::new_legacy(Bytes::from(seed.code.clone())));
+        }
+        db.insert_account_info(&seed.address, info);
+    }
+    let mut evm = Evm::new(
+        SpecId::MERGE,
+        BlockEnv::<BaseEvmTypes>::default(),
+        BaseEvmTypes::tx_registry(),
+        db,
+        Precompiles::base(SpecId::MERGE),
+    );
+
+    let tx = TxDeposit {
+        source_hash: SOURCE_HASH,
+        from: SENDER,
+        to: fixture.to,
+        mint: fixture.mint,
+        value: fixture.value,
+        gas_limit: fixture.gas_limit,
+        is_system_transaction: fixture.is_system,
+        input: Bytes::from(fixture.input.clone()),
+    };
+    let recovered = Recovered::new_unchecked(BaseTxEnvelope::Deposit(tx), SENDER);
+    let result = evm.transact(&recovered).expect("deposit must not fatally error").commit();
+
+    let mut accounts = BTreeMap::new();
+    for (address, slots) in &fixture.compare {
+        let info = evm.state_mut().account_info_untracked(address).unwrap().unwrap_or_default();
+        let mut storage = BTreeMap::new();
+        for slot in slots {
+            let value = evm.state_mut().storage_slot(address, *slot, false).unwrap().current();
+            storage.insert(*slot, value);
+        }
+        accounts.insert(
+            *address,
+            AccountState {
+                balance: info.balance,
+                nonce: info.nonce,
+                code_hash: norm_code_hash(info.code_hash),
+                storage,
+            },
+        );
+    }
+
+    Outcome {
+        success: result.status,
+        gas_used: result.tx_gas_used(),
+        created: result.created_address,
+        accounts,
+    }
+}
+
+/// Executes `fixture` through the revm-based `base-common-evm` reference and captures its outcome.
+fn run_revm(fixture: &Fixture) -> Outcome {
+    let mut db = RevmDb::default();
+    for seed in &fixture.seed {
+        let mut info =
+            RevmAccountInfo { balance: seed.balance, nonce: seed.nonce, ..Default::default() };
+        if !seed.code.is_empty() {
+            info.code = Some(RevmBytecode::new_legacy(Bytes::from(seed.code.clone())));
+        }
+        db.insert_account_info(seed.address, info);
+    }
+    let ctx = Context::base()
+        .with_db(db)
+        .with_chain(L1BlockInfo {
+            l2_block: Some(U256::ZERO),
+            operator_fee_scalar: Some(U256::ZERO),
+            operator_fee_constant: Some(U256::ZERO),
+            ..Default::default()
+        })
+        .with_cfg(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Regolith)));
+    let mut evm = ctx.build_base();
+
+    let kind = match fixture.to {
+        TxKind::Call(address) => RevmTxKind::Call(address),
+        TxKind::Create => RevmTxKind::Create,
+    };
+    let mut builder = BaseTransaction::builder()
+        .base(
+            TxEnv::builder()
+                .caller(SENDER)
+                .kind(kind)
+                .gas_limit(fixture.gas_limit)
+                .value(fixture.value)
+                .data(Bytes::from(fixture.input.clone())),
+        )
+        .source_hash(SOURCE_HASH)
+        .mint(fixture.mint);
+    if fixture.is_system {
+        builder = builder.is_system_transaction();
+    }
+    let tx = builder.build_fill();
+
+    let ResultAndState { result, state } = evm.transact(tx).unwrap();
+
+    let created = match &result {
+        ExecutionResult::Success { output: Output::Create(_, address), .. } => *address,
+        _ => None,
+    };
+    let mut accounts = BTreeMap::new();
+    for (address, slots) in &fixture.compare {
+        let account = state.get(address);
+        let mut storage = BTreeMap::new();
+        for slot in slots {
+            let value = account
+                .and_then(|a| a.storage.get(slot))
+                .map(|s| s.present_value())
+                .unwrap_or_default();
+            storage.insert(*slot, value);
+        }
+        accounts.insert(
+            *address,
+            AccountState {
+                balance: account.map(|a| a.info.balance).unwrap_or_default(),
+                nonce: account.map(|a| a.info.nonce).unwrap_or_default(),
+                code_hash: norm_code_hash(account.map(|a| a.info.code_hash).unwrap_or_default()),
+                storage,
+            },
+        );
+    }
+
+    Outcome { success: result.is_success(), gas_used: result.tx_gas_used(), created, accounts }
+}
+
+/// Asserts the two engines produce identical outcomes for `fixture`.
+fn assert_parity(fixture: Fixture) {
+    let evm2 = run_evm2(&fixture);
+    let revm = run_revm(&fixture);
+    assert_eq!(evm2, revm, "evm2 and revm deposit outcomes diverged");
+}
+
+#[test]
+fn parity_mint_only_to_eoa() {
+    assert_parity(Fixture {
+        seed: vec![],
+        to: TxKind::Call(Address::repeat_byte(0x22)),
+        mint: 1_000,
+        value: U256::ZERO,
+        gas_limit: 100_000,
+        input: vec![],
+        is_system: false,
+        compare: vec![(SENDER, vec![]), (Address::repeat_byte(0x22), vec![])],
+    });
+}
+
+#[test]
+fn parity_mint_and_value_transfer() {
+    assert_parity(Fixture {
+        seed: vec![],
+        to: TxKind::Call(Address::repeat_byte(0x22)),
+        mint: 1_000,
+        value: U256::from(300),
+        gas_limit: 100_000,
+        input: vec![],
+        is_system: false,
+        compare: vec![(SENDER, vec![]), (Address::repeat_byte(0x22), vec![])],
+    });
+}
+
+#[test]
+fn parity_call_contract_with_sstore() {
+    // Runtime code: PUSH1 0x2a, PUSH1 0x00, SSTORE, STOP  (stores 42 at slot 0).
+    let target = Address::repeat_byte(0x33);
+    assert_parity(Fixture {
+        seed: vec![Seed {
+            address: target,
+            balance: U256::ZERO,
+            nonce: 1,
+            code: vec![0x60, 0x2a, 0x60, 0x00, 0x55, 0x00],
+        }],
+        to: TxKind::Call(target),
+        mint: 1_000,
+        value: U256::from(50),
+        gas_limit: 200_000,
+        input: vec![],
+        is_system: false,
+        compare: vec![(SENDER, vec![]), (target, vec![U256::ZERO])],
+    });
+}
+
+#[test]
+fn parity_create_deposit() {
+    // Init code: PUSH1 0x00, PUSH1 0x00, RETURN  (deploys empty runtime code, succeeds).
+    assert_parity(Fixture {
+        seed: vec![],
+        to: TxKind::Create,
+        mint: 1_000,
+        value: U256::ZERO,
+        gas_limit: 200_000,
+        input: vec![0x60, 0x00, 0x60, 0x00, 0xf3],
+        is_system: false,
+        compare: vec![(SENDER, vec![]), (SENDER.create(0), vec![])],
+    });
+}
+
+#[test]
+fn parity_reverted_deposit() {
+    // Init code: PUSH1 0x00, PUSH1 0x00, REVERT.
+    assert_parity(Fixture {
+        seed: vec![],
+        to: TxKind::Create,
+        mint: 1_000,
+        value: U256::ZERO,
+        gas_limit: 200_000,
+        input: vec![0x60, 0x00, 0x60, 0x00, 0xfd],
+        is_system: false,
+        compare: vec![(SENDER, vec![])],
+    });
+}
+
+#[test]
+fn parity_halted_deposit() {
+    // Init code: INVALID.
+    assert_parity(Fixture {
+        seed: vec![],
+        to: TxKind::Create,
+        mint: 1_000,
+        value: U256::ZERO,
+        gas_limit: 200_000,
+        input: vec![0xfe],
+        is_system: false,
+        compare: vec![(SENDER, vec![])],
+    });
+}
+
+#[test]
+fn parity_system_transaction_rejected() {
+    assert_parity(Fixture {
+        seed: vec![],
+        to: TxKind::Call(Address::repeat_byte(0x22)),
+        mint: 1_000,
+        value: U256::ZERO,
+        gas_limit: 100_000,
+        input: vec![],
+        is_system: true,
+        compare: vec![(SENDER, vec![])],
+    });
+}

--- a/crates/common/evm2/tests/deposit_parity.rs
+++ b/crates/common/evm2/tests/deposit_parity.rs
@@ -326,3 +326,22 @@ fn parity_system_transaction_rejected() {
         compare: vec![(SENDER, vec![])],
     });
 }
+
+#[test]
+fn parity_halted_call_with_value_rolls_back_transfer() {
+    // Call a target whose code is `INVALID` (0xfe) with a nonzero value: both engines must
+    // transfer the value, halt, then roll the transfer back — leaving the value with the sender
+    // (mint kept) and nothing at the target. This is the authoritative cross-engine proof of the
+    // value-rollback path that the zero-value halt/revert fixtures don't exercise.
+    let target = Address::repeat_byte(0x44);
+    assert_parity(Fixture {
+        seed: vec![Seed { address: target, balance: U256::ZERO, nonce: 0, code: vec![0xfe] }],
+        to: TxKind::Call(target),
+        mint: 1_000,
+        value: U256::from(500),
+        gas_limit: 200_000,
+        input: vec![],
+        is_system: false,
+        compare: vec![(SENDER, vec![]), (target, vec![])],
+    });
+}

--- a/crates/common/evm2/tests/deposit_parity.rs
+++ b/crates/common/evm2/tests/deposit_parity.rs
@@ -345,3 +345,28 @@ fn parity_halted_call_with_value_rolls_back_transfer() {
         compare: vec![(SENDER, vec![]), (target, vec![])],
     });
 }
+
+#[test]
+fn parity_warm_account_access() {
+    // The called contract runs `EXTCODESIZE(0x1)` — an account access whose EIP-2929 warm/cold
+    // gas only agrees with the reference if the deposit handler pre-warms the same base set
+    // (sender, coinbase, destination, precompiles) that the standard handlers do. This is the
+    // account-warmth gas path the value-transfer/SSTORE fixtures never exercise.
+    let target = Address::repeat_byte(0x55);
+    assert_parity(Fixture {
+        seed: vec![Seed {
+            address: target,
+            balance: U256::ZERO,
+            nonce: 0,
+            // PUSH1 0x01, EXTCODESIZE, POP, STOP
+            code: vec![0x60, 0x01, 0x3b, 0x50, 0x00],
+        }],
+        to: TxKind::Call(target),
+        mint: 1_000,
+        value: U256::ZERO,
+        gas_limit: 200_000,
+        input: vec![],
+        is_system: false,
+        compare: vec![(SENDER, vec![])],
+    });
+}


### PR DESCRIPTION
## Summary

Fills in `handle_deposit` (previously a guarded stub) to faithfully implement the OP-stack deposit rules, matching the revm execution path (`base-common-evm`'s `BaseHandler`), for which Base is always Regolith-active. Stacked on #4696.

- **Mint**: credited to the sender before execution and kept regardless of outcome.
- **Metering**: deposits are metered like standard transactions (intrinsic gas + frame), reusing evm2's `prepare_initial_frame`/`execute_initial_frame`/`finalize_gas`, so call/create dispatch, EIP-7702 code resolution, value transfer, and refund-aware gas all match the standard path.
- **Create-kind deposits**: now supported (contract-address derivation) instead of rejected; removes `CreateDepositUnsupported`.
- **System transactions**: rejected post-Regolith and settled as failed deposits.
- **Failure gas**: a halt is charged the full gas limit (no L2 fee payer to refund); a revert reports actual gas, like any transaction.

Removes the now-unused `thiserror` dependency.

## Testing

**Unit tests** (in-memory `InMemoryDB`): mint crediting + nonce bump, value transfer, system-tx rejection, create deployment (`created_address`), and the revert-vs-halt gas distinction.

**Differential parity harness** (`tests/deposit_parity.rs`): runs the *same* deposit through both the evm2 handler and the revm `base-common-evm` reference (both at the MERGE fork / `BaseUpgrade::Regolith`) and asserts identical observable outcomes — success, **gas used**, created address, and per-account post-state (balance, nonce, code hash, storage). Covers mint-only, mint + value transfer, a contract call with `SSTORE` (storage + gas parity), create, revert, halt, and system-tx rejection. `base-common-evm`/`evm2`/`revm` are dev-dependencies only, so the normal build stays revm-free.

All tests + `clippy -D warnings` + `+nightly fmt` are clean.