### PR TITLE
feat(evm2): Pre-Execution Block Hooks (EIP-4788 / EIP-2935)

### DIFF
--- a/crates/common/evm2/src/executor.rs
+++ b/crates/common/evm2/src/executor.rs
@@ -2,10 +2,12 @@
 
 use alloy_consensus::{Eip658Value, Receipt, transaction::Recovered};
 use alloy_eips::eip2718::Typed2718;
+use alloy_primitives::{B256, Bytes};
 use base_common_consensus::{BaseReceiptEnvelope, DepositReceipt};
 use base_common_genesis::BaseUpgrade;
 use evm2::{
-    BlockStateAccumulator, Evm,
+    BlockStateAccumulator, Evm, SpecId,
+    evm::{BEACON_ROOTS_ADDRESS, HISTORY_STORAGE_ADDRESS, SystemTx},
     registry::{HandlerError, HandlerResult},
 };
 
@@ -23,6 +25,16 @@ impl core::fmt::Display for CumulativeGasOverflow {
 
 impl core::error::Error for CumulativeGasOverflow {}
 
+/// Block-boundary context for pre-execution system calls.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BaseBlockExecutionCtx {
+    /// The parent block hash, stored by the EIP-2935 block-hashes contract (Prague onwards).
+    pub parent_hash: B256,
+    /// The parent beacon block root, stored by the EIP-4788 beacon-roots contract (Cancun
+    /// onwards). `None` when the block carries no beacon root.
+    pub parent_beacon_block_root: Option<B256>,
+}
+
 /// The outcome of executing a block's transactions: one receipt per transaction (in order) and
 /// the total gas used.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -36,23 +48,52 @@ pub struct BlockExecutionResult {
 /// Executes a Base block's transactions on an EVM2 [`Evm`], building receipts and accumulating
 /// the block's state delta.
 ///
-/// This is the transaction-execution core: it runs each transaction through the registry
-/// (deposit or standard handler), builds its receipt with running cumulative gas, and commits
-/// its state into a [`BlockStateAccumulator`]. Pre-execution block-boundary system calls
-/// (EIP-4788/EIP-2935, Canyon create2-deployer, Cobalt system accounts), the EIP-8130 path, and
-/// the Jovian DA-footprint checks are layered on in follow-up work.
+/// The flow is [`apply_pre_execution`](Self::apply_pre_execution) (block-boundary system calls),
+/// then [`execute_transaction`](Self::execute_transaction) per transaction (running it through
+/// the registry, building its receipt with running cumulative gas, and committing its state into
+/// a [`BlockStateAccumulator`]), then [`finish`](Self::finish). The Canyon create2-deployer and
+/// Cobalt system-account transition hooks, the EIP-8130 path, and the Jovian DA-footprint checks
+/// are layered on in follow-up work.
 #[derive(Debug)]
 pub struct BaseBlockExecutor<'a> {
     evm: Evm<'a, BaseEvmTypes>,
