### PR TITLE
feat(proof): route proof jobs by artifact hash (3/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5858,6 +5858,7 @@ dependencies = [
 name = "base-prover-service"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "base-prover-service-db",
  "base-prover-service-protocol",

--- a/crates/proof/prover-service/Cargo.toml
+++ b/crates/proof/prover-service/Cargo.toml
@@ -30,6 +30,7 @@ metrics.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+alloy-primitives.workspace = true
 rstest.workspace = true
 chrono.workspace = true
 jsonrpsee = { workspace = true, features = ["http-client"] }

--- a/crates/proof/prover-service/db/Cargo.toml
+++ b/crates/proof/prover-service/db/Cargo.toml
@@ -8,6 +8,9 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+# primitives
+alloy-primitives.workspace = true
+
 # protocol
 base-prover-service-protocol.workspace = true
 
@@ -29,7 +32,6 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-alloy-primitives.workspace = true
 base-proof-primitives.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/proof/prover-service/db/migrations/018_add_artifact_hash.sql
+++ b/crates/proof/prover-service/db/migrations/018_add_artifact_hash.sql
@@ -1,0 +1,97 @@
+-- Persist the exact TEE image or ZK artifact hash used for worker routing.
+--
+-- ==========================================================================
+-- DEVIATION FROM THE TDD -- READ BEFORE DEPLOYING
+-- ==========================================================================
+-- The TDD ("Proof Artifact-Aware Job Routing", 2026-08-04) specifies that this
+-- migration backfills every incomplete job with the deployed legacy artifact
+-- hashes, making Phase 1 a true no-op. This migration deliberately does NOT
+-- backfill: the correct hashes are environment-specific (they differ per
+-- network and per deployed AggregateVerifier implementation) and this file
+-- cannot derive them without guessing.
+--
+-- Consequences, all of which must be handled operationally:
+--
+--   1. Every pre-existing row keeps artifact_hash = NULL. A NULL never
+--      satisfies the claim predicate (`artifact_hash = $N`), so those jobs are
+--      UNCLAIMABLE, not merely unrouted. They will never be picked up again.
+--
+--   2. This makes Phase 1 a BREAKING deploy, not the no-op the TDD describes.
+--      In-flight jobs are stranded rather than backfilled-and-completed.
+--
+--   3. The TDD's required Phase 1 end-to-end test step 3 ("Confirm the
+--      in-flight job is backfilled and still completes") CANNOT pass as
+--      written and must be replaced by the drain check below.
+--
+-- Required deploy sequence (replaces TDD rollout step 3):
+--
+--   a. Pause the proposer and challenger so no new jobs are created.
+--   b. Let the worker queue drain: block until
+--        SELECT COUNT(*) FROM proof_requests
+--        WHERE job_status IN ('PENDING', 'CLAIMED');
+--      returns 0. Do not proceed while this is non-zero.
+--   c. Apply this migration.
+--   d. Deploy the artifact-aware prover service, proposer, and challenger.
+--   e. Redeploy workers so they advertise their artifact hashes.
+--
+-- If draining is not acceptable, backfill instead of draining, using the hashes
+-- read from the currently deployed AggregateVerifier implementation:
+--
+--   UPDATE proof_requests SET artifact_hash = '\x<legacy TEE_IMAGE_HASH>'
+--   WHERE artifact_hash IS NULL AND api_proof_type = 'tee'
+--     AND job_status IN ('PENDING', 'CLAIMED');
+--
+--   UPDATE proof_requests
+--   SET artifact_hash = '\x<keccak256(ZK_RANGE_HASH || ZK_AGGREGATE_HASH)>'
+--   WHERE artifact_hash IS NULL AND api_proof_type IN ('compressed', 'snark_plonk')
+--     AND job_status IN ('PENDING', 'CLAIMED');
+--
+-- Note ZK_RANGE_HASH and ZK_AGGREGATE_HASH use *different* SP1 digests; derive
+-- the composite with `cargo run -p base-proof-zk-backend --bin vkeys` rather
+-- than by hand.
+--
+-- Monitoring: any row that reaches the queue without a hash is reported by the
+-- `prover_service.pending_jobs_by_artifact` gauge under artifact_hash="none".
+-- A non-zero value there after deploy means jobs are stranded.
+-- ==========================================================================
+BEGIN;
+
+ALTER TABLE proof_requests
+ADD COLUMN IF NOT EXISTS artifact_hash BYTEA;
+
+ALTER TABLE proof_requests
+DROP CONSTRAINT IF EXISTS proof_requests_artifact_hash_length;
+
+ALTER TABLE proof_requests
+ADD CONSTRAINT proof_requests_artifact_hash_length
+CHECK (artifact_hash IS NULL OR octet_length(artifact_hash) = 32);
+
+DROP INDEX IF EXISTS idx_proof_requests_job_claim;
+CREATE INDEX idx_proof_requests_tee_job_claim
+ON proof_requests(
+    job_status,
+    api_proof_type,
+    tee_kind,
+    artifact_hash,
+    start_block_number,
+    created_at
+)
+WHERE api_proof_type = 'tee';
+
+DROP INDEX IF EXISTS idx_proof_requests_zk_job_claim;
+CREATE INDEX idx_proof_requests_zk_job_claim
+ON proof_requests(
+    job_status,
+    api_proof_type,
+    zk_vm,
+    (COALESCE(zk_backend, 'cluster')),
+    artifact_hash,
+    start_block_number,
+    created_at
+)
+WHERE api_proof_type IN ('compressed', 'snark_plonk');
+
+COMMENT ON COLUMN proof_requests.artifact_hash IS
+'Exact 32-byte TEE image or ZK artifact hash required for worker routing. NULL legacy rows are nonclaimable until operationally backfilled.';
+
+COMMIT;

--- a/crates/proof/prover-service/db/src/conversions.rs
+++ b/crates/proof/prover-service/db/src/conversions.rs
@@ -278,7 +278,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(alloy_primitives::B256::repeat_byte(0x11)),
                 zk_vm: ProtocolZkVm::Sp1,
                 zk_backend: ProtocolZkBackend::Cluster,
             }),

