### PR TITLE
feat(proof): populate and advertise artifact hashes (2/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5577,6 +5577,7 @@ dependencies = [
 name = "base-proof-worker"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "async-trait",
  "backon",
  "base-prover-service-client",
@@ -6823,7 +6824,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -6843,7 +6844,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -9989,8 +9990,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -10895,7 +10896,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -10926,7 +10927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
 dependencies = [
  "bincode 1.3.3",
- "derive_more 1.0.0",
+ "derive_more 2.1.1",
  "iai-callgrind-macros",
  "iai-callgrind-runner",
 ]
@@ -10937,7 +10938,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
 dependencies = [
- "derive_more 1.0.0",
+ "derive_more 2.1.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -10967,7 +10968,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -13464,7 +13465,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15204,7 +15205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -15237,7 +15238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15250,7 +15251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15363,7 +15364,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -15403,7 +15404,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -23179,7 +23180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -24084,7 +24085,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -6,7 +6,7 @@ use base_cli_utils::{LogConfig, RuntimeManager};
 use base_proof_worker::{
     DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
 };
-use base_proof_zk_backend::SuccinctZkProversConfig;
+use base_proof_zk_backend::{SuccinctZkProversConfig, zk_artifact_hash};
 use base_proof_zk_host::{
     DEFAULT_PROOF_GENERATOR_HEARTBEAT_LOCK_DURATION_SECONDS,
     DEFAULT_PROOF_GENERATOR_MAX_CONSECUTIVE_HEARTBEAT_FAILURES, ProofGeneratorHeartbeatConfig,
@@ -231,10 +231,13 @@ impl WorkerArgs {
             args.proof_generator_heartbeat_lock_duration_seconds,
             args.proof_generator_max_consecutive_heartbeat_failures,
         );
+        let artifact_hash = zk_artifact_hash()
+            .await
+            .map_err(|error| eyre::eyre!("failed to derive local ZK artifact hash: {error}"))?;
 
         let worker_id =
             args.worker_id.clone().unwrap_or_else(|| format!("zk-host-{}", Uuid::new_v4()));
-        let host_config = ZkHostConfig::sp1(worker_id.clone())
+        let host_config = ZkHostConfig::sp1(worker_id.clone(), artifact_hash)
             .with_job_discovery_poll_interval(Duration::from_millis(
                 args.job_discovery_poll_interval_ms,
             ))

--- a/crates/proof/challenge/src/proof_adapter.rs
+++ b/crates/proof/challenge/src/proof_adapter.rs
@@ -7,7 +7,7 @@ use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProofResult, ProofSessionId, ProveBlockRangeRequest,
     SnarkPlonkProofRequest, TeeKind, TeeProofRequest,
 };
-use eyre::{Result, WrapErr, bail};
+use eyre::{Result, WrapErr, bail, eyre};
 
 /// Conversion helpers for challenger proof requests and dispute proof bytes.
 #[derive(Debug)]
@@ -18,22 +18,26 @@ impl ChallengerProofAdapter {
     const SESSION_NAMESPACE: &'static [u8] = b"base/challenger/proof-session/v2";
 
     /// Derives an idempotent challenger SNARK proof session ID.
-    pub fn snark_plonk_session_id(game_address: Address, invalid_index: u64) -> String {
+    pub fn snark_plonk_session_id(
+        artifact_hash: B256,
+        game_address: Address,
+        invalid_index: u64,
+    ) -> String {
         let invalid_index = invalid_index.to_be_bytes();
         ProofSessionId::derive_from_components(
             Self::SESSION_NAMESPACE,
             "zk/sp1/snark_plonk",
-            &[game_address.as_slice(), &invalid_index],
+            &[artifact_hash.as_slice(), game_address.as_slice(), &invalid_index],
         )
     }
 
     /// Derives an idempotent challenger TEE proof session ID.
-    pub fn tee_session_id(game_address: Address, invalid_index: u64) -> String {
+    pub fn tee_session_id(image_hash: B256, game_address: Address, invalid_index: u64) -> String {
         let invalid_index = invalid_index.to_be_bytes();
         ProofSessionId::derive_from_components(
             Self::SESSION_NAMESPACE,
             "tee/aws_nitro",
-            &[game_address.as_slice(), &invalid_index],
+            &[image_hash.as_slice(), game_address.as_slice(), &invalid_index],
         )
     }
 
@@ -42,12 +46,16 @@ impl ChallengerProofAdapter {
         game_address: Address,
         invalid_index: u64,
         request: SnarkPlonkProofRequest,
-    ) -> ProveBlockRangeRequest {
-        let session_id = Self::snark_plonk_session_id(game_address, invalid_index);
-        ProveBlockRangeRequest {
+    ) -> Result<ProveBlockRangeRequest> {
+        let artifact_hash = request
+            .proof
+            .zk_artifact_hash
+            .ok_or_else(|| eyre!("challenger ZK request is missing its artifact hash"))?;
+        let session_id = Self::snark_plonk_session_id(artifact_hash, game_address, invalid_index);
+        Ok(ProveBlockRangeRequest {
             proof: ProofRequest { session_id, request: ProofRequestKind::SnarkPlonk(request) },
             retry_failed: true,
-        }
+        })
     }
 
     /// Builds a prover-service request for a challenger TEE proof.
@@ -56,7 +64,7 @@ impl ChallengerProofAdapter {
         invalid_index: u64,
         request: PrimitiveProofRequest,
     ) -> ProveBlockRangeRequest {
-        let session_id = Self::tee_session_id(game_address, invalid_index);
+        let session_id = Self::tee_session_id(request.image_hash, game_address, invalid_index);
         ProveBlockRangeRequest {
             proof: ProofRequest {
                 session_id,
@@ -140,28 +148,59 @@ mod tests {
     fn challenger_session_ids_are_stable_and_type_separated() {
         let game_address = Address::repeat_byte(0xaa);
         let invalid_index = 1;
+        let artifact_hash = B256::repeat_byte(0x42);
 
         assert_eq!(
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, invalid_index),
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, invalid_index)
+            ChallengerProofAdapter::snark_plonk_session_id(
+                artifact_hash,
+                game_address,
+                invalid_index
+            ),
+            ChallengerProofAdapter::snark_plonk_session_id(
+                artifact_hash,
+                game_address,
+                invalid_index
+            )
         );
         assert_ne!(
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, invalid_index),
-            ChallengerProofAdapter::tee_session_id(game_address, invalid_index)
+            ChallengerProofAdapter::snark_plonk_session_id(
+                artifact_hash,
+                game_address,
+                invalid_index
+            ),
+            ChallengerProofAdapter::tee_session_id(artifact_hash, game_address, invalid_index)
         );
     }
 
     #[test]
     fn challenger_session_ids_separate_game_address_and_invalid_index() {
         let game_address = Address::repeat_byte(0xaa);
+        let artifact_hash = B256::repeat_byte(0x42);
 
         assert_ne!(
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, 1),
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, 2)
+            ChallengerProofAdapter::snark_plonk_session_id(artifact_hash, game_address, 1),
+            ChallengerProofAdapter::snark_plonk_session_id(artifact_hash, game_address, 2)
         );
         assert_ne!(
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, 1),
-            ChallengerProofAdapter::snark_plonk_session_id(Address::repeat_byte(0xbb), 1)
+            ChallengerProofAdapter::snark_plonk_session_id(artifact_hash, game_address, 1),
+            ChallengerProofAdapter::snark_plonk_session_id(
+                artifact_hash,
+                Address::repeat_byte(0xbb),
+                1
+            )
+        );
+    }
+
+    #[test]
+    fn challenger_session_ids_separate_artifact_hashes() {
+        let game_address = Address::repeat_byte(0xaa);
+        assert_ne!(
+            ChallengerProofAdapter::snark_plonk_session_id(B256::repeat_byte(1), game_address, 1),
+            ChallengerProofAdapter::snark_plonk_session_id(B256::repeat_byte(2), game_address, 1),
+        );
+        assert_ne!(
+            ChallengerProofAdapter::tee_session_id(B256::repeat_byte(1), game_address, 1),
+            ChallengerProofAdapter::tee_session_id(B256::repeat_byte(2), game_address, 1),
         );
     }
 
@@ -169,8 +208,12 @@ mod tests {
     fn snark_plonk_prove_block_range_request_converts_zk_request() {
         let game_address = Address::repeat_byte(0xaa);
         let invalid_index = 1;
-        let session_id =
-            ChallengerProofAdapter::snark_plonk_session_id(game_address, invalid_index);
+        let artifact_hash = B256::repeat_byte(0x42);
+        let session_id = ChallengerProofAdapter::snark_plonk_session_id(
+            artifact_hash,
+            game_address,
+            invalid_index,
+        );
         let prover_address = Address::repeat_byte(0x11);
         let l1_head = B256::repeat_byte(0x22);
         let proof = ZkProofRequest {
@@ -180,7 +223,7 @@ mod tests {
             l1_head: Some(l1_head),
             intermediate_root_interval: Some(150),
             schedule_l2_block_number: None,
-            zk_artifact_hash: None,
+            zk_artifact_hash: Some(artifact_hash),
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         };
@@ -190,10 +233,37 @@ mod tests {
             game_address,
             invalid_index,
             request.clone(),
-        );
+        )
+        .expect("artifact-aware request should wrap");
 
         assert_eq!(wrapped.proof.session_id, session_id);
         assert_eq!(wrapped.proof.request, ProofRequestKind::SnarkPlonk(request));
+    }
+
+    #[test]
+    fn snark_plonk_prove_block_range_request_rejects_missing_artifact_hash() {
+        let request = SnarkPlonkProofRequest {
+            proof: ZkProofRequest {
+                start_block_number: 100,
+                number_of_blocks_to_prove: 300,
+                sequence_window: None,
+                l1_head: None,
+                intermediate_root_interval: None,
+                schedule_l2_block_number: None,
+                zk_artifact_hash: None,
+                zk_vm: ZkVm::Sp1,
+                zk_backend: ZkBackend::Cluster,
+            },
+            prover_address: Address::repeat_byte(0x11),
+        };
+
+        let error = ChallengerProofAdapter::snark_plonk_prove_block_range_request(
+            Address::repeat_byte(0xaa),
+            1,
+            request,
+        )
+        .expect_err("missing artifact hash should fail");
+        assert!(error.to_string().contains("missing its artifact hash"));
     }
 
     #[test]
@@ -210,10 +280,11 @@ mod tests {
             proposer: Address::repeat_byte(0x04),
             intermediate_block_interval: 300,
             l1_head_number: 1200,
-            image_hash: alloy_primitives::B256::ZERO,
+            image_hash: B256::repeat_byte(0x42),
             schedule_l2_block_number: None,
         };
-        let session_id = ChallengerProofAdapter::tee_session_id(game_address, invalid_index);
+        let session_id =
+            ChallengerProofAdapter::tee_session_id(request.image_hash, game_address, invalid_index);
 
         let wrapped = ChallengerProofAdapter::tee_prove_block_range_request(
             game_address,

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -241,7 +241,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             game_address,
             invalid_index,
             proof_request.clone(),
-        );
+        )?;
 
         let prove_response = self.proof_requester.prove_block_range(request).await?;
 
@@ -296,10 +296,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             proposer,
             intermediate_block_interval: candidate.intermediate_block_interval,
             l1_head_number,
-            // Placeholder: the challenger reads the game's TEE_IMAGE_HASH and populates
-            // this when artifact routing lands. Zero is inert today because the prover
-            // service does not yet read image_hash.
-            image_hash: alloy_primitives::B256::ZERO,
+            image_hash: candidate.proof_artifacts.tee_image_hash,
             schedule_l2_block_number: Some(candidate.info.l2_block_number),
         })
     }
@@ -320,10 +317,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
                 l1_head: Some(candidate.l1_head),
                 intermediate_root_interval: Some(candidate.intermediate_block_interval),
                 schedule_l2_block_number: Some(candidate.info.l2_block_number),
-                // Placeholder: the challenger derives this from the game's ZK_RANGE_HASH
-                // and ZK_AGGREGATE_HASH when artifact routing lands. None is inert today
-                // because the prover service does not yet read zk_artifact_hash.
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(candidate.proof_artifacts.zk_artifact_hash()),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },
@@ -593,7 +587,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
             game_address,
             invalid_index,
             request,
