### PR TITLE
feat(eip8130): mirror keystore

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/eip8130/account_changes.rs
@@ -55,9 +55,9 @@ impl Scope {
         self.0
     }
 
-    /// Returns true if the scope grants the ungated `SCOPE_SENDER` context.
-    pub const fn has_sender(&self) -> bool {
-        self.0 & Eip8130Constants::SCOPE_SENDER != 0
+    /// Returns true if the scope grants the ungated `SCOPE_OPERATOR` context.
+    pub const fn has_operator(&self) -> bool {
+        self.0 & Eip8130Constants::SCOPE_OPERATOR != 0
     }
 
     /// Returns true if the scope enables policy gating.
@@ -502,18 +502,18 @@ mod tests {
     #[test]
     fn scope_bit_helpers() {
         let s = Scope(
-            Eip8130Constants::SCOPE_SENDER
+            Eip8130Constants::SCOPE_OPERATOR
                 | Eip8130Constants::SCOPE_POLICY
                 | Eip8130Constants::SCOPE_NONCE
                 | Eip8130Constants::SCOPE_SELF_PAYER
                 | Eip8130Constants::SCOPE_SPONSOR_PAYER,
         );
-        assert!(s.has_sender());
+        assert!(s.has_operator());
         assert!(s.has_policy());
         assert!(s.has_nonce());
         assert!(s.has_self_payer());
         assert!(s.has_sponsor_payer());
-        assert!(!Scope::UNRESTRICTED.has_sender());
+        assert!(!Scope::UNRESTRICTED.has_operator());
     }
 
     #[test]

--- a/crates/common/consensus/src/transaction/eip8130/account_changes.rs
+++ b/crates/common/consensus/src/transaction/eip8130/account_changes.rs
@@ -86,8 +86,11 @@ impl Scope {
 /// Per [EIP-8130], a create entry's initial actors are
 /// `[actorId, authenticator, scope, policyData]` tuples. `scope` is stored
 /// verbatim (`0x00` = unrestricted admin; unknown bits allowed), and `policyData`
-/// is empty unless `scope` sets `POLICY`, in which case it is exactly
-/// `manager (20) || commitment (32)`. Two things are deliberately **not**
+/// is either empty (no policy attached) or exactly `manager (20) || commitment
+/// (32)`. Attachment is decided by **length**, not the `POLICY` scope bit
+/// (base/eip-8130 #95): the `POLICY` bit is the protocol sender gate, while the
+/// presence of the 52-byte payload is what attaches the manager/commitment. Two
+/// things are deliberately **not**
 /// expressible here and are added afterwards via a [`ConfigChange`]: `expiry`
 /// (initial actors are always non-expiring, committed as `0`) and a
 /// self-referential `manager = account` (the account address is not known at
@@ -108,8 +111,10 @@ pub struct InitialActor {
     pub authenticator: Address,
     /// Scope bitfield (`uint16`; `0x0000` = unrestricted admin), stored verbatim.
     pub scope: u16,
-    /// Policy data: empty unless `scope` sets `POLICY`, otherwise exactly
-    /// `manager (20) || commitment (32)`. Committed to the derived address.
+    /// Policy data: empty (no policy attached) or exactly
+    /// `manager (20) || commitment (32)`. Attachment is length-based and
+    /// decoupled from the `POLICY` scope bit (base/eip-8130 #95). Committed to
+    /// the derived address.
     pub policy_data: Bytes,
 }
 

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -45,8 +45,9 @@ impl Eip8130Constants {
 
     /// Actor scope bit: ungated `sender_auth` validation context (the "operator"
     /// grant); may originate transactions to any `call.to`. Renamed from `SENDER`
-    /// to reflect that it is the more permissive grant: `OPERATOR` and `POLICY`
-    /// do not combine.
+    /// to reflect that it is the more permissive grant: length decides what gets
+    /// stored; POLICY decides whether the sender is gated; OPERATOR overrides
+    /// POLICY.
     pub const SCOPE_OPERATOR: u16 = 0x0001;
 
     /// Actor scope bit: self-pay gas; authorizes paying the account's own gas
@@ -66,15 +67,26 @@ impl Eip8130Constants {
     /// to use sequenced `nonce_key`s (otherwise nonceless-only). Optional grant.
     pub const SCOPE_NONCE: u16 = 0x0010;
 
+    /// Whether `scope` gates the sender to its policy manager.
+    ///
+    /// Length decides what gets stored; POLICY decides whether the sender is
+    /// gated; OPERATOR overrides POLICY. The protocol gates on `SCOPE_POLICY`
+    /// (not on whether policy bytes were attached); `SCOPE_OPERATOR` is not
+    /// suppressed by `SCOPE_POLICY`.
+    #[must_use]
+    pub const fn sender_is_policy_gated(scope: u16) -> bool {
+        scope & Self::SCOPE_POLICY != 0 && scope & Self::SCOPE_OPERATOR == 0
+    }
+
     // Core grants occupy bits 0-2 so a chain may omit POLICY/NONCE without
     // renumbering anything else; the optional POLICY and NONCE grants trail them.
     // ERC-1271 signing rides on operational authority (admin `scope == 0x00`, or
     // an OPERATOR actor); it is not its own scope bit, so there is no
     // `SCOPE_SIGNATURE`. The remaining bits of the `uint16` scope are spare,
-    // reserved for future pure grants. The Keystore stores `scope` verbatim and
-    // never interprets these bits; policy attachment is a length check on the
-    // authorize payload (empty vs 52 bytes), not a scope-bit test. Consumers
-    // enforce all grant meaning at use time.
+    // reserved for future pure grants. Length decides what gets stored; POLICY
+    // decides whether the sender is gated; OPERATOR overrides POLICY. The
+    // Keystore attaches policy by payload length (empty vs 52 bytes) and stores
+    // `scope` verbatim. The protocol node gates `sender_auth` on `SCOPE_POLICY`.
 
     /// Domain-separation prefix for the `replay_id` preimage
     /// (`keccak256(REPLAY_ID_TYPE || rlp([...])`).
@@ -315,6 +327,12 @@ mod tests {
         assert_eq!(Eip8130Constants::SCOPE_SPONSOR_PAYER, 0x0004);
         assert_eq!(Eip8130Constants::SCOPE_POLICY, 0x0008);
         assert_eq!(Eip8130Constants::SCOPE_NONCE, 0x0010);
+        assert!(Eip8130Constants::sender_is_policy_gated(Eip8130Constants::SCOPE_POLICY));
+        assert!(!Eip8130Constants::sender_is_policy_gated(Eip8130Constants::SCOPE_OPERATOR));
+        assert!(!Eip8130Constants::sender_is_policy_gated(
+            Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_POLICY
+        ));
+        assert!(!Eip8130Constants::sender_is_policy_gated(0));
     }
 
     #[test]

--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -43,32 +43,38 @@ impl Eip8130Constants {
     /// and replay protection relies on `valid_before` (which must be non-zero).
     pub const NONCE_KEY_MAX: U256 = U256::MAX;
 
-    /// Actor scope bit: ungated `sender_auth` validation context; may originate
-    /// transactions to any `call.to`.
-    pub const SCOPE_SENDER: u16 = 0x0001;
-
-    /// Actor scope bit: policy-gated sender context; may originate transactions
-    /// only to the actor's `policy_manager`.
-    pub const SCOPE_POLICY: u16 = 0x0002;
-
-    /// Actor scope bit: nonce authorization context; permits a restricted actor
-    /// to use sequenced `nonce_key`s (otherwise nonceless-only).
-    pub const SCOPE_NONCE: u16 = 0x0004;
+    /// Actor scope bit: ungated `sender_auth` validation context (the "operator"
+    /// grant); may originate transactions to any `call.to`. Renamed from `SENDER`
+    /// to reflect that it is the more permissive grant: `OPERATOR` and `POLICY`
+    /// do not combine.
+    pub const SCOPE_OPERATOR: u16 = 0x0001;
 
     /// Actor scope bit: self-pay gas; authorizes paying the account's own gas
     /// when `payer == sender`.
-    pub const SCOPE_SELF_PAYER: u16 = 0x0008;
+    pub const SCOPE_SELF_PAYER: u16 = 0x0002;
 
     /// Actor scope bit: sponsor gas; authorizes acting as `payer_auth` for a
     /// different sender (`payer != sender`).
-    pub const SCOPE_SPONSOR_PAYER: u16 = 0x0010;
+    pub const SCOPE_SPONSOR_PAYER: u16 = 0x0004;
 
+    /// Actor scope bit: policy-gated sender context; may originate transactions
+    /// only to the actor's `policy_manager`. Optional grant — a chain with no
+    /// policy system leaves this bit unused.
+    pub const SCOPE_POLICY: u16 = 0x0008;
+
+    /// Actor scope bit: nonce authorization context; permits a restricted actor
+    /// to use sequenced `nonce_key`s (otherwise nonceless-only). Optional grant.
+    pub const SCOPE_NONCE: u16 = 0x0010;
+
+    // Core grants occupy bits 0-2 so a chain may omit POLICY/NONCE without
+    // renumbering anything else; the optional POLICY and NONCE grants trail them.
     // ERC-1271 signing rides on operational authority (admin `scope == 0x00`, or
-    // a SENDER actor without POLICY); it is not its own scope bit, so there is no
+    // an OPERATOR actor); it is not its own scope bit, so there is no
     // `SCOPE_SIGNATURE`. The remaining bits of the `uint16` scope are spare,
-    // reserved for future pure grants. The Keystore itself is scope-agnostic
-    // except for `scope == 0` (admin) and the single interpreted `SCOPE_POLICY`
-    // bit; every other bit is stored verbatim and interpreted protocol-side.
+    // reserved for future pure grants. The Keystore stores `scope` verbatim and
+    // never interprets these bits; policy attachment is a length check on the
+    // authorize payload (empty vs 52 bytes), not a scope-bit test. Consumers
+    // enforce all grant meaning at use time.
 
     /// Domain-separation prefix for the `replay_id` preimage
     /// (`keccak256(REPLAY_ID_TYPE || rlp([...])`).
@@ -285,7 +291,7 @@ mod tests {
     #[test]
     fn scope_bits_are_orthogonal() {
         let bits = [
-            Eip8130Constants::SCOPE_SENDER,
+            Eip8130Constants::SCOPE_OPERATOR,
             Eip8130Constants::SCOPE_POLICY,
             Eip8130Constants::SCOPE_NONCE,
             Eip8130Constants::SCOPE_SELF_PAYER,
@@ -298,6 +304,17 @@ mod tests {
             acc |= b;
         }
         assert_eq!(Eip8130Constants::SCOPE_UNRESTRICTED, 0);
+    }
+
+    #[test]
+    fn scope_bit_values_match_the_keystore_ordering() {
+        // Core grants lead (bits 0-2); optional POLICY/NONCE trail (bits 3-4).
+        // Pinned to the EIP-8130 `Scopes` library ordering (base/eip-8130 #95).
+        assert_eq!(Eip8130Constants::SCOPE_OPERATOR, 0x0001);
+        assert_eq!(Eip8130Constants::SCOPE_SELF_PAYER, 0x0002);
+        assert_eq!(Eip8130Constants::SCOPE_SPONSOR_PAYER, 0x0004);
+        assert_eq!(Eip8130Constants::SCOPE_POLICY, 0x0008);
+        assert_eq!(Eip8130Constants::SCOPE_NONCE, 0x0010);
     }
 
     #[test]

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -837,7 +837,7 @@ impl Eip8130Executor {
                 .resolve_actor_config(sender, sender_actor_id)
                 .map_err(BaseTransactionError::eip8130)?
                 .scope;
-            let policy_gated = actor_scope & Eip8130Constants::SCOPE_POLICY != 0;
+            let policy_gated = Eip8130Constants::sender_is_policy_gated(actor_scope);
             let policy_target = if policy_gated {
                 acc.get_policy_manager(sender, sender_actor_id)
                     .map_err(BaseTransactionError::eip8130)?
@@ -2582,7 +2582,7 @@ mod tests {
                 payload: authorize_change_data(
                     session_actor,
                     Eip8130Constants::K1_AUTHENTICATOR,
-                    Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_POLICY,
+                    Eip8130Constants::SCOPE_POLICY,
                     0,
                     &policy_data,
                 ),
@@ -3039,8 +3039,9 @@ mod tests {
         Eip8130Signed::new(tx, Bytes::from(auth), Bytes::new())
     }
 
-    /// Seeds a policy-gated `SENDER | PAYER` k1 actor for `account`,
-    /// authorized to the `signer` key and gated to `target`, then commits it.
+    /// Seeds a policy-gated k1 actor for `account`, authorized to the `signer`
+    /// key and gated to `target`, then commits it. POLICY-only (plus payer/nonce
+    /// grants): OPERATOR would override POLICY and leave the sender ungated.
     fn seed_gated_sender(
         evm: &mut BaseEvm<InMemoryDB, NoOpInspector, PrecompilesMap>,
         account: Address,
@@ -3060,10 +3061,9 @@ mod tests {
                     .at_mut(&account)
                     .write(pack_actor(
                         Eip8130Constants::K1_AUTHENTICATOR,
-                        Eip8130Constants::SCOPE_OPERATOR
+                        Eip8130Constants::SCOPE_POLICY
                             | Eip8130Constants::SCOPE_SELF_PAYER
-                            | Eip8130Constants::SCOPE_NONCE
-                            | Eip8130Constants::SCOPE_POLICY,
+                            | Eip8130Constants::SCOPE_NONCE,
                         0,
                     ))
                     .unwrap();

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -2582,7 +2582,7 @@ mod tests {
                 payload: authorize_change_data(
                     session_actor,
                     Eip8130Constants::K1_AUTHENTICATOR,
-                    Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_POLICY,
+                    Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_POLICY,
                     0,
                     &policy_data,
                 ),
@@ -3055,19 +3055,19 @@ mod tests {
             let mut provider = JournalStorageProvider::new(internals, Address::ZERO);
             StorageCtx::enter(&mut provider, |sctx| {
                 let mut acc = AccountConfigurationStorage::new(sctx);
-                acc.actor_config
+                acc.actors
                     .at_mut(&actor_id)
                     .at_mut(&account)
                     .write(pack_actor(
                         Eip8130Constants::K1_AUTHENTICATOR,
-                        Eip8130Constants::SCOPE_SENDER
+                        Eip8130Constants::SCOPE_OPERATOR
                             | Eip8130Constants::SCOPE_SELF_PAYER
                             | Eip8130Constants::SCOPE_NONCE
                             | Eip8130Constants::SCOPE_POLICY,
                         0,
                     ))
                     .unwrap();
-                acc.policy_manager.at_mut(&actor_id).at_mut(&account).write(target).unwrap();
+                acc.set_policy(account, actor_id, target, B256::ZERO).unwrap();
             });
         }
         let state = evm.ctx_mut().journal_mut().finalize();

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -186,7 +186,10 @@ impl AccountConfigurationStorage<'_> {
         if !Eip8130Constants::sender_is_policy_gated(scope) {
             return Ok((Address::ZERO, B256::ZERO));
         }
-        Ok((self.get_policy_manager(account, actor_id)?, self.get_policy_commitment(account, actor_id)?))
+        Ok((
+            self.get_policy_manager(account, actor_id)?,
+            self.get_policy_commitment(account, actor_id)?,
+        ))
     }
 
     /// Reads only the stored policy *manager* slot for `(account, actor_id)`,

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -166,9 +166,10 @@ impl AccountConfigurationStorage<'_> {
     /// An ungated actor resolves to `(address(0), bytes32(0))`; a gated one to
     /// `(manager, commitment)`.
     ///
-    /// Unlike the contract's raw two-slot read, this gates on the actor's live
-    /// `SCOPE_POLICY` grant (via [`Self::resolve_actor_config`]): an actor without
-    /// the bit resolves to `(0, 0)` regardless of what its policy slots hold.
+    /// Unlike the contract's raw two-slot read, this gates on whether the actor
+    /// is a policy-gated sender (via [`Eip8130Constants::sender_is_policy_gated`]):
+    /// an actor without the POLICY bit, or with OPERATOR overriding POLICY,
+    /// resolves to `(0, 0)` regardless of what its policy slots hold.
     ///
     /// A `(0, 0)` result is therefore ambiguous across three cases: (a) the actor
     /// is ungated with no policy attached; (b) the actor is gated but its attached
@@ -182,7 +183,7 @@ impl AccountConfigurationStorage<'_> {
     /// [`Self::get_policy_commitment`] (raw, scope-agnostic) with the actor's scope.
     pub fn get_policy(&self, account: Address, actor_id: B256) -> Result<(Address, B256)> {
         let scope = self.resolve_actor_config(account, actor_id)?.scope;
-        if scope & Eip8130Constants::SCOPE_POLICY == 0 {
+        if !Eip8130Constants::sender_is_policy_gated(scope) {
             return Ok((Address::ZERO, B256::ZERO));
         }
         Ok((self.get_policy_manager(account, actor_id)?, self.get_policy_commitment(account, actor_id)?))

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -4,18 +4,26 @@
 use alloy_primitives::{Address, B256, U256};
 use base_common_consensus::{Eip8130Constants, Eip8130Contracts};
 use base_precompile_macros::contract;
-use base_precompile_storage::{Handler, Mapping, Result, StorageKey};
+use base_precompile_storage::{ContractStorage, Handler, Mapping, Result, Slot, StorageKey};
 
 /// Read-only view over the EIP-8130 `AccountConfiguration` system contract's
 /// storage, mirroring its layout (plain sequential slots, no ERC-7201
 /// namespace):
 ///
 /// ```solidity
-/// mapping(bytes32 actorId => mapping(address account => ActorConfig)) _actorConfig;     // slot 0
-/// mapping(bytes32 actorId => mapping(address account => bytes32))     _policyCommitment; // slot 1
-/// mapping(bytes32 actorId => mapping(address account => address))     _policyManager;    // slot 2
-/// mapping(address account => AccountState)                            _accountState;     // slot 3
+/// mapping(bytes32 actorId => mapping(address account => ActorRecord)) _actors;       // slot 0
+/// mapping(address account => AccountState)                           _accountState;  // slot 1
 /// ```
+///
+/// where `ActorRecord` is `{ ActorConfig config; address policyManager; bytes32
+/// policyCommitment; }` — the packed `config` word followed by the optional
+/// policy (`manager`, `commitment`) on the two consecutive slots, so a Verkle
+/// witness can cover an actor's config and policy together (base/eip-8130 #95).
+/// The [`Self::actors`] mapping is keyed to the `config` slot (offset 0); the
+/// policy manager and commitment are read at offsets 1 and 2 of that same record
+/// base (see [`Self::get_policy_manager`] / [`Self::get_policy_commitment`]) —
+/// note this manager-before-commitment order is the *opposite* of the
+/// pre-co-location layout.
 ///
 /// `account` is the inner mapping key (matching the contract's ERC-7562
 /// storage-access requirement). The packed `ActorConfig` and `AccountState`
@@ -23,13 +31,10 @@ use base_precompile_storage::{Handler, Mapping, Result, StorageKey};
 /// / [`AccountState::from_word`].
 #[contract(addr = Self::ADDRESS)]
 pub struct AccountConfigurationStorage {
-    /// slot 0: per-actor configuration (packed `ActorConfig` word).
-    pub actor_config: Mapping<B256, Mapping<Address, U256>>,
-    /// slot 1: per-actor signed policy commitment (set for `SCOPE_POLICY` actors).
-    pub policy_commitment: Mapping<B256, Mapping<Address, B256>>,
-    /// slot 2: per-actor policy manager (set for `SCOPE_POLICY` actors).
-    pub policy_manager: Mapping<B256, Mapping<Address, Address>>,
-    /// slot 3: per-account state (packed `AccountState` word).
+    /// slot 0: per-actor record base, holding the packed `ActorConfig` word;
+    /// the co-located policy `manager`/`commitment` live at record offsets 1/2.
+    pub actors: Mapping<B256, Mapping<Address, U256>>,
+    /// slot 1: per-account state (packed `AccountState` word).
     pub account_state: Mapping<Address, U256>,
 }
 
@@ -43,9 +48,28 @@ impl AccountConfigurationStorage<'_> {
     /// Base storage slot of the per-account state mapping.
     pub const ACCOUNT_STATE_BASE_SLOT: U256 = slots::ACCOUNT_STATE;
 
+    /// Base storage slot of the per-actor record mapping (`_actors`).
+    pub const ACTORS_BASE_SLOT: U256 = slots::ACTORS;
+
+    /// Record-relative slot offset of the policy manager (`ActorRecord` field 1).
+    pub const POLICY_MANAGER_OFFSET: usize = 1;
+
+    /// Record-relative slot offset of the policy commitment (`ActorRecord` field 2).
+    pub const POLICY_COMMITMENT_OFFSET: usize = 2;
+
     /// Returns the storage slot that holds the state for `account`.
     pub fn account_state_slot(account: Address) -> B256 {
         B256::from(account.mapping_slot(Self::ACCOUNT_STATE_BASE_SLOT).to_be_bytes::<32>())
+    }
+
+    /// Base storage slot of the co-located `ActorRecord` for `(account,
+    /// actor_id)` — the `config` slot (offset 0). The policy manager and
+    /// commitment sit at offsets [`Self::POLICY_MANAGER_OFFSET`] /
+    /// [`Self::POLICY_COMMITMENT_OFFSET`] above it. Equals the slot the
+    /// [`Self::actors`] mapping resolves to, mirroring the contract's
+    /// `keccak256(account ‖ keccak256(actorId ‖ _actors.slot))`.
+    pub fn actor_record_base(account: Address, actor_id: B256) -> U256 {
+        account.mapping_slot(actor_id.mapping_slot(Self::ACTORS_BASE_SLOT))
     }
 
     /// Reads the raw `actor_config[actor_id][account]` storage slot verbatim,
@@ -58,7 +82,7 @@ impl AccountConfigurationStorage<'_> {
     /// blends the inline self (the `getActorConfig` mirror), use
     /// [`Self::resolve_actor_config`].
     pub fn actor_config_slot(&self, account: Address, actor_id: B256) -> Result<ActorConfig> {
-        Ok(ActorConfig::from_word(self.actor_config.at(&actor_id).at(&account).read()?))
+        Ok(ActorConfig::from_word(self.actors.at(&actor_id).at(&account).read()?))
     }
 
     /// Resolves the *effective* [`ActorConfig`] for `(account, actor_id)`,
@@ -142,24 +166,23 @@ impl AccountConfigurationStorage<'_> {
     /// An ungated actor resolves to `(address(0), bytes32(0))`; a gated one to
     /// `(manager, commitment)`.
     ///
-    /// Unlike the contract's `getPolicy` — a pure two-slot raw read — this gates
-    /// on the actor's live scope (via [`Self::resolve_actor_config`]): an ungated
-    /// actor never has its policy slots written, so it resolves to `(0, 0)`. A
-    /// gated actor returns the raw slots, which may *themselves* be zero — a gated
-    /// actor may carry a zero `manager` and/or `commitment` (`slice_policy` writes
-    /// policy data verbatim); a zero `manager` simply gates the key to
-    /// `address(0)` (no productive target). So a `(0, 0)` result does not by
-    /// itself distinguish "ungated" from "gated with empty policy data". This is a
-    /// resolver, not a 1:1 mirror; for the raw reads use
-    /// [`Self::get_policy_manager`] / [`Self::get_policy_commitment`].
+    /// Unlike the contract's raw two-slot read, this gates on the actor's live
+    /// `SCOPE_POLICY` grant (via [`Self::resolve_actor_config`]): an actor without
+    /// the bit resolves to `(0, 0)` regardless of what its policy slots hold.
+    /// Because policy attachment is now length-based and decoupled from scope
+    /// (base/eip-8130 #95), an ungated actor *may* have non-zero policy slots
+    /// written — this resolver still reports `(0, 0)` for it, since only a
+    /// policy-gated sender is enforced against a policy. A gated actor returns the
+    /// raw slots, which may themselves be zero (a zero `manager` gates the key to
+    /// `address(0)`), so a `(0, 0)` result does not by itself distinguish "ungated"
+    /// from "gated with an empty policy". This is a resolver, not a 1:1 mirror; for
+    /// the raw reads use [`Self::get_policy_manager`] / [`Self::get_policy_commitment`].
     pub fn get_policy(&self, account: Address, actor_id: B256) -> Result<(Address, B256)> {
         let scope = self.resolve_actor_config(account, actor_id)?.scope;
         if scope & Eip8130Constants::SCOPE_POLICY == 0 {
             return Ok((Address::ZERO, B256::ZERO));
         }
-        let manager = self.policy_manager.at(&actor_id).at(&account).read()?;
-        let commitment = self.policy_commitment.at(&actor_id).at(&account).read()?;
-        Ok((manager, commitment))
+        Ok((self.get_policy_manager(account, actor_id)?, self.get_policy_commitment(account, actor_id)?))
     }
 
     /// Reads only the stored policy *manager* slot for `(account, actor_id)`,
@@ -169,19 +192,34 @@ impl AccountConfigurationStorage<'_> {
     /// a single trie/DB hit on the validation hot path. Mirrors the manager read
     /// in `AccountConfiguration._resolvePolicyTarget`.
     pub fn get_policy_manager(&self, account: Address, actor_id: B256) -> Result<Address> {
-        self.policy_manager.at(&actor_id).at(&account).read()
+        let base = Self::actor_record_base(account, actor_id);
+        Slot::<Address>::new_at_offset(
+            base,
+            Self::POLICY_MANAGER_OFFSET,
+            self.address(),
+            self.storage(),
+        )?
+        .read()
     }
 
     /// Reads only the stored policy *commitment* slot for `(account, actor_id)`,
     /// the single-SLOAD read a policy manager performs to validate a dispatched
     /// 8130 transaction against the actor's signed commitment. This is a raw slot
-    /// read: it is written (verbatim) only while the actor has `SCOPE_POLICY`, but
-    /// a gated actor may legitimately store a zero commitment (`slice_policy`
-    /// treats it as a valid "no parameters" value), so a zero return does **not**
-    /// by itself imply "no policy / no actor" — pair it with the actor's scope for
-    /// that distinction. Mirrors `AccountConfiguration.getPolicyCommitment`.
+    /// read: it is written (verbatim) whenever the authorize payload attached a
+    /// 52-byte policy (length-based, decoupled from scope), but an attached policy
+    /// may legitimately carry a zero commitment (`slice_policy` treats it as a
+    /// valid "no parameters" value), so a zero return does **not** by itself imply
+    /// "no policy / no actor" — pair it with the actor's scope for that
+    /// distinction. Mirrors `AccountConfiguration.getPolicyCommitment`.
     pub fn get_policy_commitment(&self, account: Address, actor_id: B256) -> Result<B256> {
-        self.policy_commitment.at(&actor_id).at(&account).read()
+        let base = Self::actor_record_base(account, actor_id);
+        Slot::<B256>::new_at_offset(
+            base,
+            Self::POLICY_COMMITMENT_OFFSET,
+            self.address(),
+            self.storage(),
+        )?
+        .read()
     }
 
     /// Returns the per-account [`AccountState`] (sequences + lock fields).
@@ -241,7 +279,7 @@ impl AccountConfigurationStorage<'_> {
         actor_id: B256,
         config: ActorConfig,
     ) -> Result<()> {
-        self.actor_config.at_mut(&actor_id).at_mut(&account).write(config.to_word())
+        self.actors.at_mut(&actor_id).at_mut(&account).write(config.to_word())
     }
 
     /// Clears the `(account, actor_id)` `actor_config` slot (Solidity `delete`).
@@ -264,8 +302,12 @@ impl AccountConfigurationStorage<'_> {
         manager: Address,
         commitment: B256,
     ) -> Result<()> {
-        self.policy_manager.at_mut(&actor_id).at_mut(&account).write(manager)?;
-        self.policy_commitment.at_mut(&actor_id).at_mut(&account).write(commitment)
+        let base = Self::actor_record_base(account, actor_id);
+        let (address, storage) = (self.address(), self.storage());
+        Slot::<Address>::new_at_offset(base, Self::POLICY_MANAGER_OFFSET, address, storage)?
+            .write(manager)?;
+        Slot::<B256>::new_at_offset(base, Self::POLICY_COMMITMENT_OFFSET, address, storage)?
+            .write(commitment)
     }
 
     /// Clears both policy slots for `(account, actor_id)` (Solidity `delete`).
@@ -646,6 +688,56 @@ mod tests {
     }
 
     #[test]
+    fn base_slots_match_the_co_located_keystore_layout() {
+        // `_actors` leads (slot 0), `_accountState` trails (slot 1) — the packed
+        // AccountState is its own standalone single-slot mapping, so the
+        // full-owner sender check stays one SLOAD. Pinned to base/eip-8130 #95.
+        assert_eq!(AccountConfigurationStorage::ACTORS_BASE_SLOT, U256::ZERO);
+        assert_eq!(AccountConfigurationStorage::ACCOUNT_STATE_BASE_SLOT, U256::from(1));
+    }
+
+    #[test]
+    fn policy_slots_are_co_located_at_record_offsets_one_and_two() {
+        // The config word is the record base; the policy manager and commitment
+        // are the next two slots (manager before commitment — the opposite of the
+        // pre-co-location layout). Writing via `set_policy` must land exactly at
+        // base+1 / base+2, adjacent to the config at base+0.
+        let manager = address!("0x00000000000000000000000000000000000000d4");
+        let commitment =
+            b256!("0x4444444444444444444444444444444444444444444444444444444444444444");
+        let config_word = pack_actor_config(manager, Eip8130Constants::SCOPE_POLICY, 0);
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, |ctx| {
+            let mut acc = AccountConfigurationStorage::new(ctx);
+
+            // The record base equals the typed `actors` mapping slot (the config slot).
+            let base = acc.actors.at(&ACTOR).at(&ACCOUNT).slot();
+            assert_eq!(base, AccountConfigurationStorage::actor_record_base(ACCOUNT, ACTOR));
+
+            acc.actors.at_mut(&ACTOR).at_mut(&ACCOUNT).write(config_word).unwrap();
+            acc.set_policy(ACCOUNT, ACTOR, manager, commitment).unwrap();
+
+            // Read the raw slots back at the expected offsets.
+            let addr = acc.address();
+            let ctx = acc.storage();
+            let at = |offset: usize| {
+                Slot::<U256>::new_at_offset(base, offset, addr, ctx).unwrap().read().unwrap()
+            };
+            assert_eq!(at(0), config_word, "config at record base");
+            assert_eq!(
+                Address::from_word(B256::from(at(1).to_be_bytes::<32>())),
+                manager,
+                "manager at base+1"
+            );
+            assert_eq!(B256::from(at(2).to_be_bytes::<32>()), commitment, "commitment at base+2");
+
+            // And the typed accessors resolve those same offsets.
+            assert_eq!(acc.get_policy_manager(ACCOUNT, ACTOR).unwrap(), manager);
+            assert_eq!(acc.get_policy_commitment(ACCOUNT, ACTOR).unwrap(), commitment);
+        });
+    }
+
+    #[test]
     fn actor_config_unpacks_each_field_from_its_slot_position() {
         let authenticator = address!("0x1234567890abcDEF1234567890aBcdef12345678");
         let expiry = (1u64 << 48) - 1; // full uint48
@@ -654,7 +746,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut acc = AccountConfigurationStorage::new(ctx);
-            acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(word).unwrap();
+            acc.actors.at_mut(&ACTOR).at_mut(&ACCOUNT).write(word).unwrap();
             let config = acc.actor_config_slot(ACCOUNT, ACTOR).unwrap();
             assert_eq!(config.authenticator, authenticator);
             assert_eq!(config.scope, 0xAB);
@@ -684,7 +776,7 @@ mod tests {
             assert_eq!(acc.resolve_actor_config(ACCOUNT, ACTOR).unwrap(), ActorConfig::EMPTY);
 
             // Explicit entry wins verbatim.
-            acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
+            acc.actors.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
             assert_eq!(
                 acc.resolve_actor_config(ACCOUNT, ACTOR).unwrap(),
                 ActorConfig { authenticator: bound, scope: 0, expiry: 0 }
@@ -693,13 +785,13 @@ mod tests {
             // Live inline self (no explicit entry) -> synthesized k1 config.
             acc.account_state
                 .at_mut(&ACCOUNT)
-                .write(pack_account_state(0, 1, 0, 0, Eip8130Constants::SCOPE_SENDER, 42))
+                .write(pack_account_state(0, 1, 0, 0, Eip8130Constants::SCOPE_OPERATOR, 42))
                 .unwrap();
             assert_eq!(
                 acc.resolve_actor_config(ACCOUNT, self_id).unwrap(),
                 ActorConfig {
                     authenticator: Eip8130Constants::K1_AUTHENTICATOR,
-                    scope: Eip8130Constants::SCOPE_SENDER,
+                    scope: Eip8130Constants::SCOPE_OPERATOR,
                     expiry: 42,
                 }
             );
@@ -712,7 +804,7 @@ mod tests {
             assert_eq!(acc.resolve_actor_config(ACCOUNT, self_id).unwrap(), ActorConfig::EMPTY);
 
             // Explicit (non-k1) self entry wins even while the revoked flag is set.
-            acc.actor_config.at_mut(&self_id).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
+            acc.actors.at_mut(&self_id).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
             assert_eq!(
                 acc.resolve_actor_config(ACCOUNT, self_id).unwrap(),
                 ActorConfig { authenticator: bound, scope: 0, expiry: 0 }
@@ -729,7 +821,7 @@ mod tests {
             let mut acc = AccountConfigurationStorage::new(ctx);
 
             // Bound to a real authenticator -> actor.
-            acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
+            acc.actors.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
             assert!(acc.is_actor(ACCOUNT, ACTOR).unwrap());
 
             // Empty slot, non-self actor id -> not an actor.
@@ -748,7 +840,7 @@ mod tests {
 
             // Explicit self entry stays live even with the flag set (re-registered
             // scoped/owner k1 self key); the entry-exists => flag-set invariant.
-            acc.actor_config.at_mut(&self_id).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
+            acc.actors.at_mut(&self_id).at_mut(&ACCOUNT).write(pack(bound)).unwrap();
             assert!(acc.is_actor(ACCOUNT, self_id).unwrap());
         });
     }
@@ -763,14 +855,14 @@ mod tests {
             let mut acc = AccountConfigurationStorage::new(ctx);
 
             // Ungated actor -> zeroed regardless of stored slots.
-            acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(manager)).unwrap();
-            acc.policy_manager.at_mut(&ACTOR).at_mut(&ACCOUNT).write(manager).unwrap();
+            acc.actors.at_mut(&ACTOR).at_mut(&ACCOUNT).write(pack(manager)).unwrap();
+            acc.set_policy(ACCOUNT, ACTOR, manager, B256::ZERO).unwrap();
             assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (Address::ZERO, B256::ZERO));
 
             // Gated actor -> (manager, commitment).
             let gated = pack_actor_config(manager, Eip8130Constants::SCOPE_POLICY, 0);
-            acc.actor_config.at_mut(&ACTOR).at_mut(&ACCOUNT).write(gated).unwrap();
-            acc.policy_commitment.at_mut(&ACTOR).at_mut(&ACCOUNT).write(commitment).unwrap();
+            acc.actors.at_mut(&ACTOR).at_mut(&ACCOUNT).write(gated).unwrap();
+            acc.set_policy(ACCOUNT, ACTOR, manager, commitment).unwrap();
             assert_eq!(acc.get_policy(ACCOUNT, ACTOR).unwrap(), (manager, commitment));
         });
     }
@@ -784,8 +876,7 @@ mod tests {
         let mut storage = HashMapStorageProvider::new(1);
         StorageCtx::enter(&mut storage, |ctx| {
             let mut acc = AccountConfigurationStorage::new(ctx);
-            acc.policy_manager.at_mut(&self_id).at_mut(&ACCOUNT).write(manager).unwrap();
-            acc.policy_commitment.at_mut(&self_id).at_mut(&ACCOUNT).write(commitment).unwrap();
+            acc.set_policy(ACCOUNT, self_id, manager, commitment).unwrap();
 
             // Live full-owner self -> ungated, slots ignored.
             assert_eq!(acc.get_policy(ACCOUNT, self_id).unwrap(), (Address::ZERO, B256::ZERO));
@@ -821,9 +912,8 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut acc = AccountConfigurationStorage::new(ctx);
             let gated = pack_actor_config(authenticator, Eip8130Constants::SCOPE_POLICY, 0);
-            acc.actor_config.at_mut(&self_id).at_mut(&ACCOUNT).write(gated).unwrap();
-            acc.policy_manager.at_mut(&self_id).at_mut(&ACCOUNT).write(manager).unwrap();
-            acc.policy_commitment.at_mut(&self_id).at_mut(&ACCOUNT).write(commitment).unwrap();
+            acc.actors.at_mut(&self_id).at_mut(&ACCOUNT).write(gated).unwrap();
+            acc.set_policy(ACCOUNT, self_id, manager, commitment).unwrap();
             acc.account_state
                 .at_mut(&ACCOUNT)
                 .write(pack_account_state(0, 1, Eip8130Constants::DEFAULT_EOA_REVOKED, 0, 0, 0))
@@ -840,7 +930,7 @@ mod tests {
         StorageCtx::enter(&mut storage, |ctx| {
             let mut acc = AccountConfigurationStorage::new(ctx);
             // No actor_config written: the targeted read does not gate on it.
-            acc.policy_manager.at_mut(&ACTOR).at_mut(&ACCOUNT).write(manager).unwrap();
+            acc.set_policy(ACCOUNT, ACTOR, manager, B256::ZERO).unwrap();
             assert_eq!(acc.get_policy_manager(ACCOUNT, ACTOR).unwrap(), manager);
         });
     }

--- a/crates/execution/eip8130/src/account_config.rs
+++ b/crates/execution/eip8130/src/account_config.rs
@@ -169,14 +169,17 @@ impl AccountConfigurationStorage<'_> {
     /// Unlike the contract's raw two-slot read, this gates on the actor's live
     /// `SCOPE_POLICY` grant (via [`Self::resolve_actor_config`]): an actor without
     /// the bit resolves to `(0, 0)` regardless of what its policy slots hold.
-    /// Because policy attachment is now length-based and decoupled from scope
-    /// (base/eip-8130 #95), an ungated actor *may* have non-zero policy slots
-    /// written — this resolver still reports `(0, 0)` for it, since only a
-    /// policy-gated sender is enforced against a policy. A gated actor returns the
-    /// raw slots, which may themselves be zero (a zero `manager` gates the key to
-    /// `address(0)`), so a `(0, 0)` result does not by itself distinguish "ungated"
-    /// from "gated with an empty policy". This is a resolver, not a 1:1 mirror; for
-    /// the raw reads use [`Self::get_policy_manager`] / [`Self::get_policy_commitment`].
+    ///
+    /// A `(0, 0)` result is therefore ambiguous across three cases: (a) the actor
+    /// is ungated with no policy attached; (b) the actor is gated but its attached
+    /// policy is all-zero (a zero `manager` gates the key to `address(0)`); and —
+    /// since attachment is now length-based and decoupled from scope
+    /// (base/eip-8130 #95) — (c) the actor is ungated yet a 52-byte policy *was*
+    /// attached and written to its raw slots, which this resolver deliberately
+    /// hides (only a policy-gated sender is enforced against a policy). A caller
+    /// that needs "is any policy metadata attached at all?" cannot answer from
+    /// this resolver alone; combine [`Self::get_policy_manager`] /
+    /// [`Self::get_policy_commitment`] (raw, scope-agnostic) with the actor's scope.
     pub fn get_policy(&self, account: Address, actor_id: B256) -> Result<(Address, B256)> {
         let scope = self.resolve_actor_config(account, actor_id)?.scope;
         if scope & Eip8130Constants::SCOPE_POLICY == 0 {

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -113,9 +113,9 @@ pub enum ApplyError {
     #[error("authenticator address(0) is not a valid selector")]
     InvalidAuthenticator,
 
-    /// `policyData` did not match the actor's `SCOPE_POLICY` bit (non-empty for
-    /// an ungated actor, or not exactly `manager(20) || commitment(32)` for a
-    /// gated actor). Mirrors `_slicePolicy`.
+    /// `policyData` was neither empty nor exactly `manager(20) || commitment(32)`.
+    /// Attachment is length-based (base/eip-8130 #95) and decoupled from
+    /// `SCOPE_POLICY`. Mirrors `_slicePolicy`.
     #[error("policy data does not match policy type")]
     InvalidPolicyData,
 
@@ -944,12 +944,12 @@ impl AccountChangeApplier {
 
     /// Validates and slices `policy_data` by **length**, returning `(manager,
     /// commitment)`. Mirrors the finalized `_slicePolicy` (base/eip-8130 #95):
-    /// policy attachment is decided by payload length and decoupled from the
-    /// scope bits. Empty data attaches no policy (both fields zero); exactly
-    /// `manager(20) || commitment(32)` attaches the two, written verbatim (either
-    /// may be zero — a zero `commitment` is a valid "no parameters" value and a
-    /// zero `manager` gates the key to `address(0)`); any other length is
-    /// rejected. The `SCOPE_POLICY` bit is a consumer-side grant signal and is
+    /// length decides what gets stored; POLICY decides whether the sender is
+    /// gated; OPERATOR overrides POLICY. Empty data attaches no policy (both
+    /// fields zero); exactly `manager(20) || commitment(32)` attaches the two,
+    /// written verbatim (either may be zero — a zero `commitment` is a valid "no
+    /// parameters" value and a zero `manager` is `address(0)`); any other length
+    /// is rejected. The `SCOPE_POLICY` bit is the protocol sender gate and is
     /// deliberately not consulted here — use [`Self::policy_attached`] to learn
     /// whether a payload carried policy bytes.
     pub fn slice_policy(policy_data: &[u8]) -> Result<(Address, B256), ApplyError> {
@@ -1646,9 +1646,10 @@ mod tests {
 
     #[test]
     fn policy_attachment_is_length_based_and_read_is_scope_gated() {
-        // base/eip-8130 #95: policy *attachment* is length-based (accepted for any
-        // 52-byte payload, decoupled from scope), while whether a sender is
-        // *policy-gated* remains a consumer-side read of the `SCOPE_POLICY` grant.
+        // base/eip-8130 #95: length decides what gets stored; POLICY decides
+        // whether the sender is gated; OPERATOR overrides POLICY. Attachment is
+        // accepted for any 52-byte payload (decoupled from scope). The protocol
+        // sender gate stays `SCOPE_POLICY`-based (not length-based).
         with_storage(|acc| {
             let mut data = Vec::new();
             data.extend_from_slice(MANAGER.as_slice());

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -921,7 +921,7 @@ impl AccountChangeApplier {
     /// rejected rather than silently truncated. Solidity's `abi.decode` reverts
     /// on non-zero padding, so the lenient decoder would otherwise let the native
     /// path accept a signed payload the contract rejects — a consensus divergence.
-    fn decode_authorize(payload: &[u8]) -> Result<(B256, ActorConfig, Bytes), ApplyError> {
+    pub fn decode_authorize(payload: &[u8]) -> Result<(B256, ActorConfig, Bytes), ApplyError> {
         let (actor_id, abi, policy_data) =
             <(B256, ActorConfigAbi, Bytes)>::abi_decode_params_validate(payload)
                 .map_err(|_| ApplyError::MalformedAuthorizeData)?;
@@ -1702,7 +1702,8 @@ mod tests {
             assert_eq!(acc.get_policy(ACCOUNT, NON_SELF).unwrap(), (MANAGER, COMMITMENT));
 
             // Upsert the same actor down to no policy: the stale manager/commitment
-            // must be cleared (policy slots are written only while SCOPE_POLICY is set).
+            // must be cleared. `set_policy` always writes both slots, so an empty
+            // `policy_data` upsert writes zeros (length-based; independent of scope).
             let ungated_cfg = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_OPERATOR);
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, ungated_cfg, &[])
                 .unwrap();

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -1565,10 +1565,7 @@ mod tests {
         // nothing; exactly 52 bytes attaches; any other length rejects.
         assert_eq!(AccountChangeApplier::slice_policy(&[]).unwrap(), (Address::ZERO, B256::ZERO));
         assert!(!AccountChangeApplier::policy_attached(&[]));
-        assert_eq!(
-            AccountChangeApplier::slice_policy(&[1]),
-            Err(ApplyError::InvalidPolicyData)
-        );
+        assert_eq!(AccountChangeApplier::slice_policy(&[1]), Err(ApplyError::InvalidPolicyData));
 
         let mut data = Vec::new();
         data.extend_from_slice(MANAGER.as_slice());

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -599,7 +599,7 @@ impl AccountChangeApplier {
             return Ok(());
         }
 
-        let (manager, commitment) = Self::slice_policy(config.scope, policy_data)?;
+        let (manager, commitment) = Self::slice_policy(policy_data)?;
         if config.authenticator != current.authenticator
             || config.scope != current.scope
             || manager != storage.get_policy_manager(account, actor_id)?
@@ -637,7 +637,7 @@ impl AccountChangeApplier {
             return Self::authorize_non_self_actor(storage, account, actor_id, config, policy_data);
         }
 
-        let (manager, commitment) = Self::slice_policy(config.scope, policy_data)?;
+        let (manager, commitment) = Self::slice_policy(policy_data)?;
         if config.authenticator == Eip8130Constants::K1_AUTHENTICATOR {
             // Upsert: overwrite a live self in place (no re-authorize guard);
             // the end state equals revoke-then-authorize.
@@ -659,7 +659,13 @@ impl AccountChangeApplier {
         // warming for the subsequent call phases.
         storage.set_policy(account, actor_id, manager, commitment)?;
         AccountConfigurationEvents::emit_actor_authorized(
-            storage, account, actor_id, &config, manager, commitment,
+            storage,
+            account,
+            actor_id,
+            &config,
+            manager,
+            commitment,
+            Self::policy_attached(policy_data),
         )?;
         Ok(())
     }
@@ -683,14 +689,20 @@ impl AccountChangeApplier {
         if config.authenticator.is_zero() {
             return Err(ApplyError::InvalidAuthenticator);
         }
-        let (manager, commitment) = Self::slice_policy(config.scope, policy_data)?;
+        let (manager, commitment) = Self::slice_policy(policy_data)?;
         // Non-self actor: a single `actor_config` home. Upsert: overwrite in
         // place. Both policy slots are always touched so zero-to-zero clears
         // preserve the reference operation's access warming.
         storage.set_actor_config(account, actor_id, config)?;
         storage.set_policy(account, actor_id, manager, commitment)?;
         AccountConfigurationEvents::emit_actor_authorized(
-            storage, account, actor_id, &config, manager, commitment,
+            storage,
+            account,
+            actor_id,
+            &config,
+            manager,
+            commitment,
+            Self::policy_attached(policy_data),
         )?;
         Ok(())
     }
@@ -930,17 +942,18 @@ impl AccountChangeApplier {
             .map_err(|_| ApplyError::MalformedRevokeData)
     }
 
-    /// Validates `policy_data` against `scope`, returning `(manager,
-    /// commitment)`. Mirrors `_slicePolicy`: an actor without `SCOPE_POLICY`
-    /// requires empty data; a gated actor requires exactly
-    /// `manager(20) || commitment(32)`, written verbatim. Neither field need be
-    /// nonzero — a zero `commitment` is a valid "no parameters" value and a zero
-    /// `manager` gates the key to `address(0)` (no productive target).
-    pub fn slice_policy(scope: u16, policy_data: &[u8]) -> Result<(Address, B256), ApplyError> {
-        if scope & Eip8130Constants::SCOPE_POLICY == 0 {
-            if !policy_data.is_empty() {
-                return Err(ApplyError::InvalidPolicyData);
-            }
+    /// Validates and slices `policy_data` by **length**, returning `(manager,
+    /// commitment)`. Mirrors the finalized `_slicePolicy` (base/eip-8130 #95):
+    /// policy attachment is decided by payload length and decoupled from the
+    /// scope bits. Empty data attaches no policy (both fields zero); exactly
+    /// `manager(20) || commitment(32)` attaches the two, written verbatim (either
+    /// may be zero — a zero `commitment` is a valid "no parameters" value and a
+    /// zero `manager` gates the key to `address(0)`); any other length is
+    /// rejected. The `SCOPE_POLICY` bit is a consumer-side grant signal and is
+    /// deliberately not consulted here — use [`Self::policy_attached`] to learn
+    /// whether a payload carried policy bytes.
+    pub fn slice_policy(policy_data: &[u8]) -> Result<(Address, B256), ApplyError> {
+        if policy_data.is_empty() {
             return Ok((Address::ZERO, B256::ZERO));
         }
         if policy_data.len() != Eip8130Constants::POLICY_DATA_LEN {
@@ -949,6 +962,15 @@ impl AccountChangeApplier {
         let manager = Address::from_slice(&policy_data[..20]);
         let commitment = B256::from_slice(&policy_data[20..Eip8130Constants::POLICY_DATA_LEN]);
         Ok((manager, commitment))
+    }
+
+    /// Whether an authorize payload's `policy_data` carries policy bytes, decided
+    /// solely by length (non-empty ⇒ attached). Distinguishes a genuine all-zero
+    /// policy attachment (`52` zero bytes) from no attachment at all, which the
+    /// `(manager, commitment)` pair alone cannot express.
+    #[must_use]
+    pub const fn policy_attached(policy_data: &[u8]) -> bool {
+        !policy_data.is_empty()
     }
 
     /// Computes the counterfactual CREATE2 address for a created account. Mirrors
@@ -1177,7 +1199,7 @@ mod tests {
         let now = 1_000u64;
         with_storage(|acc| {
             set_hard_locked(acc, 3_600);
-            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER);
+            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_OPERATOR);
             AccountChangeApplier::apply_config_change(
                 acc,
                 ACCOUNT,
@@ -1199,7 +1221,7 @@ mod tests {
                 acc,
                 ACCOUNT,
                 NON_SELF,
-                ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER),
+                ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_OPERATOR),
                 &[],
             )
             .unwrap();
@@ -1260,7 +1282,7 @@ mod tests {
             set_hard_locked(acc, 3_600);
             let widened = ActorConfig {
                 authenticator: AUTHENTICATOR,
-                scope: Eip8130Constants::SCOPE_SENDER,
+                scope: Eip8130Constants::SCOPE_OPERATOR,
                 expiry: now + 86_400,
             };
             let err = AccountChangeApplier::apply_config_change(
@@ -1295,7 +1317,7 @@ mod tests {
             acc.set_account_state(ACCOUNT, state).unwrap();
 
             let add =
-                ActorConfig { authenticator: K1, scope: Eip8130Constants::SCOPE_SENDER, expiry };
+                ActorConfig { authenticator: K1, scope: Eip8130Constants::SCOPE_OPERATOR, expiry };
             let rescope = ActorConfig { authenticator: K1, scope: 0, expiry };
             let err = AccountChangeApplier::apply_config_change(
                 acc,
@@ -1424,7 +1446,7 @@ mod tests {
         // revert `InvalidActorId`, mirroring the contract's `_authorizeActor`.
         with_storage(|acc| {
             let zero =
-                [authorize_op(B256::ZERO, &ungated(K1, Eip8130Constants::SCOPE_SENDER), &[])];
+                [authorize_op(B256::ZERO, &ungated(K1, Eip8130Constants::SCOPE_OPERATOR), &[])];
             let err = AccountChangeApplier::apply_config_change(
                 acc,
                 ACCOUNT,
@@ -1539,38 +1561,40 @@ mod tests {
 
     #[test]
     fn slice_policy_matches_contract() {
+        // Length-based (base/eip-8130 #95), decoupled from scope: empty attaches
+        // nothing; exactly 52 bytes attaches; any other length rejects.
+        assert_eq!(AccountChangeApplier::slice_policy(&[]).unwrap(), (Address::ZERO, B256::ZERO));
+        assert!(!AccountChangeApplier::policy_attached(&[]));
         assert_eq!(
-            AccountChangeApplier::slice_policy(0, &[]).unwrap(),
-            (Address::ZERO, B256::ZERO)
+            AccountChangeApplier::slice_policy(&[1]),
+            Err(ApplyError::InvalidPolicyData)
         );
-        assert_eq!(AccountChangeApplier::slice_policy(0, &[1]), Err(ApplyError::InvalidPolicyData));
 
         let mut data = Vec::new();
         data.extend_from_slice(MANAGER.as_slice());
         data.extend_from_slice(COMMITMENT.as_slice());
-        assert_eq!(
-            AccountChangeApplier::slice_policy(Eip8130Constants::SCOPE_POLICY, &data).unwrap(),
-            (MANAGER, COMMITMENT)
-        );
+        assert_eq!(AccountChangeApplier::slice_policy(&data).unwrap(), (MANAGER, COMMITMENT));
+        assert!(AccountChangeApplier::policy_attached(&data));
 
         // Wrong length rejects.
         assert_eq!(
-            AccountChangeApplier::slice_policy(Eip8130Constants::SCOPE_POLICY, &data[..51]),
+            AccountChangeApplier::slice_policy(&data[..51]),
             Err(ApplyError::InvalidPolicyData)
         );
-        // Per the frozen rule, neither field need be nonzero: a zero
-        // manager/commitment is well-formed (`manager(20) || commitment(32)`).
+        // Neither field need be nonzero: a zero manager/commitment is well-formed
+        // (`manager(20) || commitment(32)`), yet still counts as attached.
         let zero_mgr = [0u8; 52];
         assert_eq!(
-            AccountChangeApplier::slice_policy(Eip8130Constants::SCOPE_POLICY, &zero_mgr).unwrap(),
+            AccountChangeApplier::slice_policy(&zero_mgr).unwrap(),
             (Address::ZERO, B256::ZERO)
         );
+        assert!(AccountChangeApplier::policy_attached(&zero_mgr));
     }
 
     #[test]
     fn authorize_and_revoke_non_self_actor() {
         with_storage(|acc| {
-            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER);
+            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_OPERATOR);
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, config, &[]).unwrap();
             assert_eq!(acc.actor_config_slot(ACCOUNT, NON_SELF).unwrap(), config);
             assert!(acc.is_actor(ACCOUNT, NON_SELF).unwrap());
@@ -1621,20 +1645,36 @@ mod tests {
     }
 
     #[test]
-    fn policy_scope_controls_policy_data() {
+    fn policy_attachment_is_length_based_and_read_is_scope_gated() {
+        // base/eip-8130 #95: policy *attachment* is length-based (accepted for any
+        // 52-byte payload, decoupled from scope), while whether a sender is
+        // *policy-gated* remains a consumer-side read of the `SCOPE_POLICY` grant.
         with_storage(|acc| {
             let mut data = Vec::new();
             data.extend_from_slice(MANAGER.as_slice());
             data.extend_from_slice(COMMITMENT.as_slice());
 
-            // Policy data without SCOPE_POLICY is rejected.
+            // Wrong length is rejected regardless of scope.
             let unrestricted = ActorConfig { authenticator: AUTHENTICATOR, scope: 0, expiry: 0 };
             assert_eq!(
-                AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, unrestricted, &data),
+                AccountChangeApplier::authorize_actor(
+                    acc,
+                    ACCOUNT,
+                    NON_SELF,
+                    unrestricted,
+                    &data[..51]
+                ),
                 Err(ApplyError::InvalidPolicyData)
             );
 
-            // SCOPE_POLICY actor accepted; policy slots written.
+            // 52-byte policy with an ungated scope now *succeeds* (length-based)
+            // and writes the raw slots, but the scope-gated read reports no policy.
+            AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, unrestricted, &data)
+                .unwrap();
+            assert_eq!(acc.get_policy_manager(ACCOUNT, NON_SELF).unwrap(), MANAGER);
+            assert_eq!(acc.get_policy(ACCOUNT, NON_SELF).unwrap(), (Address::ZERO, B256::ZERO));
+
+            // SCOPE_POLICY actor: the same attachment now reads back as gated.
             let ok = ActorConfig {
                 authenticator: AUTHENTICATOR,
                 scope: Eip8130Constants::SCOPE_POLICY,
@@ -1663,7 +1703,7 @@ mod tests {
 
             // Upsert the same actor down to no policy: the stale manager/commitment
             // must be cleared (policy slots are written only while SCOPE_POLICY is set).
-            let ungated_cfg = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER);
+            let ungated_cfg = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_OPERATOR);
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, ungated_cfg, &[])
                 .unwrap();
             assert_eq!(acc.get_policy(ACCOUNT, NON_SELF).unwrap(), (Address::ZERO, B256::ZERO));
@@ -1676,11 +1716,11 @@ mod tests {
         with_storage(|acc| {
             let self_id = AccountConfigurationStorage::self_actor_id(ACCOUNT);
             // Account starts with the inline self live (flag unset, all-zero inline).
-            let scoped = ungated(K1, Eip8130Constants::SCOPE_SENDER);
+            let scoped = ungated(K1, Eip8130Constants::SCOPE_OPERATOR);
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, self_id, scoped, &[]).unwrap();
             let state = acc.get_account_state(ACCOUNT).unwrap();
             assert!(!state.default_eoa_revoked());
-            assert_eq!(state.default_eoa_scope, Eip8130Constants::SCOPE_SENDER);
+            assert_eq!(state.default_eoa_scope, Eip8130Constants::SCOPE_OPERATOR);
             // No explicit actor_config slot is used for the k1 self.
             assert!(acc.actor_config_slot(ACCOUNT, self_id).unwrap().is_empty());
 
@@ -1824,7 +1864,7 @@ mod tests {
 
         with_storage(|acc| {
             // Revoking a non-self actor is never the inline-self shape.
-            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER);
+            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_OPERATOR);
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, config, &[]).unwrap();
             let revoke_other = vec![revoke_op(NON_SELF)];
             let count = AccountChangeApplier::apply_config_change(
@@ -1844,7 +1884,7 @@ mod tests {
     fn config_change_advances_sequence_and_applies() {
         with_storage(|acc| {
             // Authorize a non-self actor in one multichain batch.
-            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER);
+            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_OPERATOR);
             let changes = vec![authorize_op(NON_SELF, &config, &[])];
             AccountChangeApplier::apply_config_change(
                 acc,
@@ -1862,7 +1902,7 @@ mod tests {
             // batch must be non-empty (the apply path rejects `EmptyChangeSet`),
             // so it carries a benign upsert whose actor set is not asserted here.
             let local_changes =
-                vec![authorize_op(NON_SELF, &ungated(K1, Eip8130Constants::SCOPE_SENDER), &[])];
+                vec![authorize_op(NON_SELF, &ungated(K1, Eip8130Constants::SCOPE_OPERATOR), &[])];
             AccountChangeApplier::apply_config_change(
                 acc,
                 ACCOUNT,
@@ -1952,7 +1992,7 @@ mod tests {
     fn config_change_preserves_evolving_inline_self_state() {
         with_storage(|acc| {
             let self_id = AccountConfigurationStorage::self_actor_id(ACCOUNT);
-            let scoped = ungated(K1, Eip8130Constants::SCOPE_SENDER);
+            let scoped = ungated(K1, Eip8130Constants::SCOPE_OPERATOR);
             let changes = vec![authorize_op(self_id, &scoped, &[]), revoke_op(self_id)];
 
             AccountChangeApplier::apply_config_change(
@@ -2433,7 +2473,7 @@ mod tests {
     #[test]
     fn authorize_and_revoke_emit_protocol_logs() {
         let events = with_storage_events(|acc| {
-            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER);
+            let config = ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_OPERATOR);
             AccountChangeApplier::authorize_actor(acc, ACCOUNT, NON_SELF, config, &[]).unwrap();
             AccountChangeApplier::revoke_actor(acc, ACCOUNT, NON_SELF).unwrap();
         });
@@ -2445,9 +2485,10 @@ mod tests {
         assert_eq!(
             authorized.actorData,
             AccountConfigurationEvents::pack_actor_data(
-                &ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_SENDER),
+                &ungated(AUTHENTICATOR, Eip8130Constants::SCOPE_OPERATOR),
                 Address::ZERO,
                 B256::ZERO,
+                false,
             )
         );
 
@@ -2475,7 +2516,7 @@ mod tests {
         assert_eq!(authorized.actorData.len(), 84);
         assert_eq!(
             authorized.actorData,
-            AccountConfigurationEvents::pack_actor_data(&config, MANAGER, COMMITMENT)
+            AccountConfigurationEvents::pack_actor_data(&config, MANAGER, COMMITMENT, true)
         );
     }
 

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -100,8 +100,9 @@ impl ActorAuthorizer {
                 // common EOA-as-parent case. This is also the single nested
                 // signature verification (dispatch's delegate step is structural
                 // only), so there is no redundant ecrecover. The admin gate is
-                // independent of `verifySignature` (now operational: admin, or a
-                // SENDER actor without POLICY): an operational key may sign for
+                // independent of `verifySignature` (operational authority: admin
+                // `scope == 0`, or an OPERATOR actor — OPERATOR and POLICY no
+                // longer combine): an operational key may sign for
                 // its own account but MUST NOT vouch as a delegate, to preserve
                 // non-escalation. Followed by the outer
                 // `_actorConfig[uint256(uint160(delegate))][account]` binding check.
@@ -377,12 +378,12 @@ mod tests {
             // resolves from the account-state slot alone (no `actor_config` read).
             acc.account_state
                 .at_mut(&account)
-                .write(pack_self(Eip8130Constants::SCOPE_SENDER, 0, false))
+                .write(pack_self(Eip8130Constants::SCOPE_OPERATOR, 0, false))
                 .unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW).unwrap();
             assert_eq!(resolved.actor_id, self_id);
-            assert_eq!(resolved.scope, Eip8130Constants::SCOPE_SENDER);
+            assert_eq!(resolved.scope, Eip8130Constants::SCOPE_OPERATOR);
             assert_eq!(resolved.policy_target, Address::ZERO);
         });
     }
@@ -416,7 +417,7 @@ mod tests {
                 .at_mut(&account)
                 .write(pack_self(Eip8130Constants::SCOPE_POLICY, 0, false))
                 .unwrap();
-            acc.policy_manager.at_mut(&self_id).at_mut(&account).write(manager).unwrap();
+            acc.set_policy(account, self_id, manager, B256::ZERO).unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, account, HASH, &auth, NOW).unwrap();
             assert_eq!(resolved.actor_id, self_id);
@@ -448,7 +449,7 @@ mod tests {
         let id = actor_id(k1_address(&key));
         let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
                 .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0x04, 0))
@@ -489,7 +490,7 @@ mod tests {
         let id = actor_id(k1_address(&key));
         let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
                 .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 500))
@@ -511,12 +512,12 @@ mod tests {
         let manager = address!("0x00000000000000000000000000000000000000d4");
         let auth = blob(Eip8130Constants::K1_AUTHENTICATOR, &k1_sig(&key, HASH));
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
                 .write(pack(Eip8130Constants::K1_AUTHENTICATOR, Eip8130Constants::SCOPE_POLICY, 0))
                 .unwrap();
-            acc.policy_manager.at_mut(&id).at_mut(&ACCOUNT).write(manager).unwrap();
+            acc.set_policy(ACCOUNT, id, manager, B256::ZERO).unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW).unwrap();
             assert!(resolved.is_policy_gated());
@@ -530,7 +531,7 @@ mod tests {
         let (data, id) = p256_blob(&key, HASH);
         let auth = blob(Eip8130Contracts::P256_AUTHENTICATOR, &data);
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&id)
                 .at_mut(&ACCOUNT)
                 .write(pack(Eip8130Contracts::P256_AUTHENTICATOR, 0x02, 0))
@@ -567,13 +568,13 @@ mod tests {
         let auth = delegate_auth(delegate_account, &nested_key);
         with_storage(|acc| {
             // Nested actor authorized on the delegated account.
-            acc.actor_config
+            acc.actors
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
                 .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0))
                 .unwrap();
             // Outer delegate actor on the originating account carries the surface.
-            acc.actor_config
+            acc.actors
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)
                 .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
@@ -603,7 +604,7 @@ mod tests {
             // Nested actor is bound on B but scoped (non-admin), so the delegate
             // vouch — which `DelegateAuthenticator` requires to be admin
             // (`scope == 0`) — rejects it.
-            acc.actor_config
+            acc.actors
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
                 .write(pack(
@@ -612,12 +613,12 @@ mod tests {
                     0,
                 ))
                 .unwrap();
-            acc.actor_config
+            acc.actors
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)
                 .write(pack(
                     Eip8130Contracts::DELEGATE_AUTHENTICATOR,
-                    Eip8130Constants::SCOPE_SENDER,
+                    Eip8130Constants::SCOPE_OPERATOR,
                     0,
                 ))
                 .unwrap();
@@ -638,24 +639,24 @@ mod tests {
         with_storage(|acc| {
             // Nested actor is admin (`scope == 0`), the predicate the delegate
             // vouch requires, so it satisfies the delegate gate.
-            acc.actor_config
+            acc.actors
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
                 .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0))
                 .unwrap();
-            acc.actor_config
+            acc.actors
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)
                 .write(pack(
                     Eip8130Contracts::DELEGATE_AUTHENTICATOR,
-                    Eip8130Constants::SCOPE_SENDER,
+                    Eip8130Constants::SCOPE_OPERATOR,
                     0,
                 ))
                 .unwrap();
             let resolved =
                 ActorAuthorizer::authenticate_actor(acc, ACCOUNT, HASH, &auth, NOW).unwrap();
             assert_eq!(resolved.actor_id, outer_id);
-            assert_eq!(resolved.scope, Eip8130Constants::SCOPE_SENDER);
+            assert_eq!(resolved.scope, Eip8130Constants::SCOPE_OPERATOR);
         });
     }
 
@@ -668,7 +669,7 @@ mod tests {
         let auth = delegate_auth(delegate_account, &nested_key);
         with_storage(|acc| {
             // Only the outer actor is registered; the nested actor is not bound on B.
-            acc.actor_config
+            acc.actors
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)
                 .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
@@ -716,7 +717,7 @@ mod tests {
         let outer_id = actor_id(delegate_account);
         let auth = delegate_auth(delegate_account, &nested_key);
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)
                 .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
@@ -743,7 +744,7 @@ mod tests {
         let auth = delegate_auth(delegate_account, &nested_key);
         with_storage(|acc| {
             acc.account_state.at_mut(&delegate_account).write(pack_self(0, 0, true)).unwrap();
-            acc.actor_config
+            acc.actors
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)
                 .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
@@ -767,9 +768,9 @@ mod tests {
         with_storage(|acc| {
             acc.account_state
                 .at_mut(&delegate_account)
-                .write(pack_self(Eip8130Constants::SCOPE_SENDER, 0, false))
+                .write(pack_self(Eip8130Constants::SCOPE_OPERATOR, 0, false))
                 .unwrap();
-            acc.actor_config
+            acc.actors
                 .at_mut(&outer_id)
                 .at_mut(&ACCOUNT)
                 .write(pack(Eip8130Contracts::DELEGATE_AUTHENTICATOR, 0x08, 0))
@@ -790,7 +791,7 @@ mod tests {
         let auth = delegate_auth(delegate_account, &nested_key);
         with_storage(|acc| {
             // Nested is bound, but the outer delegate actor is missing on A.
-            acc.actor_config
+            acc.actors
                 .at_mut(&nested_id)
                 .at_mut(&delegate_account)
                 .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0))
@@ -814,7 +815,7 @@ mod tests {
         with_storage(|acc| {
             // Bind the nested actor on address(0) so the nested discharge passes
             // and we reach the outer zero-actor guard.
-            acc.actor_config
+            acc.actors
                 .at_mut(&nested_id)
                 .at_mut(&Address::ZERO)
                 .write(pack(Eip8130Constants::K1_AUTHENTICATOR, 0, 0))

--- a/crates/execution/eip8130/src/authorize.rs
+++ b/crates/execution/eip8130/src/authorize.rs
@@ -199,11 +199,12 @@ impl ActorAuthorizer {
             }
             // `_resolvePolicyTarget`: address(0) when ungated, else the policy
             // manager (keyed by the self-actorId, shared keyspace). An ungated
-            // (full-owner) self costs no extra read.
-            let policy_target = if state.default_eoa_scope & Eip8130Constants::SCOPE_POLICY == 0 {
-                Address::ZERO
-            } else {
+            // (full-owner) self costs no extra read. OPERATOR overrides POLICY.
+            let policy_target = if Eip8130Constants::sender_is_policy_gated(state.default_eoa_scope)
+            {
                 storage.get_policy_manager(account, recovered)?
+            } else {
+                Address::ZERO
             };
             return Ok(ResolvedActor {
                 actor_id: recovered,
@@ -240,11 +241,11 @@ impl ActorAuthorizer {
         // `_resolvePolicyTarget`: address(0) when ungated, else the policy manager
         // (never the signed commitment). Resolved from the `config` already in
         // hand so an ungated actor costs no extra read and a gated one reads only
-        // the manager slot (no `actor_config` re-read).
-        let policy_target = if config.scope & Eip8130Constants::SCOPE_POLICY == 0 {
-            Address::ZERO
-        } else {
+        // the manager slot (no `actor_config` re-read). OPERATOR overrides POLICY.
+        let policy_target = if Eip8130Constants::sender_is_policy_gated(config.scope) {
             storage.get_policy_manager(account, actor_id)?
+        } else {
+            Address::ZERO
         };
         Ok(ResolvedActor { actor_id, scope: config.scope, policy_target, expiry: config.expiry })
     }

--- a/crates/execution/eip8130/src/config.rs
+++ b/crates/execution/eip8130/src/config.rs
@@ -328,7 +328,7 @@ mod tests {
         let change =
             signed_change(account, K1, &k, AccountChangeChannel::Multichain, 0, vec![revoke(0xcd)]);
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&id)
                 .at_mut(&account)
                 .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))
@@ -348,16 +348,16 @@ mod tests {
             signed_change(account, K1, &k, AccountChangeChannel::Multichain, 0, vec![revoke(0x01)]);
         with_storage(|acc| {
             // Bound actor that lacks CONFIG (only SENDER).
-            acc.actor_config
+            acc.actors
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR, 0))
                 .unwrap();
             assert_eq!(
                 ConfigChangeAuthorizer::authorize(acc, account, LOCAL, &change, NOW),
                 Err(TxAuthError::Scope {
                     operation: Operation::Config,
-                    scope: Eip8130Constants::SCOPE_SENDER,
+                    scope: Eip8130Constants::SCOPE_OPERATOR,
                 }),
             );
         });

--- a/crates/execution/eip8130/src/events.rs
+++ b/crates/execution/eip8130/src/events.rs
@@ -178,8 +178,7 @@ mod tests {
         };
         let manager = address!("0x00000000000000000000000000000000000000cc");
         let commitment = B256::repeat_byte(0x11);
-        let data =
-            AccountConfigurationEvents::pack_actor_data(&config, manager, commitment, true);
+        let data = AccountConfigurationEvents::pack_actor_data(&config, manager, commitment, true);
         assert_eq!(data.len(), 84);
         assert_eq!(&data[32..52], manager.as_slice());
         assert_eq!(&data[52..], commitment.as_slice());

--- a/crates/execution/eip8130/src/events.rs
+++ b/crates/execution/eip8130/src/events.rs
@@ -11,7 +11,6 @@
 
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_sol_types::{SolEvent, sol};
-use base_common_consensus::Eip8130Constants;
 use base_precompile_storage::{ContractStorage, Result as StorageResult, StorageCtx};
 
 use crate::{AccountConfigurationStorage, ActorConfig};
@@ -45,20 +44,29 @@ impl AccountConfigurationEvents {
     /// Packs `ActorAuthorized.actorData` as the finalized Keystore's
     /// `_emitActorAuthorized` does: `authenticator(20) ‖ expiry(6) ‖ scope(2) ‖
     /// reserved(4 zero bytes)` (32 bytes), plus `manager(20) ‖ commitment(32)`
-    /// when `SCOPE_POLICY` is set (84 bytes total). This mirrors the right-aligned
-    /// `ActorConfig` storage-slot field order (`authenticator ‖ expiry ‖ scope ‖
-    /// reserved`) packed left-to-right via `abi.encodePacked`.
+    /// when policy bytes were attached (84 bytes total). This mirrors the
+    /// right-aligned `ActorConfig` storage-slot field order (`authenticator ‖
+    /// expiry ‖ scope ‖ reserved`) packed left-to-right via `abi.encodePacked`.
+    ///
+    /// `policy_attached` is length-derived (base/eip-8130 #95): the trailer is
+    /// emitted whenever the authorize payload carried a 52-byte policy — even an
+    /// all-zero one — and omitted when it carried none, decoupled from the
+    /// `SCOPE_POLICY` bit.
     #[must_use]
-    pub fn pack_actor_data(config: &ActorConfig, manager: Address, commitment: B256) -> Bytes {
-        let policy = config.scope & Eip8130Constants::SCOPE_POLICY != 0;
-        let mut data = Vec::with_capacity(if policy { 84 } else { 32 });
+    pub fn pack_actor_data(
+        config: &ActorConfig,
+        manager: Address,
+        commitment: B256,
+        policy_attached: bool,
+    ) -> Bytes {
+        let mut data = Vec::with_capacity(if policy_attached { 84 } else { 32 });
         data.extend_from_slice(config.authenticator.as_slice());
         // uint48 expiry: low 6 bytes of the big-endian u64.
         data.extend_from_slice(&config.expiry.to_be_bytes()[2..]);
         // uint16 scope: 2 bytes big-endian.
         data.extend_from_slice(&config.scope.to_be_bytes());
         data.extend_from_slice(&[0u8; 4]);
-        if policy {
+        if policy_attached {
             data.extend_from_slice(manager.as_slice());
             data.extend_from_slice(commitment.as_slice());
         }
@@ -73,13 +81,14 @@ impl AccountConfigurationEvents {
         config: &ActorConfig,
         manager: Address,
         commitment: B256,
+        policy_attached: bool,
     ) -> StorageResult<()> {
         storage.storage().emit_event(
             storage.address(),
             ActorAuthorized {
                 account,
                 actorId: actor_id,
-                actorData: Self::pack_actor_data(config, manager, commitment),
+                actorData: Self::pack_actor_data(config, manager, commitment, policy_attached),
             }
             .encode_log_data(),
         )
@@ -138,36 +147,45 @@ impl AccountConfigurationEvents {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::address;
+    use base_common_consensus::Eip8130Constants;
 
     use super::*;
 
     #[test]
-    fn pack_actor_data_ungated_is_32_bytes() {
+    fn pack_actor_data_unattached_is_32_bytes() {
         let config = ActorConfig {
             authenticator: address!("0x00000000000000000000000000000000000000bb"),
-            scope: Eip8130Constants::SCOPE_SENDER,
+            scope: Eip8130Constants::SCOPE_OPERATOR,
             expiry: 0x0102_0304_0506,
         };
-        let data = AccountConfigurationEvents::pack_actor_data(&config, Address::ZERO, B256::ZERO);
+        let data =
+            AccountConfigurationEvents::pack_actor_data(&config, Address::ZERO, B256::ZERO, false);
         assert_eq!(data.len(), 32);
         assert_eq!(&data[..20], config.authenticator.as_slice());
         assert_eq!(&data[20..26], &config.expiry.to_be_bytes()[2..]);
-        assert_eq!(&data[26..28], &Eip8130Constants::SCOPE_SENDER.to_be_bytes());
+        assert_eq!(&data[26..28], &Eip8130Constants::SCOPE_OPERATOR.to_be_bytes());
         assert_eq!(&data[28..], &[0u8; 4]);
     }
 
     #[test]
-    fn pack_actor_data_policy_gated_is_84_bytes() {
+    fn pack_actor_data_policy_attached_is_84_bytes() {
+        // Length-derived: the trailer rides on attachment, not the scope bit — an
+        // all-zero (but attached) policy still emits 84 bytes.
         let config = ActorConfig {
             authenticator: address!("0x00000000000000000000000000000000000000bb"),
-            scope: Eip8130Constants::SCOPE_POLICY,
+            scope: Eip8130Constants::SCOPE_OPERATOR,
             expiry: 0,
         };
         let manager = address!("0x00000000000000000000000000000000000000cc");
         let commitment = B256::repeat_byte(0x11);
-        let data = AccountConfigurationEvents::pack_actor_data(&config, manager, commitment);
+        let data =
+            AccountConfigurationEvents::pack_actor_data(&config, manager, commitment, true);
         assert_eq!(data.len(), 84);
         assert_eq!(&data[32..52], manager.as_slice());
         assert_eq!(&data[52..], commitment.as_slice());
+
+        let zero_but_attached =
+            AccountConfigurationEvents::pack_actor_data(&config, Address::ZERO, B256::ZERO, true);
+        assert_eq!(zero_but_attached.len(), 84);
     }
 }

--- a/crates/execution/eip8130/src/intrinsic.rs
+++ b/crates/execution/eip8130/src/intrinsic.rs
@@ -603,13 +603,12 @@ impl IntrinsicGas {
         if payload.len() < OFFSET_WORD + 32 {
             return false;
         }
-        let Ok(offset) = usize::try_from(U256::from_be_slice(&payload[OFFSET_WORD..OFFSET_WORD + 32]))
+        let Ok(offset) =
+            usize::try_from(U256::from_be_slice(&payload[OFFSET_WORD..OFFSET_WORD + 32]))
         else {
             return false;
         };
-        offset
-            .checked_add(32)
-            .is_some_and(|length_end| length_end <= payload.len())
+        offset.checked_add(32).is_some_and(|length_end| length_end <= payload.len())
             && U256::from_be_slice(&payload[offset..offset + 32])
                 == U256::from(Eip8130Constants::POLICY_DATA_LEN)
     }

--- a/crates/execution/eip8130/src/intrinsic.rs
+++ b/crates/execution/eip8130/src/intrinsic.rs
@@ -589,18 +589,28 @@ impl IntrinsicGas {
     /// (base/eip-8130 #95) and decoupled from `SCOPE_POLICY`, matching the slots
     /// execution actually writes.
     ///
-    /// The params encoding is five head words (`actorId`, `authenticator`,
-    /// `expiry`, `scope`, then the `policyData` offset) followed by the
-    /// `policyData` `(length, data)` tail. A non-canonical offset only occurs on
-    /// a payload the validating decoder rejects, so meter that as no policy (the
-    /// transaction reverts regardless).
+    /// The params encoding is four static head words (`actorId`, `authenticator`,
+    /// `expiry`, `scope`) then the `policyData` offset word, and the `policyData`
+    /// `(length, data)` tail lives at that offset. This **follows the offset
+    /// pointer** rather than assuming the canonical `0xA0`, so the length read
+    /// here is exactly the one [`AccountChangeApplier::decode_authorize`] reads:
+    /// the metering can never disagree with execution on the danger direction
+    /// (metering "no policy" while a 52-byte policy is written). A payload whose
+    /// pointer is out of range is metered as no policy — the validating decoder
+    /// rejects it and the transaction reverts regardless.
     fn authorize_attaches_policy(payload: &[u8]) -> bool {
         const OFFSET_WORD: usize = 4 * 32;
-        const LENGTH_WORD: usize = 5 * 32;
-        payload.len() >= LENGTH_WORD + 32
-            && U256::from_be_slice(&payload[OFFSET_WORD..OFFSET_WORD + 32])
-                == U256::from(LENGTH_WORD)
-            && U256::from_be_slice(&payload[LENGTH_WORD..LENGTH_WORD + 32])
+        if payload.len() < OFFSET_WORD + 32 {
+            return false;
+        }
+        let Ok(offset) = usize::try_from(U256::from_be_slice(&payload[OFFSET_WORD..OFFSET_WORD + 32]))
+        else {
+            return false;
+        };
+        offset
+            .checked_add(32)
+            .is_some_and(|length_end| length_end <= payload.len())
+            && U256::from_be_slice(&payload[offset..offset + 32])
                 == U256::from(Eip8130Constants::POLICY_DATA_LEN)
     }
 }
@@ -615,6 +625,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::AccountChangeApplier;
 
     /// Builds an `AuthorizeActor` op payload `abi.encode(actorId, ActorConfig, policyData)`.
     fn authorize_op(
@@ -760,6 +771,51 @@ mod tests {
             U256::from_be_slice(&attached[160..192]),
             U256::from(Eip8130Constants::POLICY_DATA_LEN)
         );
+    }
+
+    #[test]
+    fn authorize_attaches_policy_agrees_with_apply_decode() {
+        // Cross-file coupling guard: whenever the apply-side (validating) decoder
+        // accepts a payload, intrinsic metering must agree with the *decoded*
+        // policyData on whether policy is attached. `authorize_attaches_policy`
+        // follows the same ABI offset pointer the decoder does, so it cannot
+        // under-meter (report "no policy" while a 52-byte policy is written) — the
+        // exact drift a naive "canonical offset only" check would risk if the
+        // decoder were ever relaxed.
+        let build = |policy: &[u8]| -> Vec<u8> {
+            (
+                B256::repeat_byte(0x11),
+                ActorConfigAbi {
+                    authenticator: Address::ZERO,
+                    scope: Eip8130Constants::SCOPE_OPERATOR,
+                    expiry: alloy_primitives::Uint::ZERO,
+                },
+                Bytes::from(policy.to_vec()),
+            )
+                .abi_encode_params()
+        };
+        for policy in [vec![], vec![0u8; Eip8130Constants::POLICY_DATA_LEN]] {
+            let payload = build(&policy);
+            let (_, _, decoded) = AccountChangeApplier::decode_authorize(&payload).unwrap();
+            assert_eq!(
+                IntrinsicGas::authorize_attaches_policy(&payload),
+                AccountChangeApplier::policy_attached(&decoded),
+            );
+        }
+
+        // Hand-corrupt the offset pointer to a non-canonical (but in-range) value.
+        // The validating decoder follows the pointer (it does *not* reject this),
+        // landing on an all-zero word ⇒ length 0 ⇒ no policy; the metering follows
+        // the same pointer and agrees. A canonical-offset-only check would have
+        // mismatched here.
+        let mut corrupted = build(&[0u8; Eip8130Constants::POLICY_DATA_LEN]);
+        corrupted[128..160].copy_from_slice(&U256::from(192).to_be_bytes::<32>());
+        let (_, _, decoded) = AccountChangeApplier::decode_authorize(&corrupted).unwrap();
+        assert_eq!(
+            IntrinsicGas::authorize_attaches_policy(&corrupted),
+            AccountChangeApplier::policy_attached(&decoded),
+        );
+        assert!(!AccountChangeApplier::policy_attached(&decoded));
     }
 
     #[test]

--- a/crates/execution/eip8130/src/intrinsic.rs
+++ b/crates/execution/eip8130/src/intrinsic.rs
@@ -1,6 +1,6 @@
 //! EIP-8130 intrinsic gas: the total cost to include an AA transaction.
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, U256};
 use base_common_consensus::{
     AccountChange, ChangeType, Eip8130Constants, Eip8130Contracts, Eip8130Signed, SignedChange,
 };
@@ -295,14 +295,16 @@ impl IntrinsicGas {
                     account_state_touched = true;
                     // Each initial actor writes one fresh `actor_config` slot, plus
                     // the two policy slots (`policy_manager` + `policy_commitment`)
-                    // when it sets `SCOPE_POLICY` — a POLICY initial actor is 3
-                    // slot-sets versus 1 for a non-policy actor. These slot writes
-                    // are metered per actor, mirroring the `ConfigChange` per-slot
-                    // accounting below — creation must not register actors for free
-                    // relative to a later config change authorizing the same set.
+                    // when it attaches a 52-byte `policyData` — a policy initial
+                    // actor is 3 slot-sets versus 1 for a non-policy actor.
+                    // Attachment is length-based (base/eip-8130 #95), decoupled
+                    // from `SCOPE_POLICY`. These slot writes are metered per actor,
+                    // mirroring the `ConfigChange` per-slot accounting below —
+                    // creation must not register actors for free relative to a
+                    // later config change authorizing the same set.
                     for actor in &entry.initial_actors {
                         let mut cost = Eip8130GasSchedule::ACTOR_SLOT_SET_COST;
-                        if actor.scope & Eip8130Constants::SCOPE_POLICY != 0 {
+                        if !actor.policy_data.is_empty() {
                             cost = cost.saturating_add(
                                 Eip8130GasSchedule::ACTOR_SLOT_SET_COST.saturating_mul(2),
                             );
@@ -562,7 +564,7 @@ impl IntrinsicGas {
             ChangeType::RevokeActor => Eip8130GasSchedule::ACTOR_REVOKE_COST,
             ChangeType::AuthorizeActor => {
                 let mut cost = Eip8130GasSchedule::ACTOR_SLOT_SET_COST;
-                if Self::authorize_has_policy(op.payload.as_ref()) {
+                if Self::authorize_attaches_policy(op.payload.as_ref()) {
                     // policy_commitment + policy_manager.
                     cost = cost
                         .saturating_add(Eip8130GasSchedule::ACTOR_SLOT_SET_COST.saturating_mul(2));
@@ -582,14 +584,24 @@ impl IntrinsicGas {
     }
 
     /// Whether an authorize op's ABI-encoded
-    /// `(bytes32 actorId, ActorConfig, bytes)` `payload` carries `SCOPE_POLICY`.
-    /// The payload leads with the `actorId` word; `ActorConfig` is
-    /// `(address authenticator, uint48 expiry, uint16 scope)`, so scope is the
-    /// fourth 32-byte word, right-aligned in its low 2 bytes.
-    fn authorize_has_policy(payload: &[u8]) -> bool {
-        payload.len() >= 128
-            && u16::from_be_bytes([payload[126], payload[127]]) & Eip8130Constants::SCOPE_POLICY
-                != 0
+    /// `(bytes32 actorId, ActorConfig, bytes policyData)` `payload` attaches a
+    /// policy — i.e. carries a 52-byte `policyData`. Attachment is length-based
+    /// (base/eip-8130 #95) and decoupled from `SCOPE_POLICY`, matching the slots
+    /// execution actually writes.
+    ///
+    /// The params encoding is five head words (`actorId`, `authenticator`,
+    /// `expiry`, `scope`, then the `policyData` offset) followed by the
+    /// `policyData` `(length, data)` tail. A non-canonical offset only occurs on
+    /// a payload the validating decoder rejects, so meter that as no policy (the
+    /// transaction reverts regardless).
+    fn authorize_attaches_policy(payload: &[u8]) -> bool {
+        const OFFSET_WORD: usize = 4 * 32;
+        const LENGTH_WORD: usize = 5 * 32;
+        payload.len() >= LENGTH_WORD + 32
+            && U256::from_be_slice(&payload[OFFSET_WORD..OFFSET_WORD + 32])
+                == U256::from(LENGTH_WORD)
+            && U256::from_be_slice(&payload[LENGTH_WORD..LENGTH_WORD + 32])
+                == U256::from(Eip8130Constants::POLICY_DATA_LEN)
     }
 }
 
@@ -703,7 +715,7 @@ mod tests {
 
     alloy_sol_types::sol! {
         // Mirror of the contract's `ActorConfig` authorize payload, used only to
-        // pin the byte offset `authorize_has_policy` reads.
+        // pin the byte offsets `authorize_attaches_policy` reads.
         struct ActorConfigAbi {
             address authenticator;
             uint48 expiry;
@@ -712,36 +724,42 @@ mod tests {
     }
 
     #[test]
-    fn authorize_has_policy_reads_the_scope_word() {
-        // Drift tripwire: `authorize_has_policy` reads SCOPE_POLICY from the low
-        // 2 bytes of the fourth ABI word. The payload leads with the `actorId`
-        // word, then `ActorConfig` (`authenticator, expiry, scope`), so scope is
-        // the fourth word.
+    fn authorize_attaches_policy_reads_the_policy_length_not_the_scope_bit() {
+        // Drift tripwire: attachment is length-based (base/eip-8130 #95). A
+        // 52-byte `policyData` attaches regardless of scope; an empty one does
+        // not attach even with SCOPE_POLICY set.
         let actor_id = B256::repeat_byte(0x11);
-        let gated = (
+        let attached = (
             actor_id,
             ActorConfigAbi {
+                // Scope deliberately lacks POLICY: attachment is length-only.
                 authenticator: Address::ZERO,
-                scope: Eip8130Constants::SCOPE_POLICY,
+                scope: Eip8130Constants::SCOPE_OPERATOR,
                 expiry: alloy_primitives::Uint::ZERO,
             },
-            Bytes::new(),
+            Bytes::from(vec![0u8; Eip8130Constants::POLICY_DATA_LEN]),
         )
             .abi_encode_params();
-        let ungated = (
+        // SCOPE_POLICY set but no policy bytes -> not attached.
+        let scope_only = (
             actor_id,
             ActorConfigAbi {
                 authenticator: address!("0xffffffffffffffffffffffffffffffffffffffff"),
-                scope: Eip8130Constants::SCOPE_SENDER,
+                scope: Eip8130Constants::SCOPE_POLICY,
                 expiry: alloy_primitives::Uint::from(0xffff_ffff_ffffu64),
             },
             Bytes::new(),
         )
             .abi_encode_params();
 
-        assert!(IntrinsicGas::authorize_has_policy(&gated));
-        assert!(!IntrinsicGas::authorize_has_policy(&ungated));
-        assert_eq!(u16::from_be_bytes([gated[126], gated[127]]), Eip8130Constants::SCOPE_POLICY);
+        assert!(IntrinsicGas::authorize_attaches_policy(&attached));
+        assert!(!IntrinsicGas::authorize_attaches_policy(&scope_only));
+        // The policyData length word sits at offset 5*32; canonical offset is 0xA0.
+        assert_eq!(U256::from_be_slice(&attached[128..160]), U256::from(160));
+        assert_eq!(
+            U256::from_be_slice(&attached[160..192]),
+            U256::from(Eip8130Constants::POLICY_DATA_LEN)
+        );
     }
 
     #[test]
@@ -889,14 +907,14 @@ mod tests {
     #[test]
     fn config_change_charges_auth_plus_slot_writes() {
         // One authorize without policy + one revoke, authorized by a configured k1.
-        let mut authorize_data = vec![0u8; 128];
+        let authorize_data = vec![0u8; 128];
         let cc = SignedAccountChanges {
             channel: AccountChangeChannel::Multichain,
             sequence: 0,
             changes: vec![
                 SignedChange {
                     change_type: ChangeType::AuthorizeActor,
-                    payload: Bytes::from(authorize_data.clone()),
+                    payload: Bytes::from(authorize_data),
                 },
                 SignedChange { change_type: ChangeType::RevokeActor, payload: Bytes::new() },
             ],
@@ -918,16 +936,25 @@ mod tests {
             + Eip8130GasSchedule::ACTOR_REVOKE_COST;
         assert_eq!(gas.account_changes, expected);
 
-        // With SCOPE_POLICY, the authorize also writes the two policy slots. Scope
-        // is the fourth ABI word's low 2 bytes (bytes 126..128; the payload leads
-        // with the actorId word).
-        authorize_data[126..128].copy_from_slice(&Eip8130Constants::SCOPE_POLICY.to_be_bytes());
+        // Attaching a 52-byte `policyData` makes the authorize also write the two
+        // policy slots — attachment is length-based (base/eip-8130 #95), so the
+        // scope bits are irrelevant here.
+        let policy_payload = (
+            B256::repeat_byte(0x11),
+            ActorConfigAbi {
+                authenticator: Address::ZERO,
+                scope: Eip8130Constants::SCOPE_OPERATOR,
+                expiry: alloy_primitives::Uint::ZERO,
+            },
+            Bytes::from(vec![0u8; Eip8130Constants::POLICY_DATA_LEN]),
+        )
+            .abi_encode_params();
         let cc = SignedAccountChanges {
             channel: AccountChangeChannel::Multichain,
             sequence: 0,
             changes: vec![SignedChange {
                 change_type: ChangeType::AuthorizeActor,
-                payload: Bytes::from(authorize_data),
+                payload: Bytes::from(policy_payload),
             }],
             signature: Bytes::from(configured_auth(K1)),
         };

--- a/crates/execution/eip8130/src/resolved.rs
+++ b/crates/execution/eip8130/src/resolved.rs
@@ -47,9 +47,14 @@ impl ResolvedActor {
     }
 
     /// `true` if the actor's sender authorization is policy-gated.
+    ///
+    /// Length decides what gets stored; POLICY decides whether the sender is
+    /// gated; OPERATOR overrides POLICY. The protocol gates on `SCOPE_POLICY`
+    /// (not on whether policy bytes were attached); `SCOPE_OPERATOR` is the more
+    /// permissive initiation grant and is not suppressed by `SCOPE_POLICY`.
     #[must_use]
     pub const fn is_policy_gated(&self) -> bool {
-        self.scope & Eip8130Constants::SCOPE_POLICY != 0
+        Eip8130Constants::sender_is_policy_gated(self.scope)
     }
 
     /// Whether this actor may use the transaction's nonce key.

--- a/crates/execution/eip8130/src/resolved.rs
+++ b/crates/execution/eip8130/src/resolved.rs
@@ -76,10 +76,10 @@ mod tests {
     fn nonce_scope_allows_expected_keys() {
         assert!(actor(0).can_use_nonce_key(U256::ZERO));
         assert!(
-            actor(Eip8130Constants::SCOPE_SENDER)
+            actor(Eip8130Constants::SCOPE_OPERATOR)
                 .can_use_nonce_key(Eip8130Constants::NONCE_KEY_MAX)
         );
         assert!(actor(Eip8130Constants::SCOPE_NONCE).can_use_nonce_key(U256::from(1)));
-        assert!(!actor(Eip8130Constants::SCOPE_SENDER).can_use_nonce_key(U256::ZERO));
+        assert!(!actor(Eip8130Constants::SCOPE_OPERATOR).can_use_nonce_key(U256::ZERO));
     }
 }

--- a/crates/execution/eip8130/src/scope.rs
+++ b/crates/execution/eip8130/src/scope.rs
@@ -9,7 +9,7 @@ use crate::ResolvedActor;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Operation {
-    /// Authorizing the transaction sender (`SCOPE_SENDER` or `SCOPE_POLICY`).
+    /// Authorizing the transaction sender (`SCOPE_OPERATOR` or `SCOPE_POLICY`).
     Sender,
     /// Authorizing an actor to pay the account's own gas when `payer == sender`
     /// (`SCOPE_SELF_PAYER`).
@@ -27,7 +27,7 @@ impl Operation {
     #[must_use]
     pub const fn required_bit(self) -> u16 {
         match self {
-            Self::Sender => Eip8130Constants::SCOPE_SENDER,
+            Self::Sender => Eip8130Constants::SCOPE_OPERATOR,
             Self::SelfPayer => Eip8130Constants::SCOPE_SELF_PAYER,
             Self::SponsorPayer => Eip8130Constants::SCOPE_SPONSOR_PAYER,
             Self::Config => Eip8130Constants::SCOPE_UNRESTRICTED,
@@ -41,7 +41,7 @@ impl Operation {
             Self::Config => scope == Eip8130Constants::SCOPE_UNRESTRICTED,
             Self::Sender => {
                 scope == Eip8130Constants::SCOPE_UNRESTRICTED
-                    || scope & Eip8130Constants::SCOPE_SENDER != 0
+                    || scope & Eip8130Constants::SCOPE_OPERATOR != 0
                     || scope & Eip8130Constants::SCOPE_POLICY != 0
             }
             Self::SelfPayer => {
@@ -69,14 +69,14 @@ mod tests {
     #[test]
     fn config_is_admin_only() {
         assert!(Operation::Config.is_granted_by(Eip8130Constants::SCOPE_UNRESTRICTED));
-        assert!(!Operation::Config.is_granted_by(Eip8130Constants::SCOPE_SENDER));
+        assert!(!Operation::Config.is_granted_by(Eip8130Constants::SCOPE_OPERATOR));
         assert!(!Operation::Config.is_granted_by(Eip8130Constants::SCOPE_POLICY));
     }
 
     #[test]
     fn sender_accepts_sender_or_policy() {
         assert!(Operation::Sender.is_granted_by(Eip8130Constants::SCOPE_UNRESTRICTED));
-        assert!(Operation::Sender.is_granted_by(Eip8130Constants::SCOPE_SENDER));
+        assert!(Operation::Sender.is_granted_by(Eip8130Constants::SCOPE_OPERATOR));
         assert!(Operation::Sender.is_granted_by(Eip8130Constants::SCOPE_POLICY));
         assert!(!Operation::Sender.is_granted_by(Eip8130Constants::SCOPE_SELF_PAYER));
     }

--- a/crates/execution/eip8130/src/scope.rs
+++ b/crates/execution/eip8130/src/scope.rs
@@ -22,18 +22,6 @@ pub enum Operation {
 }
 
 impl Operation {
-    /// The scope bit that grants this operation, or unrestricted scope for
-    /// admin-only configuration changes.
-    #[must_use]
-    pub const fn required_bit(self) -> u16 {
-        match self {
-            Self::Sender => Eip8130Constants::SCOPE_OPERATOR,
-            Self::SelfPayer => Eip8130Constants::SCOPE_SELF_PAYER,
-            Self::SponsorPayer => Eip8130Constants::SCOPE_SPONSOR_PAYER,
-            Self::Config => Eip8130Constants::SCOPE_UNRESTRICTED,
-        }
-    }
-
     /// Whether `scope` grants this operation.
     #[must_use]
     pub const fn is_granted_by(self, scope: u16) -> bool {

--- a/crates/execution/eip8130/src/signature.rs
+++ b/crates/execution/eip8130/src/signature.rs
@@ -262,12 +262,12 @@ mod tests {
     fn local_envelope_authenticates_bound_actor() {
         let k = key(0x22);
         let id = AccountConfigurationStorage::self_actor_id(addr(&k));
-        let scope = Eip8130Constants::SCOPE_SENDER;
+        let scope = Eip8130Constants::SCOPE_OPERATOR;
         let digest =
             SignatureVerifier::envelope_digest(SignatureType::Local, ACCOUNT, HASH, CHAIN_ID);
         let auth = envelope(SignatureType::Local as u8, K1, &sig(&k, digest));
         with_storage(|acc| {
-            acc.actor_config.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, scope, 0)).unwrap();
+            acc.actors.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, scope, 0)).unwrap();
             let resolved =
                 SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &auth, CHAIN_ID, NOW)
                     .unwrap();
@@ -286,7 +286,7 @@ mod tests {
             SignatureVerifier::envelope_digest(SignatureType::Multichain, ACCOUNT, HASH, CHAIN_ID);
         let auth = envelope(SignatureType::Multichain as u8, K1, &sig(&k, digest));
         with_storage(|acc| {
-            acc.actor_config.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, 0, 0)).unwrap();
+            acc.actors.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, 0, 0)).unwrap();
             let other_chain = CHAIN_ID + 1;
             let resolved =
                 SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &auth, other_chain, NOW)
@@ -306,7 +306,7 @@ mod tests {
             SignatureVerifier::envelope_digest(SignatureType::Local, ACCOUNT, HASH, CHAIN_ID);
         let auth = envelope(SignatureType::Local as u8, K1, &sig(&k, digest));
         with_storage(|acc| {
-            acc.actor_config.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, 0, 0)).unwrap();
+            acc.actors.at_mut(&id).at_mut(&ACCOUNT).write(pack(K1, 0, 0)).unwrap();
             // Recovers a different actor id than the one bound: AuthenticatorMismatch.
             assert!(matches!(
                 SignatureVerifier::validate_signature(acc, ACCOUNT, HASH, &auth, CHAIN_ID + 1, NOW,),

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -904,7 +904,11 @@ mod tests {
             acc.actors
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE, 0))
+                .write(pack(
+                    K1,
+                    Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE,
+                    0,
+                ))
                 .unwrap();
             acc.actors
                 .at_mut(&pid)

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -263,7 +263,7 @@ mod tests {
         let abi = TestActorConfigAbi {
             authenticator: K1,
             expiry: alloy_primitives::aliases::U48::ZERO,
-            scope: Eip8130Constants::SCOPE_SENDER,
+            scope: Eip8130Constants::SCOPE_OPERATOR,
         };
         let payload = (B256::repeat_byte(0xEE), abi, Bytes::new()).abi_encode_params();
         SignedChange { change_type: ChangeType::AuthorizeActor, payload: Bytes::from(payload) }
@@ -549,12 +549,12 @@ mod tests {
         with_storage(|acc| {
             acc.account_state
                 .at_mut(&account)
-                .write(pack_default_eoa_scope(Eip8130Constants::SCOPE_SENDER))
+                .write(pack_default_eoa_scope(Eip8130Constants::SCOPE_OPERATOR))
                 .unwrap();
 
             let ordinary =
                 TransactionAuthorizer::authorize_and_apply(&ordinary, acc, LOCAL, NOW).unwrap();
-            assert_eq!(ordinary.actors.sender.resolved.scope, Eip8130Constants::SCOPE_SENDER);
+            assert_eq!(ordinary.actors.sender.resolved.scope, Eip8130Constants::SCOPE_OPERATOR);
             assert_eq!(
                 TransactionAuthorizer::authorize_and_apply(&delegation, acc, LOCAL, NOW),
                 Err(TxAuthError::DelegationUnauthorized),
@@ -578,7 +578,7 @@ mod tests {
         );
 
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&signer_id)
                 .at_mut(&account)
                 .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))
@@ -622,12 +622,12 @@ mod tests {
         let signed = configured_signed(tx, &signer, Some(&payer));
 
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&signer_id)
                 .at_mut(&account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR, 0))
                 .unwrap();
-            acc.actor_config
+            acc.actors
                 .at_mut(&payer_id)
                 .at_mut(&payer_account)
                 .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
@@ -726,7 +726,7 @@ mod tests {
             account,
             resolved: ResolvedActor {
                 actor_id: actor_id(account),
-                scope: Eip8130Constants::SCOPE_SENDER,
+                scope: Eip8130Constants::SCOPE_OPERATOR,
                 policy_target: Address::ZERO,
                 expiry: 0,
             },
@@ -864,7 +864,7 @@ mod tests {
         let hash = tx.sender_signature_hash();
         let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&sk, hash)), Bytes::new());
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&sid)
                 .at_mut(&account)
                 .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))
@@ -901,17 +901,17 @@ mod tests {
             auth_blob(K1, &sig(&pk, payer_hash)),
         );
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE, 0))
                 .unwrap();
-            acc.actor_config
+            acc.actors
                 .at_mut(&pid)
                 .at_mut(&payer_account)
                 .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
                 .unwrap();
-            acc.actor_config
+            acc.actors
                 .at_mut(&cid)
                 .at_mut(&sender_account)
                 .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -310,7 +310,11 @@ mod tests {
             acc.actors
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE, 0))
+                .write(pack(
+                    K1,
+                    Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE,
+                    0,
+                ))
                 .unwrap();
             assert_eq!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
@@ -368,7 +372,11 @@ mod tests {
             acc.actors
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE, 0))
+                .write(pack(
+                    K1,
+                    Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE,
+                    0,
+                ))
                 .unwrap();
             acc.actors
                 .at_mut(&pid)
@@ -473,7 +481,11 @@ mod tests {
             acc.actors
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE, 0))
+                .write(pack(
+                    K1,
+                    Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE,
+                    0,
+                ))
                 .unwrap();
             // Payer actor bound but lacking SCOPE_SPONSOR_PAYER.
             acc.actors

--- a/crates/execution/eip8130/src/verify.rs
+++ b/crates/execution/eip8130/src/verify.rs
@@ -275,12 +275,12 @@ mod tests {
         let hash = tx.sender_signature_hash();
         let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&id)
                 .at_mut(&account)
                 .write(pack(
                     K1,
-                    Eip8130Constants::SCOPE_SENDER
+                    Eip8130Constants::SCOPE_OPERATOR
                         | Eip8130Constants::SCOPE_SELF_PAYER
                         | Eip8130Constants::SCOPE_NONCE,
                     0,
@@ -290,7 +290,7 @@ mod tests {
             assert_eq!(actors.sender.account, account);
             assert_eq!(
                 actors.sender.resolved.scope,
-                Eip8130Constants::SCOPE_SENDER
+                Eip8130Constants::SCOPE_OPERATOR
                     | Eip8130Constants::SCOPE_SELF_PAYER
                     | Eip8130Constants::SCOPE_NONCE
             );
@@ -307,16 +307,16 @@ mod tests {
         let hash = tx.sender_signature_hash();
         let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&id)
                 .at_mut(&account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE, 0))
                 .unwrap();
             assert_eq!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
                 Err(TxAuthError::Scope {
                     operation: Operation::SelfPayer,
-                    scope: Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE,
+                    scope: Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE,
                 }),
             );
         });
@@ -331,8 +331,8 @@ mod tests {
         let hash = tx.sender_signature_hash();
         let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
         with_storage(|acc| {
-            // Bound, non-zero scope that lacks SCOPE_SENDER.
-            acc.actor_config
+            // Bound, non-zero scope that lacks SCOPE_OPERATOR.
+            acc.actors
                 .at_mut(&id)
                 .at_mut(&account)
                 .write(pack(K1, Eip8130Constants::SCOPE_SELF_PAYER, 0))
@@ -365,12 +365,12 @@ mod tests {
             auth_blob(K1, &sig(&pk, payer_hash)),
         );
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE, 0))
                 .unwrap();
-            acc.actor_config
+            acc.actors
                 .at_mut(&pid)
                 .at_mut(&payer_account)
                 .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
@@ -404,7 +404,7 @@ mod tests {
         with_storage(|acc| {
             // Sender is an implicit-EOA owner (self-slot empty); only the payer
             // actor needs seeding.
-            acc.actor_config
+            acc.actors
                 .at_mut(&pid)
                 .at_mut(&payer_account)
                 .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
@@ -438,7 +438,7 @@ mod tests {
             auth_blob(K1, &sig(&pk, wrong_payer_hash)),
         );
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&pid)
                 .at_mut(&payer_account)
                 .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
@@ -470,22 +470,22 @@ mod tests {
             auth_blob(K1, &sig(&pk, payer_hash)),
         );
         with_storage(|acc| {
-            acc.actor_config
+            acc.actors
                 .at_mut(&sid)
                 .at_mut(&sender_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER | Eip8130Constants::SCOPE_NONCE, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR | Eip8130Constants::SCOPE_NONCE, 0))
                 .unwrap();
             // Payer actor bound but lacking SCOPE_SPONSOR_PAYER.
-            acc.actor_config
+            acc.actors
                 .at_mut(&pid)
                 .at_mut(&payer_account)
-                .write(pack(K1, Eip8130Constants::SCOPE_SENDER, 0))
+                .write(pack(K1, Eip8130Constants::SCOPE_OPERATOR, 0))
                 .unwrap();
             assert_eq!(
                 ActorTxVerifier::verify(&signed, acc, NOW),
                 Err(TxAuthError::Scope {
                     operation: Operation::SponsorPayer,
-                    scope: Eip8130Constants::SCOPE_SENDER,
+                    scope: Eip8130Constants::SCOPE_OPERATOR,
                 }),
             );
         });

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1923,9 +1923,10 @@ where
     /// spent on duplicate detection), every `authenticator` is at or above the
     /// `K1_AUTHENTICATOR` floor (i.e. not the `address(0)` empty sentinel), no
     /// two entries share the same `actor_id`, and each entry's `policy_data` is
-    /// structurally consistent with its `scope`: empty unless `SCOPE_POLICY` is
-    /// set, otherwise exactly `manager (20) || commitment (32)` (52 bytes). The
-    /// same consistency is enforced downstream in `authorize_actor`/`slice_policy`;
+    /// a valid attachment length: empty, or exactly `manager (20) ||
+    /// commitment (32)` (52 bytes). Length decides what gets stored; POLICY
+    /// decides whether the sender is gated; OPERATOR overrides POLICY. The same
+    /// length check is enforced downstream in `authorize_actor`/`slice_policy`;
     /// checking it here rejects malformed creates before the expensive overlay
     /// path runs.
     fn validate_initial_actors(actors: &[InitialActor]) -> Result<(), InvalidPoolTransactionError> {
@@ -1940,9 +1941,8 @@ where
             if previous.is_some_and(|previous| actor.actor_id <= previous) {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
-            let policy = actor.scope & Eip8130Constants::SCOPE_POLICY != 0;
-            let expected_policy_len = if policy { Eip8130Constants::POLICY_DATA_LEN } else { 0 };
-            if actor.policy_data.len() != expected_policy_len {
+            let len = actor.policy_data.len();
+            if len != 0 && len != Eip8130Constants::POLICY_DATA_LEN {
                 return Err(InvalidTransactionError::TxTypeNotSupported.into());
             }
             previous = Some(actor.actor_id);
@@ -2896,7 +2896,8 @@ mod tests {
     }
 
     #[test]
-    fn rejects_eip8130_create_with_policy_data_on_ungated_actor() {
+    fn accepts_eip8130_create_with_policy_data_on_ungated_actor() {
+        // Length decides what gets stored; POLICY is not required to attach.
         let mut entry = make_valid_create_entry();
         entry.initial_actors[0].scope = 0;
         entry.initial_actors[0].policy_data = vec![0u8; Eip8130Constants::POLICY_DATA_LEN].into();
@@ -2904,10 +2905,10 @@ mod tests {
             account_changes: vec![AccountChange::Create(entry)],
             ..minimal_valid_eoa_tx()
         };
-        assert_unsupported(TestValidator::validate_account_changes(
-            &sign_eoa_eip8130(tx),
-            test_chain_id(),
-        ));
+        assert!(
+            TestValidator::validate_account_changes(&sign_eoa_eip8130(tx), test_chain_id(),)
+                .is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Mirrors the finalized on-chain keystore into the native EIP-8130 implementation. Four coordinated changes:

- **Scope bits reordered + renamed** to match `Scopes.sol`: `OPERATOR=0x1`, `SELF_PAYER=0x2`, `SPONSOR_PAYER=0x4`, `POLICY=0x8`, `NONCE=0x10`.
- **Co-located actor record** — policy `manager`/`commitment` sit at record offsets 1/2, adjacent to the config word.
- **Length-based policy attachment** — `policy_data` is empty or exactly 52 bytes (`manager || commitment`); attachment is decided by length, decoupled from the `POLICY` scope bit.
- **Typehash update** for the renamed EIP-712 types.

## Authorization (unchanged, verified against the merged contract)

- **Sender**: admin (`scope == 0`) | `OPERATOR` | `POLICY`. A `POLICY`-only sender is policy-gated; `OPERATOR` is the more permissive grant and overrides `POLICY`. Non-sender scopes (e.g. payer-only) are rejected.
- **Config changes**: admin-only (`scope == 0`), matching the contract's flat "every signed account change is admin-only".
- **Pay**: `SELF_PAYER` (self) / `SPONSOR_PAYER` (sponsor).
- **Nonce channels**: admin or `NONCE`; nonce-free (`NONCE_KEY_MAX`) always allowed.

## Performance (no change)

SLOAD counts are identical: full-owner / operator sender = 1 SLOAD; policy-gated resolution = 2 (config word + manager). Co-location makes the manager read witness-adjacent (`base+1`) — a future Verkle win, no op-count change.

## Test plan

- [x] `cargo test -p base-execution-eip8130` (207)
- [x] `cargo test -p base-common-consensus -p base-common-evm`
- [x] `cargo test -p base-execution-txpool --lib validator::`
- New/updated tests: scope-bit values pinned, co-located record offsets/order + base slots, length-based `slice_policy` / `policy_attached`, attachment-vs-scope decoupling, length-based intrinsic metering, non-sender-scope sender rejection, `sender_is_policy_gated` (POLICY gated, OPERATOR overrides).
