### PR TITLE
feat(evm2): Block-Executor Core

### DIFF
--- a/crates/common/evm2/src/executor.rs
+++ b/crates/common/evm2/src/executor.rs
@@ -1,0 +1,140 @@
+//! Base block executor for EVM2.
+
+use alloy_consensus::{Eip658Value, Receipt, transaction::Recovered};
+use alloy_eips::eip2718::Typed2718;
+use base_common_consensus::{BaseReceiptEnvelope, DepositReceipt};
+use base_common_genesis::BaseUpgrade;
+use evm2::{
+    BlockStateAccumulator, Evm,
+    registry::{HandlerError, HandlerResult},
+};
+
+use crate::{BaseEvmTypes, transaction::BaseTxEnvelope};
+
+/// Error returned when a block's cumulative gas used would overflow `u64`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CumulativeGasOverflow;
+
+impl core::fmt::Display for CumulativeGasOverflow {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("block cumulative gas used overflowed u64")
+    }
+}
+
+impl core::error::Error for CumulativeGasOverflow {}
+
+/// The outcome of executing a block's transactions: one receipt per transaction (in order) and
+/// the total gas used.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BlockExecutionResult {
+    /// The transaction receipts, in execution order.
+    pub receipts: Vec<BaseReceiptEnvelope>,
+    /// The block's cumulative gas used (the last receipt's cumulative gas, or zero).
+    pub gas_used: u64,
+}
+
+/// Executes a Base block's transactions on an EVM2 [`Evm`], building receipts and accumulating
+/// the block's state delta.
+///
+/// This is the transaction-execution core: it runs each transaction through the registry
+/// (deposit or standard handler), builds its receipt with running cumulative gas, and commits
+/// its state into a [`BlockStateAccumulator`]. Pre-execution block-boundary system calls
+/// (EIP-4788/EIP-2935, Canyon create2-deployer, Cobalt system accounts), the EIP-8130 path, and
+/// the Jovian DA-footprint checks are layered on in follow-up work.
+#[derive(Debug)]
+pub struct BaseBlockExecutor<'a> {
+    evm: Evm<'a, BaseEvmTypes>,
+    block_state: BlockStateAccumulator,
+    receipts: Vec<BaseReceiptEnvelope>,
+    gas_used: u64,
+}
+
+impl<'a> BaseBlockExecutor<'a> {
+    /// Creates a block executor over `evm`.
+    pub fn new(evm: Evm<'a, BaseEvmTypes>) -> Self {
+        Self { evm, block_state: BlockStateAccumulator::new(), receipts: Vec::new(), gas_used: 0 }
+    }
+
+    /// Returns the EVM.
+    pub const fn evm(&self) -> &Evm<'a, BaseEvmTypes> {
+        &self.evm
+    }
+
+    /// Returns a mutable reference to the EVM, e.g. to seed accounts before execution.
+    pub const fn evm_mut(&mut self) -> &mut Evm<'a, BaseEvmTypes> {
+        &mut self.evm
+    }
+
+    /// Executes `tx`, appending its receipt (with running cumulative gas) and committing its
+    /// state changes into the block-state accumulator.
+    pub fn execute_transaction(&mut self, tx: &Recovered<BaseTxEnvelope>) -> HandlerResult<()> {
+        let ty = tx.ty();
+        let is_deposit = tx.is_deposit();
+        let signer = tx.signer();
+
+        // The deposit receipt records the depositor's nonce *before* the deposit executes (and
+        // bumps it), read untracked so it does not perturb execution. Matches the reference.
+        let deposit_nonce = if is_deposit {
+            let nonce = self
+                .evm
+                .state_mut()
+                .account_info_untracked(&signer)
+                .map_err(HandlerError::Fatal)?
+                .map(|info| info.nonce)
+                .unwrap_or_default();
+            Some(nonce)
+        } else {
+            None
+        };
+
+        let executed = self.evm.transact(tx)?;
+        let result = executed.result();
+        let success = result.status;
+        let logs = result.logs.clone();
+        // Fail on overflow rather than silently saturating, which would corrupt this and every
+        // later receipt's cumulative gas. Practically unreachable under block gas limits, but
+        // this executor has no pre-execution block-gas-limit guard yet.
+        self.gas_used = self
+            .gas_used
+            .checked_add(result.tx_gas_used())
+            .ok_or_else(|| HandlerError::external(CumulativeGasOverflow))?;
+        let cumulative_gas_used = self.gas_used;
+        let _ = executed.commit_to(&mut self.block_state);
+
+        let receipt = Receipt { status: Eip658Value::Eip658(success), cumulative_gas_used, logs };
+        let envelope = if is_deposit {
+            // The deposit receipt version is set once Canyon is active.
+            let canyon = (self.evm.config_spec_id().upgrade() as u8) >= (BaseUpgrade::Canyon as u8);
+            let deposit_receipt_version = canyon.then_some(1);
+            BaseReceiptEnvelope::Deposit(
+                DepositReceipt { inner: receipt, deposit_nonce, deposit_receipt_version }
+                    .with_bloom(),
+            )
+        } else {
+            let receipt = receipt.with_bloom();
+            match ty {
+                1 => BaseReceiptEnvelope::Eip2930(receipt),
+                2 => BaseReceiptEnvelope::Eip1559(receipt),
+                4 => BaseReceiptEnvelope::Eip7702(receipt),
+                // 0x79 is the enshrined EIP-8130 account-abstraction transaction.
+                0x79 => BaseReceiptEnvelope::Eip8130(receipt),
+                // Legacy (type 0) uses the legacy receipt shape. These type bytes mirror the
+                // handlers registered in tx_registry(); the assert flags any registered type that
+                // gains a handler but not a receipt arm here (which would mis-type its receipt).
+                other => {
+                    debug_assert_eq!(other, 0, "unmapped standard tx type {other:#x} in receipts");
+                    BaseReceiptEnvelope::Legacy(receipt)
+                }
+            }
+        };
+        self.receipts.push(envelope);
+        Ok(())
+    }
+
+    /// Finalizes the block, returning the EVM, the execution result (receipts + gas used), and
+    /// the accumulated block-state delta.
+    pub fn finish(self) -> (Evm<'a, BaseEvmTypes>, BlockExecutionResult, BlockStateAccumulator) {
+        let result = BlockExecutionResult { receipts: self.receipts, gas_used: self.gas_used };
+        (self.evm, result, self.block_state)
+    }
+}

