### PR TITLE
feat(evm2): Standard-Transaction Fee Completeness

### DIFF
--- a/crates/common/evm2/Cargo.toml
+++ b/crates/common/evm2/Cargo.toml
@@ -27,8 +27,10 @@ alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 
 [dev-dependencies]
-# base — the revm execution path, for the differential deposit-parity harness
+# base — the revm execution path, for the differential parity harnesses
 base-common-genesis.workspace = true
+base-common-l1-fees.workspace = true
+base-common-consensus.workspace = true
 base-common-evm = { workspace = true, features = ["blst", "c-kzg", "portable", "secp256k1", "std"] }
 
 # evm2
@@ -39,3 +41,4 @@ revm = { workspace = true, features = ["std"] }
 
 # alloy
 alloy-primitives.workspace = true
+alloy-consensus.workspace = true

--- a/crates/common/evm2/src/handler.rs
+++ b/crates/common/evm2/src/handler.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{Address, U256};
 use base_common_consensus::Predeploys;
 use base_common_genesis::BaseUpgrade;
 use evm2::{
-    Evm, TxResult,
+    Evm, EvmFeatures, TxResult,
     ethereum::{charge_upfront, default_settle_gas},
     handler::{GasSettlement, TxHandlerHooks},
     interpreter::Host,
@@ -61,6 +61,44 @@ impl BaseTxHandlerHooks {
         }
     }
 