+    ctx: BaseBlockExecutionCtx,
     block_state: BlockStateAccumulator,
     receipts: Vec<BaseReceiptEnvelope>,
     gas_used: u64,
 }
 
 impl<'a> BaseBlockExecutor<'a> {
-    /// Creates a block executor over `evm`.
-    pub fn new(evm: Evm<'a, BaseEvmTypes>) -> Self {
-        Self { evm, block_state: BlockStateAccumulator::new(), receipts: Vec::new(), gas_used: 0 }
+    /// Creates a block executor over `evm` with the given block-boundary context.
+    pub fn new(evm: Evm<'a, BaseEvmTypes>, ctx: BaseBlockExecutionCtx) -> Self {
+        Self {
+            evm,
+            ctx,
+            block_state: BlockStateAccumulator::new(),
+            receipts: Vec::new(),
+            gas_used: 0,
+        }
+    }
+
+    /// Applies the block-boundary pre-execution system calls, in the reference order: the
+    /// EIP-2935 block-hashes call (Prague onwards) then the EIP-4788 beacon-roots call (Cancun
+    /// onwards). Each is a system call whose state changes are committed into the block state; if
+    /// the target system contract is not deployed, the call is a no-op.
+    pub fn apply_pre_execution(&mut self) -> HandlerResult<()> {
+        let spec = self.evm.spec_id();
+        if (spec as u8) >= (SpecId::PRAGUE as u8) {
+            let data = Bytes::copy_from_slice(self.ctx.parent_hash.as_slice());
+            let executed = self.evm.system_call(SystemTx::new(HISTORY_STORAGE_ADDRESS, data))?;
+            let _ = executed.commit_to(&mut self.block_state);
+        }
+        if (spec as u8) >= (SpecId::CANCUN as u8)
+            && let Some(root) = self.ctx.parent_beacon_block_root
+        {
+            let data = Bytes::copy_from_slice(root.as_slice());
+            let executed = self.evm.system_call(SystemTx::new(BEACON_ROOTS_ADDRESS, data))?;
+            let _ = executed.commit_to(&mut self.block_state);
+        }
+        Ok(())
     }
 
     /// Returns the EVM.

--- a/crates/common/evm2/src/executor.rs
+++ b/crates/common/evm2/src/executor.rs
@@ -25,13 +25,44 @@ impl core::fmt::Display for CumulativeGasOverflow {
 
 impl core::error::Error for CumulativeGasOverflow {}
 
+/// Error returned when a block's pre-execution block-boundary state is invalid.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PreExecutionError {
+    /// A post-Cancun block did not carry a parent beacon block root. EIP-4788 requires every
+    /// post-Cancun block to supply one, so its absence makes the block invalid.
+    MissingParentBeaconBlockRoot,
+    /// A Cancun genesis block (number 0) carried a non-zero parent beacon block root. EIP-4788
+    /// requires the genesis beacon root to be zero.
+    CancunGenesisParentBeaconBlockRootNotZero {
+        /// The non-zero parent beacon block root the genesis block carried.
+        parent_beacon_block_root: B256,
+    },
+}
+
+impl core::fmt::Display for PreExecutionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::MissingParentBeaconBlockRoot => {
+                f.write_str("missing parent beacon block root for post-Cancun block")
+            }
+            Self::CancunGenesisParentBeaconBlockRootNotZero { parent_beacon_block_root } => write!(
+                f,
+                "Cancun genesis parent beacon block root must be zero, got {parent_beacon_block_root}"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for PreExecutionError {}
+
 /// Block-boundary context for pre-execution system calls.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BaseBlockExecutionCtx {
     /// The parent block hash, stored by the EIP-2935 block-hashes contract (Prague onwards).
     pub parent_hash: B256,
     /// The parent beacon block root, stored by the EIP-4788 beacon-roots contract (Cancun
-    /// onwards). `None` when the block carries no beacon root.
+    /// onwards). Required for every post-Cancun non-genesis block; `None` is only valid before
+    /// Cancun. A post-Cancun `None` is rejected by [`BaseBlockExecutor::apply_pre_execution`].
     pub parent_beacon_block_root: Option<B256>,
 }
 
@@ -79,19 +110,42 @@ impl<'a> BaseBlockExecutor<'a> {
     /// EIP-2935 block-hashes call (Prague onwards) then the EIP-4788 beacon-roots call (Cancun
     /// onwards). Each is a system call whose state changes are committed into the block state; if
     /// the target system contract is not deployed, the call is a no-op.
+    ///
+    /// The genesis block (number 0) runs neither call, matching the reference: EIP-2935 no-ops at
+    /// genesis, and EIP-4788 requires the genesis beacon root to be zero and performs no system
+    /// call. A post-Cancun block that carries no parent beacon block root, or a Cancun genesis
+    /// block whose beacon root is non-zero, is rejected as invalid ([`PreExecutionError`]).
     pub fn apply_pre_execution(&mut self) -> HandlerResult<()> {
         let spec = self.evm.spec_id();
-        if (spec as u8) >= (SpecId::PRAGUE as u8) {
+        // The genesis block never runs the pre-execution system calls, matching the reference.
+        let is_genesis = self.evm.block().number.is_zero();
+
+        // EIP-2935 block-hashes call (Prague onwards), skipped at genesis.
+        if (spec as u8) >= (SpecId::PRAGUE as u8) && !is_genesis {
             let data = Bytes::copy_from_slice(self.ctx.parent_hash.as_slice());
             let executed = self.evm.system_call(SystemTx::new(HISTORY_STORAGE_ADDRESS, data))?;
             let _ = executed.commit_to(&mut self.block_state);
         }
-        if (spec as u8) >= (SpecId::CANCUN as u8)
-            && let Some(root) = self.ctx.parent_beacon_block_root
-        {
-            let data = Bytes::copy_from_slice(root.as_slice());
-            let executed = self.evm.system_call(SystemTx::new(BEACON_ROOTS_ADDRESS, data))?;
-            let _ = executed.commit_to(&mut self.block_state);
+
+        // EIP-4788 beacon-roots call (Cancun onwards). A post-Cancun block must carry a parent
+        // beacon block root; at genesis that root must be zero and no system call runs.
+        if (spec as u8) >= (SpecId::CANCUN as u8) {
+            let root = self.ctx.parent_beacon_block_root.ok_or_else(|| {
+                HandlerError::external(PreExecutionError::MissingParentBeaconBlockRoot)
+            })?;
+            if is_genesis {
+                if !root.is_zero() {
+                    return Err(HandlerError::external(
+                        PreExecutionError::CancunGenesisParentBeaconBlockRootNotZero {
+                            parent_beacon_block_root: root,
+                        },
+                    ));
+                }
+            } else {
+                let data = Bytes::copy_from_slice(root.as_slice());
+                let executed = self.evm.system_call(SystemTx::new(BEACON_ROOTS_ADDRESS, data))?;
+                let _ = executed.commit_to(&mut self.block_state);
+            }
         }
         Ok(())
     }

--- a/crates/common/evm2/src/lib.rs
+++ b/crates/common/evm2/src/lib.rs
@@ -10,7 +10,9 @@ mod handler;
 pub use handler::BaseTxHandlerHooks;
 
 mod executor;
-pub use executor::{BaseBlockExecutor, BlockExecutionResult, CumulativeGasOverflow};
+pub use executor::{
+    BaseBlockExecutionCtx, BaseBlockExecutor, BlockExecutionResult, CumulativeGasOverflow,
+};
 
 mod registry;
 

--- a/crates/common/evm2/src/lib.rs
+++ b/crates/common/evm2/src/lib.rs
@@ -4,7 +4,7 @@ mod spec;
 pub use spec::BaseSpecId;
 
 mod transaction;
-pub use transaction::{BaseTxEnvelope, DEPOSIT_TX_TYPE, TxDeposit};
+pub use transaction::{BaseTxEnvelope, TxDeposit};
 
 mod handler;
 pub use handler::BaseTxHandlerHooks;

--- a/crates/common/evm2/src/lib.rs
+++ b/crates/common/evm2/src/lib.rs
@@ -4,7 +4,7 @@ mod spec;
 pub use spec::BaseSpecId;
 
 mod transaction;
-pub use transaction::{BaseTxEnvelope, TxDeposit};
+pub use transaction::BaseTxEnvelope;
 
 mod handler;
 pub use handler::BaseTxHandlerHooks;

--- a/crates/common/evm2/src/lib.rs
+++ b/crates/common/evm2/src/lib.rs
@@ -12,6 +12,7 @@ pub use handler::BaseTxHandlerHooks;
 mod executor;
 pub use executor::{
     BaseBlockExecutionCtx, BaseBlockExecutor, BlockExecutionResult, CumulativeGasOverflow,
+    PreExecutionError,
 };
 
 mod registry;

--- a/crates/common/evm2/src/registry.rs
+++ b/crates/common/evm2/src/registry.rs
@@ -1,7 +1,7 @@
 //! Base transaction registry.
 
 use alloy_primitives::U256;
-use base_common_consensus::DEPOSIT_TX_TYPE_ID;
+use base_common_consensus::{DEPOSIT_TX_TYPE_ID, TxDeposit};
 use evm2::{
     Evm, TxResult,
     env::TxEnvExt,
@@ -15,7 +15,7 @@ use evm2::{
     registry::{HandlerError, HandlerResult, TxRegistry, TxRequest},
 };
 
-use crate::{BaseEvmTypes, BaseTxEnvelope, BaseTxHandlerHooks, TxDeposit};
+use crate::{BaseEvmTypes, BaseTxEnvelope, BaseTxHandlerHooks};
 
 impl BaseEvmTypes {
     /// Builds the Base transaction registry.

--- a/crates/common/evm2/src/registry.rs
+++ b/crates/common/evm2/src/registry.rs
@@ -1,6 +1,7 @@
 //! Base transaction registry.
 
 use alloy_primitives::U256;
+use base_common_consensus::DEPOSIT_TX_TYPE_ID;
 use evm2::{
     Evm, TxResult,
     env::TxEnvExt,
@@ -14,10 +15,7 @@ use evm2::{
     registry::{HandlerError, HandlerResult, TxRegistry, TxRequest},
 };
 
-use crate::{
-    BaseEvmTypes, BaseTxHandlerHooks,
-    transaction::{BaseTxEnvelope, DEPOSIT_TX_TYPE, TxDeposit},
-};
+use crate::{BaseEvmTypes, BaseTxEnvelope, BaseTxHandlerHooks, TxDeposit};
 
 impl BaseEvmTypes {
     /// Builds the Base transaction registry.
@@ -29,7 +27,7 @@ impl BaseEvmTypes {
     /// settlement path.
     pub fn tx_registry() -> TxRegistry<Self, TxResult<Self>> {
         let mut registry = TxRegistry::new().with_handler(
-            DEPOSIT_TX_TYPE,
+            DEPOSIT_TX_TYPE_ID,
             BaseTxEnvelope::as_deposit,
             Self::handle_deposit,
         );
@@ -250,7 +248,7 @@ mod tests {
     #[test]
     fn registry_registers_deposit_and_standard_handlers() {
         let registry = BaseEvmTypes::tx_registry();
-        assert!(registry.contains(DEPOSIT_TX_TYPE), "deposit handler must be registered");
+        assert!(registry.contains(DEPOSIT_TX_TYPE_ID), "deposit handler must be registered");
         // Legacy (0), EIP-2930 (1), EIP-1559 (2), EIP-7702 (4). Type 3 (EIP-4844
         // blob transactions) is intentionally unregistered — Base rejects them.
         for ty in [0, 1, 2, 4] {

--- a/crates/common/evm2/src/transaction.rs
+++ b/crates/common/evm2/src/transaction.rs
@@ -2,10 +2,7 @@
 
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::Bytes;
-/// The canonical deposit transaction, re-exported from [`base_common_consensus`]
-/// rather than redeclared, so the evm2 envelope shares a single source of truth
-/// with the rest of the workspace.
-pub use base_common_consensus::TxDeposit;
+use base_common_consensus::TxDeposit;
 use evm2::ethereum::TxEnvelope;
 
 /// The Base transaction envelope: a deposit or a standard Ethereum

--- a/crates/common/evm2/src/transaction.rs
+++ b/crates/common/evm2/src/transaction.rs
@@ -2,11 +2,6 @@
 
 use alloy_eips::eip2718::Typed2718;
 use alloy_primitives::Bytes;
-/// EIP-2718 transaction type byte for deposit transactions.
-///
-/// Re-exported from [`base_common_consensus`] to keep a single source of truth
-/// shared with `base-common-evm`.
-pub use base_common_consensus::DEPOSIT_TX_TYPE_ID as DEPOSIT_TX_TYPE;
 /// The canonical deposit transaction, re-exported from [`base_common_consensus`]
 /// rather than redeclared, so the evm2 envelope shares a single source of truth
 /// with the rest of the workspace.
@@ -90,6 +85,7 @@ impl From<TxDeposit> for BaseTxEnvelope {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::{Address, TxKind};
+    use base_common_consensus::DEPOSIT_TX_TYPE_ID;
 
     use super::*;
 
@@ -105,7 +101,7 @@ mod tests {
     #[test]
     fn deposit_reports_type_byte() {
         let tx = BaseTxEnvelope::Deposit(sample_deposit());
-        assert_eq!(tx.ty(), DEPOSIT_TX_TYPE);
+        assert_eq!(tx.ty(), DEPOSIT_TX_TYPE_ID);
         assert!(tx.is_deposit());
         assert!(tx.as_deposit().is_some());
     }

--- a/crates/common/evm2/src/types.rs
+++ b/crates/common/evm2/src/types.rs
@@ -4,31 +4,7 @@ use alloy_primitives::U256;
 use base_common_l1_fees::L1FeeParams;
 use evm2::{BaseEvmConfigSelector, Evm, EvmTypesHost};
 
-use crate::{BaseSpecId, transaction::BaseTxEnvelope};
-
-/// Transaction-result extension data for Base transactions.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct BaseTxResultExt {
-    /// L1 data fee charged for this transaction (zero for deposits).
-    pub l1_fee: U256,
-}
-
-/// EVM instance-wide extension state for Base transactions.
-///
-/// Carries the L1 data fee and operator fee computed and charged in
-/// [`BaseTxHandlerHooks::before_execution`](crate::BaseTxHandlerHooks) so
-/// [`settle_transaction`](evm2::handler::TxHandlerHooks::settle_transaction) can
-/// record/refund against the exact amounts charged without recomputing them —
-/// keeping the charged and settled fees in lockstep and avoiding a second pass
-/// over the transaction.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct BaseEvmExt {
-    /// L1 data fee charged for the transaction currently executing.
-    pub l1_fee: U256,
-    /// Operator fee charged upfront (on the gas limit) for the transaction currently executing;
-    /// its unused portion is refunded at settlement.
-    pub operator_fee: U256,
-}
+use crate::{BaseSpecId, BaseTxEnvelope};
 
 /// Base's EVM2 execution type family.
 ///
@@ -52,4 +28,28 @@ impl EvmTypesHost for BaseEvmTypes {
     type TxResultExt = BaseTxResultExt;
     type BlockEnvExt = L1FeeParams;
     type Host<'a> = Evm<'a, Self>;
+}
+
+/// Transaction-result extension data for Base transactions.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct BaseTxResultExt {
+    /// L1 data fee charged for this transaction (zero for deposits).
+    pub l1_fee: U256,
+}
+
+/// EVM instance-wide extension state for Base transactions.
+///
+/// Carries the L1 data fee and operator fee computed and charged in
+/// [`BaseTxHandlerHooks::before_execution`](crate::BaseTxHandlerHooks) so
+/// [`settle_transaction`](evm2::handler::TxHandlerHooks::settle_transaction) can
+/// record/refund against the exact amounts charged without recomputing them —
+/// keeping the charged and settled fees in lockstep and avoiding a second pass
+/// over the transaction.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BaseEvmExt {
+    /// L1 data fee charged for the transaction currently executing.
+    pub l1_fee: U256,
+    /// Operator fee charged upfront (on the gas limit) for the transaction currently executing;
+    /// its unused portion is refunded at settlement.
+    pub operator_fee: U256,
 }

--- a/crates/common/evm2/tests/block_execution.rs
+++ b/crates/common/evm2/tests/block_execution.rs
@@ -9,7 +9,9 @@
 use alloy_consensus::{TxEip1559, transaction::Recovered};
 use alloy_primitives::{Address, Bytes, TxKind, U256};
 use base_common_consensus::{BaseReceiptEnvelope, Predeploys};
-use base_common_evm2::{BaseBlockExecutor, BaseEvmTypes, BaseSpecId, BaseTxEnvelope, TxDeposit};
+use base_common_evm2::{
+    BaseBlockExecutionCtx, BaseBlockExecutor, BaseEvmTypes, BaseSpecId, BaseTxEnvelope, TxDeposit,
+};
 use base_common_genesis::BaseUpgrade;
 use base_common_l1_fees::L1FeeParams;
 use evm2::{Evm, Precompiles, env::BlockEnv, ethereum::TxEnvelope, evm::InMemoryDB};
@@ -57,7 +59,7 @@ fn executes_block_of_deposit_then_standard_tx() {
     };
     let evm =
         Evm::new(spec, block, BaseEvmTypes::tx_registry(), db, Precompiles::base(spec.into()));
-    let mut executor = BaseBlockExecutor::new(evm);
+    let mut executor = BaseBlockExecutor::new(evm, BaseBlockExecutionCtx::default());
 
     // A deposit that mints to the sender, then a standard EIP-1559 transfer from the same sender.
     let deposit = TxDeposit {

--- a/crates/common/evm2/tests/block_execution.rs
+++ b/crates/common/evm2/tests/block_execution.rs
@@ -8,9 +8,9 @@
 
 use alloy_consensus::{TxEip1559, transaction::Recovered};
 use alloy_primitives::{Address, Bytes, TxKind, U256};
-use base_common_consensus::{BaseReceiptEnvelope, Predeploys};
+use base_common_consensus::{BaseReceiptEnvelope, Predeploys, TxDeposit};
 use base_common_evm2::{
-    BaseBlockExecutionCtx, BaseBlockExecutor, BaseEvmTypes, BaseSpecId, BaseTxEnvelope, TxDeposit,
+    BaseBlockExecutionCtx, BaseBlockExecutor, BaseEvmTypes, BaseSpecId, BaseTxEnvelope,
 };
 use base_common_genesis::BaseUpgrade;
 use base_common_l1_fees::L1FeeParams;

--- a/crates/common/evm2/tests/block_hooks.rs
+++ b/crates/common/evm2/tests/block_hooks.rs
@@ -1,0 +1,144 @@
+//! Pre-execution block-hook tests for `base-common-evm2`.
+//!
+//! Validates that [`BaseBlockExecutor::apply_pre_execution`] fires the EIP-4788 (beacon root)
+//! and EIP-2935 (block hashes) system calls at the correct fork and with the correct data. Each
+//! system contract is replaced with a stub that stores its calldata to slot 0, so the test
+//! asserts the executor's gating and data-passing without depending on the real system-contract
+//! bytecode.
+
+use alloy_primitives::{B256, U256};
+use base_common_evm2::{BaseBlockExecutionCtx, BaseBlockExecutor, BaseEvmTypes, BaseSpecId};
+use base_common_genesis::BaseUpgrade;
+use evm2::{
+    Evm, Precompiles,
+    bytecode::Bytecode,
+    env::BlockEnv,
+    evm::{BEACON_ROOTS_ADDRESS, HISTORY_STORAGE_ADDRESS, InMemoryDB},
+};
+
+/// Runtime code that stores `calldata[0:32]` to storage slot 0:
+/// `PUSH1 0x00, CALLDATALOAD, PUSH1 0x00, SSTORE, STOP`.
+const STORE_CALLDATA_STUB: [u8; 7] = [0x60, 0x00, 0x35, 0x60, 0x00, 0x55, 0x00];
+
+/// Builds an EVM at `upgrade` with the calldata-storing stub deployed at `system_contract`.
+fn evm_with_stub(
+    upgrade: BaseUpgrade,
+    system_contract: alloy_primitives::Address,
+) -> Evm<'static, BaseEvmTypes> {
+    let spec = BaseSpecId::new(upgrade);
+    let mut db = InMemoryDB::default();
+    db.insert_account_info(
+        &system_contract,
+        evm2::AccountInfo {
+            code: Some(Bytecode::new_legacy(STORE_CALLDATA_STUB.to_vec().into())),
+            ..Default::default()
+        },
+    );
+    Evm::new(
+        spec,
+        BlockEnv::<BaseEvmTypes>::default(),
+        BaseEvmTypes::tx_registry(),
+        db,
+        Precompiles::base(spec.into()),
+    )
+}
+
+fn slot0(evm: &mut Evm<'static, BaseEvmTypes>, addr: alloy_primitives::Address) -> U256 {
+    evm.state_mut().storage_slot(&addr, U256::ZERO, false).unwrap().current()
+}
+
+#[test]
+fn beacon_root_system_call_fires_at_ecotone() {
+    let root = B256::repeat_byte(0xbe);
+    let evm = evm_with_stub(BaseUpgrade::Ecotone, BEACON_ROOTS_ADDRESS);
+    let mut executor = BaseBlockExecutor::new(
+        evm,
+        BaseBlockExecutionCtx { parent_beacon_block_root: Some(root), ..Default::default() },
+    );
+    executor.apply_pre_execution().expect("pre-execution succeeds");
+    let (mut evm, _, _) = executor.finish();
+    // The beacon-roots system call ran with the parent beacon root as calldata.
+    assert_eq!(slot0(&mut evm, BEACON_ROOTS_ADDRESS), U256::from_be_slice(root.as_slice()));
+}
+
+#[test]
+fn beacon_root_system_call_is_skipped_before_cancun() {
+    let root = B256::repeat_byte(0xbe);
+    // Regolith maps to MERGE, which is pre-Cancun — the beacon-roots call must not fire.
+    let evm = evm_with_stub(BaseUpgrade::Regolith, BEACON_ROOTS_ADDRESS);
+    let mut executor = BaseBlockExecutor::new(
+        evm,
+        BaseBlockExecutionCtx { parent_beacon_block_root: Some(root), ..Default::default() },
+    );
+    executor.apply_pre_execution().expect("pre-execution succeeds");
+    let (mut evm, _, _) = executor.finish();
+    assert_eq!(slot0(&mut evm, BEACON_ROOTS_ADDRESS), U256::ZERO);
+}
+
+#[test]
+fn block_hashes_system_call_fires_at_isthmus() {
+    let parent_hash = B256::repeat_byte(0x29);
+    let evm = evm_with_stub(BaseUpgrade::Isthmus, HISTORY_STORAGE_ADDRESS);
+    let mut executor = BaseBlockExecutor::new(
+        evm,
+        BaseBlockExecutionCtx { parent_hash, parent_beacon_block_root: None },
+    );
+    executor.apply_pre_execution().expect("pre-execution succeeds");
+    let (mut evm, _, _) = executor.finish();
+    // The block-hashes system call (Prague onwards) ran with the parent hash as calldata.
+    assert_eq!(
+        slot0(&mut evm, HISTORY_STORAGE_ADDRESS),
+        U256::from_be_slice(parent_hash.as_slice())
+    );
+}
+
+#[test]
+fn both_system_calls_fire_at_isthmus() {
+    // Isthmus maps to PRAGUE (≥ CANCUN), so both EIP-2935 and EIP-4788 should fire and both
+    // state changes should commit independently.
+    let parent_hash = B256::repeat_byte(0x29);
+    let beacon_root = B256::repeat_byte(0xbe);
+    let mut db = InMemoryDB::default();
+    for addr in [HISTORY_STORAGE_ADDRESS, BEACON_ROOTS_ADDRESS] {
+        db.insert_account_info(
+            &addr,
+            evm2::AccountInfo {
+                code: Some(Bytecode::new_legacy(STORE_CALLDATA_STUB.to_vec().into())),
+                ..Default::default()
+            },
+        );
+    }
+    let spec = BaseSpecId::new(BaseUpgrade::Isthmus);
+    let evm = Evm::new(
+        spec,
+        BlockEnv::<BaseEvmTypes>::default(),
+        BaseEvmTypes::tx_registry(),
+        db,
+        Precompiles::base(spec.into()),
+    );
+    let mut executor = BaseBlockExecutor::new(
+        evm,
+        BaseBlockExecutionCtx { parent_hash, parent_beacon_block_root: Some(beacon_root) },
+    );
+    executor.apply_pre_execution().expect("pre-execution succeeds");
+    let (mut evm, _, _) = executor.finish();
+    assert_eq!(
+        slot0(&mut evm, HISTORY_STORAGE_ADDRESS),
+        U256::from_be_slice(parent_hash.as_slice())
+    );
+    assert_eq!(slot0(&mut evm, BEACON_ROOTS_ADDRESS), U256::from_be_slice(beacon_root.as_slice()));
+}
+
+#[test]
+fn block_hashes_system_call_is_skipped_before_prague() {
+    let parent_hash = B256::repeat_byte(0x29);
+    // Ecotone maps to CANCUN, which is pre-Prague — the block-hashes call must not fire.
+    let evm = evm_with_stub(BaseUpgrade::Ecotone, HISTORY_STORAGE_ADDRESS);
+    let mut executor = BaseBlockExecutor::new(
+        evm,
+        BaseBlockExecutionCtx { parent_hash, parent_beacon_block_root: None },
+    );
+    executor.apply_pre_execution().expect("pre-execution succeeds");
+    let (mut evm, _, _) = executor.finish();
+    assert_eq!(slot0(&mut evm, HISTORY_STORAGE_ADDRESS), U256::ZERO);
+}

--- a/crates/common/evm2/tests/block_hooks.rs
+++ b/crates/common/evm2/tests/block_hooks.rs
@@ -1,13 +1,16 @@
 //! Pre-execution block-hook tests for `base-common-evm2`.
 //!
 //! Validates that [`BaseBlockExecutor::apply_pre_execution`] fires the EIP-4788 (beacon root)
-//! and EIP-2935 (block hashes) system calls at the correct fork and with the correct data. Each
-//! system contract is replaced with a stub that stores its calldata to slot 0, so the test
-//! asserts the executor's gating and data-passing without depending on the real system-contract
-//! bytecode.
+//! and EIP-2935 (block hashes) system calls at the correct fork and with the correct data, and
+//! that it enforces the reference's block-boundary validation (genesis no-ops, post-Cancun
+//! beacon-root requirement). Each system contract is replaced with a stub that stores its
+//! calldata to slot 0, so the test asserts the executor's gating and data-passing without
+//! depending on the real system-contract bytecode.
 
-use alloy_primitives::{B256, U256};
-use base_common_evm2::{BaseBlockExecutionCtx, BaseBlockExecutor, BaseEvmTypes, BaseSpecId};
+use alloy_primitives::{Address, B256, U256};
+use base_common_evm2::{
+    BaseBlockExecutionCtx, BaseBlockExecutor, BaseEvmTypes, BaseSpecId, PreExecutionError,
+};
 use base_common_genesis::BaseUpgrade;
 use evm2::{
     Evm, Precompiles,
@@ -20,37 +23,45 @@ use evm2::{
 /// `PUSH1 0x00, CALLDATALOAD, PUSH1 0x00, SSTORE, STOP`.
 const STORE_CALLDATA_STUB: [u8; 7] = [0x60, 0x00, 0x35, 0x60, 0x00, 0x55, 0x00];
 
-/// Builds an EVM at `upgrade` with the calldata-storing stub deployed at `system_contract`.
-fn evm_with_stub(
+/// A non-genesis block number. The pre-execution system calls only run for non-genesis blocks,
+/// so tests that expect a call to fire must execute against a block past genesis.
+const NORMAL_BLOCK: u64 = 1;
+
+/// Builds an EVM at `upgrade` and block `number` with the calldata-storing stub deployed at each
+/// address in `system_contracts`.
+fn evm_with_stubs(
     upgrade: BaseUpgrade,
-    system_contract: alloy_primitives::Address,
+    number: u64,
+    system_contracts: &[Address],
 ) -> Evm<'static, BaseEvmTypes> {
     let spec = BaseSpecId::new(upgrade);
     let mut db = InMemoryDB::default();
-    db.insert_account_info(
-        &system_contract,
-        evm2::AccountInfo {
-            code: Some(Bytecode::new_legacy(STORE_CALLDATA_STUB.to_vec().into())),
-            ..Default::default()
-        },
-    );
+    for addr in system_contracts {
+        db.insert_account_info(
+            addr,
+            evm2::AccountInfo {
+                code: Some(Bytecode::new_legacy(STORE_CALLDATA_STUB.to_vec().into())),
+                ..Default::default()
+            },
+        );
+    }
     Evm::new(
         spec,
-        BlockEnv::<BaseEvmTypes>::default(),
+        BlockEnv::<BaseEvmTypes> { number: U256::from(number), ..Default::default() },
         BaseEvmTypes::tx_registry(),
         db,
         Precompiles::base(spec.into()),
     )
 }
 
-fn slot0(evm: &mut Evm<'static, BaseEvmTypes>, addr: alloy_primitives::Address) -> U256 {
+fn slot0(evm: &mut Evm<'static, BaseEvmTypes>, addr: Address) -> U256 {
     evm.state_mut().storage_slot(&addr, U256::ZERO, false).unwrap().current()
 }
 
 #[test]
 fn beacon_root_system_call_fires_at_ecotone() {
     let root = B256::repeat_byte(0xbe);
-    let evm = evm_with_stub(BaseUpgrade::Ecotone, BEACON_ROOTS_ADDRESS);
+    let evm = evm_with_stubs(BaseUpgrade::Ecotone, NORMAL_BLOCK, &[BEACON_ROOTS_ADDRESS]);
     let mut executor = BaseBlockExecutor::new(
         evm,
         BaseBlockExecutionCtx { parent_beacon_block_root: Some(root), ..Default::default() },
@@ -65,7 +76,7 @@ fn beacon_root_system_call_fires_at_ecotone() {
 fn beacon_root_system_call_is_skipped_before_cancun() {
     let root = B256::repeat_byte(0xbe);
     // Regolith maps to MERGE, which is pre-Cancun — the beacon-roots call must not fire.
-    let evm = evm_with_stub(BaseUpgrade::Regolith, BEACON_ROOTS_ADDRESS);
+    let evm = evm_with_stubs(BaseUpgrade::Regolith, NORMAL_BLOCK, &[BEACON_ROOTS_ADDRESS]);
     let mut executor = BaseBlockExecutor::new(
         evm,
         BaseBlockExecutionCtx { parent_beacon_block_root: Some(root), ..Default::default() },
@@ -78,10 +89,16 @@ fn beacon_root_system_call_is_skipped_before_cancun() {
 #[test]
 fn block_hashes_system_call_fires_at_isthmus() {
     let parent_hash = B256::repeat_byte(0x29);
-    let evm = evm_with_stub(BaseUpgrade::Isthmus, HISTORY_STORAGE_ADDRESS);
+    // Isthmus maps to PRAGUE (≥ CANCUN), so the block must also carry a beacon root. Only the
+    // block-hashes stub is deployed here, so the beacon-roots call no-ops and this test isolates
+    // the block-hashes call.
+    let evm = evm_with_stubs(BaseUpgrade::Isthmus, NORMAL_BLOCK, &[HISTORY_STORAGE_ADDRESS]);
     let mut executor = BaseBlockExecutor::new(
         evm,
-        BaseBlockExecutionCtx { parent_hash, parent_beacon_block_root: None },
+        BaseBlockExecutionCtx {
+            parent_hash,
+            parent_beacon_block_root: Some(B256::repeat_byte(0xbe)),
+        },
     );
     executor.apply_pre_execution().expect("pre-execution succeeds");
     let (mut evm, _, _) = executor.finish();
@@ -98,23 +115,10 @@ fn both_system_calls_fire_at_isthmus() {
     // state changes should commit independently.
     let parent_hash = B256::repeat_byte(0x29);
     let beacon_root = B256::repeat_byte(0xbe);
-    let mut db = InMemoryDB::default();
-    for addr in [HISTORY_STORAGE_ADDRESS, BEACON_ROOTS_ADDRESS] {
-        db.insert_account_info(
-            &addr,
-            evm2::AccountInfo {
-                code: Some(Bytecode::new_legacy(STORE_CALLDATA_STUB.to_vec().into())),
-                ..Default::default()
-            },
-        );
-    }
-    let spec = BaseSpecId::new(BaseUpgrade::Isthmus);
-    let evm = Evm::new(
-        spec,
-        BlockEnv::<BaseEvmTypes>::default(),
-        BaseEvmTypes::tx_registry(),
-        db,
-        Precompiles::base(spec.into()),
+    let evm = evm_with_stubs(
+        BaseUpgrade::Isthmus,
+        NORMAL_BLOCK,
+        &[HISTORY_STORAGE_ADDRESS, BEACON_ROOTS_ADDRESS],
     );
     let mut executor = BaseBlockExecutor::new(
         evm,
@@ -132,13 +136,73 @@ fn both_system_calls_fire_at_isthmus() {
 #[test]
 fn block_hashes_system_call_is_skipped_before_prague() {
     let parent_hash = B256::repeat_byte(0x29);
-    // Ecotone maps to CANCUN, which is pre-Prague — the block-hashes call must not fire.
-    let evm = evm_with_stub(BaseUpgrade::Ecotone, HISTORY_STORAGE_ADDRESS);
+    // Ecotone maps to CANCUN, which is pre-Prague — the block-hashes call must not fire. Cancun
+    // is active, so a beacon root is still required; the beacon stub is absent so that call
+    // no-ops.
+    let evm = evm_with_stubs(BaseUpgrade::Ecotone, NORMAL_BLOCK, &[HISTORY_STORAGE_ADDRESS]);
     let mut executor = BaseBlockExecutor::new(
         evm,
-        BaseBlockExecutionCtx { parent_hash, parent_beacon_block_root: None },
+        BaseBlockExecutionCtx {
+            parent_hash,
+            parent_beacon_block_root: Some(B256::repeat_byte(0xbe)),
+        },
     );
     executor.apply_pre_execution().expect("pre-execution succeeds");
     let (mut evm, _, _) = executor.finish();
     assert_eq!(slot0(&mut evm, HISTORY_STORAGE_ADDRESS), U256::ZERO);
+}
+
+#[test]
+fn missing_beacon_root_is_rejected_post_cancun() {
+    // Post-Cancun the reference rejects a block that carries no parent beacon block root; the
+    // executor must surface that as an error rather than silently skipping the 4788 update.
+    let evm = evm_with_stubs(BaseUpgrade::Ecotone, NORMAL_BLOCK, &[BEACON_ROOTS_ADDRESS]);
+    let mut executor = BaseBlockExecutor::new(
+        evm,
+        BaseBlockExecutionCtx { parent_beacon_block_root: None, ..Default::default() },
+    );
+    let err = executor.apply_pre_execution().expect_err("missing beacon root must be rejected");
+    assert_eq!(
+        err.external_ref::<PreExecutionError>(),
+        Some(&PreExecutionError::MissingParentBeaconBlockRoot)
+    );
+    // The beacon-roots call never ran, so its slot is untouched.
+    let (mut evm, _, _) = executor.finish();
+    assert_eq!(slot0(&mut evm, BEACON_ROOTS_ADDRESS), U256::ZERO);
+}
+
+#[test]
+fn genesis_block_skips_system_calls() {
+    // At genesis (block 0) neither EIP-2935 nor EIP-4788 runs, even at a fork where both are
+    // active. The beacon root must be zero, matching the reference.
+    let parent_hash = B256::repeat_byte(0x29);
+    let evm =
+        evm_with_stubs(BaseUpgrade::Isthmus, 0, &[HISTORY_STORAGE_ADDRESS, BEACON_ROOTS_ADDRESS]);
+    let mut executor = BaseBlockExecutor::new(
+        evm,
+        BaseBlockExecutionCtx { parent_hash, parent_beacon_block_root: Some(B256::ZERO) },
+    );
+    executor.apply_pre_execution().expect("genesis pre-execution succeeds");
+    let (mut evm, _, _) = executor.finish();
+    assert_eq!(slot0(&mut evm, HISTORY_STORAGE_ADDRESS), U256::ZERO);
+    assert_eq!(slot0(&mut evm, BEACON_ROOTS_ADDRESS), U256::ZERO);
+}
+
+#[test]
+fn genesis_nonzero_beacon_root_is_rejected() {
+    // A Cancun genesis block must carry a zero beacon root; a non-zero root is invalid.
+    let root = B256::repeat_byte(0xbe);
+    let evm = evm_with_stubs(BaseUpgrade::Ecotone, 0, &[BEACON_ROOTS_ADDRESS]);
+    let mut executor = BaseBlockExecutor::new(
+        evm,
+        BaseBlockExecutionCtx { parent_beacon_block_root: Some(root), ..Default::default() },
+    );
+    let err =
+        executor.apply_pre_execution().expect_err("non-zero genesis beacon root must be rejected");
+    assert_eq!(
+        err.external_ref::<PreExecutionError>(),
+        Some(&PreExecutionError::CancunGenesisParentBeaconBlockRootNotZero {
+            parent_beacon_block_root: root,
+        })
+    );
 }

--- a/crates/common/evm2/tests/deposit_parity.rs
+++ b/crates/common/evm2/tests/deposit_parity.rs
@@ -14,12 +14,14 @@ use std::collections::BTreeMap;
 
 use alloy_consensus::transaction::Recovered;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
+// shared consensus deposit type.
+use base_common_consensus::TxDeposit;
 // revm reference side.
 use base_common_evm::{
     BaseSpecId as RevmBaseSpecId, BaseTransaction, Builder, DefaultBase, L1BlockInfo,
 };
 // evm2 side.
-use base_common_evm2::{BaseEvmTypes, BaseSpecId, BaseTxEnvelope, TxDeposit};
+use base_common_evm2::{BaseEvmTypes, BaseSpecId, BaseTxEnvelope};
 use base_common_genesis::BaseUpgrade;
 use evm2::{Evm, Precompiles, bytecode::Bytecode as Evm2Bytecode, env::BlockEnv, evm::InMemoryDB};
 use revm::{


### PR DESCRIPTION
## Summary

Adds the block-boundary **pre-execution phase** to `BaseBlockExecutor`. Stacked on #4765.

- `BaseBlockExecutionCtx` carries the `parent_hash` and `parent_beacon_block_root`.
- `apply_pre_execution` runs the **EIP-2935** block-hashes system call (Prague onwards) then the **EIP-4788** beacon-roots system call (Cancun onwards) — the reference order — via evm2's `system_call`, committing their state into the block-state accumulator. Fork-gated by the resolved spec; a no-op when the target system contract isn't deployed (as evm2's `system_call` defines).

## Testing

Each system contract is replaced with a stub that stores its calldata to slot 0, so the tests assert the executor's **gating and data-passing** without depending on the real system-contract bytecode:
- beacon-root fires at Ecotone (Cancun) with the parent beacon root; skipped at Regolith (pre-Cancun).
- block-hashes fires at Isthmus (Prague) with the parent hash; skipped at Ecotone (pre-Prague).

All tests + `clippy -D warnings` + `+nightly fmt` clean; non-test build stays revm-free.

## Scope (deferred to follow-ups)
The transition-block hooks (Canyon create2-deployer, Cobalt system accounts) need parent/activation-timestamp context and are a natural next slice; the **EIP-8130** execution path and **Jovian DA-footprint** checks remain separate. A full block-level differential parity test (driving the reference `BaseBlockExecutor`) also belongs with those.