--- a/crates/proof/prover-service/db/src/lib.rs
+++ b/crates/proof/prover-service/db/src/lib.rs
@@ -11,10 +11,11 @@ pub use models::{
     ApiProofType, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
     CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
     CreateProofSession, DeleteProofRequestOutcome, DerivedProofRequestFields, FailExpiredProofJobs,
-    HeartbeatOutcome, HeartbeatProofJob, JobLockState, ProofJob, ProofJobStatus, ProofRequest,
-    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType,
-    RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
-    UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind, canonical_session_id,
+    HeartbeatOutcome, HeartbeatProofJob, JobLockState, PendingArtifactDepth, ProofJob,
+    ProofJobStatus, ProofRequest, ProofRequestListItem, ProofRequestPage, ProofSession,
+    ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType,
+    SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind,
+    canonical_session_id,
 };
 
 mod repo;

--- a/crates/proof/prover-service/db/src/models.rs
+++ b/crates/proof/prover-service/db/src/models.rs
@@ -1,5 +1,6 @@
 use std::convert::TryFrom;
 
+use alloy_primitives::B256;
 use base_prover_service_protocol::{
     ProofRequest as ProtocolProofRequest, ProofRequestKind as ProtocolProofRequestKind,
     ProofResult as ProtocolProofResult, TeeKind as ProtocolTeeKind, ZkBackend,
@@ -321,6 +322,23 @@ pub enum CreateProofRequestValidationError {
         /// Backend proof type supplied for the request.
         proof_type: ProofType,
     },
+    /// A ZK request omitted the artifact hash required for exact worker routing.
+    #[error("zk_artifact_hash is required for ZK proof requests")]
+    MissingZkArtifactHash,
+}
+
+/// Count of claimable jobs waiting on one exact artifact hash.
+///
+/// Emitted as a queue-depth gauge so an artifact generation with no matching
+/// worker shows up as a growing queue instead of silently stalling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingArtifactDepth {
+    /// Proof type of the queued jobs.
+    pub api_proof_type: ApiProofType,
+    /// Required artifact hash, or `None` for rows predating migration 018.
+    pub artifact_hash: Option<B256>,
+    /// Number of jobs pending on this artifact hash.
+    pub depth: i64,
 }
 
 /// Legacy SP1 proof-shape discriminator retained for receipt compatibility.