+    /// Rejects the transaction when `caller` cannot cover the full upfront charge — the maximum
+    /// gas cost, the transferred value, and the OP-stack L1 data and operator fees.
+    ///
+    /// The framework's `validate_sender` already rejects a caller that cannot cover the gas cost
+    /// and value, but it is unaware of the L1 and operator fees charged here, and
+    /// [`charge_upfront`] deducts with wrapping arithmetic. Without this guard an underfunded
+    /// caller would silently wrap to a spurious balance instead of the transaction failing; this
+    /// mirrors the revm reference, which rejects such a caller with `LackOfFundForMaxFee`.
+    ///
+    /// A no-op for deposits (funded on L1 and exempt) and when fee charging or balance checks are
+    /// disabled (e.g. `eth_call` simulation), matching the conditions under which `validate_sender`
+    /// and `charge_upfront` themselves enforce balances.
+    fn ensure_can_pay_fees(
+        host: &mut Evm<'_, BaseEvmTypes>,
+        envelope: &BaseTxEnvelope,
+        caller: Address,
+        l1_fee: U256,
+        operator_fee: U256,
+    ) -> HandlerResult<()> {
+        let Some(tx) = envelope.as_standard() else {
+            return Ok(());
+        };
+        if !host.feature(EvmFeatures::FEE_CHARGE) || !host.feature(EvmFeatures::BALANCE_CHECK) {
+            return Ok(());
+        }
+        let required = U256::from(tx.gas_limit())
+            .saturating_mul(U256::from(tx.max_fee_per_gas()))
+            .saturating_add(tx.value())
+            .saturating_add(l1_fee)
+            .saturating_add(operator_fee);
+        let balance =
+            host.state_mut().account(&caller, false).map_err(HandlerError::Fatal)?.balance();
+        if balance < required {
+            return Err(HandlerError::InsufficientFunds);
+        }
+        Ok(())
+    }
+
     /// Credits `amount` to `recipient`'s balance.
     fn credit(
         host: &mut Evm<'_, BaseEvmTypes>,
@@ -90,6 +128,10 @@ impl TxHandlerHooks<BaseEvmTypes> for BaseTxHandlerHooks {
         let ext = host.ext_mut();
         ext.l1_fee = l1_fee;
         ext.operator_fee = operator_fee;
+        // `validate_sender` only checks the gas cost and value; the L1 and operator fees are
+        // charged on top here via `charge_upfront`'s wrapping subtraction, so reject an
+        // underfunded caller up front rather than let its balance wrap to a spurious value.
+        Self::ensure_can_pay_fees(host, envelope, caller, l1_fee, operator_fee)?;
         charge_upfront(
             host,
             caller,

--- a/crates/common/evm2/src/handler.rs
+++ b/crates/common/evm2/src/handler.rs
@@ -2,40 +2,76 @@
 
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, U256};
+use base_common_consensus::Predeploys;
+use base_common_genesis::BaseUpgrade;
 use evm2::{
     Evm, TxResult,
     ethereum::{charge_upfront, default_settle_gas},
     handler::{GasSettlement, TxHandlerHooks},
     interpreter::Host,
-    registry::HandlerResult,
+    registry::{HandlerError, HandlerResult},
 };
 
 use crate::{BaseEvmTypes, transaction::BaseTxEnvelope};
 
 /// Base transaction handler hooks.
 ///
-/// Charges the L1 data fee alongside the standard upfront gas cost for
-/// non-deposit transactions; deposits are funded on L1 and exempt. All other
-/// hooks keep the default Ethereum behavior.
+/// For non-deposit transactions these charge the OP-stack L1 data fee and the Isthmus operator
+/// fee alongside the standard upfront gas cost, and distribute the collected fees to their
+/// vaults at settlement (L1 data fee → [`Predeploys::L1_FEE_VAULT`], base fee →
+/// [`Predeploys::BASE_FEE_VAULT`], operator fee → [`Predeploys::OPERATOR_FEE_VAULT`]); the
+/// coinbase priority fee and caller gas refund keep the default Ethereum behavior. Deposits are
+/// funded on L1 and exempt (and never routed through these hooks).
 #[derive(Clone, Copy, Debug, Default)]
 pub struct BaseTxHandlerHooks;
 
 impl BaseTxHandlerHooks {
-    /// Returns the L1 data fee for `envelope` under the current block's
-    /// L1 fee parameters. Deposits are funded on L1 and exempt.
+    /// Returns the L1 data fee for `envelope` at the active Base upgrade, priced over the full
+    /// EIP-2718 transaction. Deposits are funded on L1 and exempt (zero).
     fn l1_fee(host: &mut Evm<'_, BaseEvmTypes>, envelope: &BaseTxEnvelope) -> U256 {
-        match envelope {
-            // TODO: price over the full L1-posted (EIP-2718) transaction, not just
-            // the calldata, to match the revm integration. This requires the
-            // envelope to carry the enveloped tx bytes (evm2's `TxEnvelope` does not
-            // expose them), tracked as fee-completeness follow-up work.
-            BaseTxEnvelope::Standard(tx) => {
-                let upgrade = host.config_spec_id().upgrade();
-                host.block_env().ext.calculate_tx_l1_cost(tx.input(), upgrade)
-            }
-            // Deposits are funded on L1 and exempt from the L2 L1-data fee.
-            BaseTxEnvelope::Deposit(_) => U256::ZERO,
+        let Some(enveloped) = envelope.enveloped() else {
+            return U256::ZERO;
+        };
+        let upgrade = host.config_spec_id().upgrade();
+        host.block_env().ext.calculate_tx_l1_cost(enveloped, upgrade)
+    }
+
+    /// Returns the Isthmus operator fee for `envelope` over `gas`. Zero for deposits and before
+    /// Isthmus.
+    ///
+    /// The operator fee is an Isthmus feature; `L1FeeParams::operator_fee_charge` computes it
+    /// unconditionally, so the Isthmus gate is applied here (matching the reference, which gates
+    /// in its `reward_beneficiary`). The Base upgrade ladder is discriminant-ordered.
+    fn operator_fee(host: &mut Evm<'_, BaseEvmTypes>, envelope: &BaseTxEnvelope, gas: u64) -> U256 {
+        let Some(enveloped) = envelope.enveloped() else {
+            return U256::ZERO;
+        };
+        let upgrade = host.config_spec_id().upgrade();
+        if (upgrade as u8) < (BaseUpgrade::Isthmus as u8) {
+            return U256::ZERO;
         }
+        host.block_env().ext.operator_fee_charge(enveloped, U256::from(gas), upgrade)
+    }
+
+    /// Returns the transaction's gas limit.
+    fn gas_limit(envelope: &BaseTxEnvelope) -> u64 {
+        match envelope {
+            BaseTxEnvelope::Standard { tx, .. } => tx.gas_limit(),
+            BaseTxEnvelope::Deposit(tx) => tx.gas_limit,
+        }
+    }
+
+    /// Credits `amount` to `recipient`'s balance.
+    fn credit(
+        host: &mut Evm<'_, BaseEvmTypes>,
+        recipient: Address,
+        amount: U256,
+    ) -> HandlerResult<()> {
+        host.state_mut()
+            .account(&recipient, false)
+            .map_err(HandlerError::Fatal)?
+            .add_balance(amount);
+        Ok(())
     }
 }
 
@@ -46,25 +82,52 @@ impl TxHandlerHooks<BaseEvmTypes> for BaseTxHandlerHooks {
         caller: Address,
         upfront_fee: U256,
     ) -> HandlerResult<()> {
-        // Compute the L1 fee once and stash it on the EVM extension so
-        // `settle_transaction` records the exact value charged here, without a
-        // second pass over the calldata or any risk of divergence if the block's
-        // L1 fee parameters were mutated mid-transaction.
+        // Charge the upfront gas cost, the L1 data fee, and the operator fee (on the gas limit)
+        // from the caller. Both fees are stashed for settlement so it charges/refunds against the
+        // exact amounts collected here, without recomputing them.
         let l1_fee = Self::l1_fee(host, envelope);
-        host.ext_mut().l1_fee = l1_fee;
-        charge_upfront(host, caller, upfront_fee.saturating_add(l1_fee))
+        let operator_fee = Self::operator_fee(host, envelope, Self::gas_limit(envelope));
+        let ext = host.ext_mut();
+        ext.l1_fee = l1_fee;
+        ext.operator_fee = operator_fee;
+        charge_upfront(
+            host,
+            caller,
+            upfront_fee.saturating_add(l1_fee).saturating_add(operator_fee),
+        )
     }
 
     fn settle_transaction(
         host: &mut Evm<'_, BaseEvmTypes>,
-        _envelope: &BaseTxEnvelope,
+        envelope: &BaseTxEnvelope,
         gas: GasSettlement<BaseEvmTypes>,
     ) -> HandlerResult<TxResult<BaseEvmTypes>> {
-        // Surface the L1 data fee charged in `before_execution` so downstream
-        // receipt construction can report it. The default gas settlement is
-        // otherwise unchanged.
+        let caller = gas.caller;
+        let basefee = host.block_env().basefee;
         let l1_fee = host.ext().l1_fee;
+        // The operator fee charged upfront (on the gas limit), stashed in before_execution.
+        let operator_fee_charged = host.ext().operator_fee;
+
+        // Default settlement refunds the caller's unused gas and pays the coinbase the priority
+        // fee. The base fee is credited to its vault below (the OP-stack does not burn it).
         let mut result = default_settle_gas(host, gas)?;
+        let gas_used = result.tx_gas_used();
+
+        // Refund the operator fee down from the amount charged (on the gas limit) to the gas
+        // actually used; the net is credited to the operator-fee vault below.
+        let operator_fee_used = Self::operator_fee(host, envelope, gas_used);
+        let operator_fee_refund = operator_fee_charged.saturating_sub(operator_fee_used);
+        Self::credit(host, caller, operator_fee_refund)?;
+
+        // Distribute the collected OP-stack fees to their vaults.
+        Self::credit(host, Predeploys::L1_FEE_VAULT, l1_fee)?;
+        Self::credit(
+            host,
+            Predeploys::BASE_FEE_VAULT,
+            basefee.saturating_mul(U256::from(gas_used)),
+        )?;
+        Self::credit(host, Predeploys::OPERATOR_FEE_VAULT, operator_fee_used)?;
+
         result.ext.l1_fee = l1_fee;
         Ok(result)
     }

--- a/crates/common/evm2/src/transaction.rs
+++ b/crates/common/evm2/src/transaction.rs
@@ -1,6 +1,7 @@
 //! Base transaction envelope for EVM2.
 
 use alloy_eips::eip2718::Typed2718;
+use alloy_primitives::Bytes;
 /// EIP-2718 transaction type byte for deposit transactions.
 ///
 /// Re-exported from [`base_common_consensus`] to keep a single source of truth
@@ -19,15 +20,32 @@ pub enum BaseTxEnvelope {
     /// An L1-originated deposit transaction.
     Deposit(TxDeposit),
     /// A standard, signed Ethereum transaction.
-    Standard(TxEnvelope),
+    Standard {
+        /// The decoded standard transaction.
+        tx: TxEnvelope,
+        /// The EIP-2718 encoded bytes the transaction was decoded from, as posted to L1. Used
+        /// to price the L1 data fee over the full transaction (matching the revm integration),
+        /// which `TxEnvelope` alone cannot reproduce.
+        enveloped: Bytes,
+    },
 }
 
 impl BaseTxEnvelope {
+    /// Builds a standard-transaction envelope from a decoded transaction and its EIP-2718
+    /// encoded bytes.
+    pub fn standard(tx: TxEnvelope, enveloped: Bytes) -> Self {
+        // Empty enveloped bytes would make L1FeeParams::is_fee_exempt treat the transaction as
+        // fee-exempt, silently zeroing the L1 data fee and operator fee. Catch that misuse at
+        // construction rather than producing incorrect fees downstream.
+        debug_assert!(!enveloped.is_empty(), "standard tx must carry non-empty enveloped bytes");
+        Self::Standard { tx, enveloped }
+    }
+
     /// Returns the deposit transaction, if this envelope is a deposit.
     pub const fn as_deposit(&self) -> Option<&TxDeposit> {
         match self {
             Self::Deposit(tx) => Some(tx),
-            Self::Standard(_) => None,
+            Self::Standard { .. } => None,
         }
     }
 
@@ -39,7 +57,16 @@ impl BaseTxEnvelope {
     /// Returns the standard Ethereum transaction, if this envelope is not a deposit.
     pub const fn as_standard(&self) -> Option<&TxEnvelope> {
         match self {
-            Self::Standard(tx) => Some(tx),
+            Self::Standard { tx, .. } => Some(tx),
+            Self::Deposit(_) => None,
+        }
+    }
+
+    /// Returns the standard transaction's EIP-2718 encoded bytes, if this envelope is not a
+    /// deposit.
+    pub const fn enveloped(&self) -> Option<&Bytes> {
+        match self {
+            Self::Standard { enveloped, .. } => Some(enveloped),
             Self::Deposit(_) => None,
         }
     }
@@ -49,7 +76,7 @@ impl Typed2718 for BaseTxEnvelope {
     fn ty(&self) -> u8 {
         match self {
             Self::Deposit(tx) => tx.ty(),
-            Self::Standard(tx) => tx.ty(),
+            Self::Standard { tx, .. } => tx.ty(),
         }
     }
 }
@@ -57,12 +84,6 @@ impl Typed2718 for BaseTxEnvelope {
 impl From<TxDeposit> for BaseTxEnvelope {
     fn from(tx: TxDeposit) -> Self {
         Self::Deposit(tx)
-    }
-}
-
-impl From<TxEnvelope> for BaseTxEnvelope {
-    fn from(tx: TxEnvelope) -> Self {
-        Self::Standard(tx)
     }
 }
 

--- a/crates/common/evm2/src/types.rs
+++ b/crates/common/evm2/src/types.rs
@@ -15,16 +15,19 @@ pub struct BaseTxResultExt {
 
 /// EVM instance-wide extension state for Base transactions.
 ///
-/// Carries the L1 data fee computed and charged in
+/// Carries the L1 data fee and operator fee computed and charged in
 /// [`BaseTxHandlerHooks::before_execution`](crate::BaseTxHandlerHooks) so
 /// [`settle_transaction`](evm2::handler::TxHandlerHooks::settle_transaction) can
-/// record the exact same value on [`BaseTxResultExt::l1_fee`] without recomputing
-/// it — this keeps the charged and recorded fees in lockstep and avoids a second
-/// pass over the transaction calldata.
+/// record/refund against the exact amounts charged without recomputing them —
+/// keeping the charged and settled fees in lockstep and avoiding a second pass
+/// over the transaction.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BaseEvmExt {
     /// L1 data fee charged for the transaction currently executing.
     pub l1_fee: U256,
+    /// Operator fee charged upfront (on the gas limit) for the transaction currently executing;
+    /// its unused portion is refunded at settlement.
+    pub operator_fee: U256,
 }
 
 /// Base's EVM2 execution type family.

--- a/crates/common/evm2/tests/standard_fee_parity.rs
+++ b/crates/common/evm2/tests/standard_fee_parity.rs
@@ -1,0 +1,188 @@
+//! Differential parity harness for standard-transaction fee distribution.
+//!
+//! Runs the same EIP-1559 transaction through the `base-common-evm2` handler hooks and the
+//! revm-based `base-common-evm` reference, asserting the two engines agree on the fee outcome:
+//! success, gas used, and the post-state balances of the caller, the coinbase, and the three
+//! OP-stack fee vaults (L1 / base fee / operator fee).
+//!
+//! The transaction fields (from the decoded tx) drive execution and the same arbitrary
+//! enveloped bytes drive the L1 data-fee byte count on both sides, so no signing is needed.
+//! Swept across Ecotone, Fjord, Isthmus, and Jovian to exercise each fee branch (linear vs
+//! `FastLZ` L1 cost, and the Isthmus/Jovian operator-fee formulas).
+
+use std::collections::BTreeMap;
+
+use alloy_consensus::{TxEip1559, transaction::Recovered};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use base_common_consensus::Predeploys;
+use base_common_evm::{
+    BaseSpecId as RevmBaseSpecId, BaseTransaction, Builder, DefaultBase, L1BlockInfo,
+};
+use base_common_evm2::{BaseEvmTypes, BaseSpecId, BaseTxEnvelope};
+use base_common_genesis::BaseUpgrade;
+use base_common_l1_fees::L1FeeParams;
+use evm2::{Evm, Precompiles, env::BlockEnv, ethereum::TxEnvelope, evm::InMemoryDB};
+use revm::{
+    ExecuteEvm,
+    context::{BlockEnv as RevmBlockEnv, CfgEnv, Context, TxEnv},
+    context_interface::result::ResultAndState,
+    database::InMemoryDB as RevmDb,
+    state::AccountInfo as RevmAccountInfo,
+};
+
+const SENDER: Address = Address::repeat_byte(0x11);
+const TARGET: Address = Address::repeat_byte(0x22);
+const COINBASE: Address = Address::repeat_byte(0x33);
+const CHAIN_ID: u64 = 1;
+const GAS_LIMIT: u64 = 100_000;
+const MAX_FEE: u128 = 1_000;
+const PRIORITY_FEE: u128 = 100;
+const BASEFEE: u64 = 500;
+const L1_BASE_FEE: u64 = 1_000_000_000;
+const L1_BASE_FEE_SCALAR: u64 = 1_000;
+const OPERATOR_FEE_SCALAR: u64 = 2_000;
+const OPERATOR_FEE_CONSTANT: u64 = 7;
+// Ecotone (linear L1 cost), Fjord (FastLZ-estimated L1 cost), Isthmus (operator fee), and
+// Jovian (operator fee × multiplier) — exercising each distinct fee branch.
+const FORKS: [BaseUpgrade; 4] =
+    [BaseUpgrade::Ecotone, BaseUpgrade::Fjord, BaseUpgrade::Isthmus, BaseUpgrade::Jovian];
+
+/// Arbitrary EIP-2718-shaped bytes priced for the L1 data fee (same on both engines).
+fn enveloped() -> Bytes {
+    Bytes::from(vec![0x02u8; 120])
+}
+
+/// The fee accounts whose post-state is compared across engines.
+const fn fee_accounts() -> [Address; 5] {
+    [
+        SENDER,
+        COINBASE,
+        Predeploys::L1_FEE_VAULT,
+        Predeploys::BASE_FEE_VAULT,
+        Predeploys::OPERATOR_FEE_VAULT,
+    ]
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Outcome {
+    success: bool,
+    gas_used: u64,
+    balances: BTreeMap<Address, U256>,
+}
+
+fn l1_fee_params() -> L1FeeParams {
+    L1FeeParams {
+        l1_base_fee: U256::from(L1_BASE_FEE),
+        l1_base_fee_scalar: U256::from(L1_BASE_FEE_SCALAR),
+        operator_fee_scalar: Some(U256::from(OPERATOR_FEE_SCALAR)),
+        operator_fee_constant: Some(U256::from(OPERATOR_FEE_CONSTANT)),
+        ..Default::default()
+    }
+}
+
+/// Runs the EIP-1559 transfer through evm2 at `upgrade` and captures the fee outcome.
+fn run_evm2(upgrade: BaseUpgrade) -> Outcome {
+    let mut db = InMemoryDB::default();
+    db.insert_account_info(
+        &SENDER,
+        evm2::AccountInfo { balance: U256::from(10u128.pow(18)), nonce: 0, ..Default::default() },
+    );
+    let spec = BaseSpecId::new(upgrade);
+    let block = BlockEnv::<BaseEvmTypes> {
+        beneficiary: COINBASE,
+        basefee: U256::from(BASEFEE),
+        ext: l1_fee_params(),
+        ..Default::default()
+    };
+    let mut evm =
+        Evm::new(spec, block, BaseEvmTypes::tx_registry(), db, Precompiles::base(spec.into()));
+
+    let tx = TxEnvelope::Eip1559(TxEip1559 {
+        chain_id: CHAIN_ID,
+        nonce: 0,
+        gas_limit: GAS_LIMIT,
+        max_fee_per_gas: MAX_FEE,
+        max_priority_fee_per_gas: PRIORITY_FEE,
+        to: TxKind::Call(TARGET),
+        value: U256::ZERO,
+        input: Bytes::new(),
+        access_list: Default::default(),
+    });
+    let envelope = BaseTxEnvelope::standard(tx, enveloped());
+    let result = evm.transact(&Recovered::new_unchecked(envelope, SENDER)).unwrap().commit();
+
+    let balances = fee_accounts()
+        .into_iter()
+        .map(|address| {
+            let balance = evm
+                .state_mut()
+                .account_info_untracked(&address)
+                .unwrap()
+                .map(|info| info.balance)
+                .unwrap_or_default();
+            (address, balance)
+        })
+        .collect();
+
+    Outcome { success: result.status, gas_used: result.tx_gas_used(), balances }
+}
+
+/// Runs the same transfer through the revm reference at `upgrade`.
+fn run_revm(upgrade: BaseUpgrade) -> Outcome {
+    let mut db = RevmDb::default();
+    db.insert_account_info(
+        SENDER,
+        RevmAccountInfo { balance: U256::from(10u128.pow(18)), nonce: 0, ..Default::default() },
+    );
+    let params = l1_fee_params();
+    let ctx = Context::base()
+        .with_db(db)
+        .with_chain(L1BlockInfo {
+            l2_block: Some(U256::ZERO),
+            l1_base_fee: params.l1_base_fee,
+            l1_base_fee_scalar: params.l1_base_fee_scalar,
+            operator_fee_scalar: params.operator_fee_scalar,
+            operator_fee_constant: params.operator_fee_constant,
+            ..Default::default()
+        })
+        .with_block(RevmBlockEnv { basefee: BASEFEE, beneficiary: COINBASE, ..Default::default() })
+        .with_cfg(CfgEnv::new_with_spec(RevmBaseSpecId::new(upgrade)));
+    let mut evm = ctx.build_base();
+
+    let tx = BaseTransaction::builder()
+        .base(
+            // Leave tx_type unset: the builder infers EIP-1559 from the priority fee, and (unlike
+            // an explicit type) build_fill then keeps the enveloped bytes we provide instead of
+            // overriding them with a `[0x00]` placeholder.
+            TxEnv::builder()
+                .caller(SENDER)
+                .nonce(0)
+                .chain_id(Some(CHAIN_ID))
+                .kind(TxKind::Call(TARGET))
+                .gas_limit(GAS_LIMIT)
+                .max_fee_per_gas(MAX_FEE)
+                .gas_priority_fee(Some(PRIORITY_FEE)),
+        )
+        .enveloped_tx(Some(enveloped()))
+        .build_fill();
+    let ResultAndState { result, state } = evm.transact(tx).unwrap();
+
+    let balances = fee_accounts()
+        .into_iter()
+        .map(|address| {
+            let balance = state.get(&address).map(|a| a.info.balance).unwrap_or_default();
+            (address, balance)
+        })
+        .collect();
+
+    Outcome { success: result.is_success(), gas_used: result.tx_gas_used(), balances }
+}
+
+#[test]
+fn standard_transaction_fee_distribution_matches_revm() {
+    for upgrade in FORKS {
+        let evm2 = run_evm2(upgrade);
+        let revm = run_revm(upgrade);
+        assert_eq!(evm2, revm, "standard-tx fee distribution diverged at {upgrade:?}");
+    }
+}

--- a/crates/common/evm2/tests/standard_fee_parity.rs
+++ b/crates/common/evm2/tests/standard_fee_parity.rs
@@ -80,23 +80,8 @@ fn l1_fee_params() -> L1FeeParams {
     }
 }
 
-/// Runs the EIP-1559 transfer through evm2 at `upgrade` and captures the fee outcome.
-fn run_evm2(upgrade: BaseUpgrade) -> Outcome {
-    let mut db = InMemoryDB::default();
-    db.insert_account_info(
-        &SENDER,
-        evm2::AccountInfo { balance: U256::from(10u128.pow(18)), nonce: 0, ..Default::default() },
-    );
-    let spec = BaseSpecId::new(upgrade);
-    let block = BlockEnv::<BaseEvmTypes> {
-        beneficiary: COINBASE,
-        basefee: U256::from(BASEFEE),
-        ext: l1_fee_params(),
-        ..Default::default()
-    };
-    let mut evm =
-        Evm::new(spec, block, BaseEvmTypes::tx_registry(), db, Precompiles::base(spec.into()));
-
+/// The EIP-1559 transfer exercised by the harness, paired with its enveloped bytes.
+fn eip1559_envelope() -> BaseTxEnvelope {
     let tx = TxEnvelope::Eip1559(TxEip1559 {
         chain_id: CHAIN_ID,
         nonce: 0,
@@ -108,7 +93,27 @@ fn run_evm2(upgrade: BaseUpgrade) -> Outcome {
         input: Bytes::new(),
         access_list: Default::default(),
     });
-    let envelope = BaseTxEnvelope::standard(tx, enveloped());
+    BaseTxEnvelope::standard(tx, enveloped())
+}
+
+/// Builds an evm2 instance at `upgrade` with `SENDER` funded to `balance`.
+fn build_evm2(upgrade: BaseUpgrade, balance: U256) -> Evm<'static, BaseEvmTypes> {
+    let mut db = InMemoryDB::default();
+    db.insert_account_info(&SENDER, evm2::AccountInfo { balance, nonce: 0, ..Default::default() });
+    let spec = BaseSpecId::new(upgrade);
+    let block = BlockEnv::<BaseEvmTypes> {
+        beneficiary: COINBASE,
+        basefee: U256::from(BASEFEE),
+        ext: l1_fee_params(),
+        ..Default::default()
+    };
+    Evm::new(spec, block, BaseEvmTypes::tx_registry(), db, Precompiles::base(spec.into()))
+}
+
+/// Runs the EIP-1559 transfer through evm2 at `upgrade` and captures the fee outcome.
+fn run_evm2(upgrade: BaseUpgrade) -> Outcome {
+    let mut evm = build_evm2(upgrade, U256::from(10u128.pow(18)));
+    let envelope = eip1559_envelope();
     let result = evm.transact(&Recovered::new_unchecked(envelope, SENDER)).unwrap().commit();
 
     let balances = fee_accounts()
@@ -185,4 +190,29 @@ fn standard_transaction_fee_distribution_matches_revm() {
         let revm = run_revm(upgrade);
         assert_eq!(evm2, revm, "standard-tx fee distribution diverged at {upgrade:?}");
     }
+}
+
+/// A caller funded for the gas cost but not the additional L1 and operator fees must have its
+/// transaction rejected, matching the revm reference's `LackOfFundForMaxFee`. Without the
+/// affordability check the underfunded caller would wrap through `charge_upfront`'s saturating
+/// subtraction into a spurious balance instead of failing.
+#[test]
+fn underfunded_caller_is_rejected_not_wrapped() {
+    // Exactly the max gas cost (gas_limit * max_fee), with zero value: enough to clear the
+    // framework's sender validation, but nothing left for the L1 or operator fee charged on top.
+    let balance = U256::from(GAS_LIMIT) * U256::from(MAX_FEE);
+    let mut evm = build_evm2(BaseUpgrade::Isthmus, balance);
+
+    let rejected = evm.transact(&Recovered::new_unchecked(eip1559_envelope(), SENDER)).is_err();
+    assert!(rejected, "underfunded caller must be rejected, not charged");
+
+    // The rejected transaction must not have touched the caller's balance (in particular, it must
+    // not have wrapped to a spurious value).
+    let balance_after = evm
+        .state_mut()
+        .account_info_untracked(&SENDER)
+        .unwrap()
+        .map(|info| info.balance)
+        .unwrap_or_default();
+    assert_eq!(balance_after, balance, "rejected tx must leave the caller balance untouched");
 }


### PR DESCRIPTION
## Summary

Completes OP-stack fee handling for **non-deposit** transactions so it matches the revm reference (`base-common-evm`). Stacked on #4761.

- **Full-tx L1 pricing** — the envelope now carries the EIP-2718 bytes (`BaseTxEnvelope::Standard { tx, enveloped }`); the L1 data fee is priced over the full transaction, not just calldata (resolves the prior TODO). `TxEnvelope` alone can't reproduce these bytes, hence the envelope change.
- **Operator fee (Isthmus)** — charged upfront on the gas limit, unused portion refunded at settlement. The Isthmus gate is applied at the call site (l1-fees computes it unconditionally), matching the reference.
- **Fee vault distribution** — at settlement the collected fees go to their vaults: L1 data fee → `L1_FEE_VAULT`, base fee → `BASE_FEE_VAULT`, operator fee → `OPERATOR_FEE_VAULT`. Previously the L1 and base fees were effectively **burned**. Coinbase priority fee + caller gas refund keep the default Ethereum behavior. Deposits remain exempt (and never route through these hooks).

## Testing

New differential parity harness `tests/standard_fee_parity.rs`: runs the same EIP-1559 tx through both engines and asserts equal **gas used** and post-state balances for the **caller, coinbase, and all three vaults**, swept across **Ecotone** (no operator fee) and **Isthmus** (operator fee active). This harness **caught a real bug** — the missing operator-fee Isthmus gate (evm2 was charging it at Ecotone) — now fixed and verified.

All tests + `clippy -D warnings` + `+nightly fmt` clean; non-test build stays revm-free.