-        );
+        )?;
 
         match self.proof_requester.prove_block_range(prove_request).await {
             Ok(response) => {
@@ -655,7 +649,7 @@ mod tests {
                 l1_head: Some(B256::repeat_byte(0xAA)),
                 intermediate_root_interval: Some(10),
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x42)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -40,7 +40,7 @@ use std::{
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient, GameAtIndex,
-    GameInfo, GameStatus,
+    GameInfo, GameStatus, ProofArtifacts,
 };
 use eyre::Result;
 use futures::stream::{self, StreamExt};
@@ -102,6 +102,8 @@ pub struct CandidateGame {
     pub intermediate_block_interval: u64,
     /// The L1 head block hash stored at game creation time.
     pub l1_head: B256,
+    /// Proving artifacts committed by this game's verifier.
+    pub proof_artifacts: ProofArtifacts,
     /// Address of the TEE prover for this game (`Address::ZERO` if none registered).
     pub tee_prover: Address,
     /// Classification of this candidate and the action the driver should take.
@@ -393,17 +395,19 @@ impl GameScanner {
         };
 
         // Fetch remaining fields only for actionable games.
-        let ((info, starting_block_number, l1_head), intermediate_block_interval) = tokio::try_join!(
-            async {
-                tokio::try_join!(
-                    self.verifier_client.game_info(factory.proxy),
-                    self.verifier_client.starting_block_number(factory.proxy),
-                    self.verifier_client.l1_head(factory.proxy),
-                )
-                .map_err(Into::into)
-            },
-            self.resolve_intermediate_block_interval(factory.game_type),
-        )?;
+        let ((info, starting_block_number, l1_head, proof_artifacts), intermediate_block_interval) =
+            tokio::try_join!(
+                async {
+                    tokio::try_join!(
+                        self.verifier_client.game_info(factory.proxy),
+                        self.verifier_client.starting_block_number(factory.proxy),
+                        self.verifier_client.l1_head(factory.proxy),
+                        self.verifier_client.proof_artifacts(factory.proxy),
+                    )
+                    .map_err(Into::into)
+                },
+                self.resolve_intermediate_block_interval(factory.game_type),
+            )?;
 
         Ok(Some(CandidateGame {
             index,
@@ -412,6 +416,7 @@ impl GameScanner {
             starting_block_number,
             intermediate_block_interval,
             l1_head,
+            proof_artifacts,
             tee_prover,
             category,
         }))

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -49,6 +49,8 @@ pub struct MockGameState {
     pub starting_block_number: u64,
     /// L1 head block hash stored at game creation time.
     pub l1_head: B256,
+    /// Proving artifacts committed by this game.
+    pub proof_artifacts: ProofArtifacts,
     /// Intermediate output roots for this game.
     pub intermediate_output_roots: Vec<B256>,
     /// 1-based index of the challenged intermediate root (`0` = unchallenged).
@@ -86,6 +88,11 @@ impl Default for MockGameState {
             },
             starting_block_number: 0,
             l1_head: B256::ZERO,
+            proof_artifacts: ProofArtifacts {
+                tee_image_hash: B256::repeat_byte(0x11),
+                zk_range_hash: B256::repeat_byte(0x22),
+                zk_aggregate_hash: B256::repeat_byte(0x33),
+            },
             intermediate_output_roots: vec![],
             countered_index: 0,
             game_over: false,
@@ -313,9 +320,13 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         self.get(game_address, |s| s.status)
     }
 
-    async fn proof_artifacts(&self, _: Address) -> Result<ProofArtifacts, ContractError> {
-        unimplemented!("artifact routing lands with the producer changes")
+    async fn proof_artifacts(
+        &self,
+        game_address: Address,
+    ) -> Result<ProofArtifacts, ContractError> {
+        self.get(game_address, |s| s.proof_artifacts)
     }
+
     async fn zk_prover(&self, game_address: Address) -> Result<Address, ContractError> {
         self.get(game_address, |s| s.zk_prover)
     }

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -17,7 +17,9 @@ use base_challenger::{
         mock_state, mock_state_with_tee, receipt_with_status,
     },
 };
-use base_proof_contracts::{AggregateVerifierClient, DisputeGameFactoryClient, GameStatus};
+use base_proof_contracts::{
+    AggregateVerifierClient, DisputeGameFactoryClient, GameStatus, ProofArtifacts,
+};
 use base_proof_primitives::Proposal;
 use base_proof_rpc::L1Provider;
 use base_proof_submission::test_utils::SnarkReceiptFixture;
@@ -423,7 +425,16 @@ async fn test_step_proof_retry_reuses_deterministic_session_id() {
     let tx_manager = default_tx_manager();
     let mut driver = test_driver(factory, Arc::clone(&verifier), l2, Arc::clone(&zk), tx_manager);
 
-    let expected_session_id = ChallengerProofAdapter::snark_plonk_session_id(addr(0), 1);
+    let expected_session_id = ChallengerProofAdapter::snark_plonk_session_id(
+        ProofArtifacts {
+            tee_image_hash: B256::repeat_byte(0x11),
+            zk_range_hash: B256::repeat_byte(0x22),
+            zk_aggregate_hash: B256::repeat_byte(0x33),
+        }
+        .zk_artifact_hash(),
+        addr(0),
+        1,
+    );
 
     // Step 1: initial proveBlockRange call from initiate_zk_proof.
     driver.step().await.unwrap();

--- a/crates/proof/proposer/README.md
+++ b/crates/proof/proposer/README.md
@@ -25,3 +25,23 @@ matching the configured `game_type`:
 Because state is always loaded from chain, the proposer chains off games created
 by any proposer, handles `GameAlreadyExists` without special recovery logic, and
 cannot enter stale-state livelocks.
+
+### Artifact Pinning
+
+The proposer stamps every TEE proof request with the enclave image hash the
+target verifier accepts, so the prover service can route the job to a worker
+running that exact enclave image.
+
+`--tee-image-hash` / `BASE_PROPOSER_TEE_IMAGE_HASH` is **required** and has no
+default — the proposer will not start without it. It must be set to the
+`TEE_IMAGE_HASH()` of the currently deployed `AggregateVerifier` implementation.
+
+The value also feeds the TEE proof session ID, so changing it changes every
+derived session ID. During a proof-system upgrade the ordering matters:
+
+1. Pause the proposer.
+2. Point the factory at the new `AggregateVerifier` implementation.
+3. Restart the proposer with `BASE_PROPOSER_TEE_IMAGE_HASH` set to the new
+   implementation's `TEE_IMAGE_HASH`.
+
+Restarting with a stale hash creates jobs that no current worker will claim.

--- a/crates/proof/proposer/src/cli.rs
+++ b/crates/proof/proposer/src/cli.rs
@@ -2,7 +2,7 @@
 
 use std::{num::NonZeroUsize, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_cli_utils::CliStyles;
 use clap::{Args, Parser};
 use url::Url;
@@ -83,6 +83,10 @@ pub struct ProposerArgs {
     /// Game type ID for `AggregateVerifier` dispute games.
     #[arg(long = "game-type", env = cli_env!("GAME_TYPE"))]
     pub game_type: u32,
+
+    /// Nitro enclave image hash required for proposal proofs.
+    #[arg(long = "tee-image-hash", env = cli_env!("TEE_IMAGE_HASH"))]
+    pub tee_image_hash: B256,
 
     /// Polling interval for new blocks (e.g., "12s", "1m").
     #[arg(
@@ -195,6 +199,8 @@ mod tests {
             "0x2234567890123456789012345678901234567890",
             "--game-type",
             "1",
+            "--tee-image-hash",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
             "--rollup-rpc",
             "http://localhost:7545",
         ])
@@ -229,6 +235,8 @@ mod tests {
             "0x2234567890123456789012345678901234567890",
             "--game-type",
             "1",
+            "--tee-image-hash",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
             "--rollup-rpc",
             "http://localhost:7545",
             "--recovery-scan-concurrency",

--- a/crates/proof/proposer/src/config.rs
+++ b/crates/proof/proposer/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{net::SocketAddr, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_cli_utils::{LogConfig, MetricsConfig};
 use base_retry::RetryConfig;
 use eyre::{Result, WrapErr};
@@ -29,6 +29,8 @@ pub struct ProposerConfig {
     pub dispute_game_factory_addr: Address,
     /// Game type ID for `AggregateVerifier` dispute games.
     pub game_type: u32,
+    /// Nitro enclave image hash required for proposal proofs.
+    pub tee_image_hash: B256,
     /// Polling interval for new blocks.
     pub poll_interval: Duration,
     /// RPC request timeout.
@@ -123,6 +125,7 @@ impl ProposerConfig {
             anchor_state_registry_addr: proposer.anchor_state_registry_addr,
             dispute_game_factory_addr: proposer.dispute_game_factory_addr,
             game_type: proposer.game_type,
+            tee_image_hash: proposer.tee_image_hash,
             poll_interval: proposer.poll_interval,
             rpc_timeout: proposer.rpc_timeout,
             rollup_rpc: proposer.rollup_rpc,
@@ -169,6 +172,8 @@ mod tests {
             "0x2234567890123456789012345678901234567890",
             "--game-type",
             "1",
+            "--tee-image-hash",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
             "--rollup-rpc",
             "http://localhost:7545",
             "--private-key",

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -43,6 +43,8 @@ pub struct DriverConfig {
     pub intermediate_block_interval: u64,
     /// Game type ID for `AggregateVerifier` dispute games.
     pub game_type: u32,
+    /// Nitro enclave image hash required for proposal proofs.
+    pub tee_image_hash: B256,
     /// Address of the proposer that submits proof transactions onchain.
     /// Included in the proof journal so the enclave signs over the correct `msg.sender`.
     pub proposer_address: Address,
@@ -60,6 +62,7 @@ impl Default for DriverConfig {
             block_interval: 512,
             intermediate_block_interval: 512,
             game_type: 0,
+            tee_image_hash: B256::ZERO,
             proposer_address: Address::ZERO,
             anchor_state_registry_address: Address::ZERO,
         }
@@ -290,6 +293,7 @@ mod tests {
             Arc::clone(&rollup),
             proof_submitter,
             config.block_interval,
+            config.tee_image_hash,
             config.submit_timeout,
         );
         let pipeline =

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -328,6 +328,7 @@ mod tests {
             Arc::clone(&rollup),
             proof_submitter,
             config.block_interval,
+            config.tee_image_hash,
             config.submit_timeout,
         );
         ProvingPipeline::new(config, proof_dispatcher, proof_recovery, proof_collector)

--- a/crates/proof/proposer/src/proof_adapter.rs
+++ b/crates/proof/proposer/src/proof_adapter.rs
@@ -18,14 +18,19 @@ impl ProposerProofAdapter {
 
     const TEE_SESSION_LABEL: &'static str = "tee/aws_nitro";
 
-    /// Derives an idempotent TEE proof session ID from proof subtype and claimed root.
-    pub fn tee_session_id_for_root(root: B256) -> String {
-        ProofSessionId::derive(Self::SESSION_NAMESPACE, Self::TEE_SESSION_LABEL, root)
+    /// Derives an idempotent TEE proof session ID from the image hash and claimed root.
+    pub fn tee_session_id_for_root(image_hash: B256, root: B256) -> String {
+        ProofSessionId::derive_from_components(
+            Self::SESSION_NAMESPACE,
+            Self::TEE_SESSION_LABEL,
+            &[image_hash.as_slice(), root.as_slice()],
+        )
     }
 
     /// Builds a prover-service request for a TEE proposal proof.
     pub fn tee_prove_block_range_request(request: PrimitiveProofRequest) -> ProveBlockRangeRequest {
-        let session_id = Self::tee_session_id_for_root(request.claimed_l2_output_root);
+        let session_id =
+            Self::tee_session_id_for_root(request.image_hash, request.claimed_l2_output_root);
         Self::tee_prove_block_range_request_with_session_id(request, session_id)
     }
 
@@ -93,7 +98,7 @@ mod tests {
             proposer: Address::repeat_byte(0x04),
             intermediate_block_interval: 300,
             l1_head_number: 1200,
-            image_hash: alloy_primitives::B256::ZERO,
+            image_hash: B256::repeat_byte(0x06),
             schedule_l2_block_number: None,
         }
     }
@@ -102,7 +107,8 @@ mod tests {
     fn tee_prove_block_range_request_wraps_primitive_request() {
         let root = B256::repeat_byte(0xaa);
         let request = test_request(root);
-        let expected_session_id = ProposerProofAdapter::tee_session_id_for_root(root);
+        let expected_session_id =
+            ProposerProofAdapter::tee_session_id_for_root(request.image_hash, root);
 
         let wrapped = ProposerProofAdapter::tee_prove_block_range_request(request.clone());
 
@@ -114,6 +120,15 @@ mod tests {
             }
             other => panic!("unexpected proof request kind: {other:?}"),
         }
+    }
+
+    #[test]
+    fn tee_session_id_changes_with_image_hash() {
+        let root = B256::repeat_byte(0xaa);
+        assert_ne!(
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(1), root),
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(2), root),
+        );
     }
 
     #[test]

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -2,7 +2,7 @@
 
 use std::{sync::Arc, time::Duration};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_proof_rpc::RollupProvider;
 use base_proof_submission::ProofSubmissionError;
 use base_prover_service_client::ProofRequesterProvider;
@@ -34,6 +34,7 @@ where
     rollup_client: Arc<R>,
     submitter: ProofSubmitter,
     block_interval: u64,
+    tee_image_hash: B256,
     submit_timeout: Option<Duration>,
 }
 
@@ -59,9 +60,17 @@ where
         rollup_client: Arc<R>,
         submitter: ProofSubmitter,
         block_interval: u64,
+        tee_image_hash: B256,
         submit_timeout: Option<Duration>,
     ) -> Self {
-        Self { proof_requester, rollup_client, submitter, block_interval, submit_timeout }
+        Self {
+            proof_requester,
+            rollup_client,
+            submitter,
+            block_interval,
+            tee_image_hash,
+            submit_timeout,
+        }
     }
 
     /// Runs one collector tick.
@@ -109,7 +118,10 @@ where
                 return false;
             };
 
-            let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_l2_output_root);
+            let session_id = ProposerProofAdapter::tee_session_id_for_root(
+                self.tee_image_hash,
+                claimed_l2_output_root,
+            );
             let proof = match Self::poll_proof(
                 self.proof_requester.as_ref(),
                 target_block,
@@ -503,6 +515,7 @@ mod tests {
             rollup_client,
             submitter,
             BLOCK_INTERVAL,
+            B256::repeat_byte(0x42),
             Some(std::time::Duration::from_secs(60)),
         )
     }
@@ -552,6 +565,7 @@ mod tests {
             claimed_l2_block_number: target_block,
             intermediate_block_interval: BLOCK_INTERVAL,
             l1_head_number: 1000,
+            image_hash: B256::repeat_byte(0x42),
             ..Default::default()
         };
         requester
@@ -590,6 +604,7 @@ mod tests {
                 claimed_l2_block_number: target_block,
                 intermediate_block_interval: BLOCK_INTERVAL,
                 l1_head_number: 1000,
+                image_hash: B256::repeat_byte(0x42),
                 ..Default::default()
             };
             requester
@@ -648,12 +663,14 @@ mod tests {
         let requester = Arc::new(MockProofRequester::default());
         let target_block = 200;
         let claimed_root = B256::repeat_byte(target_block as u8);
-        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), claimed_root);
         let proof_request = ProofRequest {
             claimed_l2_output_root: claimed_root,
             claimed_l2_block_number: target_block,
             intermediate_block_interval: BLOCK_INTERVAL,
             l1_head_number: 1000,
+            image_hash: B256::repeat_byte(0x42),
             ..Default::default()
         };
         requester
@@ -661,13 +678,15 @@ mod tests {
             .await
             .expect("test setup should dispatch root session");
         let later_root = B256::repeat_byte(0xcc);
-        let later_session_id = ProposerProofAdapter::tee_session_id_for_root(later_root);
+        let later_session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), later_root);
         requester
             .prove_block_range(ProposerProofAdapter::tee_prove_block_range_request(ProofRequest {
                 claimed_l2_output_root: later_root,
                 claimed_l2_block_number: target_block + BLOCK_INTERVAL,
                 intermediate_block_interval: BLOCK_INTERVAL,
                 l1_head_number: 1000,
+                image_hash: B256::repeat_byte(0x42),
                 ..Default::default()
             }))
             .await
@@ -699,12 +718,14 @@ mod tests {
         let requester = Arc::new(MockProofRequester { reject_delete: true, ..Default::default() });
         let target_block = 200;
         let claimed_root = B256::repeat_byte(target_block as u8);
-        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), claimed_root);
         let proof_request = ProofRequest {
             claimed_l2_output_root: claimed_root,
             claimed_l2_block_number: target_block,
             intermediate_block_interval: BLOCK_INTERVAL,
             l1_head_number: 1000,
+            image_hash: B256::repeat_byte(0x42),
             ..Default::default()
         };
         requester
@@ -734,12 +755,14 @@ mod tests {
         let target_block = 200;
         let stale_root = B256::repeat_byte(0xaa);
         let fresh_root = B256::repeat_byte(0xbb);
-        let session_id = ProposerProofAdapter::tee_session_id_for_root(stale_root);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), stale_root);
         let proof_request = ProofRequest {
             claimed_l2_output_root: stale_root,
             claimed_l2_block_number: target_block,
             intermediate_block_interval: BLOCK_INTERVAL,
             l1_head_number: 1000,
+            image_hash: B256::repeat_byte(0x42),
             ..Default::default()
         };
         requester
@@ -778,7 +801,8 @@ mod tests {
         let requester = Arc::new(MockProofRequester::default());
         let target_block = 200;
         let claimed_root = B256::repeat_byte(0xaa);
-        let session_id = ProposerProofAdapter::tee_session_id_for_root(claimed_root);
+        let session_id =
+            ProposerProofAdapter::tee_session_id_for_root(B256::repeat_byte(0x42), claimed_root);
         requester
             .failed_sessions
             .lock()

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -27,6 +27,8 @@ pub struct ProofDispatcherConfig {
     pub proposer_address: Address,
     /// Number of L2 blocks between intermediate output root checkpoints.
     pub intermediate_block_interval: u64,
+    /// Nitro enclave image hash required for proposal proofs.
+    pub tee_image_hash: B256,
 }
 
 impl From<&DriverConfig> for ProofDispatcherConfig {
@@ -35,6 +37,7 @@ impl From<&DriverConfig> for ProofDispatcherConfig {
             block_interval: config.block_interval,
             proposer_address: config.proposer_address,
             intermediate_block_interval: config.intermediate_block_interval,
+            tee_image_hash: config.tee_image_hash,
         }
     }
 }
@@ -108,10 +111,7 @@ impl ProofDispatcher {
             proposer: self.config.proposer_address,
             intermediate_block_interval: self.config.intermediate_block_interval,
             l1_head_number: l1_header.number,
-            // Placeholder: the proposer populates this from its configured TEE image
-            // hash when artifact routing lands. Zero is inert today because the prover
-            // service does not yet read image_hash.
-            image_hash: alloy_primitives::B256::ZERO,
+            image_hash: self.config.tee_image_hash,
             schedule_l2_block_number: None,
         })
     }
@@ -310,6 +310,7 @@ mod tests {
                 block_interval: 100,
                 proposer_address: Address::repeat_byte(0x04),
                 intermediate_block_interval: 300,
+                tee_image_hash: B256::repeat_byte(0x42),
             },
         );
         let recovered = RecoveredState {

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -223,6 +223,7 @@ impl ProposerService {
             block_interval,
             intermediate_block_interval,
             game_type: config.game_type,
+            tee_image_hash: config.tee_image_hash,
             proposer_address: proposer_address.unwrap_or_default(),
             anchor_state_registry_address: config.anchor_state_registry_addr,
         };
@@ -257,6 +258,7 @@ impl ProposerService {
             Arc::clone(&rollup_client),
             proof_submitter,
             driver_config.block_interval,
+            driver_config.tee_image_hash,
             driver_config.submit_timeout,
         );
         let pipeline =

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -257,7 +257,7 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         unimplemented!("unused in proposer tests")
     }
     async fn proof_artifacts(&self, _: Address) -> Result<ProofArtifacts, ContractError> {
-        unimplemented!("artifact routing lands with the producer changes")
+        unimplemented!("unused in proposer tests")
     }
     async fn zk_prover(&self, _: Address) -> Result<Address, ContractError> {
         unimplemented!("unused in proposer tests")

--- a/crates/proof/tee/nitro-host/src/host.rs
+++ b/crates/proof/tee/nitro-host/src/host.rs
@@ -2,10 +2,12 @@
 
 use std::{sync::Arc, time::Duration};
 
+use alloy_primitives::B256;
 use base_proof_worker::{JobDiscovery, JobDiscoveryConfig, ProofSubmitter};
 use base_prover_service_client::ProverWorkerProvider;
 use base_prover_service_protocol::TeeKind;
 use tokio_util::sync::CancellationToken;
+use tracing::{error, warn};
 
 use crate::{NitroEnclavePool, ProofGenerator, ProofGeneratorHeartbeatConfig};
 
@@ -62,13 +64,49 @@ where
 {
     /// Runs the host until cancellation is requested.
     pub async fn run_until_cancelled(self, cancel: CancellationToken) {
+        let Some(artifact_hash) = self.read_artifact_hash(&cancel).await else {
+            return;
+        };
+        let discovery_config = self.discovery.with_supported_artifact_hash(artifact_hash);
         let submitter = ProofSubmitter::new(self.client.clone());
         let proof_generator = Arc::new(
             ProofGenerator::new(self.pool, submitter, self.heartbeat)
-                .with_max_pending_submissions(self.discovery.normalized_max_concurrent_jobs()),
+                .with_max_pending_submissions(discovery_config.normalized_max_concurrent_jobs()),
         );
-        let discovery = JobDiscovery::new(self.client, proof_generator, self.discovery);
+        let discovery = JobDiscovery::new(self.client, proof_generator, discovery_config);
 
         discovery.run_until_cancelled(cancel).await;
+    }
+
+    /// Reads the local enclave image hash, retrying until it succeeds or is cancelled.
+    ///
+    /// The host cannot claim any job without this hash, so a transient read failure
+    /// must not be fatal: the enclave is frequently still booting when the host
+    /// starts, and exiting here would take the worker out of the pool permanently
+    /// rather than for the few seconds the enclave needs.
+    ///
+    /// Returns `None` only if cancellation was requested while retrying.
+    async fn read_artifact_hash(&self, cancel: &CancellationToken) -> Option<B256> {
+        let retry_delay = self.discovery.normalized_poll_interval();
+        loop {
+            match self.pool.tee_image_hash().await {
+                Ok(hash) => return Some(hash),
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        retry_in_secs = retry_delay.as_secs(),
+                        "failed to read local Nitro artifact hash, retrying"
+                    );
+                }
+            }
+
+            tokio::select! {
+                () = cancel.cancelled() => {
+                    error!("cancelled before the local Nitro artifact hash could be read");
+                    return None;
+                }
+                () = tokio::time::sleep(retry_delay) => {}
+            }
+        }
     }
 }