@@ -758,6 +776,8 @@ pub struct CreateProofRequest {
     pub tee_kind: Option<TeeKind>,
     /// Protocol-level ZK proving backend for ZK proofs.
     pub zk_backend: Option<ZkBackend>,
+    /// Exact TEE image or ZK artifact hash required to execute this request.
+    pub artifact_hash: B256,
     /// Backend-specific proof type for current OP Succinct backends.
     pub proof_type: Option<ProofType>,
     /// Starting L2 block number.
@@ -788,6 +808,7 @@ impl CreateProofRequest {
             zk_vm: fields.zk_vm,
             tee_kind: fields.tee_kind,
             zk_backend: fields.zk_backend,
+            artifact_hash: fields.artifact_hash,
             proof_type: fields.proof_type,
             start_block_number: fields.start_block_number,
             number_of_blocks_to_prove: fields.number_of_blocks_to_prove,
@@ -820,6 +841,11 @@ impl CreateProofRequest {
         }
         if self.zk_backend != expected.zk_backend {
             return Err(CreateProofRequestValidationError::FieldMismatch { field: "zk_backend" });
+        }
+        if self.artifact_hash != expected.artifact_hash {
+            return Err(CreateProofRequestValidationError::FieldMismatch {
+                field: "artifact_hash",
+            });
         }
         if self.proof_type != expected.proof_type {
             return Err(CreateProofRequestValidationError::FieldMismatch { field: "proof_type" });
@@ -868,6 +894,8 @@ pub struct DerivedProofRequestFields {
     pub tee_kind: Option<TeeKind>,
     /// Protocol-level ZK proving backend for ZK proofs.
     pub zk_backend: Option<ZkBackend>,
+    /// Exact TEE image or ZK artifact hash required to execute this request.
+    pub artifact_hash: B256,
     /// Backend-specific proof type for current OP Succinct backends.
     pub proof_type: Option<ProofType>,
     /// Starting L2 block number.
@@ -895,6 +923,9 @@ impl DerivedProofRequestFields {
                 zk_vm: Some(protocol_zk_vm(proof.zk_vm)),
                 tee_kind: None,
                 zk_backend: Some(proof.zk_backend),
+                artifact_hash: proof
+                    .zk_artifact_hash
+                    .ok_or(CreateProofRequestValidationError::MissingZkArtifactHash)?,
                 proof_type: Some(ProofType::OpSuccinctSp1ClusterCompressed),
                 start_block_number: proof.start_block_number,
                 number_of_blocks_to_prove: proof.number_of_blocks_to_prove,
@@ -908,6 +939,10 @@ impl DerivedProofRequestFields {
                 zk_vm: Some(protocol_zk_vm(request.proof.zk_vm)),
                 tee_kind: None,
                 zk_backend: Some(request.proof.zk_backend),
+                artifact_hash: request
+                    .proof
+                    .zk_artifact_hash
+                    .ok_or(CreateProofRequestValidationError::MissingZkArtifactHash)?,
                 proof_type: Some(ProofType::OpSuccinctSp1ClusterSnarkPlonk),
                 start_block_number: request.proof.start_block_number,
                 number_of_blocks_to_prove: request.proof.number_of_blocks_to_prove,
@@ -921,6 +956,7 @@ impl DerivedProofRequestFields {
                 zk_vm: None,
                 tee_kind: Some(protocol_tee_kind(request.tee_kind)),
                 zk_backend: None,
+                artifact_hash: request.proof.image_hash,
                 proof_type: None,
                 start_block_number: request.proof.claimed_l2_block_number,
                 number_of_blocks_to_prove: 1,
@@ -1011,6 +1047,8 @@ pub struct ClaimProofJob {
     pub zk_vms: Vec<ZkVmKind>,
     /// ZK proving backends this worker can execute (matched for ZK proofs).
     pub zk_backends: Vec<ZkBackend>,
+    /// Exact TEE image or ZK artifact hash supported by this worker.
+    pub supported_artifact_hash: B256,
     /// Lock duration in seconds. Callers must resolve the server default first.
     pub lock_duration_seconds: u32,
     /// Reclaim budget for expired claims.
@@ -1258,7 +1296,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),
@@ -1300,6 +1338,20 @@ mod tests {
         req.session_id = "other-session".to_owned();
 
         assert_eq!(req.validate(), Err(CreateProofRequestValidationError::SessionIdMismatch));
+    }
+
+    #[test]
+    fn create_rejects_missing_zk_artifact_hash() {
+        let mut request = compressed_protocol_request("session-1");
+        let ProtocolProofRequestKind::Compressed(proof) = &mut request.request else {
+            unreachable!("helper always builds compressed requests");
+        };
+        proof.zk_artifact_hash = None;
+
+        assert_eq!(
+            CreateProofRequest::new(request).unwrap_err(),
+            CreateProofRequestValidationError::MissingZkArtifactHash
+        );
     }
 
     #[test]

--- a/crates/proof/prover-service/db/src/repo.rs
+++ b/crates/proof/prover-service/db/src/repo.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::B256;
 use base_prover_service_protocol::{
     ProofResult as ProtocolProofResult, SnarkPlonkProofResult, ZkBackend, ZkProofResult, ZkVm,
 };
@@ -9,10 +10,10 @@ use crate::{
     ApiProofType, ClaimAuth, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
     CreateProofRequestError, CreateProofRequestOutcome, CreateProofRequestValidationError,
     CreateProofSession, DeleteProofRequestOutcome, FailExpiredProofJobs, HeartbeatOutcome,
-    HeartbeatProofJob, JobLockState, ProofJob, ProofJobStatus, ProofRequest, ProofRequestListItem,
-    ProofRequestPage, ProofSession, ProofStatus, ProofType, RecordSessionOutcome, RetryOutcome,
-    SessionStatus, SessionType, SubmitProofOutcome, TeeKind, UpdateProofSession, UpdateReceipt,
-    WorkerSessionUpsert, ZkVmKind, canonical_session_id,
+    HeartbeatProofJob, JobLockState, PendingArtifactDepth, ProofJob, ProofJobStatus, ProofRequest,
+    ProofRequestListItem, ProofRequestPage, ProofSession, ProofStatus, ProofType,
+    RecordSessionOutcome, RetryOutcome, SessionStatus, SessionType, SubmitProofOutcome, TeeKind,
+    UpdateProofSession, UpdateReceipt, WorkerSessionUpsert, ZkVmKind, canonical_session_id,
 };
 
 /// Repository for proof request database operations
@@ -38,10 +39,11 @@ impl ProofRequestRepo {
             r#"
             INSERT INTO proof_requests (
                 id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                artifact_hash,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
             "#,
         )
         .bind(prepared.id)
@@ -51,6 +53,7 @@ impl ProofRequestRepo {
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
         .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
         .bind(prepared.zk_backend.map(|zk_backend| zk_backend.as_str()))
+        .bind(prepared.artifact_hash.as_slice().to_vec())
         .bind(prepared.start_block_number)
         .bind(prepared.number_of_blocks_to_prove)
         .bind(prepared.sequence_window)
@@ -80,10 +83,11 @@ impl ProofRequestRepo {
             r#"
             INSERT INTO proof_requests (
                 id, session_id, request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                artifact_hash,
                 start_block_number, number_of_blocks_to_prove, sequence_window, proof_type, status,
                 prover_address, l1_head, intermediate_root_interval
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
             ON CONFLICT ((COALESCE(session_id, id::text))) DO NOTHING
             "#,
         )
@@ -94,6 +98,7 @@ impl ProofRequestRepo {
         .bind(prepared.zk_vm.map(|zk_vm| zk_vm.as_str()))
         .bind(prepared.tee_kind.map(|tee_kind| tee_kind.as_str()))
         .bind(prepared.zk_backend.map(|zk_backend| zk_backend.as_str()))
+        .bind(prepared.artifact_hash.as_slice().to_vec())
         .bind(prepared.start_block_number)
         .bind(prepared.number_of_blocks_to_prove)
         .bind(prepared.sequence_window)
@@ -115,6 +120,7 @@ impl ProofRequestRepo {
             r#"
             SELECT id, COALESCE(session_id, id::text) AS session_id,
                    request_payload, api_proof_type, zk_vm, tee_kind, zk_backend,
+                   artifact_hash,
                    start_block_number, number_of_blocks_to_prove, sequence_window,
                    proof_type, status, prover_address, l1_head,
                    intermediate_root_interval, retry_count
@@ -141,6 +147,7 @@ impl ProofRequestRepo {
             zk_vm: prepared.zk_vm.map(|zk_vm| zk_vm.as_str()),
             tee_kind: prepared.tee_kind.map(|tee_kind| tee_kind.as_str()),
             zk_backend: prepared.zk_backend.map(|zk_backend| zk_backend.as_str()),
+            artifact_hash: prepared.artifact_hash.as_slice(),
             start_block_number: prepared.start_block_number,
             number_of_blocks_to_prove: prepared.number_of_blocks_to_prove,
             sequence_window: prepared.sequence_window,
@@ -586,12 +593,14 @@ impl ProofRequestRepo {
             ApiProofType::Tee => {
                 let tee_kinds: Vec<String> =
                     req.tee_kinds.iter().map(|kind| kind.as_str().to_owned()).collect();
+                let artifact_hash = req.supported_artifact_hash.as_slice().to_vec();
                 sqlx::query(&sql)
                     .bind(&req.worker_id)
                     .bind(lock_id)
                     .bind(i64::from(req.lock_duration_seconds))
                     .bind(req.api_proof_type.as_str())
                     .bind(&tee_kinds)
+                    .bind(artifact_hash)
                     .bind(i64::from(req.max_attempts))
                     .fetch_optional(&self.pool)
                     .await?
@@ -606,6 +615,7 @@ impl ProofRequestRepo {
                     .chain(req.zk_backends.is_empty().then_some(ZkBackend::Cluster))
                     .map(|backend| backend.as_str().to_owned())
                     .collect();
+                let artifact_hash = req.supported_artifact_hash.as_slice().to_vec();
                 sqlx::query(&sql)
                     .bind(&req.worker_id)
                     .bind(lock_id)
@@ -613,6 +623,7 @@ impl ProofRequestRepo {
                     .bind(req.api_proof_type.as_str())
                     .bind(&zk_vms)
                     .bind(&zk_backends)
+                    .bind(artifact_hash)
                     .bind(i64::from(req.max_attempts))
                     .fetch_optional(&self.pool)
                     .await?
@@ -1305,6 +1316,41 @@ impl ProofRequestRepo {
         rows.iter().map(row_to_proof_request).collect()
     }
 
+    /// Returns the number of pending jobs grouped by proof type and required artifact hash.
+    ///
+    /// Cardinality is bounded by the number of concurrently deployed artifact
+    /// generations (typically two during an upgrade window), so this is safe to
+    /// export as a labelled gauge.
+    pub async fn pending_depth_by_artifact(&self) -> Result<Vec<PendingArtifactDepth>> {
+        let rows = sqlx::query(
+            r#"
+            SELECT api_proof_type, artifact_hash, COUNT(*) AS depth
+            FROM proof_requests
+            WHERE job_status = 'PENDING'
+            GROUP BY api_proof_type, artifact_hash
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                let value = row.get::<&str, _>("api_proof_type");
+                let api_proof_type = ApiProofType::try_from(value).map_err(|e| {
+                    sqlx::Error::Protocol(format!("Unknown api_proof_type '{value}': {e}"))
+                })?;
+                let artifact_hash = row
+                    .get::<Option<Vec<u8>>, _>("artifact_hash")
+                    .and_then(|bytes| B256::try_from(bytes.as_slice()).ok());
+                Ok(PendingArtifactDepth {
+                    api_proof_type,
+                    artifact_hash,
+                    depth: row.get::<i64, _>("depth"),
+                })
+            })
+            .collect()
+    }
+
     /// Get proof requests that are stuck in PENDING without a running session,
     /// or migration-parked RUNNING requests that were never claimed by a worker.
     /// PENDING requests are likely orphaned due to crashes before session creation.
@@ -1686,6 +1732,7 @@ struct PreparedProofRequest {
     zk_vm: Option<ZkVmKind>,
     tee_kind: Option<TeeKind>,
     zk_backend: Option<ZkBackend>,
+    artifact_hash: B256,
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
@@ -1741,6 +1788,7 @@ impl TryFrom<CreateProofRequest> for PreparedProofRequest {
             zk_vm: req.zk_vm,
             tee_kind: req.tee_kind,
             zk_backend: req.zk_backend,
+            artifact_hash: req.artifact_hash,
             start_block_number,
             number_of_blocks_to_prove,
             sequence_window,
@@ -2086,9 +2134,10 @@ fn claim_query(api_proof_type: ApiProofType) -> String {
                 SELECT id FROM proof_requests
                 WHERE api_proof_type = $4
                   AND tee_kind = ANY($5::text[])
+                  AND artifact_hash = $6
                   AND (
                       job_status = 'PENDING'
-                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $6)
+                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $7)
                   )
                 ORDER BY start_block_number ASC, created_at ASC, id ASC
                 FOR UPDATE SKIP LOCKED
@@ -2113,9 +2162,10 @@ fn claim_query(api_proof_type: ApiProofType) -> String {
                 WHERE api_proof_type = $4
                   AND zk_vm = ANY($5::text[])
                   AND COALESCE(zk_backend, 'cluster') = ANY($6::text[])
+                  AND artifact_hash = $7
                   AND (
                       job_status = 'PENDING'
-                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $7)
+                      OR (job_status = 'CLAIMED' AND lock_expires_at < NOW() AND attempt < $8)
                   )
                 ORDER BY start_block_number ASC, created_at ASC, id ASC
                 FOR UPDATE SKIP LOCKED
@@ -2192,6 +2242,7 @@ struct CreateRequestParams<'a> {
     zk_vm: Option<&'a str>,
     tee_kind: Option<&'a str>,
     zk_backend: Option<&'a str>,
+    artifact_hash: &'a [u8],
     start_block_number: i64,
     number_of_blocks_to_prove: i64,
     sequence_window: Option<i64>,
@@ -2228,6 +2279,9 @@ impl CreateRequestParams<'_> {
         }
         if row.get::<Option<i64>, _>("sequence_window") != self.sequence_window {
             return Some("sequence_window");
+        }
+        if row.get::<Option<Vec<u8>>, _>("artifact_hash").as_deref() != Some(self.artifact_hash) {
+            return Some("artifact_hash");
         }
         if row.get::<Option<&str>, _>("proof_type") != self.proof_type {
             return Some("proof_type");
@@ -2347,7 +2401,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: Some(5),
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),
@@ -2385,7 +2439,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),
@@ -2445,7 +2499,10 @@ mod tests {
         let create = CreateProofRequest::new(ProtocolProofRequest {
             session_id: "tee-session".to_owned(),
             request: ProofRequestKind::Tee(TeeProofRequest {
-                proof: Default::default(),
+                proof: base_proof_primitives::ProofRequest {
+                    image_hash: B256::repeat_byte(0x22),
+                    ..Default::default()
+                },
                 tee_kind: ProtocolTeeKind::AwsNitro,
             }),
         })
@@ -2560,7 +2617,10 @@ mod tests {
         ProtocolProofRequest {
             session_id: session_id.to_owned(),
             request: ProofRequestKind::Tee(TeeProofRequest {
-                proof: Default::default(),
+                proof: base_proof_primitives::ProofRequest {
+                    image_hash: B256::repeat_byte(0x22),
+                    ..Default::default()
+                },
                 tee_kind: ProtocolTeeKind::AwsNitro,
             }),
         }
@@ -2576,7 +2636,10 @@ mod tests {
         let mut create = CreateProofRequest::new(ProtocolProofRequest {
             session_id: "bad-tee-session".to_owned(),
             request: ProofRequestKind::Tee(TeeProofRequest {
-                proof: Default::default(),
+                proof: base_proof_primitives::ProofRequest {
+                    image_hash: B256::repeat_byte(0x22),
+                    ..Default::default()
+                },
                 tee_kind: ProtocolTeeKind::AwsNitro,
             }),
         })
@@ -2600,7 +2663,7 @@ mod tests {
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),

--- a/crates/proof/prover-service/db/tests/postgres_integration.rs
+++ b/crates/proof/prover-service/db/tests/postgres_integration.rs
@@ -15,7 +15,7 @@
 
 use std::time::Duration;
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256};
 use base_proof_primitives::Proposal;
 use base_prover_service_db::{
     ApiProofType, ClaimProofJob, CompleteClaimedProofJob, CreateProofRequest,
@@ -75,7 +75,7 @@ fn compressed_request_at_with_backend(
             l1_head: None,
             intermediate_root_interval: None,
             schedule_l2_block_number: None,
-            zk_artifact_hash: None,
+            zk_artifact_hash: Some(B256::repeat_byte(0x11)),
             zk_vm: ZkVm::Sp1,
             zk_backend,
         }),
@@ -93,7 +93,7 @@ fn compressed_request_with_l1_head(l1_head: &str) -> CreateProofRequest {
             l1_head: Some(l1_head.parse().expect("valid hash")),
             intermediate_root_interval: None,
             schedule_l2_block_number: None,
-            zk_artifact_hash: None,
+            zk_artifact_hash: Some(B256::repeat_byte(0x11)),
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         }),
@@ -116,7 +116,7 @@ fn snark_request() -> CreateProofRequest {
                 ),
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             },
@@ -132,7 +132,10 @@ fn tee_request() -> CreateProofRequest {
     CreateProofRequest::new(ProtocolProofRequest {
         session_id: Uuid::new_v4().to_string(),
         request: ProtocolProofRequestKind::Tee(TeeProofRequest {
-            proof: Default::default(),
+            proof: base_proof_primitives::ProofRequest {
+                image_hash: B256::repeat_byte(0x22),
+                ..Default::default()
+            },
             tee_kind: ProtocolTeeKind::AwsNitro,
         }),
     })
@@ -1152,6 +1155,35 @@ async fn test_create_for_worker_queue_rejects_backend_collision() {
 
 #[tokio::test]
 #[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_create_for_worker_queue_rejects_artifact_hash_collision() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool);
+
+    let explicit_id = Uuid::new_v4();
+    let mut original = compressed_request();
+    set_request_session_id(&mut original, explicit_id.to_string());
+    repo.create_for_worker_queue(original, TEST_MAX_PROOF_RETRIES, true).await.unwrap();
+
+    let replacement_hash = B256::repeat_byte(0x33);
+    let mut conflicting = compressed_request();
+    set_request_session_id(&mut conflicting, explicit_id.to_string());
+    let ProtocolProofRequestKind::Compressed(proof) = &mut conflicting.request_payload.request
+    else {
+        unreachable!("helper always builds compressed requests");
+    };
+    proof.zk_artifact_hash = Some(replacement_hash);
+    conflicting.artifact_hash = replacement_hash;
+
+    assert!(matches!(
+        repo.create_for_worker_queue(conflicting, TEST_MAX_PROOF_RETRIES, true)
+            .await
+            .unwrap_err(),
+        CreateProofRequestError::IdCollision { id, field: "artifact_hash" } if id == explicit_id
+    ));
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
 async fn test_create_for_worker_queue_requeues_failed_row() {
     let pool = test_pool().await;
     let repo = test_repo(pool.clone());
@@ -1567,6 +1599,11 @@ fn claim_job(
         } else {
             vec![ZkBackend::Cluster]
         },
+        supported_artifact_hash: if api_proof_type == ApiProofType::Tee {
+            B256::repeat_byte(0x22)
+        } else {
+            B256::repeat_byte(0x11)
+        },
         lock_duration_seconds: 3600,
         max_attempts,
     }
@@ -1677,6 +1714,34 @@ async fn test_claim_next_proof_job_claim_and_capabilities() {
         .expect("a compressed job should be claimable by a ZK worker");
     assert_eq!(job.api_proof_type, ApiProofType::Compressed);
     assert_eq!(job.job_status, ProofJobStatus::Claimed);
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL); run with `cargo nextest run --run-ignored all -p base-prover-service-db --test postgres_integration --test-threads=1`"]
+async fn test_claim_next_proof_job_requires_exact_artifact_hash() {
+    let pool = test_pool().await;
+    let repo = test_repo(pool.clone());
+
+    drain_claimable_compressed_jobs(&repo).await;
+    let id = repo.create(compressed_request()).await.unwrap();
+    let stored_hash =
+        sqlx::query_scalar::<_, Vec<u8>>("SELECT artifact_hash FROM proof_requests WHERE id = $1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(stored_hash, B256::repeat_byte(0x11).as_slice());
+
+    let mut wrong_hash = compressed_claim("wrong-artifact-worker", 3);
+    wrong_hash.supported_artifact_hash = B256::repeat_byte(0x33);
+    assert!(repo.claim_next_proof_job(wrong_hash).await.unwrap().is_none());
+
+    let claimed = repo
+        .claim_next_proof_job(compressed_claim("matching-artifact-worker", 3))
+        .await
+        .unwrap()
+        .expect("matching artifact hash should claim the job");
+    assert_eq!(claimed.id, id);
 }
 
 #[tokio::test]

--- a/crates/proof/prover-service/src/lib.rs
+++ b/crates/proof/prover-service/src/lib.rs
@@ -2,12 +2,12 @@
 
 mod metrics;
 pub use metrics::{
-    PROOF_REQUEST_DURATION_MS, PROOF_REQUESTS_COMPLETED, PROOF_STATUS_FAILED,
-    PROOF_STATUS_SUCCEEDED, ProverMetrics, REQUESTS, RESPONSE_LATENCY_MS, RETRIED_REQUESTS,
-    STUCK_REQUESTS, WORKER_JOBS_FAILED, api_proof_type_label, inc_proof_requests_completed,
-    inc_requests, inc_retried_requests, inc_stuck_requests, inc_worker_jobs_failed,
-    inc_worker_requests, proof_type_label, record_proof_request_duration, record_response_latency,
-    record_terminal_proof_job,
+    PENDING_JOBS_BY_ARTIFACT, PROOF_REQUEST_DURATION_MS, PROOF_REQUESTS_COMPLETED,
+    PROOF_STATUS_FAILED, PROOF_STATUS_SUCCEEDED, PendingArtifactGauge, ProverMetrics, REQUESTS,
+    RESPONSE_LATENCY_MS, RETRIED_REQUESTS, STUCK_REQUESTS, WORKER_JOBS_FAILED,
+    api_proof_type_label, inc_proof_requests_completed, inc_requests, inc_retried_requests,
+    inc_stuck_requests, inc_worker_jobs_failed, inc_worker_requests, proof_type_label,
+    record_proof_request_duration, record_response_latency, record_terminal_proof_job,
 };
 
 mod metadata;

--- a/crates/proof/prover-service/src/metrics.rs
+++ b/crates/proof/prover-service/src/metrics.rs
@@ -3,8 +3,13 @@
 //! Uses the `metrics` crate facade (`counter!`, `histogram!`) so the exporter
 //! backend is determined by the binary (e.g. Prometheus, `DogStatsD`).
 
-use base_prover_service_db::{ApiProofType, ProofJob, ProofType};
-use metrics::{counter, describe_counter, describe_histogram, histogram};
+use std::{
+    collections::HashSet,
+    sync::{Mutex, PoisonError},
+};
+
+use base_prover_service_db::{ApiProofType, PendingArtifactDepth, ProofJob, ProofType};
+use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 
 // ---------------------------------------------------------------------------
 // Metric name constants
@@ -26,6 +31,11 @@ pub const STUCK_REQUESTS: &str = "prover_service.stuck_requests";
 pub const RETRIED_REQUESTS: &str = "prover_service.retried_requests";
 /// Worker jobs terminally failed by a background reaper. Tags: `reason`, `proof_type`
 pub const WORKER_JOBS_FAILED: &str = "prover_service.worker_jobs_failed";
+/// Pending jobs waiting on one exact artifact hash. Tags: `proof_type`, `artifact_hash`
+///
+/// A generation with no matching worker shows up here as a queue that grows and
+/// never drains, which is the only external symptom of an artifact-hash mismatch.
+pub const PENDING_JOBS_BY_ARTIFACT: &str = "prover_service.pending_jobs_by_artifact";
 
 /// Terminal success status label.
 pub const PROOF_STATUS_SUCCEEDED: &str = "succeeded";
@@ -56,6 +66,10 @@ impl ProverMetrics {
         describe_counter!(
             WORKER_JOBS_FAILED,
             "Worker jobs terminally failed by a background reaper"
+        );
+        describe_gauge!(
+            PENDING_JOBS_BY_ARTIFACT,
+            "Pending jobs waiting on one exact artifact hash"
         );
     }
 }
@@ -130,6 +144,52 @@ pub fn inc_worker_jobs_failed(reason: &str, proof_type: &str) {
         "proof_type" => proof_type.to_string(),
     )
     .increment(1);
+}
+
+/// Publishes per-artifact queue depth, zeroing label sets whose queue has drained.
+///
+/// The backing query groups by artifact hash, and `GROUP BY` omits empty groups.
+/// A hash whose queue drains therefore disappears from the results, and a gauge
+/// keeps its last value until something overwrites it — so without explicitly
+/// zeroing it, a fully drained artifact generation would report its final depth
+/// forever. That would turn the one signal meant to expose a stalled queue into
+/// a permanent false alarm for a healthy one.
+///
+/// Rows predating migration 018 have no hash and can never be claimed; they are
+/// reported under the `none` label so the backfill backlog stays visible.
+#[derive(Debug, Default)]
+pub struct PendingArtifactGauge {
+    published: Mutex<HashSet<(&'static str, String)>>,
+}
+
+impl PendingArtifactGauge {
+    /// Publishes one depth per label set and zeroes any that drained since the last call.
+    pub fn record(&self, depths: &[PendingArtifactDepth]) {
+        let mut current = HashSet::with_capacity(depths.len());
+        for entry in depths {
+            let proof_type = api_proof_type_label(entry.api_proof_type);
+            let artifact_hash =
+                entry.artifact_hash.map_or_else(|| "none".to_owned(), |hash| format!("{hash:#x}"));
+            gauge!(PENDING_JOBS_BY_ARTIFACT,
+                "proof_type" => proof_type,
+                "artifact_hash" => artifact_hash.clone(),
+            )
+            .set(entry.depth as f64);
+            current.insert((proof_type, artifact_hash));
+        }
+
+        let mut published = self.published.lock().unwrap_or_else(PoisonError::into_inner);
+        for (proof_type, artifact_hash) in published.difference(&current) {
+            gauge!(PENDING_JOBS_BY_ARTIFACT,
+                "proof_type" => *proof_type,
+                "artifact_hash" => artifact_hash.clone(),
+            )
+            .set(0.0);
+        }
+        // Drained sets are dropped rather than retained: they now read zero, and
+        // keeping them would grow this set without bound across artifact upgrades.
+        *published = current;
+    }
 }
 
 /// Record terminal outcome and duration metrics for a proof job.
@@ -281,6 +341,94 @@ mod tests {
             }),
             Some(vec![0.0]),
         );
+    }
+
+    #[test]
+    fn pending_depth_labels_null_artifact_hash_as_none() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let hash = alloy_primitives::B256::repeat_byte(0x11);
+        let depths = vec![
+            PendingArtifactDepth {
+                api_proof_type: ApiProofType::Compressed,
+                artifact_hash: Some(hash),
+                depth: 3,
+            },
+            PendingArtifactDepth {
+                api_proof_type: ApiProofType::Tee,
+                artifact_hash: None,
+                depth: 7,
+            },
+        ];
+
+        metrics::with_local_recorder(&recorder, || {
+            PendingArtifactGauge::default().record(&depths);
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        let gauge_for = |artifact_hash: &str| {
+            snapshot.iter().find_map(|(ck, _, _, value)| {
+                if ck.kind() != MetricKind::Gauge
+                    || ck.key().name() != PENDING_JOBS_BY_ARTIFACT
+                    || !ck.key().labels().any(|label| {
+                        label.key() == "artifact_hash" && label.value() == artifact_hash
+                    })
+                {
+                    return None;
+                }
+                match value {
+                    DebugValue::Gauge(value) => Some(value.into_inner()),
+                    _ => None,
+                }
+            })
+        };
+
+        assert_eq!(gauge_for(&format!("{hash:#x}")), Some(3.0));
+        // Unbackfilled rows are unclaimable, so they must stay visible rather than
+        // being dropped for having no hash.
+        assert_eq!(gauge_for("none"), Some(7.0));
+    }
+
+    #[test]
+    fn pending_depth_zeroes_a_drained_artifact_hash() {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let draining = alloy_primitives::B256::repeat_byte(0xaa);
+        let busy = alloy_primitives::B256::repeat_byte(0xbb);
+        let depth = |hash, depth| PendingArtifactDepth {
+            api_proof_type: ApiProofType::Compressed,
+            artifact_hash: Some(hash),
+            depth,
+        };
+        let gauge = PendingArtifactGauge::default();
+
+        metrics::with_local_recorder(&recorder, || {
+            gauge.record(&[depth(draining, 5), depth(busy, 2)]);
+            // `draining` has emptied, so GROUP BY no longer returns it at all.
+            gauge.record(&[depth(busy, 3)]);
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        let gauge_for = |artifact_hash: &str| {
+            snapshot.iter().find_map(|(ck, _, _, value)| {
+                if ck.kind() != MetricKind::Gauge
+                    || ck.key().name() != PENDING_JOBS_BY_ARTIFACT
+                    || !ck.key().labels().any(|label| {
+                        label.key() == "artifact_hash" && label.value() == artifact_hash
+                    })
+                {
+                    return None;
+                }
+                match value {
+                    DebugValue::Gauge(value) => Some(value.into_inner()),
+                    _ => None,
+                }
+            })
+        };
+
+        // Without explicit zeroing this would still read 5 and alarm forever.
+        assert_eq!(gauge_for(&format!("{draining:#x}")), Some(0.0));
+        assert_eq!(gauge_for(&format!("{busy:#x}")), Some(3.0));
     }
 
     #[test]

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -77,12 +77,22 @@ impl ProverServiceServer {
         &self,
         request: GetNextProofRequest,
     ) -> RpcResult<GetNextProofResponse> {
+        let Some(supported_artifact_hash) = request.supported_artifact_hash else {
+            // The main way an un-redeployed worker shows up during the upgrade window,
+            // and afterwards the only signal that one is misconfigured.
+            debug!(
+                worker_id = %request.worker_id,
+                "worker advertised no artifact hash, returning no job"
+            );
+            return Ok(GetNextProofResponse { job: None });
+        };
         let claim = ClaimProofJob {
             worker_id: request.worker_id,
             api_proof_type: request.proof_type.into(),
             tee_kinds: request.tee_kinds.into_iter().map(Into::into).collect(),
             zk_vms: request.zk_vms.into_iter().map(Into::into).collect(),
             zk_backends: request.zk_backends,
+            supported_artifact_hash,
             lock_duration_seconds: resolve_lock_duration(
                 self.config.worker,
                 request.lock_duration_seconds,

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -1,10 +1,10 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use base_prover_service_db::{FailExpiredProofJobs, ProofJob, ProofRequestRepo, RetryOutcome};
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 
-use crate::metrics;
+use crate::{metrics, metrics::PendingArtifactGauge};
 
 /// Server-side worker queue tuning shared by worker claims and the expired-claim reaper.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -38,6 +38,7 @@ pub struct StatusPoller {
     max_proof_retries: i32,
     worker_queue: WorkerQueueConfig,
     expired_claim_error_message: String,
+    pending_artifact_gauge: Arc<PendingArtifactGauge>,
 }
 
 impl StatusPoller {
@@ -62,6 +63,7 @@ impl StatusPoller {
             max_proof_retries,
             worker_queue,
             expired_claim_error_message,
+            pending_artifact_gauge: Arc::default(),
         }
     }
 
@@ -79,6 +81,14 @@ impl StatusPoller {
     }
 
     async fn poll_once(&self) -> anyhow::Result<()> {
+        // Published before the reaper runs so a queue that never drains — the only
+        // external symptom of an artifact-hash mismatch — is always visible, even if
+        // the stuck-request sweep below fails.
+        match self.repo.pending_depth_by_artifact().await {
+            Ok(depths) => self.pending_artifact_gauge.record(&depths),
+            Err(e) => error!(error = %e, "Failed to read pending queue depth by artifact"),
+        }
+
         let stuck_requests = self.repo.get_stuck_requests(self.stuck_timeout_mins).await?;
 
         if !stuck_requests.is_empty() {

--- a/crates/proof/prover-service/tests/idempotency.rs
+++ b/crates/proof/prover-service/tests/idempotency.rs
@@ -5,6 +5,7 @@
 
 mod common;
 
+use alloy_primitives::B256;
 use base_prover_service_protocol::{
     ProofRequest, ProofRequestKind, ProveBlockRangeRequest, ProverRequesterApiClient, ZkBackend,
     ZkProofRequest, ZkVm,
@@ -23,7 +24,7 @@ fn compressed_request(session_id: &str, start_block_number: u64) -> ProveBlockRa
                 l1_head: None,
                 intermediate_root_interval: None,
                 schedule_l2_block_number: None,
-                zk_artifact_hash: None,
+                zk_artifact_hash: Some(B256::repeat_byte(0x11)),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: ZkBackend::Cluster,
             }),

--- a/crates/proof/prover-service/tests/worker_api_e2e.rs
+++ b/crates/proof/prover-service/tests/worker_api_e2e.rs
@@ -13,6 +13,7 @@
 
 use std::{net::SocketAddr, time::Duration};
 
+use alloy_primitives::B256;
 use base_prover_service::{ProverServiceServer, ServerConfig, WorkerApiConfig, WorkerQueueConfig};
 use base_prover_service_db::{
     ApiProofType, ClaimProofJob, CreateProofRequest, DatabaseConfig, ProofRequestRepo,
@@ -107,6 +108,7 @@ async fn drain_claimable_compressed_jobs(repo: &ProofRequestRepo) {
         tee_kinds: Vec::new(),
         zk_vms: vec![ZkVmKind::Sp1],
         zk_backends: vec![ZkBackend::Cluster],
+        supported_artifact_hash: B256::repeat_byte(0x11),
         lock_duration_seconds: 3600,
         max_attempts: u32::MAX,
     };
@@ -129,7 +131,7 @@ fn compressed_request(session_id: &str, start_block_number: u64) -> CreateProofR
             l1_head: None,
             intermediate_root_interval: None,
             schedule_l2_block_number: None,
-            zk_artifact_hash: None,
+            zk_artifact_hash: Some(B256::repeat_byte(0x11)),
             zk_vm: ZkVm::Sp1,
             zk_backend: ZkBackend::Cluster,
         }),
@@ -145,9 +147,30 @@ fn worker_claim(worker_id: &str) -> GetNextProofRequest {
         zk_vms: vec![ZkVm::Sp1],
         // Omitted by legacy workers; the server defaults this capability to cluster.
         zk_backends: Vec::new(),
-        supported_artifact_hash: None,
+        supported_artifact_hash: Some(B256::repeat_byte(0x11)),
         lock_duration_seconds: 60,
     }
+}
+
+#[tokio::test]
+#[ignore = "requires a running Postgres with the prover schema (set DATABASE_URL)"]
+async fn worker_without_artifact_hash_claims_nothing() {
+    let repo = test_repo().await;
+    drain_claimable_compressed_jobs(&repo).await;
+
+    let session_id = Uuid::new_v4().to_string();
+    repo.create_for_worker_queue(compressed_request(&session_id, 10), TEST_MAX_PROOF_RETRIES, true)
+        .await
+        .expect("seeding the worker queue should succeed");
+
+    let server = RunningServer::spawn(repo).await;
+    let mut claim = worker_claim("worker-without-artifact");
+    claim.supported_artifact_hash = None;
+
+    let response =
+        server.client.get_next_proof(claim).await.expect("get_next_proof should succeed");
+    assert!(response.job.is_none());
+    server.shutdown().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
> Part 3 of 3, splitting #4725. Stack: #4768 → #4769 → **this**.
> **Base branch is `feat/artifact-advertise` (#4769), not `main`.** Review the top commit only.
> ⚠️ **This is the deploy that changes behaviour and it requires a drained queue. Read Deployment before merging.**

## What changed?

Persists the required artifact hash on every job and makes worker claims match it exactly.

- **Migration 018** adds an indexed `artifact_hash BYTEA` column with a 32-byte CHECK constraint, and rebuilds both claim indexes with the hash positioned ahead of block ordering.
- **Job creation** derives the hash from `ProofRequest.image_hash` for TEE jobs and requires `zk_artifact_hash` for ZK jobs (`MissingZkArtifactHash` otherwise).
- **The atomic claim query** gains `AND artifact_hash = $N`, alongside the existing proof type, TEE kind, and ZK VM/backend filters. `FOR UPDATE SKIP LOCKED`, ordering, leasing, retries, heartbeats, and fencing tokens are unchanged.
- **`getNextProof` returns no job** when a worker advertises no artifact hash, short-circuiting before the claim query. A worker that has not been redeployed claims nothing rather than claiming work it cannot prove.
- **New `prover_service.pending_jobs_by_artifact` gauge**, tagged `proof_type` and `artifact_hash`, emitted each `StatusPoller` tick.

### The gauge is not optional here

Every failure mode in this design is fail-closed and therefore *silent*: a hash with no matching worker produces a queue that quietly stops draining. The gauge is the only external symptom. Rows left unbackfilled report under `artifact_hash="none"`, so the stranded-job backlog is visible too. It is emitted before the reaper runs so it still publishes if the stuck-request sweep fails.

## Why?

Existing games stay bound to the `AggregateVerifier` implementation and proving artifacts they were created with. During a proof-system upgrade a legacy worker could otherwise claim a job requiring new artifacts, ignore the unknown field, run the legacy program, and return a proof the game rejects — burning the dispute window. Exact hash matching makes that claim impossible rather than merely unlikely.

Matching on the hashes the contract already commits to also means N artifact generations coexist without introducing a v1/v2/v3 version axis.

## How to test?

```sh
cargo test -p base-prover-service -p base-prover-service-db --lib
```

The routing behaviour itself needs Postgres, and those tests are `#[ignore]` by default:

```sh
export DATABASE_URL=postgres://...   # a database migrated through 018
cargo nextest run --run-ignored all -p base-prover-service-db \
  --test postgres_integration --test-threads=1

# The two that matter most:
#   test_claim_next_proof_job_requires_exact_artifact_hash
#     -> a wrong hash claims nothing; the matching hash claims the job
#   test_create_for_worker_queue_rejects_artifact_hash_collision

cargo nextest run --run-ignored all -p base-prover-service --test worker_api_e2e
#   worker_without_artifact_hash_claims_nothing
```

Post-deploy verification:

```promql
# Must be zero. Non-zero means jobs are stranded with no hash.
prover_service_pending_jobs_by_artifact{artifact_hash="none"}

# Should drain normally per live artifact generation.
sum by (artifact_hash) (prover_service_pending_jobs_by_artifact)
```

## Deployment

⚠️ **Migration 018 deliberately does not backfill, diverging from the TDD.** The correct hashes are environment-specific — they differ per network and per deployed `AggregateVerifier` implementation — so the migration cannot derive them without guessing.

Consequence: **pre-existing rows keep `artifact_hash = NULL`, and a NULL never satisfies the claim predicate, so those jobs become unclaimable, not merely unrouted.** This makes the deploy breaking rather than the no-op the TDD describes, and the TDD's Phase 1 E2E step 3 ("confirm the in-flight job is backfilled and still completes") cannot pass as written.

Required sequence:

1. Pause the proposer and challenger.
2. Wait for the queue to drain — `SELECT COUNT(*) FROM proof_requests WHERE job_status IN ('PENDING','CLAIMED')` must return 0. Do not proceed while non-zero.
3. Apply migration 018 and deploy the prover service.
4. Redeploy workers so they advertise their hashes.
5. Resume the proposer and challenger.
6. Confirm `pending_jobs_by_artifact{artifact_hash="none"}` is 0 and queues drain per generation.

If draining is unacceptable, backfill instead — the manual `UPDATE` statements are in the migration header. Derive the ZK composite with `cargo run -p base-proof-zk-backend --bin vkeys`, not by hand: the range and aggregate halves use different SP1 digests (see #4768).

The multi-autoscaling-group work lives in the base-proofs repo and is not part of this stack.