--- a/crates/common/evm2/src/lib.rs
+++ b/crates/common/evm2/src/lib.rs
@@ -9,6 +9,9 @@ pub use transaction::{BaseTxEnvelope, DEPOSIT_TX_TYPE, TxDeposit};
 mod handler;
 pub use handler::BaseTxHandlerHooks;
 
+mod executor;
+pub use executor::{BaseBlockExecutor, BlockExecutionResult, CumulativeGasOverflow};
+
 mod registry;
 
 mod types;

--- a/crates/common/evm2/tests/block_execution.rs
+++ b/crates/common/evm2/tests/block_execution.rs
@@ -1,0 +1,119 @@
+//! Block-executor tests for `base-common-evm2`.
+//!
+//! Runs a block of a deposit followed by a standard EIP-1559 transaction through the
+//! [`BaseBlockExecutor`] and asserts the receipts (types, status, cumulative gas, deposit
+//! nonce/version) and post-block state. Per-transaction execution is separately proven equal to
+//! the revm reference by the deposit and standard-fee parity harnesses, so this test focuses on
+//! the block-executor additions: receipt building, cumulative gas, and block-state commit.
+
+use alloy_consensus::{TxEip1559, transaction::Recovered};
+use alloy_primitives::{Address, Bytes, TxKind, U256};
+use base_common_consensus::{BaseReceiptEnvelope, Predeploys};
+use base_common_evm2::{BaseBlockExecutor, BaseEvmTypes, BaseSpecId, BaseTxEnvelope, TxDeposit};
+use base_common_genesis::BaseUpgrade;
+use base_common_l1_fees::L1FeeParams;
+use evm2::{Evm, Precompiles, env::BlockEnv, ethereum::TxEnvelope, evm::InMemoryDB};
+
+const SENDER: Address = Address::repeat_byte(0x11);
+const TARGET: Address = Address::repeat_byte(0x22);
+const COINBASE: Address = Address::repeat_byte(0x33);
+
+const fn cumulative_gas(receipt: &BaseReceiptEnvelope) -> u64 {
+    match receipt {
+        BaseReceiptEnvelope::Deposit(r) => r.receipt.inner.cumulative_gas_used,
+        BaseReceiptEnvelope::Legacy(r)
+        | BaseReceiptEnvelope::Eip2930(r)
+        | BaseReceiptEnvelope::Eip1559(r)
+        | BaseReceiptEnvelope::Eip7702(r)
+        | BaseReceiptEnvelope::Eip8130(r) => r.receipt.cumulative_gas_used,
+    }
+}
+
+fn nonce(evm: &mut Evm<'static, BaseEvmTypes>, addr: Address) -> u64 {
+    evm.state_mut().account_info_untracked(&addr).unwrap().map(|i| i.nonce).unwrap_or_default()
+}
+
+fn balance(evm: &mut Evm<'static, BaseEvmTypes>, addr: Address) -> U256 {
+    evm.state_mut().account_info_untracked(&addr).unwrap().map(|i| i.balance).unwrap_or_default()
+}
+
+#[test]
+fn executes_block_of_deposit_then_standard_tx() {
+    let spec = BaseSpecId::new(BaseUpgrade::Ecotone);
+    let mut db = InMemoryDB::default();
+    db.insert_account_info(
+        &SENDER,
+        evm2::AccountInfo { balance: U256::from(10u128.pow(18)), nonce: 0, ..Default::default() },
+    );
+    let block = BlockEnv::<BaseEvmTypes> {
+        beneficiary: COINBASE,
+        basefee: U256::from(500),
+        ext: L1FeeParams {
+            l1_base_fee: U256::from(1_000_000_000u64),
+            l1_base_fee_scalar: U256::from(1_000u64),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let evm =
+        Evm::new(spec, block, BaseEvmTypes::tx_registry(), db, Precompiles::base(spec.into()));
+    let mut executor = BaseBlockExecutor::new(evm);
+
+    // A deposit that mints to the sender, then a standard EIP-1559 transfer from the same sender.
+    let deposit = TxDeposit {
+        from: SENDER,
+        to: TxKind::Call(TARGET),
+        mint: 1_000,
+        gas_limit: 100_000,
+        ..Default::default()
+    };
+    executor
+        .execute_transaction(&Recovered::new_unchecked(BaseTxEnvelope::Deposit(deposit), SENDER))
+        .expect("deposit executes");
+
+    let standard = TxEnvelope::Eip1559(TxEip1559 {
+        chain_id: 1,
+        nonce: 1,
+        gas_limit: 100_000,
+        max_fee_per_gas: 1_000,
+        max_priority_fee_per_gas: 100,
+        to: TxKind::Call(TARGET),
+        value: U256::from(10),
+        input: Bytes::new(),
+        access_list: Default::default(),
+    });
+    let enveloped = Bytes::from(vec![0x02u8; 120]);
+    executor
+        .execute_transaction(&Recovered::new_unchecked(
+            BaseTxEnvelope::standard(standard, enveloped),
+            SENDER,
+        ))
+        .expect("standard tx executes");
+
+    let (mut evm, result, _block_state) = executor.finish();
+
+    // Two receipts, in order, of the expected variants.
+    assert_eq!(result.receipts.len(), 2);
+    match &result.receipts[0] {
+        BaseReceiptEnvelope::Deposit(r) => {
+            assert!(r.receipt.inner.status.coerce_status(), "deposit succeeded");
+            // Pre-execution sender nonce (0), and Canyon-gated receipt version (Ecotone > Canyon).
+            assert_eq!(r.receipt.deposit_nonce, Some(0));
+            assert_eq!(r.receipt.deposit_receipt_version, Some(1));
+        }
+        other => panic!("expected deposit receipt, got {other:?}"),
+    }
+    assert!(
+        matches!(result.receipts[1], BaseReceiptEnvelope::Eip1559(_)),
+        "second receipt is EIP-1559"
+    );
+
+    // Cumulative gas is monotonic and the block gas equals the last receipt's cumulative gas.
+    assert!(cumulative_gas(&result.receipts[0]) < cumulative_gas(&result.receipts[1]));
+    assert_eq!(result.gas_used, cumulative_gas(&result.receipts[1]));
+
+    // Both transactions bumped the sender nonce (deposit → 1, standard → 2).
+    assert_eq!(nonce(&mut evm, SENDER), 2);
+    // The standard transaction's L1 data fee was collected into the vault (the deposit is exempt).
+    assert!(balance(&mut evm, Predeploys::L1_FEE_VAULT) > U256::ZERO);
+}


### PR DESCRIPTION
## Summary

Adds `BaseBlockExecutor` — the transaction-execution core of a Base block executor for evm2. Stacked on #4762.

- Runs each transaction through the registry (deposit or standard handler), builds a receipt with running **cumulative gas**, and commits each tx's state into an evm2 `BlockStateAccumulator`.
- `finish()` returns the EVM, a `BlockExecutionResult` (receipts + gas used), and the block-state delta.
- Receipts are the canonical `base_common_consensus::BaseReceiptEnvelope` (**reused**, not redeclared), mapped by tx type. Deposits produce a `DepositReceipt` whose `deposit_nonce` is the depositor's **pre-execution** nonce (read untracked, matching the reference) and whose `deposit_receipt_version` is set once Canyon is active.

## Testing

Per-transaction execution is already proven equal to the revm reference by the deposit and standard-fee parity harnesses (#4759, #4762). This PR adds a **block-execution test** covering the new logic: receipt variants per tx type, monotonic cumulative gas (= block gas used), deposit receipt fields (`deposit_nonce`/`deposit_receipt_version`), and post-block state (nonces bumped, L1 fee vaulted). All tests + `clippy -D warnings` + `+nightly fmt` clean; non-test build stays revm-free.

## Scope (deferred to follow-ups)
Pre-execution block-boundary system calls (EIP-4788 beacon root, EIP-2935 block hashes, Canyon create2-deployer, Cobalt system accounts), the EIP-8130 execution path, and Jovian DA-footprint checks. A full block-level differential parity test (driving the reference `BaseBlockExecutor`) is also a natural extension once the pre-execution hooks land.