--- a/crates/proof/worker/Cargo.toml
+++ b/crates/proof/worker/Cargo.toml
@@ -23,6 +23,7 @@ async-trait.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 
 # misc
+alloy-primitives.workspace = true
 backon.workspace = true
 chrono.workspace = true
 tracing.workspace = true

--- a/crates/proof/worker/src/job_discovery.rs
+++ b/crates/proof/worker/src/job_discovery.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use alloy_primitives::B256;
 use base_prover_service_client::{ProverServiceClientError, ProverWorkerProvider};
 use base_prover_service_protocol::{
     GetNextProofRequest, ProofJob, ProofType, TeeKind, ZkBackend, ZkVm,
@@ -92,20 +93,27 @@ impl JobClaimFilter {
     pub fn get_next_proof_requests(
         &self,
         worker_id: String,
+        supported_artifact_hash: Option<B256>,
         lock_duration_seconds: u32,
     ) -> impl Iterator<Item = GetNextProofRequest> {
-        self.get_next_proof_requests_starting_at(worker_id, lock_duration_seconds, 0)
+        self.get_next_proof_requests_starting_at(
+            worker_id,
+            supported_artifact_hash,
+            lock_duration_seconds,
+            0,
+        )
     }
 
     /// Builds the worker claim requests for this filter with a proof-type rotation offset.
     ///
-    /// `supported_artifact_hash` is left `None` here as a placeholder; hosts set it
-    /// from their local enclave image or verification keys when artifact routing
-    /// lands. It is inert today because the prover service does not yet read it, but
-    /// once routing is enabled a `None` claims no jobs at all.
+    /// `supported_artifact_hash` is the artifact this worker can actually execute,
+    /// derived by the host from its local enclave image or verification keys. Once
+    /// artifact routing is enabled the prover service treats `None` as "claims
+    /// nothing", so a host that cannot determine its own hash must not poll.
     pub fn get_next_proof_requests_starting_at(
         &self,
         worker_id: String,
+        supported_artifact_hash: Option<B256>,
         lock_duration_seconds: u32,
         proof_type_offset: usize,
     ) -> impl Iterator<Item = GetNextProofRequest> {
@@ -117,7 +125,7 @@ impl JobClaimFilter {
                     tee_kinds: tee_kinds.clone(),
                     zk_vms: Vec::new(),
                     zk_backends: Vec::new(),
-                    supported_artifact_hash: None,
+                    supported_artifact_hash,
                     lock_duration_seconds,
                 }),
                 None,
@@ -139,7 +147,7 @@ impl JobClaimFilter {
                         tee_kinds: Vec::new(),
                         zk_vms: zk_vms.clone(),
                         zk_backends: zk_backends.clone(),
-                        supported_artifact_hash: None,
+                        supported_artifact_hash,
                         lock_duration_seconds,
                     }),
                     Some(GetNextProofRequest {
@@ -148,7 +156,7 @@ impl JobClaimFilter {
                         tee_kinds: Vec::new(),
                         zk_vms,
                         zk_backends,
-                        supported_artifact_hash: None,
+                        supported_artifact_hash,
                         lock_duration_seconds,
                     }),
                 ]
@@ -164,6 +172,7 @@ impl JobClaimFilter {
 pub struct JobDiscoveryConfig {
     worker_id: String,
     claim_filter: JobClaimFilter,
+    supported_artifact_hash: Option<B256>,
     poll_interval: Duration,
     lock_duration_seconds: u32,
     max_concurrent_jobs: usize,
@@ -189,6 +198,7 @@ impl JobDiscoveryConfig {
         Self {
             worker_id: worker_id.into(),
             claim_filter,
+            supported_artifact_hash: None,
             poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
             lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
             max_concurrent_jobs: DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
@@ -228,6 +238,13 @@ impl JobDiscoveryConfig {
         self
     }
 
+    /// Sets the exact artifact hash advertised on every claim request.
+    #[must_use]
+    pub const fn with_supported_artifact_hash(mut self, artifact_hash: B256) -> Self {
+        self.supported_artifact_hash = Some(artifact_hash);
+        self
+    }
+
     /// Returns the configured poll interval clamped to the minimum allowed delay.
     pub fn normalized_poll_interval(&self) -> Duration {
         self.poll_interval.max(MIN_JOB_DISCOVERY_POLL_INTERVAL)
@@ -250,6 +267,7 @@ impl JobDiscoveryConfig {
     ) -> impl Iterator<Item = GetNextProofRequest> {
         self.claim_filter.get_next_proof_requests_starting_at(
             self.worker_id.clone(),
+            self.supported_artifact_hash,
             self.lock_duration_seconds,
             proof_type_offset,
         )
@@ -676,6 +694,7 @@ mod tests {
             vec![ZkVm::Sp1],
             vec![ZkBackend::Cluster, ZkBackend::Network],
         )
+        .with_supported_artifact_hash(B256::repeat_byte(0x42))
         .with_lock_duration_seconds(30)
         .with_max_concurrent_jobs(0);
 
@@ -687,12 +706,14 @@ mod tests {
         assert!(requests[0].tee_kinds.is_empty());
         assert_eq!(requests[0].zk_vms, vec![ZkVm::Sp1]);
         assert_eq!(requests[0].zk_backends, vec![ZkBackend::Cluster, ZkBackend::Network]);
+        assert_eq!(requests[0].supported_artifact_hash, Some(B256::repeat_byte(0x42)));
         assert_eq!(requests[0].lock_duration_seconds, 30);
         assert_eq!(requests[1].worker_id, "worker-a");
         assert_eq!(requests[1].proof_type, ProofType::SnarkPlonk);
         assert!(requests[1].tee_kinds.is_empty());
         assert_eq!(requests[1].zk_vms, vec![ZkVm::Sp1]);
         assert_eq!(requests[1].zk_backends, vec![ZkBackend::Cluster, ZkBackend::Network]);
+        assert_eq!(requests[1].supported_artifact_hash, Some(B256::repeat_byte(0x42)));
         assert_eq!(requests[1].lock_duration_seconds, 30);
         assert_eq!(config.normalized_max_concurrent_jobs(), 1);
     }
@@ -700,6 +721,7 @@ mod tests {
     #[test]
     fn config_builds_nitro_claim_request() {
         let config = JobDiscoveryConfig::tee("worker-a", vec![TeeKind::AwsNitro])
+            .with_supported_artifact_hash(B256::repeat_byte(0x24))
             .with_lock_duration_seconds(45);
 
         let requests = config.get_next_proof_requests().collect::<Vec<_>>();
@@ -710,6 +732,7 @@ mod tests {
         assert_eq!(request.proof_type, ProofType::Tee);
         assert_eq!(request.tee_kinds, vec![TeeKind::AwsNitro]);
         assert!(request.zk_vms.is_empty());
+        assert_eq!(request.supported_artifact_hash, Some(B256::repeat_byte(0x24)));
         assert_eq!(request.lock_duration_seconds, 45);
     }
 

--- a/crates/proof/zk/host/Cargo.toml
+++ b/crates/proof/zk/host/Cargo.toml
@@ -23,11 +23,11 @@ async-trait.workspace = true
 tokio = { workspace = true, features = ["rt", "time"] }
 
 # misc
+alloy-primitives.workspace = true
 chrono.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-alloy-primitives.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }
 base-proof-primitives = { workspace = true, features = ["std", "serde"] }

--- a/crates/proof/zk/host/src/host.rs
+++ b/crates/proof/zk/host/src/host.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
+use alloy_primitives::B256;
 use base_proof_worker::{
     DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS, DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
     DEFAULT_JOB_DISCOVERY_POLL_INTERVAL, JobDiscovery, JobDiscoveryConfig, ProofSubmitter,
@@ -16,6 +17,7 @@ use crate::{ProofGenerator, ProofGeneratorHeartbeatConfig, ZkBackend, ZkProver, 
 pub struct ZkHostConfig {
     worker_id: String,
     zk_vms: Vec<ZkVm>,
+    supported_artifact_hash: B256,
     job_discovery_poll_interval: Duration,
     job_discovery_lock_duration_seconds: u32,
     job_discovery_max_concurrent_jobs: usize,
@@ -24,10 +26,15 @@ pub struct ZkHostConfig {
 
 impl ZkHostConfig {
     /// Creates a ZK host config with default timing settings.
-    pub fn new(worker_id: impl Into<String>, zk_vms: impl Into<Vec<ZkVm>>) -> Self {
+    pub fn new(
+        worker_id: impl Into<String>,
+        zk_vms: impl Into<Vec<ZkVm>>,
+        supported_artifact_hash: B256,
+    ) -> Self {
         Self {
             worker_id: worker_id.into(),
             zk_vms: zk_vms.into(),
+            supported_artifact_hash,
             job_discovery_poll_interval: DEFAULT_JOB_DISCOVERY_POLL_INTERVAL,
             job_discovery_lock_duration_seconds: DEFAULT_JOB_DISCOVERY_LOCK_DURATION_SECONDS,
             job_discovery_max_concurrent_jobs: DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS,
@@ -36,8 +43,8 @@ impl ZkHostConfig {
     }
 
     /// Creates an SP1 ZK host config with default timing settings.
-    pub fn sp1(worker_id: impl Into<String>) -> Self {
-        Self::new(worker_id, vec![ZkVm::Sp1])
+    pub fn sp1(worker_id: impl Into<String>, supported_artifact_hash: B256) -> Self {
+        Self::new(worker_id, vec![ZkVm::Sp1], supported_artifact_hash)
     }
 
     /// Returns the worker identifier used for prover-service claims.
@@ -148,7 +155,8 @@ where
         let discovery_config = JobDiscoveryConfig::zk(config.worker_id, config.zk_vms, zk_backends)
             .with_poll_interval(config.job_discovery_poll_interval)
             .with_lock_duration_seconds(config.job_discovery_lock_duration_seconds)
-            .with_max_concurrent_jobs(config.job_discovery_max_concurrent_jobs);
+            .with_max_concurrent_jobs(config.job_discovery_max_concurrent_jobs)
+            .with_supported_artifact_hash(config.supported_artifact_hash);
         let submitter = ProofSubmitter::new(client.clone());
         let proof_generator = Arc::new(
             ProofGenerator::new(provers, submitter, config.proof_generator_heartbeat)


### PR DESCRIPTION
> Part 2 of 3, splitting #4725. Stack: #4768 → **this** → 3/3.
> **Base branch is `feat/artifact-identity` (#4768), not `main`.** Review the top commit only; GitHub retargets this to `main` once #4768 merges.
> No runtime behaviour changes in this PR.

## What changed?

Producers now stamp the artifact each job requires, and workers advertise the artifact they can execute. The prover service still ignores both fields, so nothing routes yet.

**Proposer**
- New **required** `--tee-image-hash` / `BASE_PROPOSER_TEE_IMAGE_HASH`. Carried into `ProofRequest.image_hash` and into the TEE session-ID preimage.

**Challenger**
- Reads TEE and ZK commitments from each individual game proxy via `proof_artifacts()`, so a historical game keeps requesting the artifacts it was created against rather than whatever the factory currently points at.
- Both TEE and ZK session IDs now commit to the artifact hash.

**Workers**
- Nitro host advertises its local enclave image hash.
- ZK host advertises the composite hash derived from its embedded verification keys.

### Two things worth a closer look

**Session IDs now include the artifact hash.** This is deliberate — it stops a proof produced under one artifact generation from being reused for a game expecting another. It also means every derived session ID changes on deploy. In-flight sessions keyed by the old ID will not be found; see the ordering note below.

**The Nitro host retries instead of exiting.** Reading the enclave image hash happens before polling starts. The enclave is frequently still booting when the host starts, and returning there would drop the worker from the pool permanently rather than for the few seconds the enclave needs. It now retries on the configured poll interval and only gives up on cancellation.

## Why?

Exact artifact routing needs the request to say which artifact it requires and the worker to say which one it has. Splitting this from the enforcement in 3/3 means the config rollout — particularly the new required proposer env var — gets its own deploy window, before any behaviour depends on it.

## How to test?

```sh
cargo test -p base-proposer -p base-challenger -p base-proof-worker \
           -p base-proof-tee-nitro-host -p base-proof-zk-host --lib

cargo test -p base-challenger --test driver
```

Targeted checks for the behaviour this PR adds:

```sh
# Session IDs must separate artifact generations
cargo test -p base-challenger --lib challenger_session_ids_separate_artifact_hashes
cargo test -p base-proposer   --lib tee_session_id_changes_with_image_hash

# Workers put their advertised hash on every claim request
cargo test -p base-proof-worker --lib config_builds_nitro_claim_request
```

Manual check that the proposer refuses to start without the new variable:

```sh
unset BASE_PROPOSER_TEE_IMAGE_HASH
cargo run -p base-proposer -- --game-type 1 ...   # expect a clap error naming --tee-image-hash
```

## Deployment

⚠️ **`BASE_PROPOSER_TEE_IMAGE_HASH` is required and has no default — the proposer will not start without it.** Set it to the `TEE_IMAGE_HASH()` of the currently deployed `AggregateVerifier` implementation before rolling this out. See the Artifact Pinning section added to `crates/proof/proposer/README.md`.

Because session IDs change, drain or allow in-flight proposer/challenger sessions to complete across the restart rather than expecting them to resume.

Still a no-op server-side: the prover service does not read `zk_artifact_hash` or `supported_artifact_hash` until 3/3.