### PR TITLE
feat(evm2): Base Fork Schedule

### DIFF
--- a/crates/common/evm2/src/handler.rs
+++ b/crates/common/evm2/src/handler.rs
@@ -2,7 +2,6 @@
 
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, U256};
-use base_common_genesis::BaseUpgrade;
 use evm2::{
     Evm, TxResult,
     ethereum::{charge_upfront, default_settle_gas},
@@ -27,11 +26,12 @@ impl BaseTxHandlerHooks {
     fn l1_fee(host: &mut Evm<'_, BaseEvmTypes>, envelope: &BaseTxEnvelope) -> U256 {
         match envelope {
             // TODO: price over the full L1-posted (EIP-2718) transaction, not just
-            // the calldata, to match the revm integration. The evm2 spec schedule
-            // is also still Ecotone-only; the Base fork schedule is layered on in
-            // follow-up work.
+            // the calldata, to match the revm integration. This requires the
+            // envelope to carry the enveloped tx bytes (evm2's `TxEnvelope` does not
+            // expose them), tracked as fee-completeness follow-up work.
             BaseTxEnvelope::Standard(tx) => {
-                host.block_env().ext.calculate_tx_l1_cost(tx.input(), BaseUpgrade::Ecotone)
+                let upgrade = host.config_spec_id().upgrade();
+                host.block_env().ext.calculate_tx_l1_cost(tx.input(), upgrade)
             }
             // Deposits are funded on L1 and exempt from the L2 L1-data fee.
             BaseTxEnvelope::Deposit(_) => U256::ZERO,

--- a/crates/common/evm2/src/lib.rs
+++ b/crates/common/evm2/src/lib.rs
@@ -1,5 +1,8 @@
 #![doc = include_str!("../README.md")]
 
+mod spec;
+pub use spec::BaseSpecId;
+
 mod transaction;
 pub use transaction::{BaseTxEnvelope, DEPOSIT_TX_TYPE, TxDeposit};
 

--- a/crates/common/evm2/src/registry.rs
+++ b/crates/common/evm2/src/registry.rs
@@ -194,13 +194,15 @@ impl BaseEvmTypes {
 mod tests {
     use alloy_consensus::transaction::Recovered;
     use alloy_primitives::{Address, Bytes, TxKind, U256};
-    use evm2::{Evm, Precompiles, SpecId, env::BlockEnv, evm::InMemoryDB};
+    use base_common_genesis::BaseUpgrade;
+    use evm2::{Evm, Precompiles, env::BlockEnv, evm::InMemoryDB};
 
     use super::*;
+    use crate::BaseSpecId;
 
     const SENDER: Address = Address::repeat_byte(0x11);
     const TARGET: Address = Address::repeat_byte(0x22);
-    const SPEC: SpecId = SpecId::OSAKA;
+    const SPEC: BaseSpecId = BaseSpecId::new(BaseUpgrade::Regolith);
 
     /// Builds an in-memory EVM wired with the Base transaction registry.
     fn new_evm() -> Evm<'static, BaseEvmTypes> {
@@ -209,7 +211,7 @@ mod tests {
             BlockEnv::<BaseEvmTypes>::default(),
             BaseEvmTypes::tx_registry(),
             InMemoryDB::default(),
-            Precompiles::base(SPEC),
+            Precompiles::base(SPEC.into()),
         )
     }
 
@@ -347,7 +349,7 @@ mod tests {
             BlockEnv::<BaseEvmTypes>::default(),
             BaseEvmTypes::tx_registry(),
             db,
-            Precompiles::base(SPEC),
+            Precompiles::base(SPEC.into()),
         );
 
         let tx = deposit(TxKind::Call(TARGET), 1_000, U256::from(500), Bytes::new(), false);

--- a/crates/common/evm2/src/spec.rs
+++ b/crates/common/evm2/src/spec.rs
@@ -1,0 +1,67 @@
+//! Base fork schedule for the EVM2 execution type family.
+
+use base_common_genesis::BaseUpgrade;
+use evm2::SpecId;
+
+/// A Base fork identifier for EVM2 execution.
+///
+/// Wraps a Base network [`BaseUpgrade`] and maps it — via [`From<BaseSpecId>`] for [`SpecId`] —
+/// to the EVM2 spec whose feature set and gas schedule govern execution at that upgrade. Used
+/// as [`BaseEvmTypes::SpecId`](crate::BaseEvmTypes), it keeps the active upgrade recoverable at
+/// runtime (`Evm::config_spec_id`) for fork-dependent fee logic, even when several upgrades
+/// share one EVM2 spec (e.g. Ecotone and Fjord both map to [`SpecId::CANCUN`]).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BaseSpecId(BaseUpgrade);
+
+impl BaseSpecId {
+    /// Wraps a Base network upgrade.
+    pub const fn new(upgrade: BaseUpgrade) -> Self {
+        Self(upgrade)
+    }
+
+    /// Returns the wrapped Base network upgrade.
+    pub const fn upgrade(self) -> BaseUpgrade {
+        self.0
+    }
+}
+
+impl From<BaseUpgrade> for BaseSpecId {
+    fn from(upgrade: BaseUpgrade) -> Self {
+        Self(upgrade)
+    }
+}
+
+impl From<BaseSpecId> for SpecId {
+    /// Maps a Base upgrade to the EVM2 spec that governs execution at that upgrade.
+    ///
+    /// Mirrors the revm-side mapping (`base-common-chains`' `BaseUpgrade::into_eth_spec`),
+    /// duplicated here rather than reused because that mapping targets revm's `SpecId` and
+    /// pulls in revm, which this crate deliberately avoids.
+    fn from(spec: BaseSpecId) -> Self {
+        match spec.0 {
+            BaseUpgrade::Bedrock | BaseUpgrade::Regolith => Self::MERGE,
+            BaseUpgrade::Canyon | BaseUpgrade::Delta => Self::SHANGHAI,
+            BaseUpgrade::Ecotone
+            | BaseUpgrade::Fjord
+            | BaseUpgrade::Granite
+            | BaseUpgrade::Holocene
+            | BaseUpgrade::PectraBlobSchedule => Self::CANCUN,
+            BaseUpgrade::Isthmus | BaseUpgrade::Jovian => Self::PRAGUE,
+            // Azul, Beryl, Cobalt, Denim, Zenith, and newer upgrades inherit the latest known
+            // Ethereum spec until explicitly mapped.
+            _ => Self::OSAKA,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_the_wrapped_upgrade() {
+        let spec = BaseSpecId::new(BaseUpgrade::Fjord);
+        assert_eq!(spec.upgrade(), BaseUpgrade::Fjord);
+        assert_eq!(BaseSpecId::from(BaseUpgrade::Fjord), spec);
+    }
+}

--- a/crates/common/evm2/src/types.rs
+++ b/crates/common/evm2/src/types.rs
@@ -2,9 +2,9 @@
 
 use alloy_primitives::U256;
 use base_common_l1_fees::L1FeeParams;
-use evm2::{BaseEvmConfigSelector, Evm, EvmTypesHost, SpecId};
+use evm2::{BaseEvmConfigSelector, Evm, EvmTypesHost};
 
-use crate::transaction::BaseTxEnvelope;
+use crate::{BaseSpecId, transaction::BaseTxEnvelope};
 
 /// Transaction-result extension data for Base transactions.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -32,15 +32,15 @@ pub struct BaseEvmExt {
 /// Wires Base's transaction envelope ([`BaseTxEnvelope`], including deposits),
 /// L1 fee inputs (the shared engine-neutral [`L1FeeParams`] as the block-env
 /// extension), and L1-fee result data ([`BaseTxResultExt`]) into EVM2's
-/// [`EvmTypesHost`]. The spec schedule still uses the stock Ethereum selector;
-/// the Base fork schedule is layered on in follow-up work. Not wired into the
-/// node.
+/// [`EvmTypesHost`]. The spec schedule is driven by the Base fork schedule
+/// ([`BaseSpecId`]), which maps each Base upgrade to the governing EVM2 spec.
+/// Not wired into the node.
 #[derive(Clone, Copy, Debug)]
 pub struct BaseEvmTypes;
 
 impl EvmTypesHost for BaseEvmTypes {
     type ConfigSelector = BaseEvmConfigSelector;
-    type SpecId = SpecId;
+    type SpecId = BaseSpecId;
     type Tx = BaseTxEnvelope;
     type EvmExt = BaseEvmExt;
     type MessageExt = ();

--- a/crates/common/evm2/tests/deposit_parity.rs
+++ b/crates/common/evm2/tests/deposit_parity.rs
@@ -5,22 +5,23 @@
 //! success, gas used, the created contract address, and the post-state (balance, nonce,
 //! code hash, and storage) of every account the fixture cares about.
 //!
-//! Both engines run at the same fork — evm2 [`SpecId::MERGE`] and revm
-//! [`BaseUpgrade::Regolith`] (which maps to `MERGE`) — so gas is comparable, and both take the
-//! same `base_common_consensus::TxDeposit` fields (shared thanks to the type dedup).
+//! Every fixture is swept across [`FORKS`] (Regolith/Ecotone/Isthmus → MERGE/CANCUN/PRAGUE) on
+//! both engines, exercising the Base fork schedule: evm2 selects the spec via
+//! [`BaseSpecId`] and revm via its own `BaseSpecId`, both from the same [`BaseUpgrade`]. Both
+//! take the same `base_common_consensus::TxDeposit` fields (shared thanks to the type dedup).
 
 use std::collections::BTreeMap;
 
 use alloy_consensus::transaction::Recovered;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
 // revm reference side.
-use base_common_evm::{BaseSpecId, BaseTransaction, Builder, DefaultBase, L1BlockInfo};
-// evm2 side.
-use base_common_evm2::{BaseEvmTypes, BaseTxEnvelope, TxDeposit};
-use base_common_genesis::BaseUpgrade;
-use evm2::{
-    Evm, Precompiles, SpecId, bytecode::Bytecode as Evm2Bytecode, env::BlockEnv, evm::InMemoryDB,
+use base_common_evm::{
+    BaseSpecId as RevmBaseSpecId, BaseTransaction, Builder, DefaultBase, L1BlockInfo,
 };
+// evm2 side.
+use base_common_evm2::{BaseEvmTypes, BaseSpecId, BaseTxEnvelope, TxDeposit};
+use base_common_genesis::BaseUpgrade;
+use evm2::{Evm, Precompiles, bytecode::Bytecode as Evm2Bytecode, env::BlockEnv, evm::InMemoryDB};
 use revm::{
     ExecuteEvm,
     bytecode::Bytecode as RevmBytecode,
@@ -33,6 +34,10 @@ use revm::{
 
 const SENDER: Address = Address::repeat_byte(0x11);
 const SOURCE_HASH: B256 = B256::repeat_byte(0xab);
+
+/// Base upgrades the parity fixtures are swept across, exercising the fork schedule end to end
+/// (MERGE, CANCUN, and PRAGUE gas schedules respectively).
+const FORKS: [BaseUpgrade; 3] = [BaseUpgrade::Regolith, BaseUpgrade::Ecotone, BaseUpgrade::Isthmus];
 
 /// An account to seed into both engines before execution.
 #[derive(Clone)]
@@ -80,8 +85,8 @@ fn norm_code_hash(hash: B256) -> B256 {
     if hash == B256::ZERO { keccak256([]) } else { hash }
 }
 
-/// Executes `fixture` through the evm2 deposit handler and captures its outcome.
-fn run_evm2(fixture: &Fixture) -> Outcome {
+/// Executes `fixture` through the evm2 deposit handler at `upgrade` and captures its outcome.
+fn run_evm2(fixture: &Fixture, upgrade: BaseUpgrade) -> Outcome {
     let mut db = InMemoryDB::default();
     for seed in &fixture.seed {
         let mut info =
@@ -91,12 +96,13 @@ fn run_evm2(fixture: &Fixture) -> Outcome {
         }
         db.insert_account_info(&seed.address, info);
     }
+    let spec = BaseSpecId::new(upgrade);
     let mut evm = Evm::new(
-        SpecId::MERGE,
+        spec,
         BlockEnv::<BaseEvmTypes>::default(),
         BaseEvmTypes::tx_registry(),
         db,
-        Precompiles::base(SpecId::MERGE),
+        Precompiles::base(spec.into()),
     );
 
     let tx = TxDeposit {
@@ -139,8 +145,8 @@ fn run_evm2(fixture: &Fixture) -> Outcome {
     }
 }
 
-/// Executes `fixture` through the revm-based `base-common-evm` reference and captures its outcome.
-fn run_revm(fixture: &Fixture) -> Outcome {
+/// Executes `fixture` through the revm-based `base-common-evm` reference at `upgrade`.
+fn run_revm(fixture: &Fixture, upgrade: BaseUpgrade) -> Outcome {
     let mut db = RevmDb::default();
     for seed in &fixture.seed {
         let mut info =
@@ -158,7 +164,7 @@ fn run_revm(fixture: &Fixture) -> Outcome {
             operator_fee_constant: Some(U256::ZERO),
             ..Default::default()
         })
-        .with_cfg(CfgEnv::new_with_spec(BaseSpecId::new(BaseUpgrade::Regolith)));
+        .with_cfg(CfgEnv::new_with_spec(RevmBaseSpecId::new(upgrade)));
     let mut evm = ctx.build_base();
 
     let kind = match fixture.to {
@@ -212,11 +218,13 @@ fn run_revm(fixture: &Fixture) -> Outcome {
     Outcome { success: result.is_success(), gas_used: result.tx_gas_used(), created, accounts }
 }
 
-/// Asserts the two engines produce identical outcomes for `fixture`.
+/// Asserts the two engines produce identical outcomes for `fixture` at every fork in [`FORKS`].
 fn assert_parity(fixture: Fixture) {
-    let evm2 = run_evm2(&fixture);
-    let revm = run_revm(&fixture);
-    assert_eq!(evm2, revm, "evm2 and revm deposit outcomes diverged");
+    for upgrade in FORKS {
+        let evm2 = run_evm2(&fixture, upgrade);
+        let revm = run_revm(&fixture, upgrade);
+        assert_eq!(evm2, revm, "evm2 and revm deposit outcomes diverged at {upgrade:?}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Gives `base-common-evm2` a **Base fork schedule** so the EVM feature set / gas schedule is chosen by the active Base upgrade instead of the stock Ethereum spec. Stacked on #4759.

- Adds `BaseSpecId`, wrapping `base_common_genesis::BaseUpgrade` and mapping each upgrade to the governing evm2 `SpecId` (mirrors the revm-side `into_eth_spec` table; duplicated rather than reused because that mapping targets revm's `SpecId`).
- Wires it as `BaseEvmTypes::SpecId`. The stock `BaseEvmConfigSelector` already generically maps `T::SpecId` via `Into<SpecId>`, so no custom selector is needed.
- The active upgrade stays recoverable at runtime via `Evm::config_spec_id` — so even though several upgrades share one evm2 spec (Ecotone & Fjord → CANCUN), the **L1 data fee is now fork-aware** (formula selected by the active `BaseUpgrade`) instead of hardcoding Ecotone.

Timestamp → upgrade resolution happens at the node boundary (future PR); evm2 selects purely from the `SpecId` passed to `Evm::new`.

## Testing

The differential parity harness now **sweeps every fixture across Regolith/Ecotone/Isthmus (MERGE/CANCUN/PRAGUE)** — 7 fixtures × 3 forks = 21 differential executions, all matching between evm2 and revm, including the fork-sensitive `SSTORE` case. Plus unit tests for the mapping table. All tests + `clippy -D warnings` + `+nightly fmt` clean; non-test build stays revm-free.

## Scope note — fee completeness deferred
The roadmap grouped "fork schedule **& fee completeness**" together, but the fee half (Isthmus **operator fee**, and pricing the L1 fee over the **full EIP-2718 tx** rather than calldata) has a real prerequisite: the standard-tx envelope must carry its enveloped bytes (evm2's `TxEnvelope` doesn't expose them). That's cleaner as its own PR, so this one is scoped to the fork schedule.