### PR TITLE
feat(telemetry): add node telemetry v1 MVP [backport #4641 to releases/v1.3.0]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2917,6 +2917,8 @@ dependencies = [
  "base-execution-evm",
  "base-node-core",
  "base-node-runner",
+ "base-telemetry-client",
+ "base-telemetry-types",
  "base-txpool-rpc",
  "base-upgrade-signal",
  "clap",
@@ -2925,6 +2927,7 @@ dependencies = [
  "reth-cli-commands",
  "reth-cli-runner",
  "serde",
+ "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3439,6 +3442,7 @@ version = "1.3.0"
 dependencies = [
  "backtrace",
  "base-metrics",
+ "base-telemetry-client",
  "clap",
  "dirs-next",
  "eyre",
@@ -3747,6 +3751,8 @@ dependencies = [
  "base-jwt",
  "base-protocol",
  "base-retry",
+ "base-telemetry-client",
+ "base-telemetry-types",
  "base-upgrade-signal",
  "clap",
  "dirs 6.0.0",
@@ -3949,6 +3955,8 @@ dependencies = [
  "base-health",
  "base-metrics",
  "base-protocol",
+ "base-telemetry-client",
+ "base-telemetry-types",
  "base-upgrade-signal",
  "bytes",
  "derive_more 2.1.1",
@@ -6212,7 +6220,11 @@ dependencies = [
  "base-shadow-indexer",
  "base-shadow-indexer-db",
  "base-shadow-metrics",
+ "base-telemetry-client",
+ "base-telemetry-service",
+ "base-telemetry-types",
  "base-test-utils",
+ "base-trusted-proxy",
  "base-tx-forwarding",
  "base-tx-manager",
  "base-txpool-rpc",
@@ -6264,6 +6276,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-telemetry-client"
+version = "1.3.0"
+dependencies = [
+ "async-trait",
+ "backon",
+ "base-metrics",
+ "base-retry",
+ "base-telemetry-types",
+ "chrono",
+ "libc",
+ "metrics",
+ "mockall",
+ "reqwest 0.13.4",
+ "tempfile",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "base-telemetry-service"
 version = "1.3.0"
 dependencies = [
@@ -6272,7 +6307,11 @@ dependencies = [
  "async-trait",
  "axum 0.8.9",
  "base-health",
+ "base-retry",
+ "base-telemetry-client",
+ "base-telemetry-types",
  "base-trusted-proxy",
+ "chrono",
  "clap",
  "discv5 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
@@ -6287,10 +6326,25 @@ dependencies = [
  "reth-network-peers",
  "secp256k1 0.30.0",
  "serde",
+ "serde_json",
+ "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-appender",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "base-telemetry-types"
+version = "1.3.0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,8 @@ base-common-chains = { path = "crates/common/chains" }
 base-common-network = { path = "crates/common/network" }
 base-common-rpc-types = { path = "crates/common/rpc-types" }
 base-common-flashblocks = { path = "crates/common/flashblocks" }
+base-telemetry-types = { path = "crates/common/telemetry-types" }
+base-telemetry-client = { path = "crates/common/telemetry-client" }
 base-precompile-macros = { path = "crates/common/precompile-macros" }
 base-common-evm = { path = "crates/common/evm", default-features = false }
 base-common-flz = { path = "crates/common/flz", default-features = false }

--- a/bin/base/Cargo.toml
+++ b/bin/base/Cargo.toml
@@ -31,6 +31,8 @@ base-upgrade-signal.workspace = true
 base-builder-metering.workspace = true
 base-execution-chainspec.workspace = true
 base-execution-consensus.workspace = true
+base-telemetry-types.workspace = true
+base-telemetry-client.workspace = true
 
 # alloy
 alloy-chains = { workspace = true, features = ["std"] }
@@ -49,6 +51,7 @@ tokio.workspace = true
 tracing.workspace = true
 tokio-util.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["std"] }
 figment = { workspace = true, features = ["env", "toml"] }
 
 [dev-dependencies]

--- a/bin/base/src/cli.rs
+++ b/bin/base/src/cli.rs
@@ -66,8 +66,12 @@ impl BaseCli {
 
 #[cfg(test)]
 mod tests {
-    use std::{ffi::OsStr, path::Path};
+    use std::{
+        ffi::OsStr,
+        path::{Path, PathBuf},
+    };
 
+    use base_cli_utils::TelemetryConfig;
     use clap::{CommandFactory, Parser};
 
     use super::*;
@@ -160,11 +164,33 @@ mod tests {
     }
 
     #[test]
-    fn telemetry_id_path_defaults_to_the_chain_directory() {
-        let cli = BaseCli::parse_from(["base", "bootnode"]);
+    fn telemetry_id_path_is_chain_scoped_under_home_and_absent_without_one() {
+        assert_eq!(
+            TelemetryConfig::id_path_under(Some(Path::new("/var/lib/base")), 8453),
+            Some(PathBuf::from("/var/lib/base/.base/8453/telemetry-id"))
+        );
+        assert_eq!(
+            TelemetryConfig::id_path_under(None, 8453),
+            None,
+            "with no home directory there is nowhere durable to keep an identity, and a \
+             working-directory path would re-mint one on every restart"
+        );
+    }
 
-        let config = cli.telemetry.config(8453);
-        assert!(config.id_path.ends_with("8453/telemetry-id"), "got {}", config.id_path.display());
+    #[test]
+    fn telemetry_id_path_flag_wins_over_the_default() {
+        let cli = BaseCli::parse_from([
+            "base",
+            "--telemetry.id-path",
+            "/srv/base/telemetry-id",
+            "bootnode",
+        ]);
+
+        assert_eq!(
+            cli.telemetry.config(8453).id_path.as_deref(),
+            Some(Path::new("/srv/base/telemetry-id")),
+            "an explicit path must be used as given, whatever $HOME says"
+        );
     }
 
     #[test]
@@ -175,7 +201,7 @@ mod tests {
         let config = cli.telemetry.config(8453);
         assert_eq!(config.data_dir.as_deref(), Some(Path::new("/mnt/base-data")));
         assert!(
-            !config.id_path.starts_with("/mnt/base-data"),
+            config.id_path.as_deref().is_none_or(|path| !path.starts_with("/mnt/base-data")),
             "naming the data volume must not move the identity file"
         );
 

--- a/bin/base/src/cli.rs
+++ b/bin/base/src/cli.rs
@@ -9,6 +9,7 @@ use crate::{
 
 base_cli_utils::define_log_args!("BASE_NODE");
 base_cli_utils::define_metrics_args!("BASE_NODE", 9090);
+base_cli_utils::define_telemetry_args!("BASE_NODE");
 
 /// The `base` CLI.
 #[derive(Parser, Debug)]
@@ -36,6 +37,10 @@ pub(crate) struct BaseCli {
     #[command(flatten)]
     pub(crate) metrics: MetricsArgs,
 
+    /// Telemetry configuration.
+    #[command(flatten)]
+    pub(crate) telemetry: TelemetryArgs,
+
     /// The command to run.
     #[command(subcommand)]
     pub(crate) command: BaseCommand,
@@ -55,13 +60,13 @@ impl BaseCli {
             })
             .wrap_err("failed to install Prometheus recorder")?;
 
-        self.command.run(ChainResolver::new(self.chain), metrics_enabled)
+        self.command.run(ChainResolver::new(self.chain), metrics_enabled, self.telemetry)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsStr;
+    use std::{ffi::OsStr, path::Path};
 
     use clap::{CommandFactory, Parser};
 
@@ -123,6 +128,63 @@ mod tests {
 
         let rendered = err.to_string();
         assert!(rendered.contains("cannot be used multiple times"));
+    }
+
+    #[test]
+    fn telemetry_is_opt_out_and_inert_without_an_endpoint() {
+        let cli = BaseCli::parse_from(["base", "bootnode"]);
+
+        assert!(cli.telemetry.enabled, "telemetry is opt-out, so it parses as enabled");
+        assert_eq!(cli.telemetry.endpoint, None, "no endpoint means the node reports nowhere");
+        assert!(!cli.telemetry.config(8453).is_active());
+    }
+
+    #[test]
+    fn parses_telemetry_endpoint_and_opt_out() {
+        let cli = BaseCli::parse_from([
+            "base",
+            "--telemetry.endpoint",
+            "http://127.0.0.1:8080/v1/ingest",
+            "--telemetry.enabled=false",
+            "bootnode",
+        ]);
+
+        assert_eq!(
+            cli.telemetry.endpoint.as_ref().map(url::Url::as_str),
+            Some("http://127.0.0.1:8080/v1/ingest")
+        );
+        assert!(
+            !cli.telemetry.config(8453).is_active(),
+            "opting out must win over a configured endpoint"
+        );
+    }
+
+    #[test]
+    fn telemetry_id_path_defaults_to_the_chain_directory() {
+        let cli = BaseCli::parse_from(["base", "bootnode"]);
+
+        let config = cli.telemetry.config(8453);
+        assert!(config.id_path.ends_with("8453/telemetry-id"), "got {}", config.id_path.display());
+    }
+
+    #[test]
+    fn telemetry_data_dir_is_independent_of_the_identity_path() {
+        let cli =
+            BaseCli::parse_from(["base", "--telemetry.data-dir", "/mnt/base-data", "bootnode"]);
+
+        let config = cli.telemetry.config(8453);
+        assert_eq!(config.data_dir.as_deref(), Some(Path::new("/mnt/base-data")));
+        assert!(
+            !config.id_path.starts_with("/mnt/base-data"),
+            "naming the data volume must not move the identity file"
+        );
+
+        let defaulted = BaseCli::parse_from(["base", "bootnode"]).telemetry.config(8453);
+        assert_eq!(
+            defaulted.data_dir, None,
+            "with no data directory named, the disk fields stay absent rather than describing \
+             whichever volume holds $HOME"
+        );
     }
 
     #[test]

--- a/bin/base/src/commands/command.rs
+++ b/bin/base/src/commands/command.rs
@@ -6,9 +6,10 @@ use clap::Subcommand;
 use reth_cli_runner::CliRunner;
 
 use crate::{
+    cli::TelemetryArgs,
     commands::{
         bootnode::BootnodeCommand, reth::RethCommand, rpc::RpcCommand, sequencer::SequencerCommand,
-        snapshot::SnapshotCommand, update::UpdateCommand,
+        snapshot::SnapshotCommand, telemetry::TelemetryCommand, update::UpdateCommand,
     },
     config::ChainResolver,
 };
@@ -38,6 +39,9 @@ pub(crate) enum BaseCommand {
     /// Snapshot manifest generation and download utilities (uses its own --chain flag).
     #[command(name = "snapshot")]
     Snapshot(Box<SnapshotCommand>),
+    /// Inspect what this node would report to Base telemetry.
+    #[command(name = "telemetry")]
+    Telemetry(Box<TelemetryCommand>),
 }
 
 impl BaseCommand {
@@ -45,12 +49,13 @@ impl BaseCommand {
         self,
         chain_resolver: ChainResolver,
         metrics_enabled: bool,
+        telemetry: TelemetryArgs,
     ) -> eyre::Result<()> {
         match self {
             Self::Bootnode(bootnode) => (*bootnode).run(chain_resolver.resolve()?, metrics_enabled),
-            Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?, metrics_enabled),
+            Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?, metrics_enabled, telemetry),
             Self::Sequencer(sequencer) => {
-                (*sequencer).run(chain_resolver.resolve()?, metrics_enabled)
+                (*sequencer).run(chain_resolver.resolve()?, metrics_enabled, telemetry)
             }
             Self::Update(update) => (*update).run(),
             Self::Reth(reth) => {
@@ -67,6 +72,9 @@ impl BaseCommand {
                 chain_resolver.reject_for_reth_command("base snapshot")?;
                 (*snapshot).run()
             }
+            Self::Telemetry(command) => {
+                (*command).run(chain_resolver.resolve()?, metrics_enabled, telemetry)
+            }
         }
     }
 }
@@ -75,7 +83,10 @@ impl BaseCommand {
 mod tests {
     use clap::Parser;
 
-    use crate::{cli::BaseCli, config::ChainResolver};
+    use crate::{
+        cli::{BaseCli, TelemetryArgs},
+        config::ChainResolver,
+    };
 
     #[test]
     fn rejects_legacy_node_rpc_path() {
@@ -119,7 +130,10 @@ mod tests {
     fn rejects_top_level_chain_for_reth_subcommands() {
         let cli =
             BaseCli::try_parse_from(["base", "--chain", "sepolia", "reth", "db", "stats"]).unwrap();
-        let err = cli.command.run(ChainResolver::new(cli.chain), false).unwrap_err();
+        let err = cli
+            .command
+            .run(ChainResolver::new(cli.chain), false, TelemetryArgs::default())
+            .unwrap_err();
 
         assert!(err.to_string().contains("base reth"));
         assert!(err.to_string().contains("base --chain"));

--- a/bin/base/src/commands/mod.rs
+++ b/bin/base/src/commands/mod.rs
@@ -7,4 +7,5 @@ mod reth;
 mod rpc;
 mod sequencer;
 mod snapshot;
+mod telemetry;
 mod update;

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -14,7 +14,7 @@ use reth_cli_runner::CliRunner;
 use tokio_util::sync::CancellationToken;
 use url::Url;
 
-use crate::config::ResolvedChainConfig;
+use crate::{cli::TelemetryArgs, config::ResolvedChainConfig};
 
 /// Arguments for `base rpc`.
 #[derive(Args, Clone, Debug)]
@@ -49,6 +49,7 @@ impl RpcCommand {
         self,
         resolved_chain: ResolvedChainConfig,
         metrics_enabled: bool,
+        telemetry: TelemetryArgs,
     ) -> eyre::Result<()> {
         let Self { execution_chain, execution, consensus } = self;
         let mut execution_chain = match execution_chain {
@@ -65,6 +66,10 @@ impl RpcCommand {
             .apply_default_from(&consensus_config.l1_rpc_args.l1_eth_rpc);
         consensus_config.upgrade_signal = execution.standard.rollup_args.upgrade_signal.clone();
         let consensus_args = ConsensusNodeArgs::new(consensus_chain, consensus_config);
+        let telemetry = consensus_args.telemetry_node_config(
+            telemetry.config(consensus_args.chain.l2_chain_id.id()),
+            metrics_enabled,
+        );
         let mut rollup_config = consensus_args.load_rollup_config()?;
 
         CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
@@ -109,7 +114,8 @@ impl RpcCommand {
                         upgrade_signal_l1_rpc,
                     ))
                     .with_cancellation(consensus_cancellation.clone())
-                    .with_upgrade_signal_startup_mode(UpgradeSignalStartupMode::AlreadyApplied),
+                    .with_upgrade_signal_startup_mode(UpgradeSignalStartupMode::AlreadyApplied)
+                    .with_telemetry(Some(telemetry)),
             );
             tokio::pin!(execution_exit);
             tokio::pin!(consensus_exit);

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -22,7 +22,7 @@ use clap::Args;
 use reth_cli_runner::CliRunner;
 use tokio_util::sync::CancellationToken;
 
-use crate::{commands::rpc::engine_ipc_url, config::ResolvedChainConfig};
+use crate::{cli::TelemetryArgs, commands::rpc::engine_ipc_url, config::ResolvedChainConfig};
 
 /// Arguments for `base sequencer`.
 #[derive(Args, Clone, Debug)]
@@ -50,6 +50,7 @@ impl SequencerCommand {
         self,
         resolved_chain: ResolvedChainConfig,
         metrics_enabled: bool,
+        telemetry: TelemetryArgs,
     ) -> eyre::Result<()> {
         let Self { execution_chain, execution, mut builder, consensus } = self;
         let mut execution_chain = match execution_chain {
@@ -64,6 +65,10 @@ impl SequencerCommand {
             .apply_default_from(&consensus_config.l1_rpc_args.l1_eth_rpc);
         consensus_config.upgrade_signal = builder.rollup_args.upgrade_signal.clone();
         let consensus_args = ConsensusNodeArgs::new(consensus_chain, consensus_config);
+        let telemetry = consensus_args.telemetry_node_config(
+            telemetry.config(consensus_args.chain.l2_chain_id.id()),
+            metrics_enabled,
+        );
         let mut rollup_config = consensus_args.load_rollup_config()?;
 
         let rollup_args = builder.rollup_args.clone();
@@ -133,7 +138,8 @@ impl SequencerCommand {
                         upgrade_signal_l1_rpc,
                     ))
                     .with_cancellation(consensus_cancellation.clone())
-                    .with_upgrade_signal_startup_mode(UpgradeSignalStartupMode::AlreadyApplied),
+                    .with_upgrade_signal_startup_mode(UpgradeSignalStartupMode::AlreadyApplied)
+                    .with_telemetry(Some(telemetry)),
             );
             tokio::pin!(execution_exit);
             tokio::pin!(consensus_exit);

--- a/bin/base/src/commands/telemetry.rs
+++ b/bin/base/src/commands/telemetry.rs
@@ -1,0 +1,88 @@
+//! Telemetry inspection utilities.
+
+use base_telemetry_client::{NodeIdentity, NodeReportBuilder, TelemetryId};
+use base_telemetry_types::{Heads, NetHealth, NetworkName, NodeConfigReport, NodeLayer, NodeRole};
+use clap::{Args, Subcommand};
+
+use crate::{cli::TelemetryArgs, config::ResolvedChainConfig};
+
+/// Arguments for `base telemetry`.
+#[derive(Args, Clone, Debug)]
+pub(crate) struct TelemetryCommand {
+    /// The telemetry action to run.
+    #[command(subcommand)]
+    pub(crate) action: TelemetryAction,
+}
+
+/// Actions under `base telemetry`.
+#[derive(Subcommand, Clone, Debug)]
+pub(crate) enum TelemetryAction {
+    /// Print the report this node would send, without sending or persisting anything.
+    #[command(name = "preview")]
+    Preview,
+}
+
+impl TelemetryCommand {
+    /// Runs the selected telemetry action.
+    pub(crate) fn run(
+        self,
+        resolved_chain: ResolvedChainConfig,
+        metrics_enabled: bool,
+        telemetry: TelemetryArgs,
+    ) -> eyre::Result<()> {
+        match self.action {
+            TelemetryAction::Preview => Self::preview(resolved_chain, metrics_enabled, telemetry),
+        }
+    }
+
+    /// Prints the payload a consensus node would send, as JSON.
+    ///
+    /// Nothing is sent and no identity is minted: an operator inspecting the payload must not
+    /// become a reporter by doing so. A node that has already minted an identity sees its real
+    /// one, and every other run sees a throwaway.
+    ///
+    /// Head and network values are zeroed because there is no running node behind this command.
+    /// The point of the preview is the shape of the payload and the real `hw.*` and `cfg.*`
+    /// values, which are the fields worth reviewing before a node reports anywhere.
+    ///
+    /// The disk fields need a directory to measure and there is no node here to supply one, so
+    /// they are absent unless `--telemetry.data-dir` names it. Absent is the honest answer: the
+    /// alternative is measuring whichever volume holds the identity file and presenting that as
+    /// what the node would report.
+    fn preview(
+        resolved_chain: ResolvedChainConfig,
+        metrics_enabled: bool,
+        telemetry: TelemetryArgs,
+    ) -> eyre::Result<()> {
+        let l2_chain_id = resolved_chain.consensus_chain_args().l2_chain_id;
+        let config = telemetry.config(l2_chain_id.id());
+
+        let identity = NodeIdentity {
+            telemetry_id: TelemetryId::read(&config.id_path).unwrap_or_else(TelemetryId::generate),
+            instance_id: config.instance_id.clone(),
+            client_version: env!("CARGO_PKG_VERSION").to_string(),
+            l2_chain_id: l2_chain_id.id(),
+            network: NetworkName::for_chain_id(l2_chain_id.id()),
+            layer: NodeLayer::Consensus,
+            role: NodeRole::Validator,
+            data_dir: config.data_dir.clone(),
+        };
+        let node_config = NodeConfigReport {
+            prune_mode: None,
+            p2p_enabled: true,
+            discovery_enabled: true,
+            sequencer_enabled: false,
+            supervisor_enabled: false,
+            flashblocks_enabled: false,
+            metrics_enabled,
+            experimental_flags: Vec::new(),
+            report_interval_secs: config.report_interval.as_secs(),
+            sample_interval_secs: config.sample_interval.as_secs(),
+        };
+
+        let report = NodeReportBuilder::new(identity, node_config)
+            .build(Heads::default(), NetHealth::default());
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        Ok(())
+    }
+}

--- a/bin/base/src/commands/telemetry.rs
+++ b/bin/base/src/commands/telemetry.rs
@@ -58,7 +58,11 @@ impl TelemetryCommand {
         let config = telemetry.config(l2_chain_id.id());
 
         let identity = NodeIdentity {
-            telemetry_id: TelemetryId::read(&config.id_path).unwrap_or_else(TelemetryId::generate),
+            telemetry_id: config
+                .id_path
+                .as_deref()
+                .and_then(TelemetryId::read)
+                .unwrap_or_else(TelemetryId::generate),
             instance_id: config.instance_id.clone(),
             client_version: env!("CARGO_PKG_VERSION").to_string(),
             l2_chain_id: l2_chain_id.id(),

--- a/crates/common/telemetry-client/Cargo.toml
+++ b/crates/common/telemetry-client/Cargo.toml
@@ -1,0 +1,59 @@
+[package]
+name = "base-telemetry-client"
+description = "Collection and transport for Base node telemetry reports"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Telemetry
+base-telemetry-types.workspace = true
+
+# Retry
+base-retry.workspace = true
+backon.workspace = true
+
+# Async
+tokio-util.workspace = true
+async-trait.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+
+# HTTP
+url.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+
+# Serialization
+chrono.workspace = true
+
+# Platform
+libc.workspace = true
+
+# Utilities
+uuid = { workspace = true, features = ["v4"] }
+
+# Error handling
+thiserror.workspace = true
+
+# Observability
+base-metrics.workspace = true
+metrics = { workspace = true, optional = true }
+tracing = { workspace = true, features = ["std"] }
+
+# Test doubles
+mockall = { workspace = true, optional = true }
+
+[dev-dependencies]
+mockall.workspace = true
+tempfile.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = [ "metrics" ]
+metrics = [ "base-metrics/metrics", "dep:metrics" ]
+test-utils = [ "dep:mockall" ]

--- a/crates/common/telemetry-client/README.md
+++ b/crates/common/telemetry-client/README.md
@@ -1,0 +1,75 @@
+# `base-telemetry-client`
+
+Collection and transport for Base node telemetry. Builds a
+[`NodeReport`](../telemetry-types) from the local machine and delivers it to an
+ingest endpoint.
+
+The crate is deliberately client-agnostic. Nothing here knows about the
+consensus node specifically, so the execution node and the snapshot download
+command can reuse it without a move.
+
+## Overview
+
+- **`TelemetryConfig`**: enable flag, endpoint, intervals, identity path, and
+  the directory the disk fields are measured against. Reporting is inert unless
+  both `enabled` is set and an endpoint is configured.
+- **`TelemetryId`**: a random v4 `UUID`, minted on first run and persisted so a
+  restart keeps the same identity.
+- **`HardwareCollector`**: cloud vs bare metal, CPU, memory, disk, and whether
+  the data directory sits on network storage. Degrades field-by-field to `None`
+  rather than failing.
+- **`LatencySampler`**: accumulates head-lag point samples and the high-water
+  mark between reports.
+- **`NodeReportBuilder`**: assembles a whole `NodeReport` from a `NodeIdentity`
+  fixed at startup plus the head and network snapshots of the moment.
+- **`ReportSink`**: the delivery seam. `HttpReportSink` POSTs JSON; tests
+  substitute a mock.
+- **`TelemetryReporter`**: bounded queue in front of a sink, with a background
+  task that retries with backoff.
+- **`DeliveryStreak`**: counts consecutive delivery failures so an outage costs
+  one warning at its start and one at its end.
+
+## Operational contract
+
+The client is best-effort by construction, because a telemetry outage must never
+degrade a node:
+
+- It never blocks startup and never blocks a hot path. `enqueue` is a
+  `try_send`; a full queue drops the report and increments a counter rather than
+  applying backpressure to the caller.
+- It backs off on failure and logs one warning when delivery starts failing and
+  one when it recovers, not one per attempt and not one per reporting cycle. A
+  node pointed at an endpoint that never comes back stays quiet enough to run
+  for weeks.
+- It honors `HTTPS_PROXY` and `NO_PROXY`, which comes free with `reqwest` as
+  long as nothing calls `.no_proxy()`.
+
+## What the disk fields measure
+
+`data_dir` is a separate setting from `id_path`, and neither is derived from the
+other. The identity is a few bytes of state a node keeps wherever it is
+convenient; the disk fields are only worth collecting for the volume holding
+chain data, the one whose filling up stops the node. Those are usually different
+volumes, and on a real deployment the identity path defaults under `$HOME`, so
+measuring it would describe the OS root and label the answer as the data disk.
+
+Callers that know the data volume pass it. Callers that do not leave it unset
+and the disk fields are absent, which is recoverable in a way a confidently
+wrong number is not.
+
+## Identity
+
+`TelemetryId::load_or_create` writes to a caller-supplied path and logs a
+first-run disclosure banner the first time it mints an ID.
+
+The ID is reliable within a reporting window and not across months, which is all
+anything downstream depends on. A restart preserves it because the file does. A
+rebuild on a fresh volume does not, and no metric here survives that.
+
+The identity file must never be packaged into a snapshot. If it were, every node
+that snap-syncs would share one ID and the fleet would collapse into a single
+row.
+
+## License
+
+Licensed under the [MIT License](https://github.com/base/base/blob/main/LICENSE).

--- a/crates/common/telemetry-client/build.rs
+++ b/crates/common/telemetry-client/build.rs
@@ -1,0 +1,27 @@
+//! Captures the short git SHA of the build so reports can name the exact commit.
+//!
+//! Falls back to `unknown` rather than failing, so source-tarball and Docker builds without
+//! git metadata still compile.
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=BASE_TELEMETRY_GIT_SHA");
+
+    if std::env::var_os("BASE_TELEMETRY_GIT_SHA").is_some() {
+        return;
+    }
+
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|sha| sha.trim().to_string())
+        .filter(|sha| !sha.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=BASE_TELEMETRY_GIT_SHA={sha}");
+}

--- a/crates/common/telemetry-client/src/builder.rs
+++ b/crates/common/telemetry-client/src/builder.rs
@@ -1,0 +1,183 @@
+//! Assembly of a full [`NodeReport`] from the node's live state.
+
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+use base_telemetry_types::{
+    ClientMeta, Hardware, Heads, NODE_REPORT_SCHEMA_VERSION, NetHealth, NodeConfigReport,
+    NodeLayer, NodeReport, NodeRole,
+};
+use chrono::Utc;
+
+use crate::{GIT_SHA, HardwareCollector, TelemetryId};
+
+/// Everything about the node that is fixed for the lifetime of the process.
+///
+/// Assembled once at startup and handed to [`NodeReportBuilder`], so a report can never
+/// disagree with itself about which node produced it.
+#[derive(Debug, Clone)]
+pub struct NodeIdentity {
+    /// The persistent per-node identifier.
+    pub telemetry_id: TelemetryId,
+    /// An operator-supplied tag, set on the nodes we run ourselves so they can be excluded
+    /// from fleet counts.
+    pub instance_id: Option<String>,
+    /// The release version of the node binary.
+    pub client_version: String,
+    /// The L2 chain the node follows.
+    pub l2_chain_id: u64,
+    /// The human-readable network name, e.g. `mainnet`.
+    pub network: String,
+    /// Which layer this process runs.
+    pub layer: NodeLayer,
+    /// What the node does on the network.
+    pub role: NodeRole,
+    /// The data directory, used to size the disk the node actually writes to.
+    pub data_dir: Option<PathBuf>,
+}
+
+/// Builds one [`NodeReport`] per reporting interval.
+///
+/// Hardware is re-read on every build rather than cached at startup: a disk filling up is one
+/// of the failures this telemetry exists to see, and the cost is a handful of small reads
+/// against `sysfs` and `procfs` once every reporting interval.
+#[derive(Debug, Clone)]
+pub struct NodeReportBuilder {
+    identity: NodeIdentity,
+    node_config: NodeConfigReport,
+    started_at: Instant,
+}
+
+impl NodeReportBuilder {
+    /// Creates a builder, starting the uptime clock now.
+    pub fn new(identity: NodeIdentity, node_config: NodeConfigReport) -> Self {
+        Self { identity, node_config, started_at: Instant::now() }
+    }
+
+    /// Returns how long the node has been running, in whole seconds.
+    pub fn uptime(&self) -> Duration {
+        self.started_at.elapsed()
+    }
+
+    /// Returns the runtime environment as it looks right now.
+    pub fn hardware(&self) -> Hardware {
+        HardwareCollector::collect(self.identity.data_dir.as_deref())
+    }
+
+    /// Returns the fixed client metadata, stamped with the current uptime.
+    pub fn client_meta(&self) -> ClientMeta {
+        ClientMeta {
+            client_version: self.identity.client_version.clone(),
+            git_sha: GIT_SHA.to_string(),
+            l2_chain_id: self.identity.l2_chain_id,
+            network: self.identity.network.clone(),
+            layer: self.identity.layer,
+            role: self.identity.role,
+            uptime_secs: self.uptime().as_secs(),
+        }
+    }
+
+    /// Assembles a report from the caller's head and network snapshots.
+    pub fn build(&self, heads: Heads, net_health: NetHealth) -> NodeReport {
+        NodeReport {
+            schema_version: NODE_REPORT_SCHEMA_VERSION,
+            telemetry_id: self.identity.telemetry_id.uuid(),
+            instance_id: self.identity.instance_id.clone(),
+            reported_at: Utc::now(),
+            client: self.client_meta(),
+            heads,
+            hardware: self.hardware(),
+            config: self.node_config.clone(),
+            net_health,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use base_telemetry_types::{HardwarePlatform, PruneMode};
+
+    use super::*;
+    use crate::LatencySampler;
+
+    fn identity() -> NodeIdentity {
+        NodeIdentity {
+            telemetry_id: TelemetryId::generate(),
+            instance_id: None,
+            client_version: "1.2.3".to_string(),
+            l2_chain_id: 8453,
+            network: "mainnet".to_string(),
+            layer: NodeLayer::Consensus,
+            role: NodeRole::Validator,
+            data_dir: None,
+        }
+    }
+
+    fn node_config() -> NodeConfigReport {
+        NodeConfigReport { prune_mode: Some(PruneMode::Archive), ..Default::default() }
+    }
+
+    #[test]
+    fn test_build_stamps_the_current_schema_and_identity() {
+        let identity = identity();
+        let telemetry_id = identity.telemetry_id.uuid();
+        let builder = NodeReportBuilder::new(identity, node_config());
+
+        let report = builder.build(Heads::default(), NetHealth::default());
+
+        assert!(report.is_current_schema());
+        assert_eq!(report.telemetry_id, telemetry_id);
+        assert_eq!(report.client.client_version, "1.2.3");
+        assert_eq!(report.client.git_sha, GIT_SHA);
+        assert_eq!(report.client.l2_chain_id, 8453);
+        assert_eq!(report.config.prune_mode, Some(PruneMode::Archive));
+    }
+
+    #[test]
+    fn test_instance_id_is_carried_through() {
+        let builder = NodeReportBuilder::new(
+            NodeIdentity { instance_id: Some("base-us-east-1".to_string()), ..identity() },
+            node_config(),
+        );
+
+        let report = builder.build(Heads::default(), NetHealth::default());
+
+        assert_eq!(report.instance_id.as_deref(), Some("base-us-east-1"));
+    }
+
+    #[test]
+    fn test_hardware_is_collected_on_every_build() {
+        let builder = NodeReportBuilder::new(identity(), node_config());
+
+        let report = builder.build(Heads::default(), NetHealth::default());
+
+        assert_eq!(report.hardware.os, std::env::consts::OS);
+        assert_eq!(report.hardware.arch, std::env::consts::ARCH);
+        if !cfg!(target_os = "linux") {
+            assert_eq!(report.hardware.platform, HardwarePlatform::Unknown);
+        }
+    }
+
+    #[test]
+    fn test_latency_window_supplies_the_head_lag_fields() {
+        let builder = NodeReportBuilder::new(identity(), node_config());
+        let mut sampler = LatencySampler::new(8);
+        sampler.record(1.0);
+        sampler.record(9.0);
+        sampler.record(2.0);
+
+        let mut heads = Heads { unsafe_block: 100, safe_block: Some(90), ..Default::default() };
+        sampler.drain().apply(&mut heads);
+        let report = builder.build(heads, NetHealth::default());
+
+        assert_eq!(report.heads.unsafe_block, 100);
+        assert_eq!(report.heads.unsafe_latency_secs, 2.0);
+        assert_eq!(
+            report.heads.worst_unsafe_latency_secs, 9.0,
+            "the high-water mark must survive a later, healthier sample"
+        );
+        assert_eq!(report.heads.unsafe_latency_samples, vec![1.0, 9.0, 2.0]);
+    }
+}

--- a/crates/common/telemetry-client/src/config.rs
+++ b/crates/common/telemetry-client/src/config.rs
@@ -1,0 +1,187 @@
+//! Configuration for the telemetry client.
+
+use std::{path::PathBuf, time::Duration};
+
+use base_retry::RetryConfig;
+use url::Url;
+
+/// Short git SHA of this build, or `unknown` when the build had no git metadata.
+pub const GIT_SHA: &str = env!("BASE_TELEMETRY_GIT_SHA");
+
+/// File name of the persisted node identity, relative to the node's data directory.
+pub const TELEMETRY_ID_FILE_NAME: &str = "telemetry-id";
+
+/// How often a node sends a report.
+///
+/// This is a steady-state floor rather than a compromise: head lag is only useful at a
+/// resolution finer than the incidents it should catch.
+pub const DEFAULT_REPORT_INTERVAL: Duration = Duration::from_secs(15 * 60);
+
+/// How often a node samples head lag between reports.
+pub const DEFAULT_SAMPLE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How long a single delivery attempt may take.
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How many reports may sit in the delivery queue before new ones are dropped.
+///
+/// Small on purpose. If delivery is wedged, the useful thing to keep is the newest report, and
+/// a deep queue only delays discovering that.
+pub const DEFAULT_QUEUE_CAPACITY: usize = 4;
+
+/// Upper bound on lag samples carried by a single report.
+///
+/// Guards against an operator configuring a long report interval against a short sample
+/// interval and growing the payload without bound.
+pub const MAX_LATENCY_SAMPLES: usize = 64;
+
+/// Configuration for the telemetry client.
+///
+/// Reporting is inert unless [`TelemetryConfig::is_active`] holds, which requires both
+/// `enabled` and an `endpoint`. Opting out is `enabled = false`; having no endpoint configured
+/// is the separate, and currently normal, case of a build that has nowhere to report to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TelemetryConfig {
+    /// Whether the operator has left telemetry on. Opt-out, so this defaults to `true`.
+    pub enabled: bool,
+    /// Where to POST reports. No default; without one the client sends nothing.
+    pub endpoint: Option<Url>,
+    /// Override used to tag our own nodes so they can be excluded from fleet numbers.
+    pub instance_id: Option<String>,
+    /// Where the persisted node identity lives.
+    pub id_path: PathBuf,
+    /// Directory whose filesystem the disk fields describe.
+    ///
+    /// Separate from `id_path` on purpose. The identity is a few bytes of state the node keeps
+    /// wherever it is convenient, while the disk fields are only worth collecting for the volume
+    /// holding chain data, the one whose filling up stops the node. Deriving one from the other
+    /// measures whichever volume happens to hold `$HOME`, which on a real deployment is the OS
+    /// root and not the data disk.
+    pub data_dir: Option<PathBuf>,
+    /// How often to send a report.
+    pub report_interval: Duration,
+    /// How often to sample head lag between reports.
+    pub sample_interval: Duration,
+    /// How long a single delivery attempt may take.
+    pub request_timeout: Duration,
+    /// How many reports may sit in the delivery queue.
+    pub queue_capacity: usize,
+    /// Backoff applied to failed delivery attempts.
+    pub retry: RetryConfig,
+}
+
+impl TelemetryConfig {
+    /// Builds a config that reports to `endpoint`, using the defaults for everything else.
+    pub fn new(id_path: PathBuf, endpoint: Option<Url>) -> Self {
+        Self { endpoint, ..Self::disabled(id_path) }
+    }
+
+    /// Builds a config that sends nothing, for callers that need a value before an operator's
+    /// choice is known.
+    pub fn disabled(id_path: PathBuf) -> Self {
+        Self {
+            enabled: true,
+            endpoint: None,
+            instance_id: None,
+            id_path,
+            data_dir: None,
+            report_interval: DEFAULT_REPORT_INTERVAL,
+            sample_interval: DEFAULT_SAMPLE_INTERVAL,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            queue_capacity: DEFAULT_QUEUE_CAPACITY,
+            retry: RetryConfig::default(),
+        }
+    }
+
+    /// Returns whether this config will actually send anything.
+    pub const fn is_active(&self) -> bool {
+        self.enabled && self.endpoint.is_some()
+    }
+
+    /// Returns the default identity path for a chain, `$HOME/.base/<l2_chain_id>/telemetry-id`.
+    ///
+    /// This mirrors where the consensus node already puts its checkpoint database. The
+    /// execution node has a reth data directory and should pass that instead.
+    pub fn default_id_path(l2_chain_id: u64) -> PathBuf {
+        std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".base")
+            .join(l2_chain_id.to_string())
+            .join(TELEMETRY_ID_FILE_NAME)
+    }
+
+    /// Returns how many samples a report will carry, given the configured intervals.
+    pub fn samples_per_report(&self) -> usize {
+        if self.sample_interval.is_zero() {
+            return 1;
+        }
+        let per_report = self.report_interval.as_secs() / self.sample_interval.as_secs().max(1);
+        (per_report as usize).clamp(1, MAX_LATENCY_SAMPLES)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> TelemetryConfig {
+        TelemetryConfig::disabled(PathBuf::from("/tmp/telemetry-id"))
+    }
+
+    #[test]
+    fn test_config_without_an_endpoint_is_inert() {
+        let config = config();
+        assert!(config.enabled, "telemetry is opt-out, so it starts enabled");
+        assert!(!config.is_active(), "an enabled config with no endpoint must still send nothing");
+    }
+
+    #[test]
+    fn test_opting_out_overrides_a_configured_endpoint() {
+        let mut config = config();
+        config.endpoint = Some(Url::parse("http://127.0.0.1:8080/v1/ingest").expect("valid url"));
+        assert!(config.is_active());
+
+        config.enabled = false;
+        assert!(!config.is_active(), "--telemetry.enabled=false must win over an endpoint");
+    }
+
+    #[test]
+    fn test_sample_count_is_bounded() {
+        let mut config = config();
+        config.report_interval = Duration::from_secs(60 * 60 * 24);
+        config.sample_interval = Duration::from_secs(1);
+        assert_eq!(config.samples_per_report(), MAX_LATENCY_SAMPLES);
+    }
+
+    #[test]
+    fn test_sample_count_is_at_least_one() {
+        let mut config = config();
+        config.report_interval = Duration::from_secs(1);
+        config.sample_interval = Duration::from_secs(60);
+        assert_eq!(config.samples_per_report(), 1);
+
+        config.sample_interval = Duration::ZERO;
+        assert_eq!(
+            config.samples_per_report(),
+            1,
+            "a zero sample interval must not divide by zero"
+        );
+    }
+
+    #[test]
+    fn test_measured_directory_is_not_derived_from_the_identity_path() {
+        let config = config();
+        assert_eq!(
+            config.data_dir, None,
+            "the identity path must not stand in for the data volume: it defaults under $HOME, \
+             so the disk fields would describe the OS root rather than the chain data disk"
+        );
+    }
+
+    #[test]
+    fn test_default_id_path_is_chain_scoped() {
+        let path = TelemetryConfig::default_id_path(8453);
+        assert!(path.ends_with("8453/telemetry-id"), "got {}", path.display());
+    }
+}

--- a/crates/common/telemetry-client/src/config.rs
+++ b/crates/common/telemetry-client/src/config.rs
@@ -1,6 +1,9 @@
 //! Configuration for the telemetry client.
 
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use base_retry::RetryConfig;
 use url::Url;
@@ -48,8 +51,14 @@ pub struct TelemetryConfig {
     pub endpoint: Option<Url>,
     /// Override used to tag our own nodes so they can be excluded from fleet numbers.
     pub instance_id: Option<String>,
-    /// Where the persisted node identity lives.
-    pub id_path: PathBuf,
+    /// Where the persisted node identity lives, or `None` when nowhere could be resolved.
+    ///
+    /// `None` does not mean "use a default". It is the resolved answer that this node has no
+    /// durable place to keep an identity: neither `--telemetry.id-path` nor `$HOME` is set. A
+    /// node in that state reports nothing, because an identity minted under the working
+    /// directory would not survive a restart and one operator would show up as a new node every
+    /// time.
+    pub id_path: Option<PathBuf>,
     /// Directory whose filesystem the disk fields describe.
     ///
     /// Separate from `id_path` on purpose. The identity is a few bytes of state the node keeps
@@ -72,18 +81,22 @@ pub struct TelemetryConfig {
 
 impl TelemetryConfig {
     /// Builds a config that reports to `endpoint`, using the defaults for everything else.
-    pub fn new(id_path: PathBuf, endpoint: Option<Url>) -> Self {
+    pub fn new(id_path: impl Into<Option<PathBuf>>, endpoint: Option<Url>) -> Self {
         Self { endpoint, ..Self::disabled(id_path) }
     }
 
     /// Builds a config that sends nothing, for callers that need a value before an operator's
     /// choice is known.
-    pub fn disabled(id_path: PathBuf) -> Self {
+    ///
+    /// Takes `impl Into<Option<PathBuf>>` so a caller holding a path it knows it has can pass it
+    /// bare. The field stays an `Option`, so nothing downstream can skip the question of what to
+    /// do when there is no path.
+    pub fn disabled(id_path: impl Into<Option<PathBuf>>) -> Self {
         Self {
             enabled: true,
             endpoint: None,
             instance_id: None,
-            id_path,
+            id_path: id_path.into(),
             data_dir: None,
             report_interval: DEFAULT_REPORT_INTERVAL,
             sample_interval: DEFAULT_SAMPLE_INTERVAL,
@@ -94,21 +107,41 @@ impl TelemetryConfig {
     }
 
     /// Returns whether this config will actually send anything.
+    ///
+    /// `const` buys nothing here — every caller asks at runtime — and it forfeits the freedom to
+    /// add a check that cannot be const, such as validating the endpoint. It stays only because
+    /// the workspace enables `clippy::missing_const_for_fn`, so dropping it means an `allow`
+    /// attribute, and a suppressed lint is worse than a keyword. This crate is workspace-internal,
+    /// so the day a non-const check is needed, removing `const` is a local edit.
     pub const fn is_active(&self) -> bool {
         self.enabled && self.endpoint.is_some()
     }
 
-    /// Returns the default identity path for a chain, `$HOME/.base/<l2_chain_id>/telemetry-id`.
+    /// Returns the default identity path for a chain, `$HOME/.base/<l2_chain_id>/telemetry-id`,
+    /// or `None` when `$HOME` is unset.
     ///
     /// This mirrors where the consensus node already puts its checkpoint database. The
     /// execution node has a reth data directory and should pass that instead.
-    pub fn default_id_path(l2_chain_id: u64) -> PathBuf {
-        std::env::var_os("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(".base")
-            .join(l2_chain_id.to_string())
-            .join(TELEMETRY_ID_FILE_NAME)
+    pub fn default_id_path(l2_chain_id: u64) -> Option<PathBuf> {
+        Self::id_path_under(std::env::var_os("HOME").map(PathBuf::from).as_deref(), l2_chain_id)
+    }
+
+    /// Returns the identity path for a chain under `home`, or `None` when there is no usable home
+    /// directory.
+    ///
+    /// `None` rather than a working-directory-relative path. `$HOME` is routinely unset for a
+    /// container started by systemd, and `./.base/<chain>/telemetry-id` resolves against a
+    /// working directory such a deployment does not persist: the node would mint a fresh
+    /// identity on every restart and one operator would appear as an unbounded number of nodes.
+    /// The caller turns `None` into a warning naming `--telemetry.id-path` and a run with
+    /// telemetry off, because telemetry must never be the reason a node fails to start.
+    ///
+    /// Split from the environment lookup so the no-home case is testable without mutating the
+    /// process environment out from under every other test in the binary.
+    pub fn id_path_under(home: Option<&Path>, l2_chain_id: u64) -> Option<PathBuf> {
+        home.filter(|home| !home.as_os_str().is_empty()).map(|home| {
+            home.join(".base").join(l2_chain_id.to_string()).join(TELEMETRY_ID_FILE_NAME)
+        })
     }
 
     /// Returns how many samples a report will carry, given the configured intervals.
@@ -180,8 +213,20 @@ mod tests {
     }
 
     #[test]
-    fn test_default_id_path_is_chain_scoped() {
-        let path = TelemetryConfig::default_id_path(8453);
-        assert!(path.ends_with("8453/telemetry-id"), "got {}", path.display());
+    fn test_id_path_is_chain_scoped_under_home() {
+        let path = TelemetryConfig::id_path_under(Some(Path::new("/home/base")), 8453);
+        assert_eq!(path, Some(PathBuf::from("/home/base/.base/8453/telemetry-id")));
+    }
+
+    #[test]
+    fn test_id_path_without_a_home_is_none_rather_than_relative() {
+        for home in [None, Some(Path::new(""))] {
+            assert_eq!(
+                TelemetryConfig::id_path_under(home, 8453),
+                None,
+                "an unset $HOME must not resolve to a working-directory path: a container that \
+                 does not persist its working directory would re-mint an identity every restart"
+            );
+        }
     }
 }

--- a/crates/common/telemetry-client/src/hardware.rs
+++ b/crates/common/telemetry-client/src/hardware.rs
@@ -1,0 +1,472 @@
+//! Collection of the node's runtime environment.
+
+use std::path::Path;
+
+use base_telemetry_types::{Hardware, HardwarePlatform};
+
+/// Firmware vendor strings that identify a virtualized or cloud host.
+///
+/// Matched as a case-insensitive prefix against `/sys/class/dmi/id/sys_vendor`. Anything not on
+/// this list and not empty is reported as bare metal, and the raw vendor string travels
+/// alongside the classification so the list can be revised and the archive recomputed.
+const CLOUD_VENDOR_PREFIXES: &[&str] = &[
+    "amazon",
+    "alibaba",
+    "digitalocean",
+    "google",
+    "hetzner",
+    "linode",
+    "microsoft",
+    "openstack",
+    "oracle",
+    "parallels",
+    "qemu",
+    "scaleway",
+    "vmware",
+    "vultr",
+    "xen",
+];
+
+/// Filesystem types that are network-attached by definition.
+const NETWORK_FILESYSTEMS: &[&str] = &[
+    "9p",
+    "afs",
+    "beegfs",
+    "ceph",
+    "cifs",
+    "fuse.glusterfs",
+    "fuse.s3fs",
+    "fuse.sshfs",
+    "gfs2",
+    "glusterfs",
+    "lustre",
+    "nfs",
+    "nfs4",
+    "ocfs2",
+    "smb3",
+    "smbfs",
+];
+
+/// Block device name prefixes that are network-attached by definition.
+///
+/// These carry a local filesystem such as `ext4`, so the filesystem type alone does not reveal
+/// them: `ext4` on `rbd0` is Ceph over the network and reads exactly like `ext4` on `nvme0n1`.
+const NETWORK_BLOCK_DEVICES: &[&str] = &["drbd", "nbd", "rbd"];
+
+/// Disk model strings that identify a cloud volume attached over the network.
+///
+/// Matched case-insensitively as a prefix. These present to the guest as ordinary `NVMe` or SCSI
+/// devices, so nothing about the device name or the filesystem gives them away — only the model
+/// string the hypervisor reports does.
+const NETWORK_DISK_MODELS: &[&str] =
+    &["amazon elastic block store", "google persistentdisk", "virtual disk"];
+
+/// One line of `/proc/mounts`: what is mounted where, as what, and with which options.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MountEntry {
+    /// Device backing the mount, e.g. `/dev/nvme0n1p3` or `10.0.0.1:/export`.
+    pub device: String,
+    /// Where the filesystem is mounted.
+    pub mount_point: String,
+    /// Filesystem type, e.g. `ext4`.
+    pub fs_type: String,
+    /// Comma-separated mount options.
+    pub options: String,
+}
+
+/// Reads the node's runtime environment.
+///
+/// Collection degrades field by field. A non-Linux host, a container without `/sys` or `/proc`
+/// mounted, and a permission error all yield `None` for the affected fields rather than an
+/// error, because failing to describe the machine must never stop a node from reporting.
+#[derive(Debug, Clone, Copy)]
+pub struct HardwareCollector;
+
+impl HardwareCollector {
+    /// Collects the runtime environment, sizing the disk fields against `data_dir` when given.
+    pub fn collect(data_dir: Option<&Path>) -> Hardware {
+        let vendor = Self::read_sys_vendor();
+        let (disk_total_bytes, disk_free_bytes) =
+            data_dir.map_or((None, None), Self::filesystem_capacity);
+        let mount = data_dir.and_then(Self::mount_entry_for);
+        let device = mount.as_ref().and_then(|mount| Self::whole_disk_device(&mount.device));
+        let (disk_model, disk_rotational) =
+            device.as_deref().map_or((None, None), Self::backing_disk_details);
+
+        Hardware {
+            platform: Self::classify_platform(vendor.as_deref()),
+            cloud_vendor: vendor,
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            kernel: Self::read_kernel_release(),
+            cpu_model: Self::read_cpu_model(),
+            cpu_cores: Self::cpu_cores(),
+            ram_bytes: Self::read_memory_bytes(),
+            disk_model: disk_model.clone(),
+            disk_rotational,
+            disk_total_bytes,
+            disk_free_bytes,
+            fs_type: mount.as_ref().map(|mount| mount.fs_type.clone()),
+            fs_flags: mount.as_ref().map(|mount| mount.options.clone()),
+            is_network_storage: mount.as_ref().map(|mount| {
+                Self::is_network_storage(&mount.fs_type, &mount.device, disk_model.as_deref())
+            }),
+        }
+    }
+
+    /// Classifies a firmware vendor string as cloud or bare metal.
+    pub fn classify_platform(vendor: Option<&str>) -> HardwarePlatform {
+        let Some(vendor) = vendor else {
+            return HardwarePlatform::Unknown;
+        };
+        let vendor = vendor.trim().to_ascii_lowercase();
+        if vendor.is_empty() {
+            return HardwarePlatform::Unknown;
+        }
+        if CLOUD_VENDOR_PREFIXES.iter().any(|prefix| vendor.starts_with(prefix)) {
+            return HardwarePlatform::Cloud;
+        }
+        HardwarePlatform::BareMetal
+    }
+
+    /// Returns the number of logical cores visible to this process.
+    ///
+    /// This is the process's own view, so a container with a CPU quota reports the quota rather
+    /// than the host's core count. That is the number that explains the node's performance.
+    pub fn cpu_cores() -> Option<u32> {
+        std::thread::available_parallelism().ok().map(|cores| cores.get() as u32)
+    }
+
+    /// Returns total and free bytes on the filesystem holding `path`.
+    pub fn filesystem_capacity(path: &Path) -> (Option<u64>, Option<u64>) {
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+            return (None, None);
+        }
+        #[cfg(unix)]
+        {
+            use std::{ffi::CString, os::unix::ffi::OsStrExt};
+
+            let Ok(c_path) = CString::new(path.as_os_str().as_bytes()) else {
+                return (None, None);
+            };
+            // SAFETY: `c_path` is a valid NUL-terminated C string that outlives the call, and
+            // `stats` is a correctly sized, writable `statvfs` the kernel fills in.
+            let stats = unsafe {
+                let mut stats: libc::statvfs = std::mem::zeroed();
+                if libc::statvfs(c_path.as_ptr(), &mut stats) != 0 {
+                    return (None, None);
+                }
+                stats
+            };
+
+            let block_size = stats.f_frsize as u64;
+            (
+                Some(block_size.saturating_mul(stats.f_blocks as u64)),
+                Some(block_size.saturating_mul(stats.f_bavail as u64)),
+            )
+        }
+    }
+
+    /// Returns the model string and rotational flag of the whole-disk block device `disk`.
+    ///
+    /// Everything here comes from sysfs, so a host without `/sys/class/block` reports neither.
+    pub fn backing_disk_details(disk: &str) -> (Option<String>, Option<bool>) {
+        let sysfs = Path::new("/sys/class/block").join(disk);
+        let model = Self::read_trimmed(&sysfs.join("device/model"));
+        let rotational = Self::read_trimmed(&sysfs.join("queue/rotational"))
+            .and_then(|value| value.parse::<u8>().ok())
+            .map(|value| value != 0);
+        (model, rotational)
+    }
+
+    /// Returns the firmware vendor string, which is how we tell cloud from bare metal.
+    ///
+    /// Reading a file is passive and fast, and unlike probing a cloud metadata endpoint it does
+    /// not look intrusive in a packet capture. The DMI tree is Linux-only; anywhere else the
+    /// read simply fails and the vendor stays unknown.
+    pub fn read_sys_vendor() -> Option<String> {
+        Self::read_trimmed(Path::new("/sys/class/dmi/id/sys_vendor"))
+    }
+
+    /// Returns the CPU model string from `/proc/cpuinfo`.
+    pub fn read_cpu_model() -> Option<String> {
+        let cpuinfo = std::fs::read_to_string("/proc/cpuinfo").ok()?;
+        cpuinfo.lines().find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            let key = key.trim();
+            (key == "model name" || key == "Model").then(|| value.trim().to_string())
+        })
+    }
+
+    /// Returns total system memory in bytes from `/proc/meminfo`.
+    pub fn read_memory_bytes() -> Option<u64> {
+        let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+        Self::parse_mem_total_kib(&meminfo).map(|kib| kib.saturating_mul(1024))
+    }
+
+    /// Extracts `MemTotal` in `KiB` from the contents of `/proc/meminfo`.
+    pub fn parse_mem_total_kib(meminfo: &str) -> Option<u64> {
+        meminfo.lines().find_map(|line| {
+            let value = line.strip_prefix("MemTotal:")?;
+            value.split_whitespace().next()?.parse::<u64>().ok()
+        })
+    }
+
+    /// Returns the kernel release string, e.g. `6.8.0-45-generic`.
+    ///
+    /// Read from `procfs` rather than through `uname(2)` so it works the same in a container with
+    /// `/proc` mounted and degrades to `None` everywhere else, like every other field here.
+    pub fn read_kernel_release() -> Option<String> {
+        Self::read_trimmed(Path::new("/proc/sys/kernel/osrelease"))
+    }
+
+    /// Returns the `/proc/mounts` entry for the filesystem covering `path`.
+    pub fn mount_entry_for(path: &Path) -> Option<MountEntry> {
+        let mounts = std::fs::read_to_string("/proc/mounts").ok()?;
+        Self::parse_mount_entry(&mounts, path)
+    }
+
+    /// Picks the entry with the longest matching mount point from the contents of `/proc/mounts`.
+    ///
+    /// Longest wins because mount points nest: a data directory under `/var/lib/base` on its own
+    /// volume matches both `/` and `/var/lib/base`, and only the deeper one describes it.
+    pub fn parse_mount_entry(mounts: &str, path: &Path) -> Option<MountEntry> {
+        let target = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+
+        mounts
+            .lines()
+            .filter_map(|line| {
+                let mut fields = line.split_whitespace();
+                let device = fields.next()?;
+                let mount_point = fields.next()?;
+                let fs_type = fields.next()?;
+                let options = fields.next()?;
+                target.starts_with(mount_point).then(|| MountEntry {
+                    device: device.to_string(),
+                    mount_point: mount_point.to_string(),
+                    fs_type: fs_type.to_string(),
+                    options: options.to_string(),
+                })
+            })
+            .max_by_key(|entry| entry.mount_point.len())
+    }
+
+    /// Returns the whole-disk block device name behind a mount's device string, e.g. `nvme0n1`.
+    ///
+    /// Walks from the partition to its parent disk, so a node on `/dev/nvme0n1p3` is attributed
+    /// to `nvme0n1` and the rotational flag comes from the disk rather than the partition. A
+    /// device that is not under `/dev` — an NFS export, a tmpfs — has no block device at all.
+    pub fn whole_disk_device(device: &str) -> Option<String> {
+        let device = device.strip_prefix("/dev/")?;
+        let sysfs = Path::new("/sys/class/block").join(device);
+        if !sysfs.join("partition").exists() {
+            return Some(device.to_string());
+        }
+        // A partition's sysfs entry is nested under its whole-disk device, so the parent
+        // directory of the resolved symlink names the disk.
+        let resolved = sysfs.canonicalize().ok()?;
+        Some(resolved.parent()?.file_name()?.to_string_lossy().into_owned())
+    }
+
+    /// Returns whether a mount is network-attached rather than local.
+    ///
+    /// Three signals, because no single one covers the field. The filesystem type catches NFS and
+    /// friends; the device name catches a local filesystem layered on a network block device such
+    /// as `rbd`; the disk model catches a cloud volume that presents to the guest as ordinary
+    /// `NVMe`. Direct-attached instance storage matches none of them and reports `false`, which is
+    /// correct. This cannot see an iSCSI LUN behind a plain `sd*` device, so `false` means "no
+    /// evidence of network storage" rather than "proven local".
+    pub fn is_network_storage(fs_type: &str, device: &str, disk_model: Option<&str>) -> bool {
+        let fs_type = fs_type.to_ascii_lowercase();
+        if NETWORK_FILESYSTEMS.contains(&fs_type.as_str()) {
+            return true;
+        }
+        if let Some(name) = device.strip_prefix("/dev/")
+            && NETWORK_BLOCK_DEVICES.iter().any(|prefix| name.starts_with(prefix))
+        {
+            return true;
+        }
+        disk_model.is_some_and(|model| {
+            let model = model.trim().to_ascii_lowercase();
+            NETWORK_DISK_MODELS.iter().any(|known| model.starts_with(known))
+        })
+    }
+
+    /// Reads a file and trims it, returning `None` when it is missing, unreadable, or empty.
+    pub fn read_trimmed(path: &Path) -> Option<String> {
+        let contents = std::fs::read_to_string(path).ok()?;
+        let trimmed = contents.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collection_never_fails_on_this_host() {
+        let hardware = HardwareCollector::collect(Some(Path::new(".")));
+
+        assert_eq!(hardware.os, std::env::consts::OS);
+        assert_eq!(hardware.arch, std::env::consts::ARCH);
+        assert!(hardware.cpu_cores.is_some_and(|cores| cores > 0));
+    }
+
+    #[test]
+    fn test_collection_degrades_off_linux() {
+        let hardware = HardwareCollector::collect(None);
+
+        if cfg!(target_os = "linux") {
+            return;
+        }
+        assert_eq!(
+            hardware.platform,
+            HardwarePlatform::Unknown,
+            "there is no DMI vendor to read off Linux, so the platform is unknown, not bare metal"
+        );
+        assert!(hardware.cloud_vendor.is_none());
+        assert!(hardware.cpu_model.is_none());
+        assert!(hardware.ram_bytes.is_none());
+        assert!(hardware.kernel.is_none(), "there is no procfs osrelease to read off Linux");
+        assert!(hardware.fs_type.is_none(), "there is no /proc/mounts to read off Linux");
+    }
+
+    #[test]
+    fn test_disk_fields_are_absent_without_a_data_dir() {
+        let hardware = HardwareCollector::collect(None);
+        assert!(hardware.disk_total_bytes.is_none());
+        assert!(hardware.disk_free_bytes.is_none());
+        assert!(hardware.disk_model.is_none());
+        assert!(hardware.disk_rotational.is_none());
+        assert!(hardware.fs_type.is_none());
+        assert!(hardware.fs_flags.is_none());
+        assert!(hardware.is_network_storage.is_none());
+    }
+
+    #[test]
+    fn test_filesystem_capacity_reads_a_real_path_on_unix() {
+        let (total, free) = HardwareCollector::filesystem_capacity(Path::new("."));
+        if cfg!(unix) {
+            assert!(total.is_some_and(|bytes| bytes > 0), "the working directory has a filesystem");
+            assert!(free.is_some());
+        }
+    }
+
+    #[test]
+    fn test_filesystem_capacity_tolerates_a_missing_path() {
+        let (total, free) =
+            HardwareCollector::filesystem_capacity(Path::new("/definitely/not/a/real/path"));
+        assert!(total.is_none());
+        assert!(free.is_none());
+    }
+
+    #[test]
+    fn test_cloud_vendors_are_recognized() {
+        assert_eq!(
+            HardwareCollector::classify_platform(Some("Amazon EC2")),
+            HardwarePlatform::Cloud
+        );
+        assert_eq!(
+            HardwareCollector::classify_platform(Some("Google Compute Engine")),
+            HardwarePlatform::Cloud
+        );
+        assert_eq!(
+            HardwareCollector::classify_platform(Some("microsoft corporation")),
+            HardwarePlatform::Cloud,
+            "matching must be case-insensitive"
+        );
+    }
+
+    #[test]
+    fn test_unrecognized_vendors_are_bare_metal_and_absent_ones_are_unknown() {
+        assert_eq!(
+            HardwareCollector::classify_platform(Some("Supermicro")),
+            HardwarePlatform::BareMetal
+        );
+        assert_eq!(HardwareCollector::classify_platform(None), HardwarePlatform::Unknown);
+        assert_eq!(
+            HardwareCollector::classify_platform(Some("   ")),
+            HardwarePlatform::Unknown,
+            "an empty DMI file tells us nothing, which is not the same as bare metal"
+        );
+    }
+
+    #[test]
+    fn test_mem_total_is_parsed_from_meminfo() {
+        let meminfo = "MemTotal:       65809192 kB\nMemFree:         1234 kB\n";
+        assert_eq!(HardwareCollector::parse_mem_total_kib(meminfo), Some(65_809_192));
+    }
+
+    #[test]
+    fn test_mem_total_absent_from_meminfo_is_none() {
+        assert_eq!(HardwareCollector::parse_mem_total_kib("MemFree: 1234 kB\n"), None);
+        assert_eq!(HardwareCollector::parse_mem_total_kib("MemTotal:  not-a-number kB\n"), None);
+    }
+
+    /// A `/proc/mounts` excerpt with nested mount points, a network export, and a pseudo-filesystem.
+    const MOUNTS: &str = "\
+/dev/nvme0n1p3 / ext4 rw,relatime 0 0
+proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+/dev/nvme0n1p3 /var ext4 rw,relatime 0 0
+10.0.0.1:/export /var/lib/base nfs4 rw,noatime,vers=4.2 0 0
+";
+
+    #[test]
+    fn test_the_deepest_matching_mount_point_wins() {
+        let entry = HardwareCollector::parse_mount_entry(MOUNTS, Path::new("/var/lib/base/chain"))
+            .expect("a mount covers the path");
+
+        assert_eq!(entry.mount_point, "/var/lib/base", "/var and / also match but are shallower");
+        assert_eq!(entry.fs_type, "nfs4");
+        assert_eq!(entry.options, "rw,noatime,vers=4.2");
+        assert_eq!(entry.device, "10.0.0.1:/export");
+    }
+
+    #[test]
+    fn test_a_path_under_no_mount_point_has_no_entry() {
+        assert_eq!(HardwareCollector::parse_mount_entry("", Path::new("/var/lib/base")), None);
+    }
+
+    #[test]
+    fn test_network_filesystems_are_network_storage() {
+        assert!(HardwareCollector::is_network_storage("nfs4", "10.0.0.1:/export", None));
+        assert!(HardwareCollector::is_network_storage("NFS", "10.0.0.1:/export", None));
+        assert!(HardwareCollector::is_network_storage("cifs", "//server/share", None));
+    }
+
+    #[test]
+    fn test_a_local_filesystem_on_a_network_block_device_is_network_storage() {
+        assert!(
+            HardwareCollector::is_network_storage("ext4", "/dev/rbd0", None),
+            "ext4 on Ceph reads exactly like ext4 on NVMe from the filesystem type alone"
+        );
+    }
+
+    #[test]
+    fn test_a_cloud_volume_is_network_storage_despite_looking_local() {
+        assert!(HardwareCollector::is_network_storage(
+            "ext4",
+            "/dev/nvme1n1",
+            Some("Amazon Elastic Block Store")
+        ));
+    }
+
+    #[test]
+    fn test_direct_attached_storage_is_not_network_storage() {
+        assert!(!HardwareCollector::is_network_storage(
+            "ext4",
+            "/dev/nvme0n1p3",
+            Some("Samsung SSD 990 PRO 2TB")
+        ));
+        assert!(!HardwareCollector::is_network_storage("zfs", "tank/base", None));
+    }
+
+    #[test]
+    fn test_a_device_outside_dev_has_no_whole_disk() {
+        assert_eq!(HardwareCollector::whole_disk_device("10.0.0.1:/export"), None);
+        assert_eq!(HardwareCollector::whole_disk_device("tmpfs"), None);
+    }
+}

--- a/crates/common/telemetry-client/src/identity.rs
+++ b/crates/common/telemetry-client/src/identity.rs
@@ -1,0 +1,168 @@
+//! The persisted node identity.
+
+use std::{
+    fmt, fs, io,
+    path::{Path, PathBuf},
+};
+
+use tracing::warn;
+use uuid::Uuid;
+
+/// Failures encountered while loading or minting a node identity.
+#[derive(Debug, thiserror::Error)]
+pub enum TelemetryIdError {
+    /// The parent directory of the identity file could not be created.
+    #[error("failed to create telemetry id directory {}: {source}", path.display())]
+    CreateDir {
+        /// The directory that could not be created.
+        path: PathBuf,
+        /// The underlying filesystem error.
+        #[source]
+        source: io::Error,
+    },
+    /// The identity file could not be written.
+    #[error("failed to write telemetry id to {}: {source}", path.display())]
+    Write {
+        /// The file that could not be written.
+        path: PathBuf,
+        /// The underlying filesystem error.
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// A node's telemetry identity: a random v4 UUID.
+///
+/// A UUID rather than a bare hex string because every store the reports land in has a native UUID
+/// type. Identities minted before the switch were 32 undashed hex characters, which is exactly the
+/// simple UUID form, so an existing `telemetry-id` file still parses and the node keeps its
+/// identity across the upgrade.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TelemetryId(Uuid);
+
+impl TelemetryId {
+    /// Mints a fresh random identity.
+    pub fn generate() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Loads the identity at `path`, minting and persisting one if it is absent or unreadable.
+    ///
+    /// Minting logs a first-run disclosure banner stating what the node sends and how to turn
+    /// it off. That banner lives here rather than at the call site so it cannot be forgotten:
+    /// the first mint is exactly the moment an operator becomes a reporter.
+    ///
+    /// A file that exists but does not hold a well-formed ID is replaced rather than treated as
+    /// fatal. A truncated write from a crash should not stop a node from starting.
+    pub fn load_or_create(path: &Path) -> Result<Self, TelemetryIdError> {
+        if let Some(existing) = Self::read(path) {
+            return Ok(existing);
+        }
+
+        let id = Self::generate();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).map_err(|source| TelemetryIdError::CreateDir {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+        fs::write(path, id.to_string())
+            .map_err(|source| TelemetryIdError::Write { path: path.to_path_buf(), source })?;
+
+        warn!(
+            target: "telemetry",
+            path = %path.display(),
+            "Base node telemetry is enabled. This node will periodically report its version, \
+             chain head position, hardware, normalized config, and peer counts to Base. It never \
+             reports the command line, keys, or panic messages. Disable it with \
+             --telemetry.enabled=false, or run `base telemetry preview` to see the exact payload."
+        );
+
+        Ok(id)
+    }
+
+    /// Returns the identity as a `UUID`.
+    pub const fn uuid(&self) -> Uuid {
+        self.0
+    }
+
+    /// Reads a well-formed identity from `path`, or `None` if there is not one there.
+    ///
+    /// Unlike [`Self::load_or_create`] this never writes, so `base telemetry preview` can show
+    /// the real identity of a node that already reports without making a node that does not
+    /// report identifiable.
+    pub fn read(path: &Path) -> Option<Self> {
+        let contents = fs::read_to_string(path).ok()?;
+        let Ok(id) = Uuid::parse_str(contents.trim()) else {
+            warn!(
+                target: "telemetry",
+                path = %path.display(),
+                "telemetry id file is malformed; minting a replacement"
+            );
+            return None;
+        };
+        Some(Self(id))
+    }
+}
+
+impl fmt::Display for TelemetryId {
+    /// Renders the hyphenated form, which is what gets persisted and reported.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn test_generated_ids_are_random_v4_uuids() {
+        let first = TelemetryId::generate();
+        let second = TelemetryId::generate();
+
+        assert_eq!(first.uuid().get_version_num(), 4);
+        assert_ne!(first, second, "two mints must not collide");
+    }
+
+    #[test]
+    fn test_id_survives_a_reload() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("nested").join("telemetry-id");
+
+        let minted = TelemetryId::load_or_create(&path).expect("mint should succeed");
+        let reloaded = TelemetryId::load_or_create(&path).expect("reload should succeed");
+
+        assert_eq!(minted, reloaded, "a restart must preserve the identity");
+    }
+
+    #[test]
+    fn test_malformed_file_is_replaced_rather_than_fatal() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("telemetry-id");
+        fs::write(&path, "not-a-telemetry-id").expect("seed the file");
+
+        let id = TelemetryId::load_or_create(&path).expect("a bad file must not stop startup");
+        assert_eq!(
+            TelemetryId::load_or_create(&path).expect("reload"),
+            id,
+            "the replacement must be persisted, not re-minted every start"
+        );
+    }
+
+    #[test]
+    fn test_an_id_minted_before_the_uuid_switch_is_preserved() {
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("telemetry-id");
+        fs::write(&path, "0123456789ABCDEF0123456789ABCDEF\n").expect("seed the file");
+
+        let id = TelemetryId::load_or_create(&path).expect("load");
+        assert_eq!(
+            id.to_string(),
+            "01234567-89ab-cdef-0123-456789abcdef",
+            "an upgrade must not change a node's identity"
+        );
+    }
+}

--- a/crates/common/telemetry-client/src/identity.rs
+++ b/crates/common/telemetry-client/src/identity.rs
@@ -1,7 +1,8 @@
 //! The persisted node identity.
 
 use std::{
-    fmt, fs, io,
+    fmt, fs,
+    io::{self, Write},
     path::{Path, PathBuf},
 };
 
@@ -54,20 +55,25 @@ impl TelemetryId {
     ///
     /// A file that exists but does not hold a well-formed ID is replaced rather than treated as
     /// fatal. A truncated write from a crash should not stop a node from starting.
+    ///
+    /// Minting is atomic and racing callers converge, so the banner is logged by exactly the
+    /// process whose ID reached the disk. See [`Self::install`] for why that matters: the
+    /// telemetry ID is the fleet's primary key, and a lost race would count one operator twice.
+    ///
+    /// `path` is a location the caller has already resolved. Deciding there is nowhere durable to
+    /// keep an identity happens where the config is assembled, as
+    /// [`TelemetryConfig::id_path`](crate::TelemetryConfig::id_path) being `None`, so this
+    /// function never has to guess what an unusable path means.
     pub fn load_or_create(path: &Path) -> Result<Self, TelemetryIdError> {
         if let Some(existing) = Self::read(path) {
             return Ok(existing);
         }
 
-        let id = Self::generate();
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).map_err(|source| TelemetryIdError::CreateDir {
-                path: parent.to_path_buf(),
-                source,
-            })?;
+        let minted = Self::generate();
+        let resolved = minted.install(path)?;
+        if resolved != minted {
+            return Ok(resolved);
         }
-        fs::write(path, id.to_string())
-            .map_err(|source| TelemetryIdError::Write { path: path.to_path_buf(), source })?;
 
         warn!(
             target: "telemetry",
@@ -78,7 +84,64 @@ impl TelemetryId {
              --telemetry.enabled=false, or run `base telemetry preview` to see the exact payload."
         );
 
-        Ok(id)
+        Ok(minted)
+    }
+
+    /// Persists this identity at `path` unless one is already there, returning whichever identity
+    /// ended up on disk.
+    ///
+    /// Creating the file is a single atomic step: the contents are written to a temporary file in
+    /// the same directory and linked into place, which fails rather than clobbers when another
+    /// process got there first. A plain read-then-write lets two processes both observe absence
+    /// and mint different IDs, and the loser would go on reporting under an ID no longer on disk.
+    ///
+    /// The link is what makes the file appear complete or not at all. `create_new` alone would
+    /// also stop the second writer, but it leaves a window in which the racing reader opens a
+    /// zero-length file, reads it as corrupt, and replaces the winner's ID.
+    pub fn install(&self, path: &Path) -> Result<Self, TelemetryIdError> {
+        let parent = path.parent().unwrap_or_else(|| Path::new(""));
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(|source| TelemetryIdError::CreateDir {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        }
+
+        let temp = path.with_extension(format!("{}.tmp", self.0.simple()));
+        if let Err(error) = Self::write_temp(&temp, self.to_string().as_bytes()) {
+            let _ = fs::remove_file(&temp);
+            return Err(error);
+        }
+
+        let Err(error) = fs::hard_link(&temp, path) else {
+            let _ = fs::remove_file(&temp);
+            return Ok(*self);
+        };
+
+        // The file already exists, so another process minted first and owns the identity for this
+        // node. Adopt it: whoever wins the race must win it for every process on the box.
+        if error.kind() == io::ErrorKind::AlreadyExists
+            && let Some(existing) = Self::read(path)
+        {
+            let _ = fs::remove_file(&temp);
+            return Ok(existing);
+        }
+
+        // Either the file holds no usable ID, or the filesystem has no hard links. A rename is
+        // atomic in both cases, so a reader still never sees a partial file; it just cannot
+        // refuse to overwrite, which is why the value is read back rather than assumed.
+        fs::rename(&temp, path)
+            .map_err(|source| TelemetryIdError::Write { path: path.to_path_buf(), source })?;
+        Ok(Self::read(path).unwrap_or(*self))
+    }
+
+    /// Writes `contents` to `path` and flushes them to the device, so the file that gets linked
+    /// into place is whole even if the machine loses power immediately afterwards.
+    pub fn write_temp(path: &Path, contents: &[u8]) -> Result<(), TelemetryIdError> {
+        let write_error = |source| TelemetryIdError::Write { path: path.to_path_buf(), source };
+        let mut file = fs::File::create(path).map_err(write_error)?;
+        file.write_all(contents).map_err(write_error)?;
+        file.sync_all().map_err(write_error)
     }
 
     /// Returns the identity as a `UUID`.
@@ -114,6 +177,11 @@ impl fmt::Display for TelemetryId {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        sync::{Arc, Barrier},
+        thread,
+    };
+
     use tempfile::TempDir;
 
     use super::*;
@@ -149,6 +217,43 @@ mod tests {
             TelemetryId::load_or_create(&path).expect("reload"),
             id,
             "the replacement must be persisted, not re-minted every start"
+        );
+    }
+
+    #[test]
+    fn test_racing_processes_settle_on_one_identity() {
+        const RACERS: usize = 16;
+
+        let dir = TempDir::new().expect("temp dir");
+        let path = dir.path().join("telemetry-id");
+        let gate = Arc::new(Barrier::new(RACERS));
+
+        let racers: Vec<_> = (0..RACERS)
+            .map(|_| {
+                let path = path.clone();
+                let gate = Arc::clone(&gate);
+                thread::spawn(move || {
+                    gate.wait();
+                    TelemetryId::load_or_create(&path).expect("a racing mint must not fail")
+                })
+            })
+            .collect();
+        let ids: Vec<_> = racers.into_iter().map(|racer| racer.join().expect("racer")).collect();
+
+        let winner = TelemetryId::read(&path).expect("the race must leave a readable identity");
+        assert!(
+            ids.iter().all(|id| *id == winner),
+            "every racer must report under the identity that reached the disk, got {ids:?}"
+        );
+
+        let left_behind: Vec<_> = fs::read_dir(dir.path())
+            .expect("list the identity directory")
+            .map(|entry| entry.expect("entry").path())
+            .collect();
+        assert_eq!(
+            left_behind,
+            vec![path],
+            "the losers must leave no second identity and no temp files"
         );
     }
 

--- a/crates/common/telemetry-client/src/lib.rs
+++ b/crates/common/telemetry-client/src/lib.rs
@@ -1,0 +1,37 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    issue_tracker_base_url = "https://github.com/base/base/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod config;
+pub use config::{
+    DEFAULT_QUEUE_CAPACITY, DEFAULT_REPORT_INTERVAL, DEFAULT_REQUEST_TIMEOUT,
+    DEFAULT_SAMPLE_INTERVAL, GIT_SHA, MAX_LATENCY_SAMPLES, TELEMETRY_ID_FILE_NAME, TelemetryConfig,
+};
+
+mod identity;
+pub use identity::{TelemetryId, TelemetryIdError};
+
+mod hardware;
+pub use hardware::{HardwareCollector, MountEntry};
+
+mod builder;
+pub use builder::{NodeIdentity, NodeReportBuilder};
+
+mod sampler;
+pub use sampler::{LatencySampler, LatencyWindow};
+
+mod sink;
+#[cfg(any(test, feature = "test-utils"))]
+pub use sink::MockReportSink;
+pub use sink::{HttpReportSink, ReportSink, ReportSinkError};
+
+mod reporter;
+pub use reporter::{DeliveryStreak, TelemetryReporter};
+
+mod metrics;
+pub use metrics::Metrics;

--- a/crates/common/telemetry-client/src/metrics.rs
+++ b/crates/common/telemetry-client/src/metrics.rs
@@ -1,0 +1,13 @@
+//! Metrics for the telemetry client's own delivery path.
+
+base_metrics::define_metrics! {
+    base_telemetry_client
+    #[describe("Reports handed to the reporter queue")]
+    reports_enqueued: counter,
+    #[describe("Reports dropped because the reporter queue was full")]
+    reports_dropped: counter,
+    #[describe("Reports accepted by the ingest endpoint")]
+    reports_sent: counter,
+    #[describe("Reports abandoned after exhausting retries")]
+    reports_failed: counter,
+}

--- a/crates/common/telemetry-client/src/reporter.rs
+++ b/crates/common/telemetry-client/src/reporter.rs
@@ -1,0 +1,360 @@
+//! The bounded queue and background delivery task in front of a [`ReportSink`].
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+use backon::Retryable;
+use base_retry::RetryConfig;
+use base_telemetry_types::NodeReport;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::{Metrics, ReportSink};
+
+/// Hands reports to a sink without ever blocking the caller.
+///
+/// The queue is bounded and lossy. A caller that cannot enqueue drops the report and increments
+/// a counter rather than waiting, which is the same discipline the transaction event writer
+/// uses: a telemetry outage must never degrade a node.
+#[derive(Debug, Clone)]
+pub struct TelemetryReporter {
+    sender: mpsc::Sender<NodeReport>,
+    dropped: Arc<AtomicU64>,
+}
+
+/// Tracks a run of consecutive delivery failures.
+///
+/// A node pointed at an endpoint that never comes back should stay quiet enough to run for
+/// weeks, so only the first failure of an outage is worth a warning. This decides which one
+/// that is, and how many failures a recovery ended.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct DeliveryStreak {
+    consecutive_failures: u64,
+}
+
+impl DeliveryStreak {
+    /// Creates a streak with no failures recorded.
+    pub const fn new() -> Self {
+        Self { consecutive_failures: 0 }
+    }
+
+    /// Records a failed delivery, returning whether it opened a new outage.
+    ///
+    /// Only the opening failure warrants a warning; the rest of the outage belongs at debug.
+    pub const fn record_failure(&mut self) -> bool {
+        self.consecutive_failures += 1;
+        self.consecutive_failures == 1
+    }
+
+    /// Records a successful delivery, returning how many consecutive failures it ended.
+    ///
+    /// Zero means delivery was already healthy and the success is unremarkable.
+    pub const fn record_success(&mut self) -> u64 {
+        let ended = self.consecutive_failures;
+        self.consecutive_failures = 0;
+        ended
+    }
+
+    /// Returns how many deliveries have failed in a row.
+    pub const fn consecutive_failures(&self) -> u64 {
+        self.consecutive_failures
+    }
+}
+
+impl TelemetryReporter {
+    /// Starts the background delivery task and returns a handle for enqueueing reports.
+    ///
+    /// The task exits when `cancellation` fires or when every handle is dropped.
+    pub fn spawn(
+        sink: Arc<dyn ReportSink>,
+        retry: RetryConfig,
+        queue_capacity: usize,
+        cancellation: CancellationToken,
+    ) -> Self {
+        let (sender, receiver) = mpsc::channel(queue_capacity.max(1));
+        tokio::spawn(Self::deliver(sink, retry, receiver, cancellation));
+        Self { sender, dropped: Arc::new(AtomicU64::new(0)) }
+    }
+
+    /// Queues a report for delivery, returning whether it was accepted.
+    ///
+    /// Never blocks and never awaits. A full queue means delivery is wedged, and in that state
+    /// the useful thing to keep is the newest report rather than a backlog of stale ones.
+    pub fn enqueue(&self, report: NodeReport) -> bool {
+        Metrics::reports_enqueued().increment(1);
+        if self.sender.try_send(report).is_ok() {
+            return true;
+        }
+
+        let dropped = self.dropped.fetch_add(1, Ordering::Relaxed) + 1;
+        Metrics::reports_dropped().increment(1);
+        warn!(
+            target: "telemetry",
+            dropped_total = dropped,
+            "telemetry queue is full; dropping report"
+        );
+        false
+    }
+
+    /// Returns how many reports have been dropped for lack of queue space.
+    pub fn dropped_reports(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    /// Drains the queue, delivering each report with backoff.
+    async fn deliver(
+        sink: Arc<dyn ReportSink>,
+        retry: RetryConfig,
+        mut receiver: mpsc::Receiver<NodeReport>,
+        cancellation: CancellationToken,
+    ) {
+        let mut streak = DeliveryStreak::new();
+        loop {
+            let report = tokio::select! {
+                _ = cancellation.cancelled() => return,
+                report = receiver.recv() => match report {
+                    Some(report) => report,
+                    None => return,
+                },
+            };
+
+            let delivery = (|| async { sink.send(&report).await })
+                .retry(retry.to_backoff_builder())
+                .when(|error| error.is_retryable())
+                .notify(|error, delay| {
+                    debug!(
+                        target: "telemetry",
+                        backoff_ms = delay.as_millis(),
+                        error_kind = error.kind(),
+                        "telemetry delivery failed; retrying"
+                    );
+                });
+
+            let outcome = tokio::select! {
+                _ = cancellation.cancelled() => return,
+                outcome = delivery => outcome,
+            };
+
+            match outcome {
+                Ok(()) => {
+                    Metrics::reports_sent().increment(1);
+                    let ended = streak.record_success();
+                    if ended > 0 {
+                        warn!(
+                            target: "telemetry",
+                            failed_reports = ended,
+                            "telemetry delivery recovered"
+                        );
+                    }
+                    debug!(target: "telemetry", "report delivered");
+                }
+                Err(error) => {
+                    Metrics::reports_failed().increment(1);
+                    if streak.record_failure() {
+                        warn!(
+                            target: "telemetry",
+                            error = %error,
+                            error_kind = error.kind(),
+                            "giving up on telemetry report; further failures log at debug until \
+                             delivery recovers"
+                        );
+                    } else {
+                        debug!(
+                            target: "telemetry",
+                            error = %error,
+                            error_kind = error.kind(),
+                            consecutive_failures = streak.consecutive_failures(),
+                            "giving up on telemetry report"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use base_telemetry_types::NODE_REPORT_SCHEMA_VERSION;
+    use tokio::sync::{mpsc as test_mpsc, oneshot};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{MockReportSink, ReportSinkError};
+
+    /// A fixed identity, so a delivered report can be matched back to the one that was enqueued.
+    const TELEMETRY_ID: Uuid = Uuid::from_u128(0x0123_4567_89ab_cdef_0123_4567_89ab_cdef);
+
+    fn report() -> NodeReport {
+        NodeReport {
+            schema_version: NODE_REPORT_SCHEMA_VERSION,
+            telemetry_id: TELEMETRY_ID,
+            ..Default::default()
+        }
+    }
+
+    fn fast_retry() -> RetryConfig {
+        RetryConfig::new(2, Duration::from_millis(1), Duration::from_millis(2))
+    }
+
+    #[tokio::test]
+    async fn test_enqueued_reports_reach_the_sink() {
+        let (tx, mut rx) = test_mpsc::channel(4);
+        let mut sink = MockReportSink::new();
+        sink.expect_send().returning(move |report| {
+            let tx = tx.clone();
+            let id = report.telemetry_id;
+            Box::pin(async move {
+                tx.try_send(id).expect("test channel should accept");
+                Ok(())
+            })
+        });
+
+        let reporter =
+            TelemetryReporter::spawn(Arc::new(sink), fast_retry(), 4, CancellationToken::new());
+        assert!(reporter.enqueue(report()));
+
+        let delivered = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("delivery should not time out")
+            .expect("sink should have been called");
+        assert_eq!(delivered, TELEMETRY_ID);
+    }
+
+    #[tokio::test]
+    async fn test_a_full_queue_drops_rather_than_blocking() {
+        let (release_tx, release_rx) = oneshot::channel::<()>();
+        let release_rx = std::sync::Mutex::new(Some(release_rx));
+
+        let mut sink = MockReportSink::new();
+        sink.expect_send().returning(move |_| {
+            // Wedge the first delivery so the queue backs up behind the in-flight report.
+            let gate = release_rx.lock().expect("release lock should not be poisoned").take();
+            Box::pin(async move {
+                if let Some(gate) = gate {
+                    let _ = gate.await;
+                }
+                Ok(())
+            })
+        });
+
+        let reporter =
+            TelemetryReporter::spawn(Arc::new(sink), fast_retry(), 1, CancellationToken::new());
+
+        // At most one report can be in flight and one queued. Everything after that is dropped,
+        // and the point of the test is that every `enqueue` returns immediately either way.
+        let accepted = (0..16).filter(|_| reporter.enqueue(report())).count();
+        assert!(accepted < 16, "a wedged sink must not let the queue grow without bound");
+        assert!(reporter.dropped_reports() > 0, "drops must be counted, not silent");
+
+        let _ = release_tx.send(());
+    }
+
+    #[tokio::test]
+    async fn test_delivery_retries_a_retryable_failure() {
+        let (tx, mut rx) = test_mpsc::channel(8);
+        let mut sink = MockReportSink::new();
+        sink.expect_send()
+            .times(1)
+            .returning(|_| Box::pin(async { Err(ReportSinkError::Status { status: 503 }) }));
+        sink.expect_send().returning(move |_| {
+            let tx = tx.clone();
+            Box::pin(async move {
+                tx.try_send(()).expect("test channel should accept");
+                Ok(())
+            })
+        });
+
+        let reporter =
+            TelemetryReporter::spawn(Arc::new(sink), fast_retry(), 4, CancellationToken::new());
+        reporter.enqueue(report());
+
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("the retry should not time out")
+            .expect("the second attempt should have succeeded");
+    }
+
+    #[tokio::test]
+    async fn test_a_permanent_failure_is_not_retried_and_does_not_stop_the_task() {
+        let (tx, mut rx) = test_mpsc::channel(4);
+        let mut sink = MockReportSink::new();
+        sink.expect_send()
+            .times(1)
+            .returning(|_| Box::pin(async { Err(ReportSinkError::Status { status: 400 }) }));
+        sink.expect_send().returning(move |_| {
+            let tx = tx.clone();
+            Box::pin(async move {
+                tx.try_send(()).expect("test channel should accept");
+                Ok(())
+            })
+        });
+
+        let reporter =
+            TelemetryReporter::spawn(Arc::new(sink), fast_retry(), 4, CancellationToken::new());
+        reporter.enqueue(report());
+        reporter.enqueue(report());
+
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("the second report should still be delivered")
+            .expect("the delivery task must survive a permanent failure");
+    }
+
+    #[tokio::test]
+    async fn test_cancellation_stops_the_delivery_task() {
+        let mut sink = MockReportSink::new();
+        sink.expect_send().returning(|_| Box::pin(async { Ok(()) }));
+
+        let cancellation = CancellationToken::new();
+        let reporter =
+            TelemetryReporter::spawn(Arc::new(sink), fast_retry(), 4, cancellation.clone());
+        cancellation.cancel();
+        tokio::task::yield_now().await;
+
+        // Enqueueing after cancellation must still not block or panic, only fill and drop.
+        for _ in 0..16 {
+            reporter.enqueue(report());
+        }
+    }
+
+    /// Only the first failure of an outage is loud.
+    ///
+    /// A node pointed at a dead endpoint reports on every cycle forever. Warning on each one
+    /// fills an operator's logs with a problem they were already told about once.
+    #[test]
+    fn test_only_the_first_failure_of_an_outage_warrants_a_warning() {
+        let mut streak = DeliveryStreak::new();
+
+        assert!(streak.record_failure(), "the first failure opens the outage");
+        for cycle in 2..=100 {
+            assert!(!streak.record_failure(), "cycle {cycle} must stay quiet");
+        }
+        assert_eq!(streak.consecutive_failures(), 100);
+    }
+
+    /// A recovery reports the outage it ended, and reopens the next one loudly.
+    #[test]
+    fn test_recovery_reports_the_outage_it_ended_and_rearms_the_warning() {
+        let mut streak = DeliveryStreak::new();
+        streak.record_failure();
+        streak.record_failure();
+
+        assert_eq!(streak.record_success(), 2, "recovery reports how many reports were lost");
+        assert_eq!(streak.consecutive_failures(), 0);
+        assert!(streak.record_failure(), "the next outage is worth a warning of its own");
+    }
+
+    /// A success during healthy delivery says nothing.
+    #[test]
+    fn test_a_success_without_a_preceding_failure_is_unremarkable() {
+        let mut streak = DeliveryStreak::new();
+        assert_eq!(streak.record_success(), 0);
+        assert_eq!(streak.record_success(), 0);
+    }
+}

--- a/crates/common/telemetry-client/src/sampler.rs
+++ b/crates/common/telemetry-client/src/sampler.rs
@@ -1,0 +1,141 @@
+//! Head-lag sampling between reports.
+
+use base_telemetry_types::Heads;
+
+/// A window of head-lag samples, drained once per report.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct LatencyWindow {
+    /// Every sample taken in the window, oldest first.
+    pub samples: Vec<f64>,
+    /// The largest sample seen in the window.
+    ///
+    /// This is the value only the client can supply. A node that stalls for two minutes and
+    /// recovers looks perfectly healthy in every point sample taken by the server.
+    pub worst_secs: f64,
+}
+
+impl LatencyWindow {
+    /// Returns the most recent sample, or zero if the window is empty.
+    pub fn latest_secs(&self) -> f64 {
+        self.samples.last().copied().unwrap_or_default()
+    }
+
+    /// Writes the window into the three latency fields of `heads`.
+    ///
+    /// The sampler owns those fields; the caller fills in the block numbers. Keeping the
+    /// mapping here means the reporting actor and `base telemetry preview` cannot disagree
+    /// about which sample becomes `unsafe_latency_secs`.
+    pub fn apply(self, heads: &mut Heads) {
+        heads.unsafe_latency_secs = self.latest_secs();
+        heads.worst_unsafe_latency_secs = self.worst_secs;
+        heads.unsafe_latency_samples = self.samples;
+    }
+}
+
+/// Accumulates head-lag samples and their high-water mark between reports.
+///
+/// Pure and synchronous. Sampling is how often we look; reporting is how often we send.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LatencySampler {
+    samples: Vec<f64>,
+    worst_secs: f64,
+    max_samples: usize,
+}
+
+impl LatencySampler {
+    /// Creates a sampler that carries at most `max_samples` readings per report.
+    pub fn new(max_samples: usize) -> Self {
+        let max_samples = max_samples.max(1);
+        Self { samples: Vec::with_capacity(max_samples), worst_secs: 0.0, max_samples }
+    }
+
+    /// Records one head-lag reading, in seconds.
+    ///
+    /// Negative readings are clamped to zero. A head timestamp slightly ahead of local wall
+    /// clock is a clock-skew artifact, not negative lag, and letting it through would drag the
+    /// fleet's lag distribution below zero.
+    ///
+    /// Once the window is full the sample is still folded into the high-water mark but is not
+    /// retained, so a misconfigured interval cannot grow the payload without bound.
+    pub fn record(&mut self, latency_secs: f64) {
+        if !latency_secs.is_finite() {
+            return;
+        }
+        let latency_secs = latency_secs.max(0.0);
+        self.worst_secs = self.worst_secs.max(latency_secs);
+        if self.samples.len() < self.max_samples {
+            self.samples.push(latency_secs);
+        }
+    }
+
+    /// Takes the accumulated window and resets for the next report.
+    pub fn drain(&mut self) -> LatencyWindow {
+        let window = LatencyWindow {
+            samples: std::mem::take(&mut self.samples),
+            worst_secs: self.worst_secs,
+        };
+        self.worst_secs = 0.0;
+        window
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_worst_tracks_the_high_water_mark() {
+        let mut sampler = LatencySampler::new(8);
+        for latency in [0.1, 12.5, 0.2, 0.1] {
+            sampler.record(latency);
+        }
+
+        let window = sampler.drain();
+        assert_eq!(window.worst_secs, 12.5, "a stall between samples must survive to the report");
+        assert_eq!(window.latest_secs(), 0.1, "the point value is the most recent sample");
+        assert_eq!(window.samples.len(), 4);
+    }
+
+    #[test]
+    fn test_drain_resets_the_window() {
+        let mut sampler = LatencySampler::new(8);
+        sampler.record(30.0);
+        assert_eq!(sampler.drain().worst_secs, 30.0);
+
+        sampler.record(1.0);
+        let window = sampler.drain();
+        assert_eq!(window.worst_secs, 1.0, "the high-water mark must not leak across reports");
+        assert_eq!(window.samples, vec![1.0]);
+    }
+
+    #[test]
+    fn test_empty_window_reports_zero() {
+        let window = LatencySampler::new(8).drain();
+        assert_eq!(window.worst_secs, 0.0);
+        assert_eq!(window.latest_secs(), 0.0);
+        assert!(window.samples.is_empty());
+    }
+
+    #[test]
+    fn test_samples_are_capped_but_the_worst_is_not() {
+        let mut sampler = LatencySampler::new(2);
+        sampler.record(1.0);
+        sampler.record(2.0);
+        sampler.record(99.0);
+
+        let window = sampler.drain();
+        assert_eq!(window.samples, vec![1.0, 2.0], "the payload must stay bounded");
+        assert_eq!(window.worst_secs, 99.0, "a capped sample still counts toward the worst case");
+    }
+
+    #[test]
+    fn test_clock_skew_does_not_produce_negative_lag() {
+        let mut sampler = LatencySampler::new(4);
+        sampler.record(-3.0);
+        sampler.record(f64::NAN);
+
+        let window = sampler.drain();
+        assert_eq!(window.samples, vec![0.0], "skew clamps to zero and NaN is discarded");
+        assert_eq!(window.worst_secs, 0.0);
+    }
+}

--- a/crates/common/telemetry-client/src/sink.rs
+++ b/crates/common/telemetry-client/src/sink.rs
@@ -1,0 +1,124 @@
+//! Where a built report goes.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base_telemetry_types::NodeReport;
+use url::Url;
+
+/// Failures encountered while delivering a report.
+#[derive(Debug, thiserror::Error)]
+pub enum ReportSinkError {
+    /// The request could not be built or sent.
+    #[error("telemetry request failed: {0}")]
+    Transport(#[from] reqwest::Error),
+    /// The endpoint answered, but not with success.
+    #[error("telemetry endpoint returned HTTP {status}")]
+    Status {
+        /// The HTTP status code returned by the endpoint.
+        status: u16,
+    },
+    /// The sink could not accept the report for a reason of its own.
+    #[error("telemetry sink rejected the report: {0}")]
+    Rejected(String),
+}
+
+impl ReportSinkError {
+    /// Returns whether retrying this failure could plausibly succeed.
+    ///
+    /// A 4xx other than 429 means this build is sending something the endpoint will never
+    /// accept, and retrying it is a waste of the node's time and ours.
+    pub const fn is_retryable(&self) -> bool {
+        match self {
+            Self::Transport(_) => true,
+            Self::Status { status } => *status == 429 || *status >= 500,
+            Self::Rejected(_) => false,
+        }
+    }
+
+    /// Returns a stable label for this failure, for use as a metric or log field.
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::Transport(_) => "transport",
+            Self::Status { .. } => "status",
+            Self::Rejected(_) => "rejected",
+        }
+    }
+}
+
+/// The delivery seam for a built report.
+///
+/// Implementations must be cheap to clone-free share and must not panic: the reporter treats
+/// every error as data, never as a reason to stop.
+#[async_trait]
+#[cfg_attr(any(test, feature = "test-utils"), mockall::automock)]
+pub trait ReportSink: std::fmt::Debug + Send + Sync + 'static {
+    /// Delivers one report.
+    async fn send(&self, report: &NodeReport) -> Result<(), ReportSinkError>;
+}
+
+/// Delivers reports as JSON over HTTP to an ingest endpoint.
+#[derive(Debug, Clone)]
+pub struct HttpReportSink {
+    client: reqwest::Client,
+    endpoint: Url,
+}
+
+impl HttpReportSink {
+    /// Builds a sink that POSTs to `endpoint`.
+    ///
+    /// The client deliberately does not call `.no_proxy()`, so `HTTPS_PROXY` and `NO_PROXY` are
+    /// honored for operators who route egress through a proxy.
+    pub fn new(endpoint: Url, request_timeout: Duration) -> Result<Self, ReportSinkError> {
+        let client = reqwest::Client::builder().timeout(request_timeout).build()?;
+        Ok(Self { client, endpoint })
+    }
+
+    /// Returns the endpoint this sink posts to.
+    pub const fn endpoint(&self) -> &Url {
+        &self.endpoint
+    }
+}
+
+#[async_trait]
+impl ReportSink for HttpReportSink {
+    async fn send(&self, report: &NodeReport) -> Result<(), ReportSinkError> {
+        let response = self.client.post(self.endpoint.clone()).json(report).send().await?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        Err(ReportSinkError::Status { status: status.as_u16() })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_server_errors_and_throttling_are_retryable() {
+        assert!(ReportSinkError::Status { status: 500 }.is_retryable());
+        assert!(ReportSinkError::Status { status: 503 }.is_retryable());
+        assert!(
+            ReportSinkError::Status { status: 429 }.is_retryable(),
+            "a throttled node should back off and try again, not give up"
+        );
+    }
+
+    #[test]
+    fn test_client_errors_are_not_retryable() {
+        assert!(
+            !ReportSinkError::Status { status: 400 }.is_retryable(),
+            "retrying a payload the endpoint will never accept wastes the node's time"
+        );
+        assert!(!ReportSinkError::Status { status: 413 }.is_retryable());
+        assert!(!ReportSinkError::Rejected("no".to_string()).is_retryable());
+    }
+
+    #[test]
+    fn test_error_kinds_are_stable_labels() {
+        assert_eq!(ReportSinkError::Status { status: 500 }.kind(), "status");
+        assert_eq!(ReportSinkError::Rejected("no".to_string()).kind(), "rejected");
+    }
+}

--- a/crates/common/telemetry-types/Cargo.toml
+++ b/crates/common/telemetry-types/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "base-telemetry-types"
+description = "Wire schema for Base node telemetry reports"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+uuid = { workspace = true, features = ["serde"] }
+chrono = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive", "std"] }
+
+[dev-dependencies]
+serde_json = { workspace = true, features = ["std"] }

--- a/crates/common/telemetry-types/README.md
+++ b/crates/common/telemetry-types/README.md
@@ -1,0 +1,43 @@
+# `base-telemetry-types`
+
+Wire schema for Base node telemetry. Serde types only, no I/O.
+
+This crate is the single definition of the version 1 `node_report` payload that
+`base-telemetry-client` sends and that the `base-telemetry-service` ingest
+endpoint accepts. Both sides depend on this crate so the schema cannot drift.
+
+## Overview
+
+- **`NodeReport`**: the payload a node POSTs to `/v1/ingest`.
+- **`ClientMeta`**: version, git sha, network, role, layer.
+- **`Heads`**: chain head positions plus the client's own lag samples and
+  high-water mark.
+- **`Hardware`**: cloud vs bare metal, CPU, memory, and disk.
+- **`NodeConfigReport`**: an allowlisted, normalized view of node config.
+- **`NetHealth`**: peer counts, churn, and gossip/request error rates.
+- **`NodeReportEvent`**: the flattened record the ingest service writes, which
+  is a `NodeReport` plus the server-side `received_at`, `reported_ip`, and
+  `ip_source`.
+
+## Contract notes
+
+Field names are `snake_case` on the wire because they become log facets
+(`hardware.cpu_cores`, `net_health.peer_count`), not because the rest of the repo's HTTP
+APIs are. This matches the `base-observability-events` JSONL journal, which is
+`snake_case` for the same reason.
+
+Two rules constrain what may be added here:
+
+- **Never the raw command line.** It carries L1 RPC URLs with API keys, JWT
+  paths, and signer endpoints. `NodeConfigReport` is an allowlisted, normalized
+  set of fields, and `experimental_flags` carries flag *names* only, never
+  their values.
+- **Never panic messages.** Stack frames are symbols from our own binary and
+  are safe; panic messages can carry operator data.
+
+Every field on `NodeReport` is either a scalar the node knows about itself or a
+value it already publishes to the p2p network.
+
+## License
+
+Licensed under the [MIT License](https://github.com/base/base/blob/main/LICENSE).

--- a/crates/common/telemetry-types/README.md
+++ b/crates/common/telemetry-types/README.md
@@ -16,8 +16,8 @@ endpoint accepts. Both sides depend on this crate so the schema cannot drift.
 - **`NodeConfigReport`**: an allowlisted, normalized view of node config.
 - **`NetHealth`**: peer counts, churn, and gossip/request error rates.
 - **`NodeReportEvent`**: the flattened record the ingest service writes, which
-  is a `NodeReport` plus the server-side `received_at`, `reported_ip`, and
-  `ip_source`.
+  is a `NodeReport` plus the server-side `received_at`, `reported_ip`,
+  `ip_source`, and `observed_ip`.
 
 ## Contract notes
 

--- a/crates/common/telemetry-types/src/config.rs
+++ b/crates/common/telemetry-types/src/config.rs
@@ -1,0 +1,62 @@
+//! The allowlisted, normalized view of node configuration reported as `config.*`.
+
+use serde::{Deserialize, Serialize};
+
+/// How much history the node retains.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PruneMode {
+    /// Full history retained.
+    #[default]
+    Archive,
+    /// History pruned to the default recent window.
+    Full,
+    /// History pruned according to a node-specific prune configuration.
+    Custom,
+}
+
+impl PruneMode {
+    /// Returns the stable wire label for this prune mode.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Archive => "archive",
+            Self::Full => "full",
+            Self::Custom => "custom",
+        }
+    }
+}
+
+/// The `config.*` block, present on every report event.
+///
+/// This is an allowlist by construction. The raw command line is never reported, because it
+/// carries L1 RPC URLs with credentials, JWT paths, and signer endpoints. Adding a field here
+/// means deciding that this specific normalized value is safe to send, and `experimental_flags`
+/// carries flag *names* only, never their values.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeConfigReport {
+    /// How much history the node retains, absent on a node that has no prune setting at all.
+    ///
+    /// A consensus-only node omits this rather than reporting a placeholder, so the field
+    /// distinguishes "not applicable" from a real retention choice.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prune_mode: Option<PruneMode>,
+    /// Whether the node participates in p2p gossip.
+    pub p2p_enabled: bool,
+    /// Whether discv5 discovery is enabled.
+    pub discovery_enabled: bool,
+    /// Whether the node is configured to sequence blocks.
+    pub sequencer_enabled: bool,
+    /// Whether the node runs the interop supervisor integration.
+    pub supervisor_enabled: bool,
+    /// Whether the node consumes flashblocks.
+    pub flashblocks_enabled: bool,
+    /// Whether the operator enabled the Prometheus metrics endpoint.
+    pub metrics_enabled: bool,
+    /// Names of enabled experimental flags, sorted. Names only, never values.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub experimental_flags: Vec<String>,
+    /// How often the node sends a report, in seconds.
+    pub report_interval_secs: u64,
+    /// How often the node samples head lag between reports, in seconds.
+    pub sample_interval_secs: u64,
+}

--- a/crates/common/telemetry-types/src/hardware.rs
+++ b/crates/common/telemetry-types/src/hardware.rs
@@ -1,0 +1,92 @@
+//! Runtime environment of the reporting node: cloud vs bare metal, CPU, memory, and disk.
+
+use serde::{Deserialize, Serialize};
+
+/// Whether the node runs on a cloud instance or on bare metal.
+///
+/// Derived from the firmware description at `/sys/class/dmi/id/sys_vendor` rather than by
+/// probing a cloud metadata endpoint: reading a file is passive, fast, and does not look
+/// intrusive in a packet capture.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HardwarePlatform {
+    /// A recognized cloud provider's virtual machine.
+    Cloud,
+    /// Physical hardware with no recognized cloud vendor string.
+    #[serde(rename = "baremetal")]
+    BareMetal,
+    /// The platform could not be determined, typically because the DMI path does not exist.
+    #[default]
+    Unknown,
+}
+
+impl HardwarePlatform {
+    /// Returns the stable wire label for this platform.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Cloud => "cloud",
+            Self::BareMetal => "baremetal",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// The `hardware.*` block, present on every report event.
+///
+/// Every field beyond `platform`, `os`, and `arch` is optional because collection degrades
+/// rather than fails: a non-Linux host, a container without `/sys` mounted, or a permission
+/// error each yield `None` instead of an error. `hardware.class` is deliberately absent, since it is
+/// bucketed at ingest from `cpu_cores`, `ram_bytes`, and `disk_rotational` so the bucketing
+/// can be redefined later and recomputed from the archive.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Hardware {
+    /// Cloud instance or bare metal.
+    pub platform: HardwarePlatform,
+    /// Raw firmware vendor string, kept next to `platform` so the classification can be redone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cloud_vendor: Option<String>,
+    /// Target operating system, from `std::env::consts::OS`.
+    pub os: String,
+    /// Target CPU architecture, from `std::env::consts::ARCH`.
+    pub arch: String,
+    /// Kernel release string, e.g. `6.8.0-45-generic`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kernel: Option<String>,
+    /// CPU model string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_model: Option<String>,
+    /// Number of logical CPU cores visible to the process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cpu_cores: Option<u32>,
+    /// Total system memory in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ram_bytes: Option<u64>,
+    /// Model string of the disk backing the node's data directory.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk_model: Option<String>,
+    /// Whether that disk is rotational. Distinguishes `baremetal-nvme` from `baremetal-spinning`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk_rotational: Option<bool>,
+    /// Total capacity of the filesystem holding the node's data directory, in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk_total_bytes: Option<u64>,
+    /// Free space on that filesystem, in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk_free_bytes: Option<u64>,
+    /// Filesystem type backing the node's data directory, e.g. `ext4` or `zfs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fs_type: Option<String>,
+    /// Mount options for that filesystem, comma-separated as `/proc/mounts` reports them.
+    ///
+    /// Carries the flags that change how the node performs, `noatime` and `discard` among them,
+    /// and the one that explains a node that cannot write at all: `ro`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fs_flags: Option<String>,
+    /// Whether the data directory sits on network-attached rather than local storage.
+    ///
+    /// The single most useful hardware fact we can collect: `ext4` on a local `NVMe` and `ext4` on
+    /// a network volume are indistinguishable from `disk_model` alone and perform nothing alike,
+    /// so a release that regresses only on network storage is invisible without this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_network_storage: Option<bool>,
+}

--- a/crates/common/telemetry-types/src/lib.rs
+++ b/crates/common/telemetry-types/src/lib.rs
@@ -1,0 +1,26 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    html_favicon_url = "https://avatars.githubusercontent.com/u/16627100?s=200&v=4",
+    issue_tracker_base_url = "https://github.com/base/base/issues/"
+)]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod report;
+pub use report::{
+    ClientMeta, Heads, IpSource, NODE_REPORT_SCHEMA_VERSION, NodeLayer, NodeReport,
+    NodeReportEvent, NodeRole,
+};
+
+mod hardware;
+pub use hardware::{Hardware, HardwarePlatform};
+
+mod network;
+pub use network::NetworkName;
+
+mod config;
+pub use config::{NodeConfigReport, PruneMode};
+
+mod net;
+pub use net::NetHealth;

--- a/crates/common/telemetry-types/src/net.rs
+++ b/crates/common/telemetry-types/src/net.rs
@@ -1,0 +1,51 @@
+//! The `net_health.*` block: peer counts, churn, and gossip/request error rates.
+
+use std::net::IpAddr;
+
+use serde::{Deserialize, Serialize};
+
+/// The `net_health.*` block, present on every report event.
+///
+/// This describes the reporting node's own view of the network, not its peers. Per-peer detail
+/// is deliberately excluded: it describes other operators' nodes, who never saw an opt-out
+/// prompt, and a per-peer `user_agent` would yield a version distribution for nodes that opted
+/// out, which is a crawler by another route.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NetHealth {
+    /// Peers currently connected.
+    pub peer_count: u32,
+    /// Configured target peer count, when the node has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_target: Option<u32>,
+    /// Nodes known to the discovery table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discovered_count: Option<u32>,
+    /// Peers that connected since the previous report.
+    pub peers_joined: u32,
+    /// Peers that disconnected since the previous report.
+    pub peers_left: u32,
+    /// The node's own libp2p peer identifier. Never the peer ID secret.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub peer_id: Option<String>,
+    /// The node's own Ethereum node record, as it is already published to the p2p network.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enr: Option<String>,
+    /// The address the node advertises to peers, when it advertises one.
+    ///
+    /// Reported so the backend can compare it against the observed edge IP. Disagreement is the
+    /// ground truth `basectl doctor` needs to tell an operator their connectivity is
+    /// misconfigured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub advertised_ip: Option<IpAddr>,
+    /// Gossip messages rejected or errored, as a fraction of those seen since the last report.
+    ///
+    /// Absent rather than zero when the client cannot measure it, so a client that never
+    /// learned the rate is distinguishable from one reporting a clean interval.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gossip_error_rate: Option<f64>,
+    /// p2p requests that failed, as a fraction of those issued since the last report.
+    ///
+    /// Absent rather than zero for the same reason as [`NetHealth::gossip_error_rate`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rpc_error_rate: Option<f64>,
+}

--- a/crates/common/telemetry-types/src/network.rs
+++ b/crates/common/telemetry-types/src/network.rs
@@ -1,0 +1,52 @@
+//! Derivation of the human-readable `network` facet from an L2 chain ID.
+
+/// Resolves the `network` wire value reports carry.
+///
+/// The facet is the label dashboards group by and the archive partitions on, so it must be a
+/// name rather than a number: `l2_chain_id` already carries the number, and a partition key of
+/// `8453` tells a reader nothing that `mainnet` does not tell them better.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NetworkName;
+
+impl NetworkName {
+    /// Base mainnet.
+    pub const MAINNET_CHAIN_ID: u64 = 8453;
+    /// Base Sepolia.
+    pub const SEPOLIA_CHAIN_ID: u64 = 84532;
+    /// The local devnet the `etc/docker` stack brings up.
+    pub const DEVNET_CHAIN_ID: u64 = 84538453;
+
+    /// Returns the network name for `l2_chain_id`.
+    ///
+    /// An unrecognized chain reports `chain-<id>` rather than the bare number, so a new network
+    /// is legible in a dashboard before anyone adds it here, and never collides with a name.
+    pub fn for_chain_id(l2_chain_id: u64) -> String {
+        match l2_chain_id {
+            Self::MAINNET_CHAIN_ID => "mainnet".to_string(),
+            Self::SEPOLIA_CHAIN_ID => "sepolia".to_string(),
+            Self::DEVNET_CHAIN_ID => "devnet".to_string(),
+            other => format!("chain-{other}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_known_chains_resolve_to_names() {
+        assert_eq!(NetworkName::for_chain_id(8453), "mainnet");
+        assert_eq!(NetworkName::for_chain_id(84532), "sepolia");
+        assert_eq!(NetworkName::for_chain_id(84538453), "devnet");
+    }
+
+    #[test]
+    fn test_unknown_chain_is_labelled_not_bare() {
+        assert_eq!(
+            NetworkName::for_chain_id(1234),
+            "chain-1234",
+            "an unnamed chain must still be distinguishable from a named one"
+        );
+    }
+}

--- a/crates/common/telemetry-types/src/network.rs
+++ b/crates/common/telemetry-types/src/network.rs
@@ -13,6 +13,8 @@ impl NetworkName {
     pub const MAINNET_CHAIN_ID: u64 = 8453;
     /// Base Sepolia.
     pub const SEPOLIA_CHAIN_ID: u64 = 84532;
+    /// The internal zeronet test network.
+    pub const ZERONET_CHAIN_ID: u64 = 763360;
     /// The local devnet the `etc/docker` stack brings up.
     pub const DEVNET_CHAIN_ID: u64 = 84538453;
 
@@ -24,6 +26,7 @@ impl NetworkName {
         match l2_chain_id {
             Self::MAINNET_CHAIN_ID => "mainnet".to_string(),
             Self::SEPOLIA_CHAIN_ID => "sepolia".to_string(),
+            Self::ZERONET_CHAIN_ID => "zeronet".to_string(),
             Self::DEVNET_CHAIN_ID => "devnet".to_string(),
             other => format!("chain-{other}"),
         }
@@ -38,6 +41,7 @@ mod tests {
     fn test_known_chains_resolve_to_names() {
         assert_eq!(NetworkName::for_chain_id(8453), "mainnet");
         assert_eq!(NetworkName::for_chain_id(84532), "sepolia");
+        assert_eq!(NetworkName::for_chain_id(763360), "zeronet");
         assert_eq!(NetworkName::for_chain_id(84538453), "devnet");
     }
 

--- a/crates/common/telemetry-types/src/report.rs
+++ b/crates/common/telemetry-types/src/report.rs
@@ -241,6 +241,16 @@ pub struct NodeReportEvent {
     /// Equal to `reported_ip` whenever the node advertised nothing.
     pub observed_ip: IpAddr,
     /// The report as the node sent it.
+    ///
+    /// This flatten nests inside another: `NodeReport` itself flattens `ClientMeta`. Nested
+    /// flatten is a known cost — serde buffers each level into an intermediate map instead of
+    /// streaming, and a malformed field is reported against the outer type rather than the one
+    /// that owns it. Both are accepted deliberately. The wire shape is fixed: the ingest schema,
+    /// the Datadog dashboard, and the ingest tests all read these fields at the top level, so
+    /// removing a level of flatten would either change the JSON or replace it with hand-written
+    /// `Serialize`/`Deserialize` impls that restate every field. Buffering a payload the ingest
+    /// route caps at 16 `KiB` costs nothing measurable, and the error quality only degrades on
+    /// input that is already being rejected.
     #[serde(flatten)]
     pub report: NodeReport,
 }
@@ -398,6 +408,22 @@ mod tests {
         assert!(
             encoded.get("telemetry_id").is_some(),
             "report fields should sit next to server fields, not nested under report"
+        );
+    }
+
+    #[test]
+    fn test_event_round_trips_through_two_levels_of_flatten() {
+        let observed = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 4));
+        let event = NodeReportEvent::new(sample_report(), Utc::now(), observed);
+
+        let encoded = serde_json::to_string(&event).expect("event should serialize");
+        let decoded: NodeReportEvent =
+            serde_json::from_str(&encoded).expect("event should deserialize");
+
+        assert_eq!(
+            decoded, event,
+            "flattening the report into the event, and the client meta into the report, must \
+             still decode back to the same value"
         );
     }
 

--- a/crates/common/telemetry-types/src/report.rs
+++ b/crates/common/telemetry-types/src/report.rs
@@ -1,0 +1,449 @@
+//! The `node_report` payload a node POSTs to `/v1/ingest`, and the event the ingest service writes.
+
+use std::net::IpAddr;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{Hardware, NetHealth, NodeConfigReport};
+
+/// Major version of the node report schema this build produces and understands.
+///
+/// An integer rather than a string so a receiver can order versions and reject an unknown major,
+/// which is the rule the schema is specified against. An exact string match cannot express it.
+pub const NODE_REPORT_SCHEMA_VERSION: u16 = 1;
+
+/// Which layer of the stack produced a report.
+///
+/// Standalone execution-layer and consensus-layer deployments each mint their own telemetry ID
+/// and are joined server-side on the reported IP rather than coordinated in the client. The
+/// combined binary removes the problem for most of the fleet.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeLayer {
+    /// A `base-consensus` node.
+    #[default]
+    Consensus,
+    /// A `base-node-reth` execution node.
+    Execution,
+    /// Both layers in one process.
+    Combined,
+}
+
+impl NodeLayer {
+    /// Returns the stable wire label for this layer.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Consensus => "consensus",
+            Self::Execution => "execution",
+            Self::Combined => "combined",
+        }
+    }
+}
+
+/// What the node does on the network.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeRole {
+    /// The node sequences blocks.
+    Sequencer,
+    /// The node derives and validates the chain from L1.
+    #[default]
+    Validator,
+    /// The node follows another node rather than deriving for itself.
+    Follower,
+}
+
+impl NodeRole {
+    /// Returns the stable wire label for this role.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Sequencer => "sequencer",
+            Self::Validator => "validator",
+            Self::Follower => "follower",
+        }
+    }
+}
+
+/// Whether the address on an ingest event came from the node or from the connection.
+///
+/// Nodes with no advertised address, such as execution-only deployments or nodes with discovery
+/// disabled, fall back to the observed edge IP so they still contribute geography.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IpSource {
+    /// The node advertised the address in its report.
+    NodeProvided,
+    /// The server used the observed edge IP of the connection.
+    #[default]
+    ServerObserved,
+}
+
+impl IpSource {
+    /// Returns the stable wire label for this source.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::NodeProvided => "node_provided",
+            Self::ServerObserved => "server_observed",
+        }
+    }
+}
+
+/// Identity and build of the reporting client.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClientMeta {
+    /// Crate version of the running binary.
+    pub client_version: String,
+    /// Short git SHA of the build, or `unknown` when the build had no git metadata.
+    pub git_sha: String,
+    /// L2 chain ID the node is following.
+    pub l2_chain_id: u64,
+    /// Human-readable network name, used as the log facet and the S3 partition key.
+    pub network: String,
+    /// Which layer produced this report.
+    pub layer: NodeLayer,
+    /// What the node does on the network.
+    pub role: NodeRole,
+    /// Seconds since process start.
+    pub uptime_secs: u64,
+}
+
+/// Chain head positions and the client's own view of how far behind it is.
+///
+/// Performance ships as head positions rather than duration distributions because a block number
+/// is a scalar that merges across the fleet by counting. Duration distributions only merge if
+/// every node on every release agrees on the same bucket boundaries forever.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Heads {
+    /// Latest unsafe head block number.
+    ///
+    /// Serialized as `unsafe`, which the doc's facet tables use and Rust reserves as a keyword.
+    #[serde(rename = "unsafe")]
+    pub unsafe_block: u64,
+    /// Latest locally-derived safe head, absent until derivation has established one.
+    ///
+    /// This runs ahead of `safe`, which additionally requires the L1 batch to be reflected in the
+    /// canonical chain. A node deriving correctly from an L1 that is itself lagging shows a
+    /// healthy `local_safe` and a stalled `safe`; without both, the two look identical.
+    #[serde(rename = "local_safe", default, skip_serializing_if = "Option::is_none")]
+    pub local_safe_block: Option<u64>,
+    /// Latest safe head block number, absent until derivation has established one.
+    ///
+    /// Absent rather than zero so a node that has just restarted is distinguishable from a node
+    /// sitting at genesis. Both report the same number otherwise, and only one of them is broken.
+    #[serde(rename = "safe", default, skip_serializing_if = "Option::is_none")]
+    pub safe_block: Option<u64>,
+    /// Latest finalized head block number, absent for the same reason as [`Heads::safe_block`].
+    #[serde(rename = "finalized", default, skip_serializing_if = "Option::is_none")]
+    pub finalized_block: Option<u64>,
+    /// Seconds the unsafe head is behind wall clock, sampled when the report was built.
+    ///
+    /// The backend recomputes lag against the canonical head at `received_at` rather than
+    /// trusting this, but keeps it, since disagreement between the two is a clock-skew signal.
+    pub unsafe_latency_secs: f64,
+    /// The largest `unsafe_latency_secs` seen since the previous report.
+    ///
+    /// This is the one value only the client can supply. A node that stalls for two minutes and
+    /// recovers looks perfectly healthy in every point sample; the high-water mark, reset each
+    /// report, is what makes that visible.
+    pub worst_unsafe_latency_secs: f64,
+    /// Every lag sample taken since the previous report, oldest first.
+    ///
+    /// The report interval is how often we send. This is how often we look, so one report
+    /// carries a full interval of readings for a few tens of bytes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unsafe_latency_samples: Vec<f64>,
+}
+
+/// The payload a node POSTs to `/v1/ingest`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeReport {
+    /// Schema version, always [`NODE_REPORT_SCHEMA_VERSION`] for reports this crate builds.
+    pub schema_version: u16,
+    /// Random identifier minted on first run.
+    ///
+    /// A UUID rather than a bare hex string because every store this lands in — Datadog, Athena,
+    /// Postgres — has a native UUID type, and none of them can do anything with opaque text.
+    ///
+    /// Reliable within a reporting window and not across months, and nothing downstream depends
+    /// on more than that. A restart preserves it because the file does; a rebuild on a fresh
+    /// volume does not.
+    pub telemetry_id: Uuid,
+    /// Operator-supplied override used to tag our own nodes so they can be excluded from fleet
+    /// numbers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    /// When the node built this report.
+    pub reported_at: DateTime<Utc>,
+    /// Identity and build of the reporting client.
+    ///
+    /// Flattened, so `client_version`, `git_sha`, `network`, `role`, and `uptime_secs` sit at the
+    /// top level of the payload where the schema places them, while staying one struct in Rust.
+    #[serde(flatten)]
+    pub client: ClientMeta,
+    /// Chain head positions and lag.
+    pub heads: Heads,
+    /// Runtime environment.
+    pub hardware: Hardware,
+    /// Allowlisted, normalized node config.
+    pub config: NodeConfigReport,
+    /// Peer counts, churn, and error rates.
+    pub net_health: NetHealth,
+}
+
+impl Default for NodeReport {
+    /// Returns an empty report stamped with the current schema version, so a report assembled
+    /// with struct-update syntax can never be published under an empty version string.
+    fn default() -> Self {
+        Self {
+            schema_version: NODE_REPORT_SCHEMA_VERSION,
+            telemetry_id: Uuid::nil(),
+            instance_id: None,
+            reported_at: DateTime::default(),
+            client: ClientMeta::default(),
+            heads: Heads::default(),
+            hardware: Hardware::default(),
+            config: NodeConfigReport::default(),
+            net_health: NetHealth::default(),
+        }
+    }
+}
+
+impl NodeReport {
+    /// Returns whether this report declares the schema version this build understands.
+    pub const fn is_current_schema(&self) -> bool {
+        self.schema_version == NODE_REPORT_SCHEMA_VERSION
+    }
+}
+
+/// A received report plus the fields only the server can supply.
+///
+/// This is the flattened shape the ingest service records. `reported_ip` is retained rather than
+/// dropped after enrichment so geography can be re-derived as enrichment datasets improve, and
+/// so it can serve as the correlation key when joining standalone execution and consensus
+/// deployments.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeReportEvent {
+    /// When ingest accepted the report.
+    pub received_at: DateTime<Utc>,
+    /// The address attributed to the reporting node.
+    pub reported_ip: IpAddr,
+    /// Whether `reported_ip` came from the node or from the connection.
+    pub ip_source: IpSource,
+    /// The report as the node sent it.
+    #[serde(flatten)]
+    pub report: NodeReport,
+}
+
+impl NodeReportEvent {
+    /// Builds an event from a received report, preferring the node's advertised address and
+    /// falling back to the observed edge IP.
+    pub fn new(report: NodeReport, received_at: DateTime<Utc>, observed_ip: IpAddr) -> Self {
+        let (reported_ip, ip_source) = report
+            .net_health
+            .advertised_ip
+            .map_or((observed_ip, IpSource::ServerObserved), |advertised| {
+                (advertised, IpSource::NodeProvided)
+            });
+        Self { received_at, reported_ip, ip_source, report }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use super::*;
+
+    fn sample_report() -> NodeReport {
+        NodeReport {
+            schema_version: NODE_REPORT_SCHEMA_VERSION,
+            telemetry_id: Uuid::from_u128(0x0123_4567_89ab_cdef_0123_4567_89ab_cdef),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_report_round_trips_through_json() {
+        let report = sample_report();
+        let encoded = serde_json::to_string(&report).expect("report should serialize");
+        let decoded: NodeReport =
+            serde_json::from_str(&encoded).expect("report should deserialize");
+        assert_eq!(decoded, report);
+        assert!(decoded.is_current_schema());
+    }
+
+    #[test]
+    fn test_report_uses_snake_case_facet_names() {
+        let encoded = serde_json::to_value(sample_report()).expect("report should serialize");
+        assert!(encoded.get("telemetry_id").is_some(), "identity facet should be snake_case");
+        assert!(
+            encoded.get("client_version").is_some(),
+            "client meta should be flattened to the top level, not nested under `client`"
+        );
+        assert!(
+            encoded.get("client").is_none(),
+            "the `client` wrapper must not appear on the wire"
+        );
+        assert!(encoded["hardware"].get("platform").is_some(), "hardware block should be present");
+        assert!(
+            encoded["net_health"].get("peer_count").is_some(),
+            "network facet should be snake_case"
+        );
+        assert!(
+            encoded["config"].get("p2p_enabled").is_some(),
+            "config facet should be snake_case"
+        );
+    }
+
+    #[test]
+    fn test_absent_optional_fields_are_omitted() {
+        let encoded = serde_json::to_value(sample_report()).expect("report should serialize");
+        assert!(encoded.get("instance_id").is_none(), "unset instance id should be omitted");
+        assert!(
+            encoded["hardware"].get("cpu_model").is_none(),
+            "unset cpu model should be omitted"
+        );
+    }
+
+    #[test]
+    fn test_event_prefers_the_advertised_address() {
+        let advertised = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
+        let observed = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 4));
+        let mut report = sample_report();
+        report.net_health.advertised_ip = Some(advertised);
+
+        let event = NodeReportEvent::new(report, Utc::now(), observed);
+        assert_eq!(event.reported_ip, advertised);
+        assert_eq!(event.ip_source, IpSource::NodeProvided);
+    }
+
+    #[test]
+    fn test_event_falls_back_to_the_observed_address() {
+        let observed = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 4));
+        let event = NodeReportEvent::new(sample_report(), Utc::now(), observed);
+        assert_eq!(event.reported_ip, observed);
+        assert_eq!(event.ip_source, IpSource::ServerObserved);
+    }
+
+    #[test]
+    fn test_the_payload_carries_exactly_the_specified_top_level_keys() {
+        let encoded = serde_json::to_value(sample_report()).expect("report should serialize");
+        let mut keys: Vec<&str> = encoded
+            .as_object()
+            .expect("a report is a JSON object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+
+        assert_eq!(
+            keys,
+            [
+                "client_version",
+                "config",
+                "git_sha",
+                "hardware",
+                "heads",
+                "l2_chain_id",
+                "layer",
+                "net_health",
+                "network",
+                "reported_at",
+                "role",
+                "schema_version",
+                "telemetry_id",
+                "uptime_secs",
+            ],
+            "the flattened client meta must land at the top level and nowhere else"
+        );
+    }
+
+    #[test]
+    fn test_event_flattens_the_report_alongside_server_fields() {
+        let observed = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 4));
+        let event = NodeReportEvent::new(sample_report(), Utc::now(), observed);
+        let encoded = serde_json::to_value(&event).expect("event should serialize");
+
+        assert_eq!(encoded["ip_source"], "server_observed");
+        assert!(
+            encoded.get("telemetry_id").is_some(),
+            "report fields should sit next to server fields, not nested under report"
+        );
+    }
+
+    #[test]
+    fn test_the_event_carries_exactly_the_specified_top_level_keys() {
+        let observed = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 4));
+        let event = NodeReportEvent::new(sample_report(), Utc::now(), observed);
+        let encoded = serde_json::to_value(&event).expect("event should serialize");
+        let mut keys: Vec<&str> = encoded
+            .as_object()
+            .expect("an event is a JSON object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+
+        assert_eq!(
+            keys,
+            [
+                "client_version",
+                "config",
+                "git_sha",
+                "hardware",
+                "heads",
+                "ip_source",
+                "l2_chain_id",
+                "layer",
+                "net_health",
+                "network",
+                "received_at",
+                "reported_at",
+                "reported_ip",
+                "role",
+                "schema_version",
+                "telemetry_id",
+                "uptime_secs",
+            ],
+            "the archived event is the report's keys plus exactly the three the server adds"
+        );
+    }
+
+    #[test]
+    fn test_server_fields_never_shadow_a_flattened_report_field() {
+        // `flatten` merges keys rather than nesting them, and a duplicate key is not an error:
+        // the flattened report simply overwrites the server's value and the event is archived
+        // with a field the server never set. The destructure below is an exhaustiveness
+        // tripwire, not a read - adding a field to `NodeReportEvent` stops compiling here until
+        // the name is listed, and the assertion then proves it does not collide.
+        let NodeReportEvent { received_at: _, reported_ip: _, ip_source: _, report: _ } =
+            NodeReportEvent::new(sample_report(), Utc::now(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        const SERVER_OWNED_FIELDS: [&str; 3] = ["received_at", "reported_ip", "ip_source"];
+
+        let observed = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 4));
+        let report = serde_json::to_value(sample_report()).expect("report should serialize");
+        let report_keys = report.as_object().expect("a report is a JSON object");
+        let event =
+            serde_json::to_value(NodeReportEvent::new(sample_report(), Utc::now(), observed))
+                .expect("event should serialize");
+        let event_keys = event.as_object().expect("an event is a JSON object");
+
+        for field in SERVER_OWNED_FIELDS {
+            assert!(
+                !report_keys.contains_key(field),
+                "`{field}` is owned by the server but the node also sends it, so the server's \
+                 value is dropped and the archive records the node's instead"
+            );
+        }
+
+        for (key, value) in report_keys {
+            assert_eq!(
+                event_keys.get(key),
+                Some(value),
+                "`{key}` did not survive flattening into the event intact"
+            );
+        }
+    }
+}

--- a/crates/common/telemetry-types/src/report.rs
+++ b/crates/common/telemetry-types/src/report.rs
@@ -223,6 +223,11 @@ impl NodeReport {
 /// dropped after enrichment so geography can be re-derived as enrichment datasets improve, and
 /// so it can serve as the correlation key when joining standalone execution and consensus
 /// deployments.
+///
+/// Both addresses are kept. `reported_ip` is the better one to geolocate, because a node behind
+/// a load balancer or inside the reporting VPC is observed at an address that says nothing about
+/// where it runs. `observed_ip` is the one that cannot be forged, so keeping it is what makes a
+/// spoofed or misconfigured advertisement detectable rather than invisible.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NodeReportEvent {
     /// When ingest accepted the report.
@@ -231,6 +236,10 @@ pub struct NodeReportEvent {
     pub reported_ip: IpAddr,
     /// Whether `reported_ip` came from the node or from the connection.
     pub ip_source: IpSource,
+    /// The address the connection actually arrived from.
+    ///
+    /// Equal to `reported_ip` whenever the node advertised nothing.
+    pub observed_ip: IpAddr,
     /// The report as the node sent it.
     #[serde(flatten)]
     pub report: NodeReport,
@@ -246,7 +255,16 @@ impl NodeReportEvent {
             .map_or((observed_ip, IpSource::ServerObserved), |advertised| {
                 (advertised, IpSource::NodeProvided)
             });
-        Self { received_at, reported_ip, ip_source, report }
+        Self { received_at, reported_ip, ip_source, observed_ip, report }
+    }
+
+    /// Returns whether the node advertised an address other than the one it connected from.
+    ///
+    /// True is not by itself a fault: a node behind NAT or a proxy legitimately advertises a
+    /// different address than the edge sees. It is the signal that the two need reconciling
+    /// before either is trusted as the node's location.
+    pub fn addresses_disagree(&self) -> bool {
+        self.reported_ip != self.observed_ip
     }
 }
 
@@ -317,6 +335,11 @@ mod tests {
         let event = NodeReportEvent::new(report, Utc::now(), observed);
         assert_eq!(event.reported_ip, advertised);
         assert_eq!(event.ip_source, IpSource::NodeProvided);
+        assert_eq!(
+            event.observed_ip, observed,
+            "preferring the advertised address must not discard the unforgeable one"
+        );
+        assert!(event.addresses_disagree());
     }
 
     #[test]
@@ -325,6 +348,11 @@ mod tests {
         let event = NodeReportEvent::new(sample_report(), Utc::now(), observed);
         assert_eq!(event.reported_ip, observed);
         assert_eq!(event.ip_source, IpSource::ServerObserved);
+        assert_eq!(event.observed_ip, observed);
+        assert!(
+            !event.addresses_disagree(),
+            "a node that advertised nothing cannot be in disagreement with itself"
+        );
     }
 
     #[test]
@@ -399,6 +427,7 @@ mod tests {
                 "layer",
                 "net_health",
                 "network",
+                "observed_ip",
                 "received_at",
                 "reported_at",
                 "reported_ip",
@@ -407,7 +436,7 @@ mod tests {
                 "telemetry_id",
                 "uptime_secs",
             ],
-            "the archived event is the report's keys plus exactly the three the server adds"
+            "the archived event is the report's keys plus exactly the four the server adds"
         );
     }
 
@@ -418,9 +447,15 @@ mod tests {
         // with a field the server never set. The destructure below is an exhaustiveness
         // tripwire, not a read - adding a field to `NodeReportEvent` stops compiling here until
         // the name is listed, and the assertion then proves it does not collide.
-        let NodeReportEvent { received_at: _, reported_ip: _, ip_source: _, report: _ } =
-            NodeReportEvent::new(sample_report(), Utc::now(), IpAddr::V4(Ipv4Addr::LOCALHOST));
-        const SERVER_OWNED_FIELDS: [&str; 3] = ["received_at", "reported_ip", "ip_source"];
+        let NodeReportEvent {
+            received_at: _,
+            reported_ip: _,
+            ip_source: _,
+            observed_ip: _,
+            report: _,
+        } = NodeReportEvent::new(sample_report(), Utc::now(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        const SERVER_OWNED_FIELDS: [&str; 4] =
+            ["received_at", "reported_ip", "ip_source", "observed_ip"];
 
         let observed = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 4));
         let report = serde_json::to_value(sample_report()).expect("report should serialize");

--- a/crates/consensus/cli/Cargo.toml
+++ b/crates/consensus/cli/Cargo.toml
@@ -32,6 +32,10 @@ base-consensus-node = { workspace = true, features = ["metrics"] }
 base-consensus-providers = { workspace = true, features = ["metrics"] }
 reth-node-core.workspace = true
 
+# telemetry
+base-telemetry-types.workspace = true
+base-telemetry-client.workspace = true
+
 # retry
 backon.workspace = true
 base-retry.workspace = true

--- a/crates/consensus/cli/src/app.rs
+++ b/crates/consensus/cli/src/app.rs
@@ -10,6 +10,7 @@ use crate::{
 
 base_cli_utils::define_log_args!("BASE_NODE");
 base_cli_utils::define_metrics_args!("BASE_NODE", 9090);
+base_cli_utils::define_telemetry_args!("BASE_NODE");
 
 /// The Base Consensus CLI.
 #[derive(Parser, Clone, Debug)]
@@ -88,6 +89,60 @@ mod tests {
         let cli = ConsensusCli::parse_from(["base-consensus", "bootnode-enr"]);
 
         assert!(matches!(cli.command, ConsensusCommands::BootnodeEnr(_)));
+    }
+
+    /// The standalone binary is what the node containers launch, so telemetry flags reaching
+    /// `base-consensus node` is the property that decides whether a deployed node reports at all.
+    #[test]
+    fn node_command_accepts_telemetry_arguments() {
+        let cli = ConsensusCli::parse_from([
+            "base-consensus",
+            "node",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+            "--l2-engine-rpc",
+            "http://localhost:8551",
+            "--telemetry.endpoint",
+            "https://telemetry.example.com/v1/ingest",
+            "--telemetry.report-interval",
+            "120",
+        ]);
+
+        let ConsensusCommands::Node(node) = cli.command else {
+            panic!("expected the node command");
+        };
+        assert_eq!(
+            node.telemetry.endpoint.map(|endpoint| endpoint.to_string()),
+            Some("https://telemetry.example.com/v1/ingest".to_string())
+        );
+        assert_eq!(node.telemetry.report_interval, 120);
+    }
+
+    /// Deployments configure telemetry entirely through the environment, so a rename of these
+    /// variables silently disables reporting rather than failing to start.
+    #[test]
+    fn node_telemetry_arguments_read_the_deployed_environment_variables() {
+        let node = ConsensusCli::command()
+            .get_subcommands()
+            .find(|command| command.get_name() == "node")
+            .expect("node subcommand")
+            .clone();
+        let env_for = |id: &str| {
+            node.get_arguments()
+                .find(|arg| arg.get_id() == id)
+                .and_then(|arg| arg.get_env())
+                .map(|env| env.to_string_lossy().into_owned())
+        };
+
+        assert_eq!(env_for("telemetry_enabled").as_deref(), Some("BASE_NODE_TELEMETRY_ENABLED"));
+        assert_eq!(env_for("telemetry_endpoint").as_deref(), Some("BASE_NODE_TELEMETRY_ENDPOINT"));
+        assert_eq!(env_for("telemetry_data_dir").as_deref(), Some("BASE_NODE_TELEMETRY_DATA_DIR"));
+        assert_eq!(
+            env_for("telemetry_report_interval").as_deref(),
+            Some("BASE_NODE_TELEMETRY_REPORT_INTERVAL")
+        );
     }
 
     #[test]

--- a/crates/consensus/cli/src/lib.rs
+++ b/crates/consensus/cli/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 mod app;
-pub use app::{ConsensusCli, ConsensusCommands, LogArgs, MetricsArgs};
+pub use app::{ConsensusCli, ConsensusCommands, LogArgs, MetricsArgs, TelemetryArgs};
 
 mod bootnode;
 pub use bootnode::{Bootnode, BootnodeEnr, BootnodeP2PArgs, resolve_host};

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -192,6 +192,13 @@ pub struct ConsensusNodeArgs {
 }
 
 impl ConsensusNodeArgs {
+    /// Reported name of the DA batcher sender override, mirroring the `long` name of
+    /// [`L1ClientArgs::l1_da_batcher_sender_override`](crate::L1ClientArgs).
+    ///
+    /// Only the name is ever reported: the value is an L1 address and belongs to the operator.
+    pub const DA_BATCHER_SENDER_OVERRIDE_FLAG: &'static str =
+        "l1.dangerously-override-da-batcher-sender";
+
     /// Creates reusable consensus node arguments from typed chain and node config components.
     pub const fn new(chain: ConsensusChainArgs, config: ConsensusNodeConfigArgs) -> Self {
         Self { chain, config }
@@ -207,16 +214,36 @@ impl ConsensusNodeArgs {
         client: TelemetryConfig,
         metrics_enabled: bool,
     ) -> TelemetryNodeConfig {
+        // Sorted by construction, as the wire contract requires. Names only, never values.
+        let mut experimental_flags = Vec::new();
+        if self.config.l1_rpc_args.l1_da_batcher_sender_override.is_some() {
+            experimental_flags.push(Self::DA_BATCHER_SENDER_OVERRIDE_FLAG.to_string());
+        }
+
         let node_config = NodeConfigReport {
             // A consensus node holds no chain history, so pruning is not a property it has.
             prune_mode: None,
+            // `RollupNodeBuilder` takes a `NetworkConfig` by value and `RollupNode::start` always
+            // spawns the network actor from it. No flag can turn the gossip stack off, so this is
+            // structurally true for every consensus node; only discovery is optional.
             p2p_enabled: true,
             discovery_enabled: !self.config.p2p_flags.no_discovery,
             sequencer_enabled: self.config.node_mode.is_sequencer(),
+            // Nothing in `ConsensusNodeConfigArgs` configures an interop supervisor, and the
+            // consensus service has no supervisor integration to enable. Read this from config
+            // once one exists.
             supervisor_enabled: false,
+            // Flashblocks are an execution-side concern: `--flashblocks-url` in
+            // `base-flashblocks-node` and `--flashblocks.port` in `base-builder-cli`. A consensus
+            // node neither produces nor consumes them.
             flashblocks_enabled: false,
             metrics_enabled,
-            experimental_flags: Vec::new(),
+            // The names of the non-default, protocol-affecting flags this node runs with, so a
+            // fleet view can tell which nodes are running something unusual. Names only: the DA
+            // batcher sender override carries an address, and reporting it would leak operator
+            // configuration. Anyone adding such a flag to `ConsensusNodeConfigArgs`, or to an
+            // argument group it flattens, pushes its name here when it is enabled.
+            experimental_flags,
             report_interval_secs: client.report_interval.as_secs(),
             sample_interval_secs: client.sample_interval.as_secs(),
         };
@@ -1028,5 +1055,59 @@ mod tests {
         assert_eq!(config.rpc_flags.listen_port, 9546);
         assert!(config.sequencer_flags.stopped);
         assert_eq!(config.sequencer_flags.conductor_rpc, Some(conductor_rpc));
+    }
+
+    #[rstest]
+    #[case::override_set(
+        Some(address!("2222222222222222222222222222222222222222")),
+        vec![ConsensusNodeArgs::DA_BATCHER_SENDER_OVERRIDE_FLAG.to_string()]
+    )]
+    #[case::override_unset(None, Vec::new())]
+    fn reports_da_batcher_sender_override_by_name(
+        #[case] da_batcher_sender_override: Option<Address>,
+        #[case] expected: Vec<String>,
+    ) {
+        let args = ConsensusNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            ConsensusNodeConfigArgs {
+                l1_rpc_args: L1ClientArgs {
+                    l1_da_batcher_sender_override: da_batcher_sender_override,
+                    ..L1ClientArgs::default()
+                },
+                ..default_node_config_args()
+            },
+        );
+
+        let report = args
+            .telemetry_node_config(
+                TelemetryConfig::disabled(PathBuf::from("/tmp/telemetry-id")),
+                false,
+            )
+            .node_config;
+
+        assert_eq!(report.experimental_flags, expected);
+    }
+
+    /// The reported name is a copy of the clap `long` name, so it can silently drift from the
+    /// flag it describes. Parsing the CLI with the reported name proves it has not.
+    #[test]
+    fn reported_da_batcher_flag_name_matches_the_cli_flag() {
+        let args = CommandParser::<ConsensusNodeConfigArgs>::parse_from([
+            "base-consensus",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+            "--l2-engine-rpc",
+            "http://localhost:8551",
+            &format!("--{}", ConsensusNodeArgs::DA_BATCHER_SENDER_OVERRIDE_FLAG),
+            "0x2222222222222222222222222222222222222222",
+        ])
+        .args;
+
+        assert_eq!(
+            args.l1_rpc_args.l1_da_batcher_sender_override,
+            Some(address!("2222222222222222222222222222222222222222"))
+        );
     }
 }

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -8,9 +8,11 @@ use base_cli_utils::{LogConfig, RuntimeManager};
 use base_common_chains::ChainConfig;
 use base_common_genesis::RollupConfig;
 use base_consensus_node::{
-    EngineConfig, L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder,
+    EngineConfig, L1ConfigBuilder, NodeMode, RollupNode, RollupNodeBuilder, TelemetryNodeConfig,
     UpgradeSignalBuilderConfig,
 };
+use base_telemetry_client::TelemetryConfig;
+use base_telemetry_types::{NetworkName, NodeConfigReport};
 use base_upgrade_signal::{
     UpgradeSignalArgs, UpgradeSignalConfig, UpgradeSignalMetricLayer, UpgradeSignalRuntimeApplier,
     UpgradeSignalSchedule, UpgradeSignalStartupMode,
@@ -126,6 +128,8 @@ pub struct ConsensusNodeStartOptions {
     pub cancellation: CancellationToken,
     /// Startup behavior for contract-backed upgrade signal application.
     pub upgrade_signal_startup_mode: UpgradeSignalStartupMode,
+    /// Telemetry settings, or `None` when this node reports nothing.
+    pub telemetry: Option<TelemetryNodeConfig>,
 }
 
 impl ConsensusNodeStartOptions {
@@ -136,6 +140,7 @@ impl ConsensusNodeStartOptions {
             overrides: ConsensusNodeOverrides::default(),
             cancellation: CancellationToken::new(),
             upgrade_signal_startup_mode: UpgradeSignalStartupMode::ReadAndApply,
+            telemetry: None,
         }
     }
 
@@ -156,6 +161,11 @@ impl ConsensusNodeStartOptions {
     ) -> Self {
         Self { upgrade_signal_startup_mode, ..self }
     }
+
+    /// Sets the telemetry settings for the node.
+    pub fn with_telemetry(self, telemetry: Option<TelemetryNodeConfig>) -> Self {
+        Self { telemetry, ..self }
+    }
 }
 
 /// Consensus node arguments shared by the standalone and unified binaries.
@@ -174,6 +184,37 @@ impl ConsensusNodeArgs {
     /// Creates reusable consensus node arguments from typed chain and node config components.
     pub const fn new(chain: ConsensusChainArgs, config: ConsensusNodeConfigArgs) -> Self {
         Self { chain, config }
+    }
+
+    /// Builds the telemetry settings for this node from resolved client settings.
+    ///
+    /// Only the allowlisted, normalized values in [`NodeConfigReport`] are reported. The raw
+    /// command line is never sent: it carries L1 RPC URLs with credentials, JWT paths, and
+    /// signer endpoints.
+    pub fn telemetry_node_config(
+        &self,
+        client: TelemetryConfig,
+        metrics_enabled: bool,
+    ) -> TelemetryNodeConfig {
+        let node_config = NodeConfigReport {
+            // A consensus node holds no chain history, so pruning is not a property it has.
+            prune_mode: None,
+            p2p_enabled: true,
+            discovery_enabled: !self.config.p2p_flags.no_discovery,
+            sequencer_enabled: self.config.node_mode.is_sequencer(),
+            supervisor_enabled: false,
+            flashblocks_enabled: false,
+            metrics_enabled,
+            experimental_flags: Vec::new(),
+            report_interval_secs: client.report_interval.as_secs(),
+            sample_interval_secs: client.sample_interval.as_secs(),
+        };
+        TelemetryNodeConfig::new(
+            client,
+            env!("CARGO_PKG_VERSION").to_string(),
+            NetworkName::for_chain_id(self.chain.l2_chain_id.id()),
+            node_config,
+        )
     }
 }
 
@@ -405,6 +446,7 @@ impl ConsensusNodeArgs {
             cfg,
             overrides,
             UpgradeSignalStartupMode::ReadAndApply,
+            None,
         )
         .await
     }
@@ -415,6 +457,7 @@ impl ConsensusNodeArgs {
         mut cfg: RollupConfig,
         overrides: ConsensusNodeOverrides,
         startup_mode: UpgradeSignalStartupMode,
+        telemetry: Option<TelemetryNodeConfig>,
     ) -> eyre::Result<RollupNode> {
         self.validate_sequencer_key()?;
         self.validate_da_batcher_sender_override()?;
@@ -507,7 +550,8 @@ impl ConsensusNodeArgs {
         .with_upgrade_signal_config(UpgradeSignalBuilderConfig {
             metrics_config: upgrade_signal_config,
             l1_rpc: upgrade_signal_l1_rpc,
-        });
+        })
+        .with_telemetry_config(telemetry);
 
         if let Some(interval) = self.config.l1_rpc_args.l1_finalized_poll_interval {
             builder = builder.with_finalized_poll_interval(interval);
@@ -601,11 +645,13 @@ impl ConsensusNodeArgs {
             overrides,
             cancellation,
             upgrade_signal_startup_mode,
+            telemetry,
         } = options;
         self.build_rollup_node_with_overrides_and_upgrade_signal_startup(
             rollup_config,
             overrides,
             upgrade_signal_startup_mode,
+            telemetry,
         )
         .await?
         .start_with_cancellation(cancellation)

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -28,7 +28,7 @@ use url::Url;
 use crate::{
     ConsensusChainArgs, EmbeddedL2ClientArgs, EmbeddedP2PArgs, EmbeddedRpcArgs, L1ClientArgs,
     L1ConfigFile, L2ClientArgs, L2ConfigFile, LogArgs, MetricsArgs, P2PArgs, RpcArgs,
-    SequencerArgs, metrics::CliMetrics,
+    SequencerArgs, TelemetryArgs, metrics::CliMetrics,
 };
 
 /// Overrides supplied by callers that embed consensus alongside another service.
@@ -73,6 +73,10 @@ pub struct ConsensusNodeCommand {
     #[command(flatten)]
     pub traces: TraceArgs,
 
+    /// Telemetry configuration.
+    #[command(flatten)]
+    pub telemetry: TelemetryArgs,
+
     /// Consensus node arguments.
     #[command(flatten)]
     pub args: ConsensusNodeConfigArgs,
@@ -93,6 +97,10 @@ impl ConsensusNodeCommand {
         }
 
         let metrics_enabled = self.metrics.enabled;
+        let telemetry = args.telemetry_node_config(
+            self.telemetry.config(args.chain.l2_chain_id.id()),
+            metrics_enabled,
+        );
         let rt = RuntimeManager::new().tokio_runtime()?;
         // Build the subscriber — including the gRPC OTLP layer — inside the main runtime
         // so tonic's transport channel lives for the full program lifetime (reth pattern).
@@ -110,7 +118,10 @@ impl ConsensusNodeCommand {
                 res = async move {
                     let _upgrade_countdown_metrics = metrics_enabled
                         .then(|| CliMetrics::spawn_upgrade_countdown_recorder(cfg.clone()));
-                    args.start_with_overrides(cfg, Default::default()).await
+                    args.start_with_options(
+                        ConsensusNodeStartOptions::new(cfg).with_telemetry(Some(telemetry)),
+                    )
+                    .await
                 } => res,
             }
         })

--- a/crates/consensus/peers/src/boot.rs
+++ b/crates/consensus/peers/src/boot.rs
@@ -64,6 +64,23 @@ impl BootNode {
         }
     }
 
+    /// Returns the routable address this record advertises, when it carries one.
+    ///
+    /// This is the address the node tells the network to reach it on, which is not necessarily
+    /// the address a given connection arrives from: a node behind NAT, a load balancer, or a
+    /// private subnet is observed at one address and reachable at another. `IPv4` is preferred
+    /// because a record carrying both is reached over `IPv4` by the majority of the network.
+    pub fn advertised_ip(&self) -> Option<IpAddr> {
+        match self {
+            Self::Enr(enr) => enr.ip4().map(IpAddr::V4).or_else(|| enr.ip6().map(IpAddr::V6)),
+            Self::Enode(addr) => addr.iter().find_map(|protocol| match protocol {
+                Protocol::Ip4(ip) => Some(IpAddr::V4(ip)),
+                Protocol::Ip6(ip) => Some(IpAddr::V6(ip)),
+                _ => None,
+            }),
+        }
+    }
+
     /// Helper method to parse a bootnode from a string.
     pub fn parse_bootnode(raw: &str) -> Result<Self, BootNodeParseError> {
         // If the string starts with "enr:" it is an ENR record.
@@ -90,6 +107,24 @@ mod tests {
 
     use super::*;
     use crate::PeerUtils;
+
+    /// A real Base ENR, reused across the tree as the canonical parseable record.
+    const SAMPLE_ENR: &str = "enr:-J64QBbwPjPLZ6IOOToOLsSjtFUjjzN66qmBZdUexpO32Klrc458Q24kbty2PdRaLacHM5z-cZQr8mjeQu3pik6jPSOGAYYFIqBfgmlkgnY0gmlwhDaRWFWHb3BzdGFja4SzlAUAiXNlY3AyNTZrMaECmeSnJh7zjKrDSPoNMGXoopeDF4hhpj5I0OsQUUt4u8uDdGNwgiQGg3VkcIIkBg";
+
+    #[test]
+    fn test_signed_record_advertises_its_ip() {
+        let boot_node = BootNode::parse_bootnode(SAMPLE_ENR).unwrap();
+
+        assert_eq!(boot_node.advertised_ip(), Some(IpAddr::V4(Ipv4Addr::new(54, 145, 88, 85))));
+    }
+
+    #[test]
+    fn test_unsigned_record_advertises_its_ip() {
+        let enode = "enode://2bd2e657bb3c8efffb8ff6db9071d9eb7be70d7c6d7d980ff80fc93b2629675c5f750bc0a5ef27cd788c2e491b8795a7e9a4a6e72178c14acc6753c0e5d77ae4@34.65.205.244:30305";
+        let boot_node = BootNode::parse_bootnode(enode).unwrap();
+
+        assert_eq!(boot_node.advertised_ip(), Some(IpAddr::V4(Ipv4Addr::new(34, 65, 205, 244))));
+    }
 
     #[test]
     fn test_derive_bootnode_enode_multiaddr() {

--- a/crates/consensus/service/Cargo.toml
+++ b/crates/consensus/service/Cargo.toml
@@ -16,6 +16,8 @@ base-health.workspace = true
 base-metrics.workspace = true
 base-protocol.workspace = true
 base-upgrade-signal.workspace = true
+base-telemetry-types.workspace = true
+base-telemetry-client.workspace = true
 base-consensus-disc.workspace = true
 base-consensus-peers.workspace = true
 base-consensus-gossip.workspace = true
@@ -98,6 +100,7 @@ metrics-util = { workspace = true, features = ["debugging"] }
 base-common-genesis = { workspace = true, features = ["test-utils"] }
 base-consensus-derive = { workspace = true, features = ["test-utils"] }
 base-consensus-engine = { workspace = true, features = ["test-utils"] }
+base-telemetry-client = { workspace = true, features = ["test-utils"] }
 alloy-consensus = { workspace = true, features = ["arbitrary", "std"] }
 base-common-consensus = { workspace = true, features = ["arbitrary", "k256"] }
 alloy-rpc-types-engine = { workspace = true, features = ["arbitrary", "std"] }

--- a/crates/consensus/service/src/actors/mod.rs
+++ b/crates/consensus/service/src/actors/mod.rs
@@ -47,6 +47,11 @@ pub use l1_watcher::{
 mod upgrade_signal;
 pub use upgrade_signal::{UpgradeSignalMetricsActor, UpgradeSignalNodeConfig};
 
+mod telemetry;
+pub use telemetry::{
+    P2P_QUERY_TIMEOUT, TelemetryActor, TelemetryNodeConfig, TelemetryNodeFacts, TelemetrySources,
+};
+
 mod network;
 #[cfg(test)]
 pub use network::MockUnsafePayloadGossipClient;

--- a/crates/consensus/service/src/actors/telemetry.rs
+++ b/crates/consensus/service/src/actors/telemetry.rs
@@ -1,0 +1,709 @@
+//! Node telemetry reporting actor.
+
+use std::{
+    collections::HashSet,
+    convert::Infallible,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use base_consensus_engine::EngineState;
+use base_consensus_gossip::{P2pRpcRequest, PeerDump, PeerInfo};
+use base_telemetry_client::{
+    HttpReportSink, LatencySampler, NodeIdentity, NodeReportBuilder, TelemetryConfig, TelemetryId,
+    TelemetryReporter,
+};
+use base_telemetry_types::{Heads, NetHealth, NodeConfigReport, NodeLayer, NodeRole};
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+use crate::NodeActor;
+
+/// How long a single p2p RPC round trip may take before the field is reported as absent.
+///
+/// A wedged network actor must cost telemetry one field, never a reporting cycle.
+pub const P2P_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Node facts derived by [`RollupNode`] at startup rather than supplied on the command line.
+///
+/// [`RollupNode`]: crate::RollupNode
+#[derive(Debug, Clone)]
+pub struct TelemetryNodeFacts {
+    /// The L2 chain ID this node follows.
+    pub l2_chain_id: u64,
+    /// Whether this node sequences, validates, or follows.
+    pub role: NodeRole,
+    /// Directory whose filesystem is measured for the disk fields, when there is one.
+    pub data_dir: Option<PathBuf>,
+    /// Configured maximum established connections, reported as the peer target.
+    pub peer_target: Option<u32>,
+}
+
+/// The live in-process sources the telemetry actor reads each cycle.
+///
+/// Every value in a report comes from typed node state rather than a rendered metrics registry,
+/// so a metric rename cannot silently empty the payload.
+#[derive(Debug, Clone)]
+pub struct TelemetrySources {
+    /// Chain head state published by the engine actor.
+    pub engine_state: watch::Receiver<EngineState>,
+    /// Request channel into the network actor.
+    pub p2p_rpc: mpsc::Sender<P2pRpcRequest>,
+    /// Cancellation token shared with the rollup node.
+    pub cancellation: CancellationToken,
+}
+
+/// Telemetry settings resolved for a running consensus node.
+///
+/// Holds what the command line settles. Everything the node derives for itself arrives
+/// separately as [`TelemetryNodeFacts`].
+#[derive(Debug, Clone)]
+pub struct TelemetryNodeConfig {
+    /// Transport, cadence, and identity-file settings.
+    pub client: TelemetryConfig,
+    /// Client version reported as `client.client_version`.
+    pub version: String,
+    /// Human-readable network name, e.g. `mainnet`.
+    pub network: String,
+    /// Allowlisted snapshot of the node's configuration.
+    pub node_config: NodeConfigReport,
+}
+
+impl TelemetryNodeConfig {
+    /// Creates telemetry settings for a node running `version` on `network`.
+    pub const fn new(
+        client: TelemetryConfig,
+        version: String,
+        network: String,
+        node_config: NodeConfigReport,
+    ) -> Self {
+        Self { client, version, network, node_config }
+    }
+
+    /// Builds the telemetry actor, or `None` when this node will not report.
+    ///
+    /// Returns `None` when telemetry is switched off, when no endpoint is configured, and when
+    /// the identity or the HTTP sink cannot be constructed. Every one of those is a warning and
+    /// a disabled reporter rather than a startup failure: a node that cannot report telemetry is
+    /// still a working node.
+    pub fn actor(
+        &self,
+        facts: TelemetryNodeFacts,
+        sources: TelemetrySources,
+    ) -> Option<TelemetryActor> {
+        if !self.client.is_active() {
+            return None;
+        }
+        let endpoint = self.client.endpoint.clone()?;
+
+        let telemetry_id = match TelemetryId::load_or_create(&self.client.id_path) {
+            Ok(id) => id,
+            Err(error) => {
+                warn!(
+                    target: "telemetry",
+                    error = %error,
+                    "could not establish a telemetry identity; telemetry is off for this run"
+                );
+                return None;
+            }
+        };
+
+        let sink = match HttpReportSink::new(endpoint, self.client.request_timeout) {
+            Ok(sink) => sink,
+            Err(error) => {
+                warn!(
+                    target: "telemetry",
+                    error = %error,
+                    "could not build the telemetry sink; telemetry is off for this run"
+                );
+                return None;
+            }
+        };
+
+        let identity = NodeIdentity {
+            telemetry_id,
+            instance_id: self.client.instance_id.clone(),
+            client_version: self.version.clone(),
+            l2_chain_id: facts.l2_chain_id,
+            network: self.network.clone(),
+            layer: NodeLayer::Consensus,
+            role: facts.role,
+            data_dir: facts.data_dir,
+        };
+        let reporter = TelemetryReporter::spawn(
+            Arc::new(sink),
+            self.client.retry,
+            self.client.queue_capacity,
+            sources.cancellation.clone(),
+        );
+
+        Some(TelemetryActor::new(
+            &self.client,
+            NodeReportBuilder::new(identity, self.node_config.clone()),
+            reporter,
+            sources,
+            facts.peer_target,
+        ))
+    }
+}
+
+/// Actor that samples node health and periodically enqueues a report for delivery.
+///
+/// Two cadences share one loop. Sampling records a head-lag point and refreshes the connected
+/// peer set; reporting drains the accumulated window into a payload and hands it to the
+/// [`TelemetryReporter`], which owns delivery and retry.
+#[derive(Debug)]
+pub struct TelemetryActor {
+    /// Assembles the fixed and per-cycle halves of a report.
+    builder: NodeReportBuilder,
+    /// Queue in front of the sink; never blocks this actor.
+    reporter: TelemetryReporter,
+    /// Head-lag samples accumulated since the last report.
+    sampler: LatencySampler,
+    /// Live node state read each cycle.
+    sources: TelemetrySources,
+    /// Configured maximum established connections.
+    peer_target: Option<u32>,
+    /// Connected peer IDs as of the last sample, used to derive churn.
+    connected_peers: HashSet<String>,
+    /// Peers that appeared since the last report.
+    peers_joined: u32,
+    /// Peers that disappeared since the last report.
+    peers_left: u32,
+    /// Interval between head-lag samples.
+    sample_interval: Duration,
+    /// Interval between reports.
+    report_interval: Duration,
+}
+
+impl TelemetryActor {
+    /// Creates a telemetry actor from a resolved report builder and the node's live sources.
+    pub fn new(
+        config: &TelemetryConfig,
+        builder: NodeReportBuilder,
+        reporter: TelemetryReporter,
+        sources: TelemetrySources,
+        peer_target: Option<u32>,
+    ) -> Self {
+        Self {
+            builder,
+            reporter,
+            sampler: LatencySampler::new(config.samples_per_report()),
+            sources,
+            peer_target,
+            connected_peers: HashSet::new(),
+            peers_joined: 0,
+            peers_left: 0,
+            sample_interval: config.sample_interval,
+            report_interval: config.report_interval,
+        }
+    }
+
+    /// Records one head-lag sample and folds in peer churn since the previous sample.
+    pub async fn sample(&mut self) {
+        if let Some(latency_secs) = self.unsafe_head_latency_secs() {
+            self.sampler.record(latency_secs);
+        }
+        if let Some(peers) = self.connected_peer_ids().await {
+            self.fold_peer_churn(peers);
+        }
+    }
+
+    /// Builds a report from the accumulated window and enqueues it for delivery.
+    pub async fn report(&mut self) {
+        if let Some(peers) = self.connected_peer_ids().await {
+            self.fold_peer_churn(peers);
+        }
+
+        let mut heads = self.heads();
+        self.sampler.drain().apply(&mut heads);
+        let net = self.net_health().await;
+
+        debug!(
+            target: "telemetry",
+            unsafe_block = heads.unsafe_block,
+            unsafe_latency_secs = heads.unsafe_latency_secs,
+            peer_count = net.peer_count,
+            "enqueueing telemetry report"
+        );
+        self.reporter.enqueue(self.builder.build(heads, net));
+    }
+
+    /// Returns the current head numbers, without the latency fields the sampler owns.
+    pub fn heads(&self) -> Heads {
+        let sync_state = self.sources.engine_state.borrow().sync_state;
+        Heads {
+            unsafe_block: sync_state.unsafe_head().block_info.number,
+            local_safe_block: Self::known_head(sync_state.local_safe_head().block_info.number),
+            safe_block: Self::known_head(sync_state.safe_head().block_info.number),
+            finalized_block: Self::known_head(sync_state.finalized_head().block_info.number),
+            ..Default::default()
+        }
+    }
+
+    /// Returns a head number the engine has actually established, or `None` at the zero value.
+    ///
+    /// The engine reports zero for a head it has not derived yet, which is also a real block
+    /// number. Reporting `None` keeps a node that restarted minutes ago distinguishable from one
+    /// genuinely sitting at genesis, which is the difference between a healthy rollout and an
+    /// outage on every dashboard downstream.
+    pub const fn known_head(number: u64) -> Option<u64> {
+        if number == 0 { None } else { Some(number) }
+    }
+
+    /// Returns wall-clock seconds behind the unsafe head, or `None` before the engine has one.
+    ///
+    /// The engine publishes a zeroed head until it learns a real one, and the seconds since the
+    /// unix epoch is not a head-lag measurement worth reporting.
+    pub fn unsafe_head_latency_secs(&self) -> Option<f64> {
+        let head = self.sources.engine_state.borrow().sync_state.unsafe_head();
+        (head.block_info.number != 0).then(|| Self::seconds_since(head.block_info.timestamp))
+    }
+
+    /// Returns seconds elapsed since a block timestamp, clamped at zero.
+    ///
+    /// A head timestamp in the future is clock skew, not negative lag.
+    pub fn seconds_since(block_timestamp: u64) -> f64 {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        now.saturating_sub(block_timestamp) as f64
+    }
+
+    /// Accumulates joins and departures against the previously observed peer set.
+    ///
+    /// The actor starts with an empty set, so the first fold counts the node's initial peers as
+    /// joins. That is the honest reading of "peers joined since this reporter started".
+    pub fn fold_peer_churn(&mut self, current: HashSet<String>) {
+        self.peers_joined += current.difference(&self.connected_peers).count() as u32;
+        self.peers_left += self.connected_peers.difference(&current).count() as u32;
+        self.connected_peers = current;
+    }
+
+    /// Builds the network half of a report, resetting the churn counters.
+    ///
+    /// `advertised_ip` is deliberately left unset: the ingest server records the address it
+    /// observed, which is the one that actually reached it.
+    pub async fn net_health(&mut self) -> NetHealth {
+        let peer_info = self.local_peer_info().await;
+        NetHealth {
+            peer_count: self.connected_peers.len() as u32,
+            peer_target: self.peer_target,
+            discovered_count: self.discovered_peer_count().await,
+            peers_joined: std::mem::take(&mut self.peers_joined),
+            peers_left: std::mem::take(&mut self.peers_left),
+            peer_id: peer_info.as_ref().map(|info| info.peer_id.clone()),
+            enr: peer_info.and_then(|info| info.enr),
+            advertised_ip: None,
+            gossip_error_rate: None,
+            rpc_error_rate: None,
+        }
+    }
+
+    /// Returns the IDs of the currently connected peers.
+    pub async fn connected_peer_ids(&self) -> Option<HashSet<String>> {
+        let dump: PeerDump =
+            self.query_p2p(|out| P2pRpcRequest::Peers { out, connected: true }).await?;
+        Some(dump.peers.into_keys().collect())
+    }
+
+    /// Returns how many peers discovery currently knows about.
+    pub async fn discovered_peer_count(&self) -> Option<u32> {
+        let (discovered, _gossip) = self.query_p2p(P2pRpcRequest::PeerCount).await?;
+        discovered.map(|count| count as u32)
+    }
+
+    /// Returns this node's own peer identity.
+    pub async fn local_peer_info(&self) -> Option<PeerInfo> {
+        self.query_p2p(P2pRpcRequest::PeerInfo).await
+    }
+
+    /// Sends one p2p RPC request and awaits its reply, giving up after [`P2P_QUERY_TIMEOUT`].
+    pub async fn query_p2p<T, F>(&self, request: F) -> Option<T>
+    where
+        T: Send,
+        F: FnOnce(oneshot::Sender<T>) -> P2pRpcRequest,
+    {
+        let (tx, rx) = oneshot::channel();
+        let request = request(tx);
+        let exchange = async {
+            self.sources.p2p_rpc.send(request).await.ok()?;
+            rx.await.ok()
+        };
+
+        tokio::time::timeout(P2P_QUERY_TIMEOUT, exchange).await.unwrap_or_else(|_| {
+            debug!(target: "telemetry", "p2p query timed out; omitting the field");
+            None
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl NodeActor for TelemetryActor {
+    type StartData = ();
+    type Error = Infallible;
+
+    /// Runs the sample and report cadences until the node shuts down.
+    ///
+    /// This function must not return while the node is running. `spawn_and_wait!` installs a
+    /// [`CancellationToken`] drop guard per actor task, so returning at all — `Ok` included —
+    /// cancels every other actor and stops the node. Telemetry failures are logged and
+    /// swallowed; the only exit is cancellation, at which point the node is already stopping.
+    async fn start(mut self, _ctx: ()) -> Result<(), Self::Error> {
+        let cancellation = self.sources.cancellation.clone();
+
+        let mut sample_tick = tokio::time::interval(self.sample_interval);
+        sample_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // The first report waits a full interval. Reporting immediately would publish a payload
+        // assembled before the engine has a head or the network has a peer.
+        let mut report_tick = tokio::time::interval_at(
+            tokio::time::Instant::now() + self.report_interval,
+            self.report_interval,
+        );
+        report_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                _ = cancellation.cancelled() => return Ok(()),
+                _ = sample_tick.tick() => {
+                    tokio::select! {
+                        _ = cancellation.cancelled() => return Ok(()),
+                        () = self.sample() => {}
+                    }
+                }
+                _ = report_tick.tick() => {
+                    tokio::select! {
+                        _ = cancellation.cancelled() => return Ok(()),
+                        () = self.report() => {}
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    };
+
+    use base_consensus_engine::{EngineSyncState, EngineSyncStateUpdate};
+    use base_protocol::L2BlockInfo;
+    use base_telemetry_client::{MockReportSink, ReportSink, ReportSinkError};
+    use base_telemetry_types::PruneMode;
+    use tempfile::TempDir;
+    use url::Url;
+
+    use super::*;
+
+    /// Answers p2p RPC queries with a fixed peer set for as long as the channel stays open.
+    ///
+    /// Hand-rolled rather than mocked: the actor talks to the network over a channel of enum
+    /// requests, not through a trait `automock` can stand in for.
+    fn spawn_fake_p2p(connected: &[&str]) -> mpsc::Sender<P2pRpcRequest> {
+        let connected: Vec<String> = connected.iter().map(|peer| (*peer).to_string()).collect();
+        let (tx, mut rx) = mpsc::channel(16);
+        tokio::spawn(async move {
+            while let Some(request) = rx.recv().await {
+                match request {
+                    P2pRpcRequest::Peers { out, .. } => {
+                        let mut dump = PeerDump {
+                            total_connected: connected.len() as u32,
+                            ..Default::default()
+                        };
+                        for peer in &connected {
+                            dump.peers.insert(peer.clone(), PeerInfo::default());
+                        }
+                        let _ = out.send(dump);
+                    }
+                    P2pRpcRequest::PeerCount(out) => {
+                        let _ = out.send((Some(42), connected.len()));
+                    }
+                    P2pRpcRequest::PeerInfo(out) => {
+                        let _ = out.send(PeerInfo {
+                            peer_id: "local-peer".to_string(),
+                            enr: Some("enr:local".to_string()),
+                            ..Default::default()
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        });
+        tx
+    }
+
+    /// Publishes an engine state whose unsafe head is `number` blocks in, `lag_secs` behind now.
+    fn engine_state(number: u64, lag_secs: u64) -> watch::Receiver<EngineState> {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        let mut head = L2BlockInfo::default();
+        head.block_info.number = number;
+        head.block_info.timestamp = now.saturating_sub(lag_secs);
+        let sync_state = EngineSyncState::default()
+            .updated(EngineSyncStateUpdate { unsafe_head: Some(head), ..Default::default() });
+        watch::channel(EngineState { sync_state, el_sync_finished: true }).1
+    }
+
+    fn config(id_path: PathBuf) -> TelemetryConfig {
+        TelemetryConfig {
+            report_interval: Duration::from_secs(10),
+            sample_interval: Duration::from_secs(1),
+            ..TelemetryConfig::disabled(id_path)
+        }
+    }
+
+    fn node_config() -> TelemetryNodeConfig {
+        TelemetryNodeConfig::new(
+            config(PathBuf::from("/telemetry-id-should-not-be-written")),
+            "1.2.3".to_string(),
+            "devnet".to_string(),
+            NodeConfigReport { prune_mode: Some(PruneMode::Archive), ..Default::default() },
+        )
+    }
+
+    fn facts() -> TelemetryNodeFacts {
+        TelemetryNodeFacts {
+            l2_chain_id: 8453,
+            role: NodeRole::Validator,
+            data_dir: None,
+            peer_target: Some(64),
+        }
+    }
+
+    fn sources(
+        engine_state: watch::Receiver<EngineState>,
+        p2p_rpc: mpsc::Sender<P2pRpcRequest>,
+    ) -> TelemetrySources {
+        TelemetrySources { engine_state, p2p_rpc, cancellation: CancellationToken::new() }
+    }
+
+    /// Builds an actor whose sink behaves as `sink` dictates.
+    fn actor(sink: MockReportSink, sources: TelemetrySources) -> TelemetryActor {
+        let client = config(PathBuf::from("/unused"));
+        let reporter = TelemetryReporter::spawn(
+            Arc::new(sink),
+            client.retry,
+            client.queue_capacity,
+            sources.cancellation.clone(),
+        );
+        let identity = NodeIdentity {
+            telemetry_id: TelemetryId::generate(),
+            instance_id: None,
+            client_version: "1.2.3".to_string(),
+            l2_chain_id: 8453,
+            network: "devnet".to_string(),
+            layer: NodeLayer::Consensus,
+            role: NodeRole::Validator,
+            data_dir: None,
+        };
+        TelemetryActor::new(
+            &client,
+            NodeReportBuilder::new(identity, NodeConfigReport::default()),
+            reporter,
+            sources,
+            Some(64),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_a_config_without_an_endpoint_builds_no_actor_and_mints_no_identity() {
+        let dir = TempDir::new().expect("temp dir");
+        let id_path = dir.path().join("telemetry-id");
+        let mut telemetry = node_config();
+        telemetry.client = config(id_path.clone());
+
+        let sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]));
+        assert!(telemetry.actor(facts(), sources).is_none());
+        assert!(
+            !id_path.exists(),
+            "a node that will never report must not become identifiable on disk"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_opting_out_builds_no_actor_even_with_an_endpoint() {
+        let dir = TempDir::new().expect("temp dir");
+        let mut telemetry = node_config();
+        telemetry.client = TelemetryConfig {
+            enabled: false,
+            endpoint: Some(Url::parse("http://127.0.0.1:1/v1/ingest").expect("valid url")),
+            ..config(dir.path().join("telemetry-id"))
+        };
+
+        let sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]));
+        assert!(telemetry.actor(facts(), sources).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_an_endpoint_builds_an_actor_and_mints_an_identity() {
+        let dir = TempDir::new().expect("temp dir");
+        let id_path = dir.path().join("nested").join("telemetry-id");
+        let mut telemetry = node_config();
+        telemetry.client = TelemetryConfig {
+            endpoint: Some(Url::parse("http://127.0.0.1:1/v1/ingest").expect("valid url")),
+            ..config(id_path.clone())
+        };
+
+        let sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]));
+        assert!(telemetry.actor(facts(), sources).is_some());
+        assert!(id_path.exists(), "the identity is minted once, on the first reporting run");
+    }
+
+    #[tokio::test]
+    async fn test_peer_churn_is_measured_against_the_previous_sample() {
+        let sources = sources(engine_state(10, 2), mpsc::channel(1).0);
+        let mut actor = actor(MockReportSink::new(), sources);
+
+        actor.fold_peer_churn(["a", "b"].iter().map(ToString::to_string).collect());
+        assert_eq!((actor.peers_joined, actor.peers_left), (2, 0));
+
+        actor.fold_peer_churn(["b", "c", "d"].iter().map(ToString::to_string).collect());
+        assert_eq!(
+            (actor.peers_joined, actor.peers_left),
+            (4, 1),
+            "churn accumulates across samples and is only reset when a report is built"
+        );
+        assert_eq!(actor.connected_peers.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_latency_is_absent_until_the_engine_has_a_head() {
+        let headless =
+            actor(MockReportSink::new(), sources(engine_state(0, 0), mpsc::channel(1).0));
+        assert_eq!(
+            headless.unsafe_head_latency_secs(),
+            None,
+            "a zeroed head must not be reported as decades of lag"
+        );
+
+        let synced = actor(MockReportSink::new(), sources(engine_state(10, 7), mpsc::channel(1).0));
+        assert!(synced.unsafe_head_latency_secs().is_some_and(|secs| (6.0..=9.0).contains(&secs)));
+    }
+
+    #[test]
+    fn test_a_head_timestamp_in_the_future_reads_as_zero_lag() {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        assert_eq!(TelemetryActor::seconds_since(now + 600), 0.0);
+    }
+
+    #[tokio::test]
+    async fn test_a_report_carries_heads_peers_and_identity() {
+        let delivered = Arc::new(AtomicU64::new(0));
+        let (report_tx, mut report_rx) = mpsc::channel(4);
+        let mut sink = MockReportSink::new();
+        let counter = Arc::clone(&delivered);
+        sink.expect_send().returning(move |report| {
+            counter.fetch_add(1, Ordering::Relaxed);
+            report_tx.try_send(report.clone()).expect("test channel has room");
+            Box::pin(async { Ok(()) })
+        });
+
+        let sources = sources(engine_state(1_234, 3), spawn_fake_p2p(&["peer-a", "peer-b"]));
+        let mut actor = actor(sink, sources);
+
+        actor.sample().await;
+        actor.report().await;
+
+        let report = tokio::time::timeout(Duration::from_secs(5), report_rx.recv())
+            .await
+            .expect("the reporter should deliver within the timeout")
+            .expect("a report should be delivered");
+
+        assert_eq!(report.heads.unsafe_block, 1_234);
+        assert!(report.heads.unsafe_latency_secs >= 3.0);
+        assert_eq!(report.heads.unsafe_latency_samples.len(), 1);
+        assert_eq!(report.net_health.peer_count, 2);
+        assert_eq!(report.net_health.peers_joined, 2);
+        assert_eq!(report.net_health.peers_left, 0);
+        assert_eq!(report.net_health.peer_target, Some(64));
+        assert_eq!(report.net_health.discovered_count, Some(42));
+        assert_eq!(report.net_health.peer_id.as_deref(), Some("local-peer"));
+        assert_eq!(report.net_health.enr.as_deref(), Some("enr:local"));
+        assert!(report.is_current_schema());
+        assert_eq!(delivered.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn test_churn_counters_reset_once_reported() {
+        let mut sink = MockReportSink::new();
+        sink.expect_send().returning(|_| Box::pin(async { Ok(()) }));
+
+        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&["peer-a"]));
+        let mut actor = actor(sink, sources);
+
+        actor.sample().await;
+        let first = actor.net_health().await;
+        assert_eq!(first.peers_joined, 1);
+
+        let second = actor.net_health().await;
+        assert_eq!(
+            (second.peers_joined, second.peers_left),
+            (0, 0),
+            "churn is per-report, so a second report must not re-count the same joins"
+        );
+    }
+
+    /// A sink that fails every call must not take the node down with it.
+    ///
+    /// `spawn_and_wait!` installs a cancellation drop guard per actor task, so a telemetry actor
+    /// that returns — for any reason, including `Ok` — stops every other actor. This test is the
+    /// guard on that: the actor has to outlive a totally dead endpoint.
+    #[tokio::test(start_paused = true)]
+    async fn test_a_failing_sink_never_stops_the_actor() {
+        let attempts = Arc::new(AtomicU64::new(0));
+        let (attempt_tx, mut attempt_rx) = mpsc::channel(64);
+        let counter = Arc::clone(&attempts);
+        let mut sink = MockReportSink::new();
+        sink.expect_send().returning(move |_| {
+            counter.fetch_add(1, Ordering::Relaxed);
+            let _ = attempt_tx.try_send(());
+            Box::pin(async { Err(ReportSinkError::Rejected("endpoint is gone".to_string())) })
+        });
+
+        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&["peer-a"]));
+        let cancellation = sources.cancellation.clone();
+        let handle = tokio::spawn(actor(sink, sources).start(()));
+
+        // The clock is paused and auto-advances whenever every task is idle, so this waits for
+        // several report intervals of virtual time without sleeping for real.
+        for _ in 0..3 {
+            tokio::time::timeout(Duration::from_secs(120), attempt_rx.recv())
+                .await
+                .expect("the actor should keep reporting into a dead endpoint")
+                .expect("the sink should still be attached");
+            assert!(!handle.is_finished(), "the actor must survive an endpoint that never answers");
+        }
+        assert!(attempts.load(Ordering::Relaxed) >= 3, "every cycle should attempt delivery");
+
+        cancellation.cancel();
+        handle.await.expect("the actor task should not panic").expect("the actor cannot fail");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_cancellation_stops_the_actor() {
+        let mut sink = MockReportSink::new();
+        sink.expect_send().returning(|_| Box::pin(async { Ok(()) }));
+
+        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&[]));
+        let cancellation = sources.cancellation.clone();
+        let handle = tokio::spawn(actor(sink, sources).start(()));
+
+        cancellation.cancel();
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("a cancelled actor should stop promptly")
+            .expect("the actor task should not panic")
+            .expect("the actor cannot fail");
+    }
+
+    /// The mocked sink is only ever used through the trait, so keep the import honest.
+    #[tokio::test]
+    async fn test_mock_sink_implements_the_trait() {
+        let mut sink = MockReportSink::new();
+        sink.expect_send().returning(|_| Box::pin(async { Ok(()) }));
+        let sink: &dyn ReportSink = &sink;
+        assert!(sink.send(&Default::default()).await.is_ok());
+    }
+}

--- a/crates/consensus/service/src/actors/telemetry.rs
+++ b/crates/consensus/service/src/actors/telemetry.rs
@@ -266,10 +266,16 @@ impl TelemetryActor {
 
     /// Returns seconds elapsed since a block timestamp, clamped at zero.
     ///
+    /// The elapsed side is read at sub-second resolution on purpose. Block timestamps step in whole
+    /// seconds, so truncating the current time as well would quantize the result twice: a node
+    /// keeping up with two-second blocks would report 0 or 1 depending only on where in the second
+    /// the sample happened to land, and the difference between healthy and half a block behind
+    /// would be invisible.
+    ///
     /// A head timestamp in the future is clock skew, not negative lag.
     pub fn seconds_since(block_timestamp: u64) -> f64 {
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
-        now.saturating_sub(block_timestamp) as f64
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs_f64();
+        (now - block_timestamp as f64).max(0.0)
     }
 
     /// Accumulates joins and departures against the previously observed peer set.
@@ -621,6 +627,20 @@ mod tests {
     fn test_a_head_timestamp_in_the_future_reads_as_zero_lag() {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
         assert_eq!(TelemetryActor::seconds_since(now + 600), 0.0);
+    }
+
+    #[test]
+    fn test_lag_resolves_below_a_whole_second() {
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+        let first = TelemetryActor::seconds_since(now);
+        std::thread::sleep(Duration::from_millis(50));
+        let second = TelemetryActor::seconds_since(now);
+
+        assert!(
+            second > first,
+            "lag must grow within a single second, otherwise a node keeping pace with 2s blocks \
+             reads as 0 or 1 depending only on when the sample was taken"
+        );
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/actors/telemetry.rs
+++ b/crates/consensus/service/src/actors/telemetry.rs
@@ -100,7 +100,20 @@ impl TelemetryNodeConfig {
         }
         let endpoint = self.client.endpoint.clone()?;
 
-        let telemetry_id = match TelemetryId::load_or_create(&self.client.id_path) {
+        // No path resolved: neither `--telemetry.id-path` nor `$HOME` named a location that
+        // survives a restart. Reporting from a throwaway identity would count this operator as a
+        // new node every time the process starts, so the run goes without telemetry instead.
+        let Some(id_path) = self.client.id_path.as_deref() else {
+            warn!(
+                target: "telemetry",
+                flag = "--telemetry.id-path",
+                "no durable location for the telemetry identity because $HOME is unset; \
+                 set the flag to a file on a persistent volume. telemetry is off for this run"
+            );
+            return None;
+        };
+
+        let telemetry_id = match TelemetryId::load_or_create(id_path) {
             Ok(id) => id,
             Err(error) => {
                 warn!(
@@ -181,6 +194,14 @@ pub struct TelemetryActor {
 }
 
 impl TelemetryActor {
+    /// Smallest period either telemetry cadence may tick at.
+    ///
+    /// [`tokio::time::interval`] panics on a zero period, and `spawn_and_wait!` installs a
+    /// cancellation drop guard per actor task, so a panic here stops every other actor with it.
+    /// `--telemetry.sample-interval=0` is a misconfiguration; it must cost the operator a warning
+    /// and a clamped cadence, never a node.
+    pub const MIN_TICK_INTERVAL: Duration = Duration::from_secs(1);
+
     /// Creates a telemetry actor from a resolved report builder and the node's live sources.
     pub fn new(
         config: &TelemetryConfig,
@@ -214,11 +235,15 @@ impl TelemetryActor {
     }
 
     /// Builds a report from the accumulated window and enqueues it for delivery.
+    ///
+    /// The connected peer set is whatever the last sample established, rather than a fresh query.
+    /// Under the default cadences the sample interval divides the report interval, so the two
+    /// ticks coincide and a query here would repeat the sample's within the same millisecond;
+    /// under any other pair the set is at most one sample interval stale. Neither costs anything,
+    /// because churn is a windowed count and whatever the last sample missed is counted in the
+    /// next window instead. What it saves is a third round trip, each one of which can hold the
+    /// cycle for [`P2P_QUERY_TIMEOUT`] against a wedged network actor.
     pub async fn report(&mut self) {
-        if let Some(peers) = self.connected_peer_ids().await {
-            self.fold_peer_churn(peers);
-        }
-
         let mut heads = self.heads();
         self.sampler.drain().apply(&mut heads);
         let net = self.net_health().await;
@@ -283,9 +308,20 @@ impl TelemetryActor {
     /// The actor starts with an empty set, so the first fold counts the node's initial peers as
     /// joins. That is the honest reading of "peers joined since this reporter started".
     pub fn fold_peer_churn(&mut self, current: HashSet<String>) {
-        self.peers_joined += current.difference(&self.connected_peers).count() as u32;
-        self.peers_left += self.connected_peers.difference(&current).count() as u32;
+        let joined = Self::saturating_u32(current.difference(&self.connected_peers).count());
+        let left = Self::saturating_u32(self.connected_peers.difference(&current).count());
+        self.peers_joined = self.peers_joined.saturating_add(joined);
+        self.peers_left = self.peers_left.saturating_add(left);
         self.connected_peers = current;
+    }
+
+    /// Narrows a count to the `u32` the report schema uses, saturating instead of truncating.
+    ///
+    /// A truncating `as u32` turns an implausibly large count into a small one, which is the
+    /// worse failure: a wrapped value reads as healthy on every dashboard downstream, while a
+    /// pinned [`u32::MAX`] reads as the bug it is.
+    pub const fn saturating_u32(count: usize) -> u32 {
+        if count > u32::MAX as usize { u32::MAX } else { count as u32 }
     }
 
     /// Builds the network half of a report, resetting the churn counters.
@@ -297,20 +333,32 @@ impl TelemetryActor {
     /// address the node already publishes to every peer it meets, which is the one that says
     /// where it actually runs.
     pub async fn net_health(&mut self) -> NetHealth {
-        let peer_info = self.local_peer_info().await;
+        // Concurrent, not sequential: the two queries are independent and each is bounded by
+        // P2P_QUERY_TIMEOUT, so awaiting them in turn would let one wedged network actor stall a
+        // reporting cycle for twice as long as it has to.
+        let (peer_info, discovered_count) =
+            tokio::join!(self.local_peer_info(), self.discovered_peer_count());
         let peer_id = peer_info.as_ref().map(|info| info.peer_id.clone());
         let enr = peer_info.and_then(|info| info.enr);
         let advertised_ip = enr.as_deref().and_then(Self::advertised_ip);
 
         NetHealth {
-            peer_count: self.connected_peers.len() as u32,
+            peer_count: Self::saturating_u32(self.connected_peers.len()),
             peer_target: self.peer_target,
-            discovered_count: self.discovered_peer_count().await,
+            discovered_count,
             peers_joined: std::mem::take(&mut self.peers_joined),
             peers_left: std::mem::take(&mut self.peers_left),
             peer_id,
             enr,
             advertised_ip,
+            // Left absent because this node has no typed source for either rate. Gossip
+            // validation outcomes and dial/connection failures are only ever incremented into the
+            // metrics registry (`base_consensus_gossip::Metrics`), which telemetry deliberately
+            // does not read, and no `P2pRpcRequest` variant returns them. Reporting them would
+            // take a counter pair on `GossipDriver` plus a new request variant to read it, both
+            // inside the gossip crate. Until that exists, `None` is the honest value: the schema
+            // distinguishes "could not measure" from a clean interval, and a fabricated zero
+            // would throw that away.
             gossip_error_rate: None,
             rpc_error_rate: None,
         }
@@ -344,12 +392,30 @@ impl TelemetryActor {
     /// Returns how many peers discovery currently knows about.
     pub async fn discovered_peer_count(&self) -> Option<u32> {
         let (discovered, _gossip) = self.query_p2p(P2pRpcRequest::PeerCount).await?;
-        discovered.map(|count| count as u32)
+        discovered.map(Self::saturating_u32)
     }
 
     /// Returns this node's own peer identity.
     pub async fn local_peer_info(&self) -> Option<PeerInfo> {
         self.query_p2p(P2pRpcRequest::PeerInfo).await
+    }
+
+    /// Returns a tick period safe to hand to [`tokio::time::interval`].
+    ///
+    /// A zero period panics the timer constructor, and a panicking telemetry task takes the node
+    /// down with it, so a zero is clamped up to [`Self::MIN_TICK_INTERVAL`] and reported. `cadence`
+    /// names which of the two intervals was misconfigured so the operator can find the flag.
+    pub fn tick_interval(configured: Duration, cadence: &'static str) -> Duration {
+        if configured.is_zero() {
+            warn!(
+                target: "telemetry",
+                cadence,
+                minimum_secs = Self::MIN_TICK_INTERVAL.as_secs(),
+                "a zero telemetry interval cannot drive a timer; clamping to the minimum"
+            );
+            return Self::MIN_TICK_INTERVAL;
+        }
+        configured
     }
 
     /// Sends one p2p RPC request and awaits its reply, giving up after [`P2P_QUERY_TIMEOUT`].
@@ -386,13 +452,16 @@ impl NodeActor for TelemetryActor {
     async fn start(mut self, _ctx: ()) -> Result<(), Self::Error> {
         let cancellation = self.sources.cancellation.clone();
 
-        let mut sample_tick = tokio::time::interval(self.sample_interval);
+        let sample_interval = Self::tick_interval(self.sample_interval, "sample");
+        let report_interval = Self::tick_interval(self.report_interval, "report");
+
+        let mut sample_tick = tokio::time::interval(sample_interval);
         sample_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         // The first report waits a full interval. Reporting immediately would publish a payload
         // assembled before the engine has a head or the network has a peer.
         let mut report_tick = tokio::time::interval_at(
-            tokio::time::Instant::now() + self.report_interval,
-            self.report_interval,
+            tokio::time::Instant::now() + report_interval,
+            report_interval,
         );
         report_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -439,17 +508,40 @@ mod tests {
     /// The address [`SAMPLE_ENR`] advertises.
     const SAMPLE_ENR_IP: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(54, 145, 88, 85));
 
-    /// Answers p2p RPC queries with a fixed peer set for as long as the channel stays open.
+    /// Tally of the p2p RPC variants an actor issued, so a test can assert round trips saved.
+    #[derive(Debug, Default)]
+    struct P2pCalls {
+        peers: AtomicU64,
+        peer_count: AtomicU64,
+        peer_info: AtomicU64,
+    }
+
+    impl P2pCalls {
+        /// Returns the `(peers, peer_count, peer_info)` counts observed so far.
+        fn totals(&self) -> (u64, u64, u64) {
+            (
+                self.peers.load(Ordering::Relaxed),
+                self.peer_count.load(Ordering::Relaxed),
+                self.peer_info.load(Ordering::Relaxed),
+            )
+        }
+    }
+
+    /// Answers p2p RPC queries with a fixed peer set for as long as the channel stays open, and
+    /// records how many of each variant it answered.
     ///
     /// Hand-rolled rather than mocked: the actor talks to the network over a channel of enum
     /// requests, not through a trait `automock` can stand in for.
-    fn spawn_fake_p2p(connected: &[&str]) -> mpsc::Sender<P2pRpcRequest> {
+    fn spawn_fake_p2p(connected: &[&str]) -> (mpsc::Sender<P2pRpcRequest>, Arc<P2pCalls>) {
         let connected: Vec<String> = connected.iter().map(|peer| (*peer).to_string()).collect();
+        let calls = Arc::new(P2pCalls::default());
+        let observed = Arc::clone(&calls);
         let (tx, mut rx) = mpsc::channel(16);
         tokio::spawn(async move {
             while let Some(request) = rx.recv().await {
                 match request {
                     P2pRpcRequest::Peers { out, .. } => {
+                        observed.peers.fetch_add(1, Ordering::Relaxed);
                         let mut dump = PeerDump {
                             total_connected: connected.len() as u32,
                             ..Default::default()
@@ -460,9 +552,11 @@ mod tests {
                         let _ = out.send(dump);
                     }
                     P2pRpcRequest::PeerCount(out) => {
+                        observed.peer_count.fetch_add(1, Ordering::Relaxed);
                         let _ = out.send((Some(42), connected.len()));
                     }
                     P2pRpcRequest::PeerInfo(out) => {
+                        observed.peer_info.fetch_add(1, Ordering::Relaxed);
                         let _ = out.send(PeerInfo {
                             peer_id: "local-peer".to_string(),
                             enr: Some(SAMPLE_ENR.to_string()),
@@ -473,7 +567,7 @@ mod tests {
                 }
             }
         });
-        tx
+        (tx, calls)
     }
 
     /// Publishes an engine state whose unsafe head is `number` blocks in, `lag_secs` behind now.
@@ -555,7 +649,7 @@ mod tests {
         let mut telemetry = node_config();
         telemetry.client = config(id_path.clone());
 
-        let sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]));
+        let sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]).0);
         assert!(telemetry.actor(facts(), sources).is_none());
         assert!(
             !id_path.exists(),
@@ -573,7 +667,7 @@ mod tests {
             ..config(dir.path().join("telemetry-id"))
         };
 
-        let sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]));
+        let sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]).0);
         assert!(telemetry.actor(facts(), sources).is_none());
     }
 
@@ -587,9 +681,48 @@ mod tests {
             ..config(id_path.clone())
         };
 
-        let sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]));
+        let sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]).0);
         assert!(telemetry.actor(facts(), sources).is_some());
         assert!(id_path.exists(), "the identity is minted once, on the first reporting run");
+    }
+
+    #[tokio::test]
+    async fn test_an_unresolved_identity_path_turns_telemetry_off_rather_than_reporting_anyway() {
+        let dir = TempDir::new().expect("temp dir");
+        let endpoint = Url::parse("http://127.0.0.1:1/v1/ingest").expect("valid url");
+        let id_path = dir.path().join("telemetry-id");
+
+        // Neither `--telemetry.id-path` nor `$HOME` resolved a location, so there is nowhere to
+        // keep an identity that survives a restart. Reporting from a throwaway one would count
+        // this operator as a new node on every start.
+        let mut unresolved = node_config();
+        unresolved.client = TelemetryConfig {
+            endpoint: Some(endpoint.clone()),
+            id_path: None,
+            ..config(id_path.clone())
+        };
+        let unresolved_sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]).0);
+
+        assert!(
+            unresolved.actor(facts(), unresolved_sources).is_none(),
+            "no durable identity path must disable telemetry, not fail the node's startup"
+        );
+        assert!(
+            !id_path.exists(),
+            "a node that will not report must not leave an identity behind either"
+        );
+
+        // The same construction with a path does build an actor. Without this half, an actor that
+        // failed to build for some unrelated reason would read as the behavior above.
+        let mut resolved = node_config();
+        resolved.client = TelemetryConfig { endpoint: Some(endpoint), ..config(id_path.clone()) };
+        let resolved_sources = sources(engine_state(10, 2), spawn_fake_p2p(&[]).0);
+
+        assert!(
+            resolved.actor(facts(), resolved_sources).is_some(),
+            "the missing path is the only thing that differs between these two configs"
+        );
+        assert!(id_path.exists());
     }
 
     #[tokio::test]
@@ -655,7 +788,7 @@ mod tests {
             Box::pin(async { Ok(()) })
         });
 
-        let sources = sources(engine_state(1_234, 3), spawn_fake_p2p(&["peer-a", "peer-b"]));
+        let sources = sources(engine_state(1_234, 3), spawn_fake_p2p(&["peer-a", "peer-b"]).0);
         let mut actor = actor(sink, sources);
 
         actor.sample().await;
@@ -699,7 +832,7 @@ mod tests {
         let mut sink = MockReportSink::new();
         sink.expect_send().returning(|_| Box::pin(async { Ok(()) }));
 
-        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&["peer-a"]));
+        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&["peer-a"]).0);
         let mut actor = actor(sink, sources);
 
         actor.sample().await;
@@ -731,7 +864,7 @@ mod tests {
             Box::pin(async { Err(ReportSinkError::Rejected("endpoint is gone".to_string())) })
         });
 
-        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&["peer-a"]));
+        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&["peer-a"]).0);
         let cancellation = sources.cancellation.clone();
         let handle = tokio::spawn(actor(sink, sources).start(()));
 
@@ -755,7 +888,7 @@ mod tests {
         let mut sink = MockReportSink::new();
         sink.expect_send().returning(|_| Box::pin(async { Ok(()) }));
 
-        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&[]));
+        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&[]).0);
         let cancellation = sources.cancellation.clone();
         let handle = tokio::spawn(actor(sink, sources).start(()));
 
@@ -765,6 +898,99 @@ mod tests {
             .expect("a cancelled actor should stop promptly")
             .expect("the actor task should not panic")
             .expect("the actor cannot fail");
+    }
+
+    #[test]
+    fn test_a_zero_cadence_is_clamped_and_a_configured_one_is_left_alone() {
+        assert_eq!(
+            TelemetryActor::tick_interval(Duration::ZERO, "sample"),
+            TelemetryActor::MIN_TICK_INTERVAL,
+            "tokio::time::interval panics on a zero period, so zero must never reach it"
+        );
+        assert_eq!(
+            TelemetryActor::tick_interval(Duration::from_secs(900), "report"),
+            Duration::from_secs(900),
+            "a cadence the operator actually set must be used as given"
+        );
+    }
+
+    /// `--telemetry.report-interval=0` must cost a warning, not the node.
+    ///
+    /// `spawn_and_wait!` installs a cancellation drop guard per actor task, so a panic in the
+    /// timer constructor would stop every other actor with it.
+    #[tokio::test(start_paused = true)]
+    async fn test_a_zero_interval_keeps_the_actor_running() {
+        let (attempt_tx, mut attempt_rx) = mpsc::channel(8);
+        let mut sink = MockReportSink::new();
+        sink.expect_send().returning(move |_| {
+            let _ = attempt_tx.try_send(());
+            Box::pin(async { Ok(()) })
+        });
+
+        let sources = sources(engine_state(10, 1), spawn_fake_p2p(&["peer-a"]).0);
+        let cancellation = sources.cancellation.clone();
+        let mut misconfigured = actor(sink, sources);
+        misconfigured.sample_interval = Duration::ZERO;
+        misconfigured.report_interval = Duration::ZERO;
+        let handle = tokio::spawn(misconfigured.start(()));
+
+        tokio::time::timeout(Duration::from_secs(60), attempt_rx.recv())
+            .await
+            .expect("a clamped actor should still reach its first report")
+            .expect("the sink should still be attached");
+        assert!(!handle.is_finished(), "a misconfigured interval must not stop the actor");
+
+        cancellation.cancel();
+        handle.await.expect("the actor task should not panic").expect("the actor cannot fail");
+    }
+
+    #[test]
+    fn test_a_count_past_u32_saturates_rather_than_truncating() {
+        assert_eq!(TelemetryActor::saturating_u32(7), 7);
+        assert_eq!(
+            TelemetryActor::saturating_u32((u32::MAX as usize).saturating_add(1)),
+            u32::MAX,
+            "one past the boundary must pin at the maximum, not wrap around to zero"
+        );
+        assert_eq!(TelemetryActor::saturating_u32(usize::MAX), u32::MAX);
+    }
+
+    #[tokio::test]
+    async fn test_churn_counters_saturate_rather_than_wrapping() {
+        let sources = sources(engine_state(10, 2), mpsc::channel(1).0);
+        let mut actor = actor(MockReportSink::new(), sources);
+        actor.peers_joined = u32::MAX;
+        actor.peers_left = u32::MAX;
+
+        actor.fold_peer_churn(["a"].iter().map(ToString::to_string).collect());
+        actor.fold_peer_churn(HashSet::new());
+
+        assert_eq!(
+            (actor.peers_joined, actor.peers_left),
+            (u32::MAX, u32::MAX),
+            "a churn counter at its ceiling must stay there rather than wrap back to zero"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_report_reuses_the_peer_set_the_sampler_already_fetched() {
+        let mut sink = MockReportSink::new();
+        sink.expect_send().returning(|_| Box::pin(async { Ok(()) }));
+
+        let (p2p, calls) = spawn_fake_p2p(&["peer-a"]);
+        let mut actor = actor(sink, sources(engine_state(10, 1), p2p));
+
+        actor.sample().await;
+        assert_eq!(calls.totals(), (1, 0, 0), "a sample only needs the connected peer set");
+
+        actor.report().await;
+        assert_eq!(
+            calls.totals(),
+            (1, 1, 1),
+            "a report needs the local peer info and the discovered count, and nothing else: \
+             re-querying the peer set would duplicate the query the coinciding sample tick just \
+             issued, at the cost of a third P2P_QUERY_TIMEOUT on a wedged network actor"
+        );
     }
 
     /// The mocked sink is only ever used through the trait, so keep the import honest.

--- a/crates/consensus/service/src/actors/telemetry.rs
+++ b/crates/consensus/service/src/actors/telemetry.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::HashSet,
     convert::Infallible,
+    net::IpAddr,
     path::PathBuf,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -10,6 +11,7 @@ use std::{
 
 use base_consensus_engine::EngineState;
 use base_consensus_gossip::{P2pRpcRequest, PeerDump, PeerInfo};
+use base_consensus_peers::BootNode;
 use base_telemetry_client::{
     HttpReportSink, LatencySampler, NodeIdentity, NodeReportBuilder, TelemetryConfig, TelemetryId,
     TelemetryReporter,
@@ -282,21 +284,47 @@ impl TelemetryActor {
 
     /// Builds the network half of a report, resetting the churn counters.
     ///
-    /// `advertised_ip` is deliberately left unset: the ingest server records the address it
-    /// observed, which is the one that actually reached it.
+    /// `advertised_ip` is decoded from the node's own ENR rather than left for the ingest server
+    /// to infer from the connection. The observed address is whichever hop last touched the
+    /// request - a load balancer, or a private range when the node and the collector share a
+    /// network - so it describes the reporting path rather than the node. The ENR carries the
+    /// address the node already publishes to every peer it meets, which is the one that says
+    /// where it actually runs.
     pub async fn net_health(&mut self) -> NetHealth {
         let peer_info = self.local_peer_info().await;
+        let peer_id = peer_info.as_ref().map(|info| info.peer_id.clone());
+        let enr = peer_info.and_then(|info| info.enr);
+        let advertised_ip = enr.as_deref().and_then(Self::advertised_ip);
+
         NetHealth {
             peer_count: self.connected_peers.len() as u32,
             peer_target: self.peer_target,
             discovered_count: self.discovered_peer_count().await,
             peers_joined: std::mem::take(&mut self.peers_joined),
             peers_left: std::mem::take(&mut self.peers_left),
-            peer_id: peer_info.as_ref().map(|info| info.peer_id.clone()),
-            enr: peer_info.and_then(|info| info.enr),
-            advertised_ip: None,
+            peer_id,
+            enr,
+            advertised_ip,
             gossip_error_rate: None,
             rpc_error_rate: None,
+        }
+    }
+
+    /// Decodes the routable address a node record advertises.
+    ///
+    /// An undecodable record costs the report one field and nothing else: telemetry must never
+    /// turn a malformed string into a failed reporting cycle.
+    pub fn advertised_ip(enr: &str) -> Option<IpAddr> {
+        match BootNode::parse_bootnode(enr) {
+            Ok(record) => record.advertised_ip(),
+            Err(error) => {
+                debug!(
+                    target: "telemetry",
+                    error = %error,
+                    "could not decode the local ENR; omitting the advertised address"
+                );
+                None
+            }
         }
     }
 
@@ -398,6 +426,13 @@ mod tests {
 
     use super::*;
 
+    /// A real Base ENR, so the advertised address the actor decodes is a genuine decode rather
+    /// than a value handed to it.
+    const SAMPLE_ENR: &str = "enr:-J64QBbwPjPLZ6IOOToOLsSjtFUjjzN66qmBZdUexpO32Klrc458Q24kbty2PdRaLacHM5z-cZQr8mjeQu3pik6jPSOGAYYFIqBfgmlkgnY0gmlwhDaRWFWHb3BzdGFja4SzlAUAiXNlY3AyNTZrMaECmeSnJh7zjKrDSPoNMGXoopeDF4hhpj5I0OsQUUt4u8uDdGNwgiQGg3VkcIIkBg";
+
+    /// The address [`SAMPLE_ENR`] advertises.
+    const SAMPLE_ENR_IP: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(54, 145, 88, 85));
+
     /// Answers p2p RPC queries with a fixed peer set for as long as the channel stays open.
     ///
     /// Hand-rolled rather than mocked: the actor talks to the network over a channel of enum
@@ -424,7 +459,7 @@ mod tests {
                     P2pRpcRequest::PeerInfo(out) => {
                         let _ = out.send(PeerInfo {
                             peer_id: "local-peer".to_string(),
-                            enr: Some("enr:local".to_string()),
+                            enr: Some(SAMPLE_ENR.to_string()),
                             ..Default::default()
                         });
                     }
@@ -620,9 +655,23 @@ mod tests {
         assert_eq!(report.net_health.peer_target, Some(64));
         assert_eq!(report.net_health.discovered_count, Some(42));
         assert_eq!(report.net_health.peer_id.as_deref(), Some("local-peer"));
-        assert_eq!(report.net_health.enr.as_deref(), Some("enr:local"));
+        assert_eq!(report.net_health.enr.as_deref(), Some(SAMPLE_ENR));
+        assert_eq!(
+            report.net_health.advertised_ip,
+            Some(SAMPLE_ENR_IP),
+            "the report should carry the address the node publishes to its peers"
+        );
         assert!(report.is_current_schema());
         assert_eq!(delivered.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_an_undecodable_enr_costs_only_the_address() {
+        assert_eq!(
+            TelemetryActor::advertised_ip("enr:not-a-real-record"),
+            None,
+            "a malformed record must yield no address rather than propagate an error"
+        );
     }
 
     #[tokio::test]

--- a/crates/consensus/service/src/lib.rs
+++ b/crates/consensus/service/src/lib.rs
@@ -37,8 +37,8 @@ pub use actors::{
     L1WatcherQueryProcessor, L2Finalizer, LogRetrier, NetworkActor, NetworkActorError,
     NetworkBuilder, NetworkBuilderError, NetworkConfig, NetworkDriver, NetworkDriverError,
     NetworkEngineClient, NetworkHandler, NetworkInboundData, NodeActor, NoopCheckpointWriter,
-    OriginSelector, PayloadBuilder, PayloadSealer, PendingStopSender, PoolActivation,
-    PrefetchedChainProvider, PrefetchedChainProviderError, PreparedL1Origin,
+    OriginSelector, P2P_QUERY_TIMEOUT, PayloadBuilder, PayloadSealer, PendingStopSender,
+    PoolActivation, PrefetchedChainProvider, PrefetchedChainProviderError, PreparedL1Origin,
     QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
     QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
     QueuedSequencerEngineClient, QueuedUnsafePayloadGossipClient, ReconcileShadowRequest,
@@ -46,9 +46,10 @@ pub use actors::{
     RpcActor, RpcActorError, RpcContext, ScheduledTicker, SealState, SealStepError,
     SealStepOutcome, SequencerActor, SequencerActorError, SequencerAdminQuery, SequencerConfig,
     SequencerEngineClient, SequencerEngineRequestCoordinator, SequencerEngineState, ShadowCycle,
-    ShadowReconciliationGate, ShadowReconciliationTask, ShadowSequencingState,
-    UnsafePayloadGossipClient, UnsafePayloadGossipClientError, UnsealedPayloadHandle,
-    UpgradeSignalMetricsActor, UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
+    ShadowReconciliationGate, ShadowReconciliationTask, ShadowSequencingState, TelemetryActor,
+    TelemetryNodeConfig, TelemetryNodeFacts, TelemetrySources, UnsafePayloadGossipClient,
+    UnsafePayloadGossipClientError, UnsealedPayloadHandle, UpgradeSignalMetricsActor,
+    UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
 };
 
 mod metrics;

--- a/crates/consensus/service/src/service/builder.rs
+++ b/crates/consensus/service/src/service/builder.rs
@@ -15,8 +15,8 @@ use base_upgrade_signal::UpgradeSignalConfig;
 use url::Url;
 
 use crate::{
-    EngineConfig, NetworkConfig, RollupNode, SequencerConfig, UpgradeSignalNodeConfig,
-    actors::DerivationDelegateClient, service::node::L1Config,
+    EngineConfig, NetworkConfig, RollupNode, SequencerConfig, TelemetryNodeConfig,
+    UpgradeSignalNodeConfig, actors::DerivationDelegateClient, service::node::L1Config,
 };
 
 /// Upgrade signal configuration for the [`RollupNodeBuilder`].
@@ -100,6 +100,8 @@ pub struct RollupNodeBuilder {
     pub safedb_path: Option<PathBuf>,
     /// Upgrade signal configuration.
     pub upgrade_signal_config: UpgradeSignalBuilderConfig,
+    /// Optional telemetry configuration for the node.
+    pub telemetry_config: Option<TelemetryNodeConfig>,
 }
 
 impl RollupNodeBuilder {
@@ -138,6 +140,7 @@ impl RollupNodeBuilder {
             finalized_poll_interval: None,
             checkpoint_path: None,
             safedb_path: None,
+            telemetry_config: None,
             upgrade_signal_config: UpgradeSignalBuilderConfig {
                 metrics_config: None,
                 l1_rpc: None,
@@ -191,6 +194,11 @@ impl RollupNodeBuilder {
     /// Sets the upgrade signal configuration.
     pub fn with_upgrade_signal_config(self, config: UpgradeSignalBuilderConfig) -> Self {
         Self { upgrade_signal_config: config, ..self }
+    }
+
+    /// Sets the telemetry configuration for the node.
+    pub fn with_telemetry_config(self, config: Option<TelemetryNodeConfig>) -> Self {
+        Self { telemetry_config: config, ..self }
     }
 
     /// Assembles the [`RollupNode`] service.
@@ -280,6 +288,7 @@ impl RollupNodeBuilder {
             checkpoint_path,
             safedb_path: self.safedb_path,
             upgrade_signal_config,
+            telemetry_config: self.telemetry_config,
         })
     }
 

--- a/crates/consensus/service/src/service/node.rs
+++ b/crates/consensus/service/src/service/node.rs
@@ -1,7 +1,7 @@
 //! Contains the [`RollupNode`] implementation.
 use std::{
     ops::Not as _,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU64},
     time::Duration,
 };
@@ -22,6 +22,7 @@ use base_consensus_providers::{
 use base_consensus_rpc::RpcBuilder;
 use base_consensus_safedb::{DisabledSafeDB, SafeDB, SafeDBReader, SafeHeadListener};
 use base_protocol::L2BlockInfo;
+use base_telemetry_types::NodeRole;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
@@ -35,8 +36,8 @@ use crate::{
     QueuedDerivationEngineClient, QueuedEngineDerivationClient, QueuedEngineRpcClient,
     QueuedL1WatcherDerivationClient, QueuedNetworkEngineClient, QueuedSequencerAdminAPIClient,
     QueuedSequencerEngineClient, RecoveryModeGuard, RpcActor, RpcContext, SequencerActor,
-    SequencerConfig, SequencerEngineRequestCoordinator, UpgradeSignalNodeConfig,
-    ValidatorEngineRequestHandler,
+    SequencerConfig, SequencerEngineRequestCoordinator, TelemetryNodeConfig, TelemetryNodeFacts,
+    TelemetrySources, UpgradeSignalNodeConfig, ValidatorEngineRequestHandler,
     actors::{BlockStream, NetworkInboundData, QueuedUnsafePayloadGossipClient},
 };
 
@@ -145,6 +146,10 @@ pub struct RollupNode {
     pub safedb_path: Option<PathBuf>,
     /// Optional upgrade signal configuration for the consensus node.
     pub upgrade_signal_config: Option<UpgradeSignalNodeConfig>,
+    /// Optional telemetry configuration for the consensus node.
+    ///
+    /// `None`, or a configuration with no endpoint, means the node reports nothing.
+    pub telemetry_config: Option<TelemetryNodeConfig>,
 }
 
 /// A RollupNode-level derivation actor wrapper.
@@ -188,6 +193,25 @@ impl RollupNode {
     /// The mode of operation for the node.
     const fn mode(&self) -> NodeMode {
         self.engine_config.mode
+    }
+
+    /// Returns the telemetry facts this node derives for itself.
+    ///
+    /// The measured directory is whatever `--telemetry.data-dir` names, and otherwise the one
+    /// holding the checkpoint database. The fallback is the best guess this node can make on its
+    /// own, but it is only a guess: an operator who keeps chain data on a separate volume has to
+    /// say so, or the disk fields describe the wrong device.
+    fn telemetry_facts(&self, mode: NodeMode) -> TelemetryNodeFacts {
+        TelemetryNodeFacts {
+            l2_chain_id: self.config.l2_chain_id.into(),
+            role: if mode.is_sequencer() { NodeRole::Sequencer } else { NodeRole::Validator },
+            data_dir: self
+                .telemetry_config
+                .as_ref()
+                .and_then(|config| config.client.data_dir.clone())
+                .or_else(|| self.checkpoint_path.parent().map(Path::to_path_buf)),
+            peer_target: Some(self.p2p_config.connection_limits_config.max_established),
+        }
     }
 
     /// Creates a network builder for the node.
@@ -575,6 +599,16 @@ impl RollupNode {
             .as_ref()
             .map(|c| c.metrics_actor(upgrade_signal_refresher.clone(), cancellation.clone()));
         let node_mode = self.mode();
+        let telemetry_actor = self.telemetry_config.as_ref().and_then(|config| {
+            config.actor(
+                self.telemetry_facts(node_mode),
+                TelemetrySources {
+                    engine_state: sequencer_engine_state_rx.clone(),
+                    p2p_rpc: network_rpc.clone(),
+                    cancellation: cancellation.clone(),
+                },
+            )
+        });
         // Create the sequencer if needed
         let (sequencer_actor, sequencer_admin_client) = if node_mode.is_sequencer() {
             let delayed_l1_provider = DelayedL1OriginSelectorProvider::new(
@@ -660,6 +694,7 @@ impl RollupNode {
                 Some((l1_watcher, ())),
                 Some((l1_query_processor, ())),
                 upgrade_signal_metrics_actor.map(|actor| (actor, ())),
+                telemetry_actor.map(|actor| (actor, ())),
                 Some((derivation, ())),
                 Some((checkpoint_actor, cancellation.clone())),
                 Some((engine_actor, ())),

--- a/crates/infra/telemetry/Cargo.toml
+++ b/crates/infra/telemetry/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 ipnet.workspace = true
+chrono.workspace = true
 discv5.workspace = true
 futures.workspace = true
 governor.workspace = true
@@ -19,9 +20,12 @@ tokio-util.workspace = true
 async-trait.workspace = true
 reth-ecies.workspace = true
 reth-eth-wire.workspace = true
+tracing-appender.workspace = true
 alloy-primitives.workspace = true
 base-trusted-proxy.workspace = true
+base-telemetry-types.workspace = true
 anyhow = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
 tracing = { workspace = true, features = ["std"] }
 thiserror = { workspace = true, features = ["std"] }
 secp256k1 = { workspace = true, features = ["rand"] }
@@ -35,5 +39,11 @@ libp2p = { workspace = true, features = ["tokio", "tcp", "noise", "yamux", "iden
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
+url.workspace = true
+uuid.workspace = true
 mockall.workspace = true
+tempfile.workspace = true
+base-retry.workspace = true
+tokio-util.workspace = true
+base-telemetry-client.workspace = true
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -8,6 +8,55 @@ Axum backend for Base telemetry services.
 - `GET /readyz`
 - `POST /v1/p2p/reachability/el`
 - `POST /v1/p2p/reachability/cl`
+- `POST /v1/ingest`
+
+## Node report ingest
+
+`POST /v1/ingest` accepts one `node_report` from a Base node. The payload schema
+lives in [`base-telemetry-types`](../../common/telemetry-types) so the client
+and this service cannot drift apart.
+
+```http
+POST /v1/ingest
+Content-Type: application/json
+
+{
+  "schema_version": 1,
+  "telemetry_id": "01234567-89ab-cdef-0123-456789abcdef",
+  "reported_at": "2026-08-21T17:04:11Z",
+  "client_version": "1.2.3",
+  "git_sha": "abc1234",
+  "l2_chain_id": 8453,
+  "network": "mainnet",
+  "layer": "consensus",
+  "role": "validator",
+  "uptime_secs": 86400,
+  "heads": { "unsafe": 42, "local_safe": 40, "safe": 38, ... },
+  "hardware": { "platform": "cloud", "fs_type": "ext4", ... },
+  "config": { ... },
+  "net_health": { "peer_count": 17, ... }
+}
+```
+
+The response is `202 Accepted` with an empty body. Recording is asynchronous:
+a node must never wait on our storage to finish its reporting cycle. Malformed
+bodies return `400` and bodies over 16 `KiB` return `413`. A report declaring an
+unrecognized `schema_version` is still recorded with a warning, because a node
+must keep reporting across a schema change. The version is an integer major so a
+receiver can order it and reject an unknown major; this build warns rather than
+rejects, and tightening that is a backend decision, not a client one.
+
+Accepted reports are emitted as a structured log event and, when
+`--node-report-path` (or `BASE_TELEMETRY_NODE_REPORT_PATH`) is set, appended as
+JSONL through a non-blocking background writer. Each recorded line is the report
+plus the three fields only the server can supply: `received_at`, `reported_ip`,
+and `ip_source`. `reported_ip` is the node's advertised address when it sent
+one and the observed edge IP otherwise.
+
+Ingest has its own rate limit, separate from the probe quota: 60 reports per
+hour per client IP by default, configurable with
+`--node-report-requests-per-hour` or
+`BASE_TELEMETRY_NODE_REPORT_REQUESTS_PER_HOUR`.
 
 ## Execution-layer reachability
 

--- a/crates/infra/telemetry/README.md
+++ b/crates/infra/telemetry/README.md
@@ -49,9 +49,18 @@ rejects, and tightening that is a backend decision, not a client one.
 Accepted reports are emitted as a structured log event and, when
 `--node-report-path` (or `BASE_TELEMETRY_NODE_REPORT_PATH`) is set, appended as
 JSONL through a non-blocking background writer. Each recorded line is the report
-plus the three fields only the server can supply: `received_at`, `reported_ip`,
-and `ip_source`. `reported_ip` is the node's advertised address when it sent
-one and the observed edge IP otherwise.
+plus the four fields only the server can supply: `received_at`, `reported_ip`,
+`ip_source`, and `observed_ip`. `reported_ip` is the node's advertised address
+when it sent one and the observed edge IP otherwise; `observed_ip` is always the
+address the connection arrived from.
+
+Both are kept because they answer different questions. A node behind a load
+balancer, or one reporting to a collector inside its own network, is observed at
+an address that locates the reporting path rather than the node, so
+`reported_ip` is the one worth geolocating. It is also the one a node controls,
+so `observed_ip` is what makes a spoofed or simply misconfigured advertisement
+visible instead of silently authoritative. Rate limiting keys on the observed
+edge IP and never on anything in the payload.
 
 Ingest has its own rate limit, separate from the probe quota: 60 reports per
 hour per client IP by default, configurable with

--- a/crates/infra/telemetry/src/ingest.rs
+++ b/crates/infra/telemetry/src/ingest.rs
@@ -1,0 +1,359 @@
+//! HTTP API for node telemetry report ingest.
+
+use std::{net::SocketAddr, num::NonZeroU32, sync::Arc};
+
+use axum::{
+    Json, Router,
+    extract::{ConnectInfo, DefaultBodyLimit, State, rejection::JsonRejection},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use base_telemetry_types::{NodeReport, NodeReportEvent};
+use base_trusted_proxy::TrustedProxyConfig;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+use crate::ReportRecorder;
+
+/// HTTP path that accepts node report submissions.
+pub const NODE_REPORT_PATH: &str = "/v1/ingest";
+/// Maximum JSON request body size accepted by the ingest route.
+///
+/// A full report is around a kilobyte. The limit leaves room for the latency sample array and
+/// for fields added by later schema versions, and nothing else.
+pub const NODE_REPORT_MAX_REQUEST_BYTES: usize = 16 * 1024;
+/// Default node reports accepted per client IP per hour.
+///
+/// Nodes report every fifteen minutes, so four an hour is the honest rate. Sixty leaves room for
+/// a restart loop and for many nodes sharing one NAT without ever throttling honest traffic.
+pub const DEFAULT_NODE_REPORT_REQUESTS_PER_HOUR: NonZeroU32 = NonZeroU32::new(60).unwrap();
+
+/// JSON error returned when a node report is rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IngestErrorResponse {
+    /// Stable error code.
+    pub error: IngestApiError,
+}
+
+/// HTTP error returned when a node report is rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IngestApiError {
+    /// The JSON body was malformed or did not match the report schema.
+    InvalidRequest,
+    /// The JSON body exceeded the route limit.
+    PayloadTooLarge,
+}
+
+impl IngestApiError {
+    /// Maps an Axum JSON rejection to the stable ingest API error surface.
+    pub fn from_json_rejection(rejection: &JsonRejection) -> Self {
+        if rejection.status() == StatusCode::PAYLOAD_TOO_LARGE {
+            Self::PayloadTooLarge
+        } else {
+            Self::InvalidRequest
+        }
+    }
+
+    /// Returns the HTTP status for this error.
+    pub const fn status(&self) -> StatusCode {
+        match self {
+            Self::InvalidRequest => StatusCode::BAD_REQUEST,
+            Self::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+        }
+    }
+}
+
+impl IntoResponse for IngestApiError {
+    fn into_response(self) -> Response {
+        (self.status(), Json(IngestErrorResponse { error: self })).into_response()
+    }
+}
+
+/// State shared by the ingest handler.
+#[derive(Debug, Clone)]
+pub struct IngestState {
+    recorder: Arc<dyn ReportRecorder>,
+    proxy: Arc<TrustedProxyConfig>,
+}
+
+impl IngestState {
+    /// Creates handler state from a recorder and the trusted proxy configuration.
+    pub const fn new(recorder: Arc<dyn ReportRecorder>, proxy: Arc<TrustedProxyConfig>) -> Self {
+        Self { recorder, proxy }
+    }
+}
+
+/// Axum routes for node telemetry ingest.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IngestRoutes;
+
+impl IngestRoutes {
+    /// Returns an ingest router writing to the supplied recorder.
+    pub fn router(recorder: Arc<dyn ReportRecorder>, proxy: Arc<TrustedProxyConfig>) -> Router {
+        Router::new()
+            .route(NODE_REPORT_PATH, post(Self::ingest_node_report))
+            .layer(DefaultBodyLimit::max(NODE_REPORT_MAX_REQUEST_BYTES))
+            .with_state(IngestState::new(recorder, proxy))
+    }
+
+    /// Accepts one node report.
+    ///
+    /// Returns 202 with an empty body: recording is asynchronous, and a node must never wait on
+    /// our storage to finish its reporting cycle.
+    pub async fn ingest_node_report(
+        State(state): State<IngestState>,
+        ConnectInfo(peer): ConnectInfo<SocketAddr>,
+        headers: HeaderMap,
+        body: Result<Json<NodeReport>, JsonRejection>,
+    ) -> Result<StatusCode, IngestApiError> {
+        let Json(report) = body.map_err(|rejection| {
+            debug!(status = %rejection.status(), "node report body rejected");
+            IngestApiError::from_json_rejection(&rejection)
+        })?;
+
+        if !report.is_current_schema() {
+            // Accepted anyway: an old or new node must keep reporting across a schema change,
+            // and every field that did parse is still worth having.
+            warn!(
+                schema_version = %report.schema_version,
+                telemetry_id = %report.telemetry_id,
+                "node report declares an unrecognized schema version"
+            );
+        }
+
+        let observed_ip = state.proxy.client_ip(peer.ip(), &headers);
+        let event = NodeReportEvent::new(report, Utc::now(), observed_ip);
+        state.recorder.record(&event);
+
+        Ok(StatusCode::ACCEPTED)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        sync::{Arc, Mutex},
+    };
+
+    use axum::{Router, http::StatusCode};
+    use base_telemetry_types::{
+        ClientMeta, Heads, IpSource, NODE_REPORT_SCHEMA_VERSION, NetHealth, NodeReportEvent,
+    };
+    use base_trusted_proxy::TrustedProxyConfig;
+    use tokio::{net::TcpListener, task::JoinHandle};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::CLIENT_IP_HEADER;
+
+    /// Captures recorded events in memory.
+    ///
+    /// Hand-rolled rather than `automock`ed because the assertions are about the events that
+    /// accumulate across several requests, not about call counts on a single one.
+    #[derive(Debug, Default)]
+    struct CapturingRecorder {
+        events: Mutex<Vec<NodeReportEvent>>,
+    }
+
+    impl CapturingRecorder {
+        fn events(&self) -> Vec<NodeReportEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl ReportRecorder for CapturingRecorder {
+        fn record(&self, event: &NodeReportEvent) {
+            self.events.lock().unwrap().push(event.clone());
+        }
+    }
+
+    fn sample_report() -> NodeReport {
+        NodeReport {
+            telemetry_id: Uuid::from_u128(0x0123_4567_89ab_cdef_0123_4567_89ab_cdef),
+            client: ClientMeta {
+                client_version: "1.2.3".to_string(),
+                git_sha: "abc1234".to_string(),
+                l2_chain_id: 8453,
+                network: "mainnet".to_string(),
+                uptime_secs: 600,
+                ..Default::default()
+            },
+            heads: Heads { unsafe_block: 42, safe_block: Some(40), ..Default::default() },
+            net_health: NetHealth { peer_count: 17, ..Default::default() },
+            ..Default::default()
+        }
+    }
+
+    async fn start_test_server(router: Router) -> (SocketAddr, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>())
+                .await
+                .unwrap();
+        });
+        (address, handle)
+    }
+
+    fn router_with(recorder: Arc<CapturingRecorder>, trusted_cidrs: Vec<ipnet::IpNet>) -> Router {
+        IngestRoutes::router(
+            recorder,
+            Arc::new(TrustedProxyConfig::new(CLIENT_IP_HEADER.to_string(), trusted_cidrs)),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_valid_report_is_accepted_with_an_empty_body() {
+        let recorder = Arc::new(CapturingRecorder::default());
+        let (address, handle) =
+            start_test_server(router_with(Arc::clone(&recorder), Vec::new())).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}{NODE_REPORT_PATH}"))
+            .json(&sample_report())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert!(response.bytes().await.unwrap().is_empty());
+
+        let events = recorder.events();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].report.heads.unsafe_block, 42);
+        assert_eq!(events[0].report.net_health.peer_count, 17);
+        assert_eq!(
+            events[0].ip_source,
+            IpSource::ServerObserved,
+            "a report without an advertised IP is attributed to the connection"
+        );
+        assert_eq!(events[0].reported_ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_advertised_ip_wins_over_the_observed_one() {
+        let recorder = Arc::new(CapturingRecorder::default());
+        let (address, handle) =
+            start_test_server(router_with(Arc::clone(&recorder), Vec::new())).await;
+        let advertised = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 9));
+        let report = NodeReport {
+            net_health: NetHealth { advertised_ip: Some(advertised), ..Default::default() },
+            ..sample_report()
+        };
+
+        reqwest::Client::new()
+            .post(format!("http://{address}{NODE_REPORT_PATH}"))
+            .json(&report)
+            .send()
+            .await
+            .unwrap();
+
+        let events = recorder.events();
+        assert_eq!(events[0].reported_ip, advertised);
+        assert_eq!(events[0].ip_source, IpSource::NodeProvided);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_forwarded_ip_is_used_only_from_a_trusted_proxy() {
+        let recorder = Arc::new(CapturingRecorder::default());
+        let trusted = vec!["127.0.0.0/8".parse().unwrap()];
+        let (address, handle) =
+            start_test_server(router_with(Arc::clone(&recorder), trusted)).await;
+
+        reqwest::Client::new()
+            .post(format!("http://{address}{NODE_REPORT_PATH}"))
+            .header(CLIENT_IP_HEADER, "198.51.100.4")
+            .json(&sample_report())
+            .send()
+            .await
+            .unwrap();
+
+        let events = recorder.events();
+        assert_eq!(events[0].reported_ip, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 4)));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_malformed_json_is_rejected() {
+        let recorder = Arc::new(CapturingRecorder::default());
+        let (address, handle) =
+            start_test_server(router_with(Arc::clone(&recorder), Vec::new())).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}{NODE_REPORT_PATH}"))
+            .header("content-type", "application/json")
+            .body("{\"schema_version\":")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body: IngestErrorResponse = response.json().await.unwrap();
+        assert_eq!(body.error, IngestApiError::InvalidRequest);
+        assert!(recorder.events().is_empty());
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_oversized_body_is_rejected() {
+        let recorder = Arc::new(CapturingRecorder::default());
+        let (address, handle) =
+            start_test_server(router_with(Arc::clone(&recorder), Vec::new())).await;
+        let report = NodeReport {
+            config: base_telemetry_types::NodeConfigReport {
+                experimental_flags: vec!["x".repeat(1024); 32],
+                ..Default::default()
+            },
+            ..sample_report()
+        };
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}{NODE_REPORT_PATH}"))
+            .json(&report)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let body: IngestErrorResponse = response.json().await.unwrap();
+        assert_eq!(body.error, IngestApiError::PayloadTooLarge);
+        assert!(recorder.events().is_empty());
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_unrecognized_schema_version_is_still_recorded() {
+        let recorder = Arc::new(CapturingRecorder::default());
+        let (address, handle) =
+            start_test_server(router_with(Arc::clone(&recorder), Vec::new())).await;
+        let report =
+            NodeReport { schema_version: NODE_REPORT_SCHEMA_VERSION + 1, ..sample_report() };
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}{NODE_REPORT_PATH}"))
+            .json(&report)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::ACCEPTED,
+            "a node must keep reporting across a schema change"
+        );
+        assert_eq!(recorder.events().len(), 1);
+
+        handle.abort();
+    }
+}

--- a/crates/infra/telemetry/src/ingest.rs
+++ b/crates/infra/telemetry/src/ingest.rs
@@ -257,6 +257,12 @@ mod tests {
         let events = recorder.events();
         assert_eq!(events[0].reported_ip, advertised);
         assert_eq!(events[0].ip_source, IpSource::NodeProvided);
+        assert_eq!(
+            events[0].observed_ip,
+            IpAddr::V4(Ipv4Addr::LOCALHOST),
+            "the advertised address must not overwrite the one the request came from"
+        );
+        assert!(events[0].addresses_disagree());
 
         handle.abort();
     }

--- a/crates/infra/telemetry/src/ingest.rs
+++ b/crates/infra/telemetry/src/ingest.rs
@@ -92,6 +92,18 @@ pub struct IngestRoutes;
 
 impl IngestRoutes {
     /// Returns an ingest router writing to the supplied recorder.
+    ///
+    /// The handler needs the peer address to attribute a report, so it extracts
+    /// [`ConnectInfo`] of [`SocketAddr`]. The returned router must therefore be served through
+    /// `into_make_service_with_connect_info::<SocketAddr>()`:
+    ///
+    /// ```ignore
+    /// let router = IngestRoutes::router(recorder, proxy);
+    /// axum::serve(listener, router.into_make_service_with_connect_info::<SocketAddr>()).await
+    /// ```
+    ///
+    /// Serving it as a plain `axum::serve(listener, router)` compiles and then fails the
+    /// extractor at runtime, answering every report with a 500.
     pub fn router(recorder: Arc<dyn ReportRecorder>, proxy: Arc<TrustedProxyConfig>) -> Router {
         Router::new()
             .route(NODE_REPORT_PATH, post(Self::ingest_node_report))

--- a/crates/infra/telemetry/src/lib.rs
+++ b/crates/infra/telemetry/src/lib.rs
@@ -26,6 +26,15 @@ pub use cl_prober::{
     Libp2pProbeResult, Libp2pProbeStage, Libp2pProbeTarget, Libp2pProber,
 };
 
+mod ingest;
+pub use ingest::{
+    DEFAULT_NODE_REPORT_REQUESTS_PER_HOUR, IngestApiError, IngestErrorResponse, IngestRoutes,
+    IngestState, NODE_REPORT_MAX_REQUEST_BYTES, NODE_REPORT_PATH,
+};
+
+mod recorder;
+pub use recorder::{DEFAULT_RECORDER_QUEUE_CAPACITY, JsonlRecorder, ReportRecorder};
+
 mod rate_limit;
 pub use rate_limit::{
     CLIENT_IP_HEADER, DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE, IpRateLimiter, PerIpRateLimit,

--- a/crates/infra/telemetry/src/rate_limit.rs
+++ b/crates/infra/telemetry/src/rate_limit.rs
@@ -84,6 +84,13 @@ impl IpRateLimiter {
         Self { limiter: RateLimiter::dashmap_with_clock(quota, clock.clone()), clock }
     }
 
+    /// Creates a limiter allowing `per_hour` requests per key.
+    pub fn per_hour(per_hour: NonZeroU32) -> Self {
+        let clock = DefaultClock::default();
+        let quota = Quota::per_hour(per_hour);
+        Self { limiter: RateLimiter::dashmap_with_clock(quota, clock.clone()), clock }
+    }
+
     /// Returns the rate-limit bucket key for `ip`.
     ///
     /// `IPv4` addresses key individually, while `IPv6` addresses key by
@@ -133,6 +140,11 @@ impl PerIpRateLimit {
     /// Creates middleware state from a limiter and trusted proxy configuration.
     pub const fn new(limiter: Arc<IpRateLimiter>, proxy: Arc<TrustedProxyConfig>) -> Self {
         Self { limiter, proxy }
+    }
+
+    /// Returns the trusted proxy configuration used to resolve the client IP.
+    pub const fn proxy(&self) -> &Arc<TrustedProxyConfig> {
+        &self.proxy
     }
 
     /// Axum middleware entry point; use with `middleware::from_fn_with_state`.

--- a/crates/infra/telemetry/src/recorder.rs
+++ b/crates/infra/telemetry/src/recorder.rs
@@ -1,0 +1,226 @@
+//! Durable recording of accepted node reports.
+
+use std::{
+    fmt,
+    fs::{OpenOptions, create_dir_all},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use base_telemetry_types::NodeReportEvent;
+use tracing::{info, warn};
+use tracing_appender::non_blocking::{ErrorCounter, NonBlocking, NonBlockingBuilder, WorkerGuard};
+
+/// Bounded queue depth in front of the JSONL file.
+///
+/// A report is roughly a kilobyte and arrives once per node per reporting interval, so this
+/// absorbs a large burst. Past it the recorder drops rather than blocking the handler.
+pub const DEFAULT_RECORDER_QUEUE_CAPACITY: usize = 8192;
+
+/// Accepts node reports that passed validation.
+///
+/// This is the fan-out seam. v1 has one implementation; Datadog and S3 land behind it without
+/// touching the ingest handler.
+pub trait ReportRecorder: fmt::Debug + Send + Sync + 'static {
+    /// Records one accepted report. Must not block and must not fail the request.
+    fn record(&self, event: &NodeReportEvent);
+}
+
+/// Records reports as a structured log event and, when a path is configured, as JSONL.
+///
+/// The file is opened in append mode and written through a background worker, so a slow or
+/// full disk cannot stall the ingest handler. Rotation is left to the operator's log rotation:
+/// the worker reopens nothing, so configure `copytruncate` or restart the service after a
+/// rotation.
+pub struct JsonlRecorder {
+    inner: Arc<RecorderInner>,
+}
+
+struct RecorderInner {
+    writer: Option<NonBlocking>,
+    errors: Option<ErrorCounter>,
+    reported_drops: AtomicU64,
+    path: Option<PathBuf>,
+    _guard: Option<WorkerGuard>,
+}
+
+impl fmt::Debug for JsonlRecorder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JsonlRecorder")
+            .field("path", &self.inner.path)
+            .field("dropped", &self.dropped())
+            .finish_non_exhaustive()
+    }
+}
+
+impl JsonlRecorder {
+    /// Opens `path` for append and starts the background writer.
+    ///
+    /// Parent directories are created if missing.
+    pub fn new(path: impl Into<PathBuf>) -> io::Result<Self> {
+        let path = path.into();
+        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+            create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let (writer, guard) = NonBlockingBuilder::default()
+            .lossy(true)
+            .buffered_lines_limit(DEFAULT_RECORDER_QUEUE_CAPACITY)
+            .finish(file);
+        let errors = writer.error_counter();
+
+        info!(path = %path.display(), "recording node reports to JSONL");
+
+        Ok(Self {
+            inner: Arc::new(RecorderInner {
+                writer: Some(writer),
+                errors: Some(errors),
+                reported_drops: AtomicU64::new(0),
+                path: Some(path),
+                _guard: Some(guard),
+            }),
+        })
+    }
+
+    /// Returns a recorder that only emits the structured log event.
+    pub fn log_only() -> Self {
+        Self {
+            inner: Arc::new(RecorderInner {
+                writer: None,
+                errors: None,
+                reported_drops: AtomicU64::new(0),
+                path: None,
+                _guard: None,
+            }),
+        }
+    }
+
+    /// Returns the number of reports the background writer has dropped.
+    pub fn dropped(&self) -> u64 {
+        self.inner.errors.as_ref().map_or(0, |errors| errors.dropped_lines() as u64)
+    }
+
+    /// Returns the JSONL path, if one is configured.
+    pub fn path(&self) -> Option<&Path> {
+        self.inner.path.as_deref()
+    }
+
+    /// Logs newly observed drops exactly once each, so a full queue does not log per report.
+    fn report_new_drops(&self) {
+        let dropped = self.dropped();
+        let previous = self.inner.reported_drops.swap(dropped, Ordering::Relaxed);
+        if dropped > previous {
+            warn!(
+                dropped_total = dropped,
+                newly_dropped = dropped - previous,
+                "node report writer queue full, reports dropped"
+            );
+        }
+    }
+}
+
+impl Clone for JsonlRecorder {
+    fn clone(&self) -> Self {
+        Self { inner: Arc::clone(&self.inner) }
+    }
+}
+
+impl ReportRecorder for JsonlRecorder {
+    fn record(&self, event: &NodeReportEvent) {
+        info!(
+            telemetry_id = %event.report.telemetry_id,
+            schema_version = %event.report.schema_version,
+            version = %event.report.client.client_version,
+            git_sha = %event.report.client.git_sha,
+            l2_chain_id = event.report.client.l2_chain_id,
+            network = %event.report.client.network,
+            layer = event.report.client.layer.as_str(),
+            role = event.report.client.role.as_str(),
+            unsafe_block = event.report.heads.unsafe_block,
+            unsafe_latency_secs = event.report.heads.unsafe_latency_secs,
+            worst_unsafe_latency_secs = event.report.heads.worst_unsafe_latency_secs,
+            peer_count = event.report.net_health.peer_count,
+            hardware_platform = event.report.hardware.platform.as_str(),
+            ip_source = event.ip_source.as_str(),
+            "node report accepted"
+        );
+
+        let Some(writer) = self.inner.writer.as_ref() else {
+            return;
+        };
+        let Ok(mut line) = serde_json::to_vec(event) else {
+            warn!(telemetry_id = %event.report.telemetry_id, "failed to serialize node report");
+            return;
+        };
+        line.push(b'\n');
+
+        let mut writer = writer.clone();
+        if let Err(error) = writer.write_all(&line) {
+            warn!(error = %error, "failed to append node report to JSONL");
+        }
+        self.report_new_drops();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr};
+
+    use base_telemetry_types::{Heads, IpSource, NodeReport, NodeReportEvent};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    use super::*;
+
+    fn event() -> NodeReportEvent {
+        let report = NodeReport {
+            telemetry_id: Uuid::from_u128(0x0123_4567_89ab_cdef_0123_4567_89ab_cdef),
+            heads: Heads { unsafe_block: 42, ..Default::default() },
+            ..Default::default()
+        };
+        NodeReportEvent::new(report, Utc::now(), IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)))
+    }
+
+    #[test]
+    fn test_records_one_jsonl_line_per_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("node-reports.jsonl");
+        let recorder = JsonlRecorder::new(&path).unwrap();
+
+        recorder.record(&event());
+        recorder.record(&event());
+        drop(recorder);
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<_> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let decoded: NodeReportEvent = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(decoded.report.heads.unsafe_block, 42);
+        assert_eq!(decoded.ip_source, IpSource::ServerObserved);
+        assert_eq!(decoded.reported_ip, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)));
+    }
+
+    #[test]
+    fn test_log_only_recorder_writes_no_file() {
+        let recorder = JsonlRecorder::log_only();
+
+        recorder.record(&event());
+
+        assert!(recorder.path().is_none());
+        assert_eq!(recorder.dropped(), 0);
+    }
+
+    #[test]
+    fn test_opening_an_unwritable_path_is_an_error_not_a_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node-reports.jsonl");
+        std::fs::create_dir(&path).unwrap();
+
+        assert!(JsonlRecorder::new(&path).is_err());
+    }
+}

--- a/crates/infra/telemetry/src/recorder.rs
+++ b/crates/infra/telemetry/src/recorder.rs
@@ -145,6 +145,7 @@ impl ReportRecorder for JsonlRecorder {
             worst_unsafe_latency_secs = event.report.heads.worst_unsafe_latency_secs,
             peer_count = event.report.net_health.peer_count,
             hardware_platform = event.report.hardware.platform.as_str(),
+            reported_ip = %event.reported_ip,
             ip_source = event.ip_source.as_str(),
             "node report accepted"
         );

--- a/crates/infra/telemetry/src/recorder.rs
+++ b/crates/infra/telemetry/src/recorder.rs
@@ -147,6 +147,7 @@ impl ReportRecorder for JsonlRecorder {
             hardware_platform = event.report.hardware.platform.as_str(),
             reported_ip = %event.reported_ip,
             ip_source = event.ip_source.as_str(),
+            observed_ip = %event.observed_ip,
             "node report accepted"
         );
 
@@ -204,6 +205,7 @@ mod tests {
         assert_eq!(decoded.report.heads.unsafe_block, 42);
         assert_eq!(decoded.ip_source, IpSource::ServerObserved);
         assert_eq!(decoded.reported_ip, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)));
+        assert_eq!(decoded.observed_ip, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)));
     }
 
     #[test]

--- a/crates/infra/telemetry/src/recorder.rs
+++ b/crates/infra/telemetry/src/recorder.rs
@@ -36,6 +36,12 @@ pub trait ReportRecorder: fmt::Debug + Send + Sync + 'static {
 /// full disk cannot stall the ingest handler. Rotation is left to the operator's log rotation:
 /// the worker reopens nothing, so configure `copytruncate` or restart the service after a
 /// rotation.
+///
+/// Clones share one background worker. The worker is flushed and joined when the *last* clone
+/// drops, and nothing else flushes it, so a clone must outlive every request handler that can
+/// call [`ReportRecorder::record`] — the server holds one for the process lifetime. Shortening
+/// that lifetime silently truncates the tail of the file. A signal that skips destructors
+/// (`SIGKILL`) loses the queued lines by design: the alternative is blocking ingest on the disk.
 pub struct JsonlRecorder {
     inner: Arc<RecorderInner>,
 }
@@ -45,6 +51,10 @@ struct RecorderInner {
     errors: Option<ErrorCounter>,
     reported_drops: AtomicU64,
     path: Option<PathBuf>,
+    /// Flushes queued lines and joins the writer thread when the last [`JsonlRecorder`] drops.
+    ///
+    /// Held here rather than by the caller so that any live clone keeps the worker running: a
+    /// handler cannot observe a shut-down writer while it still holds a recorder.
     _guard: Option<WorkerGuard>,
 }
 
@@ -101,7 +111,10 @@ impl JsonlRecorder {
 
     /// Returns the number of reports the background writer has dropped.
     pub fn dropped(&self) -> u64 {
-        self.inner.errors.as_ref().map_or(0, |errors| errors.dropped_lines() as u64)
+        self.inner
+            .errors
+            .as_ref()
+            .map_or(0, |errors| u64::try_from(errors.dropped_lines()).unwrap_or(u64::MAX))
     }
 
     /// Returns the JSONL path, if one is configured.
@@ -206,6 +219,26 @@ mod tests {
         assert_eq!(decoded.ip_source, IpSource::ServerObserved);
         assert_eq!(decoded.reported_ip, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)));
         assert_eq!(decoded.observed_ip, IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7)));
+    }
+
+    #[test]
+    fn test_writer_survives_until_the_last_clone_drops() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("node-reports.jsonl");
+        let recorder = JsonlRecorder::new(&path).unwrap();
+        let held = recorder.clone();
+
+        recorder.record(&event());
+        drop(recorder);
+        held.record(&event());
+        drop(held);
+
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(
+            contents.lines().count(),
+            2,
+            "dropping one clone must not shut the writer down, and the last drop must flush"
+        );
     }
 
     #[test]

--- a/crates/infra/telemetry/src/server.rs
+++ b/crates/infra/telemetry/src/server.rs
@@ -1,6 +1,7 @@
 use std::{
     net::SocketAddr,
     num::NonZeroU32,
+    path::PathBuf,
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
@@ -18,9 +19,10 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    CLIENT_IP_HEADER, ClReachabilityProber, DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE,
-    DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES, IpRateLimiter, Libp2pProber, P2pRoutes,
-    PerIpRateLimit, ReachabilityProber, RlpxProber,
+    CLIENT_IP_HEADER, ClReachabilityProber, DEFAULT_NODE_REPORT_REQUESTS_PER_HOUR,
+    DEFAULT_P2P_PROBE_REQUESTS_PER_MINUTE, DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+    IngestRoutes, IpRateLimiter, JsonlRecorder, Libp2pProber, P2pRoutes, PerIpRateLimit,
+    ReachabilityProber, ReportRecorder, RlpxProber,
 };
 
 /// Configuration for the Base telemetry HTTP server.
@@ -52,6 +54,18 @@ pub struct ServerConfig {
         value_parser = RangedU64ValueParser::<usize>::new().range(1..=Semaphore::MAX_PERMITS as u64)
     )]
     pub p2p_max_concurrent_probes: usize,
+    /// Node reports accepted per hour from each client IP.
+    #[arg(
+        long,
+        env = "BASE_TELEMETRY_NODE_REPORT_REQUESTS_PER_HOUR",
+        default_value_t = DEFAULT_NODE_REPORT_REQUESTS_PER_HOUR
+    )]
+    pub node_report_requests_per_hour: NonZeroU32,
+    /// File accepted node reports are appended to as JSONL.
+    ///
+    /// When unset, reports are only emitted as structured log events.
+    #[arg(long, env = "BASE_TELEMETRY_NODE_REPORT_PATH")]
+    pub node_report_path: Option<PathBuf>,
 }
 
 /// Base telemetry Axum server scaffold.
@@ -76,6 +90,15 @@ impl BaseTelemetryServer {
         HealthServer::router(ready).merge(p2p)
     }
 
+    /// Returns the node report ingest router, rate limited on its own quota.
+    ///
+    /// Ingest is limited separately from the reachability probes: a probe costs an outbound
+    /// connection and a report costs an append, so one quota cannot serve both.
+    pub fn ingest_router(recorder: Arc<dyn ReportRecorder>, per_ip: PerIpRateLimit) -> Router {
+        IngestRoutes::router(recorder, Arc::clone(per_ip.proxy()))
+            .layer(middleware::from_fn_with_state(per_ip, PerIpRateLimit::enforce))
+    }
+
     /// Starts the telemetry service with the provided configuration.
     pub async fn serve(config: ServerConfig, cancel: CancellationToken) -> anyhow::Result<()> {
         let listen_addr = config.listen_addr;
@@ -85,15 +108,25 @@ impl BaseTelemetryServer {
         ));
         let limiter = Arc::new(IpRateLimiter::per_minute(config.p2p_probe_requests_per_minute));
         let eviction = limiter.spawn_eviction_task(cancel.clone());
+        let ingest_limiter =
+            Arc::new(IpRateLimiter::per_hour(config.node_report_requests_per_hour));
+        let ingest_eviction = ingest_limiter.spawn_eviction_task(cancel.clone());
+
+        let recorder = Arc::new(match config.node_report_path {
+            Some(path) => JsonlRecorder::new(&path)
+                .with_context(|| format!("failed to open node report file {}", path.display()))?,
+            None => JsonlRecorder::log_only(),
+        });
 
         let ready = Arc::new(AtomicBool::new(false));
         let app = Self::router_with_probers(
             Arc::clone(&ready),
-            PerIpRateLimit::new(limiter, proxy),
+            PerIpRateLimit::new(limiter, Arc::clone(&proxy)),
             config.p2p_max_concurrent_probes,
             Arc::new(RlpxProber::ephemeral()),
             Arc::new(Libp2pProber::ephemeral()),
-        );
+        )
+        .merge(Self::ingest_router(recorder, PerIpRateLimit::new(ingest_limiter, proxy)));
         let listener = TcpListener::bind(listen_addr)
             .await
             .with_context(|| format!("failed to bind base telemetry server to {listen_addr}"))?;
@@ -110,6 +143,7 @@ impl BaseTelemetryServer {
             .context("base telemetry server exited unexpectedly")?;
 
         let _ = eviction.await;
+        let _ = ingest_eviction.await;
 
         Ok(())
     }
@@ -125,14 +159,15 @@ mod tests {
     };
 
     use axum::{Router, http::StatusCode};
+    use base_telemetry_types::NodeReport;
     use base_trusted_proxy::TrustedProxyConfig;
     use tokio::{net::TcpListener, sync::Semaphore, task::JoinHandle};
 
     use crate::{
         BaseTelemetryServer, BlockingProber, DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
-        ElReachabilityRequest, IpRateLimiter, MockClReachabilityProber, MockReachabilityProber,
-        P2P_REACHABILITY_EL_PATH, PerIpRateLimit, RlpxProbeOutcome, RlpxProbeResult,
-        RlpxProbeStage, TEST_NODE_ID,
+        ElReachabilityRequest, IpRateLimiter, JsonlRecorder, MockClReachabilityProber,
+        MockReachabilityProber, NODE_REPORT_PATH, P2P_REACHABILITY_EL_PATH, PerIpRateLimit,
+        RlpxProbeOutcome, RlpxProbeResult, RlpxProbeStage, TEST_NODE_ID,
     };
 
     /// Returns a mock prober that answers every probe as reachable.
@@ -271,6 +306,43 @@ mod tests {
         // Health routes are not subject to the per-IP limit.
         let health = client.get(format!("http://{addr}/healthz")).send().await.unwrap();
         assert_eq!(health.status(), StatusCode::OK);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn ingest_is_rate_limited_on_its_own_quota() {
+        let router = BaseTelemetryServer::router_with_probers(
+            Arc::new(AtomicBool::new(true)),
+            per_ip(1, vec![]),
+            DEFAULT_P2P_REACHABILITY_MAX_CONCURRENT_PROBES,
+            reachable_prober(),
+            Arc::new(MockClReachabilityProber::new()),
+        )
+        .merge(BaseTelemetryServer::ingest_router(
+            Arc::new(JsonlRecorder::log_only()),
+            per_ip(1, vec![]),
+        ));
+        let (addr, handle) = start_router(router).await;
+        let client = reqwest::Client::new();
+        let ingest_url = format!("http://{addr}{NODE_REPORT_PATH}");
+        let report = NodeReport::default();
+
+        let first = client.post(&ingest_url).json(&report).send().await.unwrap();
+        assert_eq!(first.status(), StatusCode::ACCEPTED);
+
+        let second = client.post(&ingest_url).json(&report).send().await.unwrap();
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(second.headers().contains_key("retry-after"));
+
+        // The probe quota is a separate bucket, so exhausting ingest does not close probing.
+        let probe = client
+            .post(format!("http://{addr}{P2P_REACHABILITY_EL_PATH}"))
+            .json(&test_request())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(probe.status(), StatusCode::OK);
 
         handle.abort();
     }

--- a/crates/infra/telemetry/tests/round_trip.rs
+++ b/crates/infra/telemetry/tests/round_trip.rs
@@ -1,0 +1,196 @@
+//! Round trip between the real telemetry client and the real ingest service.
+//!
+//! The in-crate ingest tests hand-build a `NodeReport` and POST it with `reqwest`, which proves
+//! the handler but not that the client and the service agree. These tests drive the actual
+//! [`NodeReportBuilder`] and [`TelemetryReporter`] against a live [`IngestRoutes`] router, so a
+//! field the client renames or a shape the service cannot parse fails here rather than in the
+//! Docker-backed system test.
+
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use base_retry::RetryConfig;
+use base_telemetry_client::{
+    HttpReportSink, NodeIdentity, NodeReportBuilder, ReportSink, TelemetryId, TelemetryReporter,
+};
+use base_telemetry_service::{IngestRoutes, NODE_REPORT_PATH, ReportRecorder};
+use base_telemetry_types::{
+    Heads, NODE_REPORT_SCHEMA_VERSION, NetHealth, NodeConfigReport, NodeLayer, NodeReport,
+    NodeReportEvent, NodeRole, PruneMode,
+};
+use base_trusted_proxy::TrustedProxyConfig;
+use tokio::{net::TcpListener, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+use url::Url;
+
+/// How long to wait for an asynchronously delivered report to reach the recorder.
+const DELIVERY_TIMEOUT: Duration = Duration::from_secs(5);
+/// Interval between recorder polls while awaiting delivery.
+const DELIVERY_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Collects accepted events in memory.
+///
+/// Hand-rolled rather than `automock`ed because the assertions read the accumulated events,
+/// not call counts on the trait.
+#[derive(Debug, Default)]
+struct CapturingRecorder {
+    events: Mutex<Vec<NodeReportEvent>>,
+}
+
+impl CapturingRecorder {
+    fn events(&self) -> Vec<NodeReportEvent> {
+        self.events.lock().expect("recorder lock poisoned").clone()
+    }
+}
+
+impl ReportRecorder for CapturingRecorder {
+    fn record(&self, event: &NodeReportEvent) {
+        self.events.lock().expect("recorder lock poisoned").push(event.clone());
+    }
+}
+
+/// A running ingest endpoint and the events it has accepted.
+struct Ingest {
+    endpoint: Url,
+    recorder: Arc<CapturingRecorder>,
+    server: JoinHandle<()>,
+}
+
+impl Drop for Ingest {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+impl Ingest {
+    /// Serves the real ingest router on an ephemeral loopback port.
+    async fn start() -> Self {
+        let recorder = Arc::new(CapturingRecorder::default());
+        let proxy = Arc::new(TrustedProxyConfig::new("x-forwarded-for".to_string(), Vec::new()));
+        let router = IngestRoutes::router(Arc::clone(&recorder) as Arc<dyn ReportRecorder>, proxy);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind loopback");
+        let address = listener.local_addr().expect("read bound address");
+        let server = tokio::spawn(async move {
+            let service = router.into_make_service_with_connect_info::<SocketAddr>();
+            let _ = axum::serve(listener, service).await;
+        });
+
+        Self {
+            endpoint: Url::parse(&format!("http://{address}{NODE_REPORT_PATH}"))
+                .expect("valid endpoint URL"),
+            recorder,
+            server,
+        }
+    }
+
+    /// Waits for the recorder to hold at least `count` events.
+    async fn wait_for_events(&self, count: usize) -> Vec<NodeReportEvent> {
+        let deadline = tokio::time::Instant::now() + DELIVERY_TIMEOUT;
+        loop {
+            let events = self.recorder.events();
+            if events.len() >= count {
+                return events;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "only {} of {count} reports reached the recorder",
+                events.len()
+            );
+            tokio::time::sleep(DELIVERY_POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// Builds a report the way a running consensus node does.
+fn report() -> NodeReport {
+    let identity = NodeIdentity {
+        telemetry_id: TelemetryId::generate(),
+        instance_id: Some("round-trip".to_string()),
+        client_version: "1.2.3".to_string(),
+        l2_chain_id: 8453,
+        network: "mainnet".to_string(),
+        layer: NodeLayer::Consensus,
+        role: NodeRole::Validator,
+        data_dir: None,
+    };
+    let node_config = NodeConfigReport {
+        prune_mode: Some(PruneMode::Archive),
+        p2p_enabled: true,
+        discovery_enabled: true,
+        sequencer_enabled: false,
+        supervisor_enabled: false,
+        flashblocks_enabled: false,
+        metrics_enabled: false,
+        experimental_flags: vec!["round-trip".to_string()],
+        report_interval_secs: 900,
+        sample_interval_secs: 60,
+    };
+    let heads = Heads {
+        unsafe_block: 1_234,
+        local_safe_block: Some(1_232),
+        safe_block: Some(1_230),
+        finalized_block: Some(1_200),
+        unsafe_latency_secs: 1.5,
+        worst_unsafe_latency_secs: 4.25,
+        unsafe_latency_samples: vec![0.5, 1.5, 4.25],
+    };
+    let net = NetHealth {
+        peer_count: 17,
+        peer_target: Some(64),
+        peers_joined: 3,
+        peers_left: 1,
+        peer_id: Some("16Uiu2HAm".to_string()),
+        gossip_error_rate: Some(0.0),
+        ..Default::default()
+    };
+    NodeReportBuilder::new(identity, node_config).build(heads, net)
+}
+
+/// A report the client builds survives the wire and arrives at the recorder unchanged.
+#[tokio::test]
+async fn test_a_client_built_report_arrives_at_the_recorder_intact() {
+    let ingest = Ingest::start().await;
+    let sent = report();
+
+    let sink = HttpReportSink::new(ingest.endpoint.clone(), Duration::from_secs(5))
+        .expect("build the HTTP sink");
+    sink.send(&sent).await.expect("the ingest endpoint should accept a well-formed report");
+
+    let events = ingest.wait_for_events(1).await;
+    let received = &events[0].report;
+
+    assert_eq!(received, &sent, "every field must survive serialization and parsing");
+    assert_eq!(received.schema_version, NODE_REPORT_SCHEMA_VERSION);
+    assert!(events[0].reported_ip.is_loopback(), "the observed IP falls back to the connection");
+}
+
+/// The reporter's background delivery task reaches the ingest endpoint.
+///
+/// This is the path a node actually uses: the actor enqueues and moves on, and delivery happens
+/// off the reporting cycle.
+#[tokio::test]
+async fn test_the_reporter_delivers_queued_reports_to_ingest() {
+    let ingest = Ingest::start().await;
+    let cancellation = CancellationToken::new();
+    let sink = Arc::new(
+        HttpReportSink::new(ingest.endpoint.clone(), Duration::from_secs(5))
+            .expect("build the HTTP sink"),
+    );
+    let reporter = TelemetryReporter::spawn(sink, RetryConfig::default(), 4, cancellation.clone());
+
+    let first = report();
+    let second = report();
+    assert!(reporter.enqueue(first.clone()), "the queue starts empty");
+    assert!(reporter.enqueue(second.clone()), "the queue has room for a second report");
+
+    let events = ingest.wait_for_events(2).await;
+    assert_eq!(events[0].report, first);
+    assert_eq!(events[1].report, second);
+    assert_eq!(reporter.dropped_reports(), 0, "nothing should have been dropped");
+
+    cancellation.cancel();
+}

--- a/crates/utilities/cli/Cargo.toml
+++ b/crates/utilities/cli/Cargo.toml
@@ -24,6 +24,9 @@ opentelemetry_sdk.workspace = true
 reth-node-core.workspace = true
 reth-tracing-otlp = { workspace = true, optional = true }
 
+# telemetry
+base-telemetry-client.workspace = true
+
 # metrics
 metrics.workspace = true
 base-metrics = { workspace = true, features = ["metrics"] }

--- a/crates/utilities/cli/src/lib.rs
+++ b/crates/utilities/cli/src/lib.rs
@@ -14,6 +14,8 @@ mod backtrace;
 pub use backtrace::Backtracing;
 
 mod prometheus;
+/// Re-exported so `define_telemetry_args!` can name the type it builds.
+pub use base_telemetry_client::TelemetryConfig;
 pub use prometheus::{BuildError, MetricsConfig, PrometheusServer};
 
 mod styles;

--- a/crates/utilities/cli/src/macros.rs
+++ b/crates/utilities/cli/src/macros.rs
@@ -167,7 +167,9 @@ macro_rules! define_telemetry_args {
 
             /// Where the persisted telemetry identity lives.
             ///
-            /// Defaults to `$HOME/.base/<l2_chain_id>/telemetry-id`.
+            /// Defaults to `$HOME/.base/<l2_chain_id>/telemetry-id`. Set this when `$HOME` is
+            /// unset, as it is for most containers: with neither, there is nowhere durable to
+            /// keep an identity and the node reports nothing.
             #[arg(
                 id = "telemetry_id_path",
                 long = "telemetry.id-path",
@@ -229,10 +231,19 @@ macro_rules! define_telemetry_args {
             ///
             /// `l2_chain_id` only decides where the identity is persisted, and only when
             /// `--telemetry.id-path` is not set.
+            ///
+            /// The identity path resolves to `None` when neither the flag nor `$HOME` names a
+            /// location. That is the whole answer: the node warns and reports nothing, rather
+            /// than writing an identity to a working directory it may not have next restart.
             pub fn config(&self, l2_chain_id: u64) -> $crate::TelemetryConfig {
-                let id_path = self.id_path.clone().unwrap_or_else(|| {
-                    $crate::TelemetryConfig::default_id_path(l2_chain_id)
-                });
+                // An empty value counts as unset. A declared-but-empty
+                // `<PREFIX>_TELEMETRY_ID_PATH` is how a container manifest routinely spells "not
+                // configured", and clap hands that through as an empty path rather than `None`.
+                let id_path = self
+                    .id_path
+                    .clone()
+                    .filter(|path| !path.as_os_str().is_empty())
+                    .or_else(|| $crate::TelemetryConfig::default_id_path(l2_chain_id));
                 $crate::TelemetryConfig {
                     enabled: self.enabled,
                     endpoint: self.endpoint.clone(),

--- a/crates/utilities/cli/src/macros.rs
+++ b/crates/utilities/cli/src/macros.rs
@@ -105,6 +105,148 @@ macro_rules! define_metrics_args {
     };
 }
 
+/// Generates a `TelemetryArgs` struct with node telemetry configuration,
+/// parameterized by env var prefix at compile time.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// base_cli_utils::define_telemetry_args!("BASE_NODE");
+/// ```
+///
+/// Telemetry is opt-*out*: `enabled` defaults to `true` and is switched off with
+/// `--telemetry.enabled=false`. Reporting is nevertheless inert until an endpoint is configured,
+/// so a build with no `--telemetry.endpoint` sends nothing and mints no identity.
+///
+/// Each env-backed field appends `_TELEMETRY_ENABLED`, `_TELEMETRY_ENDPOINT`,
+/// `_TELEMETRY_INSTANCE_ID`, `_TELEMETRY_ID_PATH`, `_TELEMETRY_DATA_DIR`,
+/// `_TELEMETRY_REPORT_INTERVAL`, or `_TELEMETRY_SAMPLE_INTERVAL` to the given prefix.
+///
+/// Also generates `impl Default for TelemetryArgs` and
+/// `TelemetryArgs::config(&self, l2_chain_id)`, which resolves the identity path for the chain
+/// when `--telemetry.id-path` is not set.
+#[rustfmt::skip]
+#[macro_export]
+macro_rules! define_telemetry_args {
+    ($prefix:literal) => {
+        /// Configuration for node telemetry reporting.
+        ///
+        /// Telemetry is opt-out. Switch it off with `--telemetry.enabled=false`.
+        #[derive(Debug, Clone, ::clap::Parser)]
+        #[command(next_help_heading = "Telemetry")]
+        pub struct TelemetryArgs {
+            /// Controls whether this node reports telemetry. Enabled by default; reporting still
+            /// requires an endpoint.
+            #[arg(
+                id = "telemetry_enabled",
+                long = "telemetry.enabled",
+                global = true,
+                default_value_t = true,
+                action = ::clap::ArgAction::Set,
+                env = concat!($prefix, "_TELEMETRY_ENABLED")
+            )]
+            pub enabled: bool,
+
+            /// Where to send telemetry reports. Nothing is sent while this is unset.
+            #[arg(
+                id = "telemetry_endpoint",
+                long = "telemetry.endpoint",
+                global = true,
+                env = concat!($prefix, "_TELEMETRY_ENDPOINT")
+            )]
+            pub endpoint: Option<::url::Url>,
+
+            /// Operator-chosen tag for this node, used to identify a node across restarts.
+            #[arg(
+                id = "telemetry_instance_id",
+                long = "telemetry.instance-id",
+                global = true,
+                env = concat!($prefix, "_TELEMETRY_INSTANCE_ID")
+            )]
+            pub instance_id: Option<String>,
+
+            /// Where the persisted telemetry identity lives.
+            ///
+            /// Defaults to `$HOME/.base/<l2_chain_id>/telemetry-id`.
+            #[arg(
+                id = "telemetry_id_path",
+                long = "telemetry.id-path",
+                global = true,
+                env = concat!($prefix, "_TELEMETRY_ID_PATH")
+            )]
+            pub id_path: Option<::std::path::PathBuf>,
+
+            /// Directory whose filesystem the reported disk fields describe.
+            ///
+            /// Defaults to the directory holding the node's own on-disk state. Set this when
+            /// chain data lives on a volume the node does not otherwise name, or the disk
+            /// fields describe the wrong device.
+            #[arg(
+                id = "telemetry_data_dir",
+                long = "telemetry.data-dir",
+                global = true,
+                env = concat!($prefix, "_TELEMETRY_DATA_DIR")
+            )]
+            pub data_dir: Option<::std::path::PathBuf>,
+
+            /// How often to send a report, in seconds.
+            #[arg(
+                id = "telemetry_report_interval",
+                long = "telemetry.report-interval",
+                global = true,
+                default_value = "900",
+                env = concat!($prefix, "_TELEMETRY_REPORT_INTERVAL")
+            )]
+            pub report_interval: u64,
+
+            /// How often to sample head lag between reports, in seconds.
+            #[arg(
+                id = "telemetry_sample_interval",
+                long = "telemetry.sample-interval",
+                global = true,
+                default_value = "60",
+                env = concat!($prefix, "_TELEMETRY_SAMPLE_INTERVAL")
+            )]
+            pub sample_interval: u64,
+        }
+
+        impl Default for TelemetryArgs {
+            fn default() -> Self {
+                Self {
+                    enabled: true,
+                    endpoint: None,
+                    instance_id: None,
+                    id_path: None,
+                    data_dir: None,
+                    report_interval: 900,
+                    sample_interval: 60,
+                }
+            }
+        }
+
+        impl TelemetryArgs {
+            /// Resolves these arguments into a telemetry client configuration.
+            ///
+            /// `l2_chain_id` only decides where the identity is persisted, and only when
+            /// `--telemetry.id-path` is not set.
+            pub fn config(&self, l2_chain_id: u64) -> $crate::TelemetryConfig {
+                let id_path = self.id_path.clone().unwrap_or_else(|| {
+                    $crate::TelemetryConfig::default_id_path(l2_chain_id)
+                });
+                $crate::TelemetryConfig {
+                    enabled: self.enabled,
+                    endpoint: self.endpoint.clone(),
+                    instance_id: self.instance_id.clone(),
+                    data_dir: self.data_dir.clone(),
+                    report_interval: ::std::time::Duration::from_secs(self.report_interval),
+                    sample_interval: ::std::time::Duration::from_secs(self.sample_interval),
+                    ..$crate::TelemetryConfig::disabled(id_path)
+                }
+            }
+        }
+    };
+}
+
 /// Generates a `LogArgs` struct with logging configuration,
 /// parameterized by env var prefix at compile time.
 ///

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -31,6 +31,12 @@ base-protocol = { workspace = true, features = ["serde", "std"] }
 base-node-runner = { workspace = true, features = ["test-utils"] }
 base-builder-core = { workspace = true, features = ["test-utils"] }
 
+# telemetry
+base-trusted-proxy.workspace = true
+base-telemetry-types.workspace = true
+base-telemetry-client.workspace = true
+base-telemetry-service.workspace = true
+
 # consensus
 base-consensus-disc.workspace = true
 base-consensus-node.workspace = true

--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -20,7 +20,7 @@ use base_common_genesis::RollupConfig;
 use base_consensus_disc::LocalNode;
 use base_consensus_node::{
     EngineConfig, L1ConfigBuilder, NetworkConfig, NodeMode, RollupNodeBuilder, SequencerConfig,
-    UpgradeSignalBuilderConfig,
+    TelemetryNodeConfig, UpgradeSignalBuilderConfig,
 };
 use base_consensus_peers::{PeerScoreLevel, SecretKeyLoader};
 use base_consensus_rpc::{AdminApiClient, BaseP2PApiClient, RollupNodeApiClient, RpcBuilder};
@@ -89,6 +89,11 @@ pub struct InProcessConsensusConfig {
     /// CLI. The config is also passed to the node for live polling (and, in runtime-admin mode,
     /// automatic re-application of observed L1 changes).
     pub upgrade_signal: Option<UpgradeSignalConfig>,
+    /// Optional node telemetry configuration.
+    ///
+    /// When set, the node reports to the configured endpoint on the configured cadence. When
+    /// [`None`], the telemetry actor is never built and the node sends nothing.
+    pub telemetry: Option<TelemetryNodeConfig>,
 }
 
 /// A running in-process consensus node.
@@ -236,7 +241,8 @@ impl InProcessConsensus {
             metrics_config: config.upgrade_signal,
             l1_rpc: None,
         })
-        .with_checkpoint_path(checkpoint_path);
+        .with_checkpoint_path(checkpoint_path)
+        .with_telemetry_config(config.telemetry);
 
         if config.mode == NodeMode::Sequencer {
             builder = builder.with_sequencer_config(SequencerConfig {

--- a/etc/systems/src/l2/shadow_sequencer.rs
+++ b/etc/systems/src/l2/shadow_sequencer.rs
@@ -113,6 +113,7 @@ impl ShadowSequencer {
             verifier_l1_confs: 0,
             shadow_blocks_per_cycle: Some(config.shadow_blocks_per_cycle),
             upgrade_signal: None,
+            telemetry: None,
         })
         .await
         .wrap_err("Failed to start shadow consensus")?;

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -20,7 +20,7 @@ use alloy_signer_local::PrivateKeySigner;
 use base_common_genesis::RollupConfig;
 use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionRequest;
-use base_consensus_node::NodeMode;
+use base_consensus_node::{NodeMode, TelemetryNodeConfig};
 use base_execution_cli::ExecutionUpgradeSignalConfig;
 use base_node_runner::BaseNodeExtension;
 use base_tx_forwarding::TxForwardingConfig;
@@ -86,6 +86,12 @@ pub struct L2StackConfig {
     pub upgrade_signal: Option<UpgradeSignalConfig>,
     /// Optional L1 upgrade signal configuration for the client execution node.
     pub execution_upgrade_signal: Option<ExecutionUpgradeSignalConfig>,
+    /// Optional telemetry configuration for the client (validator) consensus node.
+    ///
+    /// Only the client node reports. It is the node a third-party operator runs, so it is the
+    /// one whose reports are worth proving end to end; the builder and the shadows are stack
+    /// fixtures and reporting from them would only add duplicate rows.
+    pub telemetry: Option<TelemetryNodeConfig>,
     /// Shadow sequencer configuration. When [`None`], no shadow sequencers are started.
     pub shadow_sequencers: Option<ShadowSequencersConfig>,
     /// Additional node extensions installed on the builder, after its built-in RPC wiring.
@@ -230,6 +236,7 @@ impl L2Stack {
             verifier_l1_confs: 0,
             shadow_blocks_per_cycle: None,
             upgrade_signal: config.upgrade_signal.clone(),
+            telemetry: None,
         };
         let builder_consensus = InProcessConsensus::start(builder_consensus_config)
             .await
@@ -310,6 +317,7 @@ impl L2Stack {
                     verifier_l1_confs: config.verifier_l1_confs,
                     shadow_blocks_per_cycle: None,
                     upgrade_signal: config.upgrade_signal.clone(),
+                    telemetry: config.telemetry.clone(),
                 };
                 let client_consensus = InProcessConsensus::start(client_consensus_config)
                     .await

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -72,6 +72,9 @@ mod smoke;
 pub use smoke::RuntimeUpgradeSignalGuard;
 pub use smoke::{SystemTestStack, SystemTestStackBuilder};
 
+mod telemetry;
+pub use telemetry::{ChannelRecorder, TelemetryIngest, TelemetryStackOptions};
+
 mod system_config;
 pub use system_config::{StableSystemTestConfig, SystemTestPorts};
 

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -35,6 +35,7 @@ use crate::{
     },
     setup::{L1GenesisOutput, L2DeploymentOutput, SetupContainer},
     system_config::StableSystemTestConfig,
+    telemetry::{TelemetryIngest, TelemetryStackOptions},
 };
 
 const DEFAULT_L1_CHAIN_ID: u64 = 1337;
@@ -43,6 +44,11 @@ const DEFAULT_L2_CHAIN_ID: u64 = 84538453;
 /// slot, so this dominates stack startup time.
 const DEFAULT_SLOT_DURATION: u64 = 1;
 const DEFAULT_SHADOW_BLOCKS_PER_CYCLE: NonZeroU64 = NonZeroU64::new(3).unwrap();
+/// Prefix for the network name reported by a telemetry-enabled stack.
+///
+/// A system test chain has no registered network name, so reports are labelled by chain ID
+/// behind a prefix that can never be mistaken for a real network.
+const TELEMETRY_NETWORK_PREFIX: &str = "system-test-";
 
 /// Longest wait for a live L1 schedule change to be re-applied by a runtime-admin node (the
 /// upgrade signal poll interval is 12s).
@@ -110,6 +116,7 @@ pub struct SystemTestStack {
     l1_stack: L1Stack,
     l2_stack: L2Stack,
     l1_rpc_proxy: Option<L1RpcProxy>,
+    telemetry: Option<TelemetryIngest>,
     #[cfg(feature = "upgrade-signal")]
     upgrade_signal: Option<MockProtocolVersionsClient>,
     /// Must be the last field: it clears the runtime registry on drop, so the stacks above
@@ -215,6 +222,16 @@ impl SystemTestStack {
         Ok(RootProvider::<Base>::new(client))
     }
 
+    /// Returns the telemetry ingest endpoint, when the stack was built with
+    /// [`SystemTestStackBuilder::with_telemetry`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the stack was built without telemetry.
+    pub const fn telemetry(&self) -> &TelemetryIngest {
+        self.telemetry.as_ref().expect("stack was not built with telemetry enabled")
+    }
+
     /// Returns the mock L1 upgrade signal contract client, when the stack was built with
     /// [`SystemTestStackBuilder::with_upgrade_signal`].
     #[cfg(feature = "upgrade-signal")]
@@ -299,6 +316,7 @@ pub struct SystemTestStackBuilder {
     l1_fault_injection: bool,
     extra_builder_extensions: Vec<Box<dyn BaseNodeExtension>>,
     extra_client_extensions: Vec<Box<dyn BaseNodeExtension>>,
+    telemetry: Option<TelemetryStackOptions>,
     #[cfg(feature = "upgrade-signal")]
     upgrade_signal: Option<UpgradeSignalStackOptions>,
 }
@@ -460,6 +478,13 @@ impl SystemTestStackBuilder {
     /// method — onto the standard client wiring without forking this crate.
     pub fn with_client_extension(mut self, extension: Box<dyn BaseNodeExtension>) -> Self {
         self.extra_client_extensions.push(extension);
+        self
+    }
+
+    /// Enables node telemetry: starts an ingest endpoint on an ephemeral loopback port and
+    /// starts the client consensus node reporting to it.
+    pub const fn with_telemetry(mut self, options: TelemetryStackOptions) -> Self {
+        self.telemetry = Some(options);
         self
     }
 
@@ -671,6 +696,15 @@ impl SystemTestStackBuilder {
             .as_ref()
             .map_or_else(|| direct_l1_rpc_url.to_string(), |proxy| proxy.url().to_string());
 
+        // Started before the L2 stack so the node has an endpoint to report to from its first
+        // reporting cycle, rather than failing the first one against a port nothing is on yet.
+        let telemetry = match self.telemetry {
+            Some(options) => Some(
+                options.start().await.wrap_err("Failed to start the telemetry ingest endpoint")?,
+            ),
+            None => None,
+        };
+
         let l2_config = L2StackConfig {
             l2_genesis: l2_genesis_bytes,
             rollup_config: rollup_config_bytes,
@@ -690,6 +724,12 @@ impl SystemTestStackBuilder {
             client_consensus_mode: self.client_consensus_mode,
             upgrade_signal: l2_upgrade_signal,
             execution_upgrade_signal: l2_execution_upgrade_signal,
+            telemetry: telemetry.as_ref().map(|ingest| {
+                ingest.node_config(
+                    env!("CARGO_PKG_VERSION").to_string(),
+                    format!("{TELEMETRY_NETWORK_PREFIX}{l2_chain_id}"),
+                )
+            }),
             shadow_sequencers,
             extra_builder_extensions: self.extra_builder_extensions,
             extra_client_extensions: self.extra_client_extensions,
@@ -706,6 +746,7 @@ impl SystemTestStackBuilder {
             l1_stack,
             l2_stack,
             l1_rpc_proxy,
+            telemetry,
             #[cfg(feature = "upgrade-signal")]
             upgrade_signal,
             #[cfg(feature = "upgrade-signal")]

--- a/etc/systems/src/telemetry.rs
+++ b/etc/systems/src/telemetry.rs
@@ -1,0 +1,217 @@
+//! In-process node telemetry ingest for system test stacks.
+//!
+//! Starts the real [`IngestRoutes`] router on an ephemeral loopback port, points the client
+//! consensus node's telemetry endpoint at it, and hands the reports it accepts back to the test.
+//! The whole loop — actor, HTTP transport, ingest handler, wire schema — runs unmocked.
+
+use std::{
+    net::SocketAddr,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use base_consensus_node::TelemetryNodeConfig;
+use base_telemetry_client::TelemetryConfig;
+use base_telemetry_service::{IngestRoutes, NODE_REPORT_PATH, ReportRecorder};
+use base_telemetry_types::{NodeConfigReport, NodeReportEvent};
+use base_trusted_proxy::TrustedProxyConfig;
+use eyre::{OptionExt, Result, WrapErr};
+use tempfile::TempDir;
+use tokio::{
+    net::TcpListener,
+    sync::{Mutex, mpsc},
+    task::JoinHandle,
+};
+use url::Url;
+
+/// Report cadence used when a test does not ask for one.
+///
+/// Short enough that a report lands inside a normal system test's lifetime, and the production
+/// default of fifteen minutes would never fire at all.
+const DEFAULT_REPORT_INTERVAL: Duration = Duration::from_secs(3);
+/// Lag sampling cadence used when a test does not ask for one.
+const DEFAULT_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+/// Header the ingest router reads a forwarded client IP from.
+///
+/// Nothing sits in front of the test router, so this only has to be a valid header name.
+const CLIENT_IP_HEADER: &str = "x-forwarded-for";
+
+/// Options for enabling node telemetry on a system test stack.
+///
+/// When set on [`SystemTestStackBuilder`](crate::SystemTestStackBuilder), the stack starts an
+/// ingest endpoint and configures the client consensus node to report to it.
+#[derive(Debug, Clone, Copy)]
+pub struct TelemetryStackOptions {
+    /// How often the node builds and sends a report.
+    pub report_interval: Duration,
+    /// How often the node samples head lag between reports.
+    pub sample_interval: Duration,
+}
+
+impl Default for TelemetryStackOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TelemetryStackOptions {
+    /// Creates telemetry options with test-scale reporting and sampling intervals.
+    pub const fn new() -> Self {
+        Self { report_interval: DEFAULT_REPORT_INTERVAL, sample_interval: DEFAULT_SAMPLE_INTERVAL }
+    }
+
+    /// Sets how often the node sends a report.
+    pub const fn with_report_interval(mut self, interval: Duration) -> Self {
+        self.report_interval = interval;
+        self
+    }
+
+    /// Sets how often the node samples head lag between reports.
+    pub const fn with_sample_interval(mut self, interval: Duration) -> Self {
+        self.sample_interval = interval;
+        self
+    }
+
+    /// Starts the ingest endpoint these options describe.
+    pub async fn start(self) -> Result<TelemetryIngest> {
+        TelemetryIngest::start(self).await
+    }
+}
+
+/// Forwards every accepted report to the test.
+///
+/// Hand-rolled rather than `automock`ed because the test consumes reports as a stream over the
+/// life of the stack, which is a channel, not a call expectation.
+#[derive(Debug)]
+pub struct ChannelRecorder {
+    reports: mpsc::UnboundedSender<NodeReportEvent>,
+}
+
+impl ReportRecorder for ChannelRecorder {
+    fn record(&self, event: &NodeReportEvent) {
+        // The stack drops the receiver on teardown, and a report arriving after that is not an
+        // error: the node is still running while the test winds down.
+        let _ = self.reports.send(event.clone());
+    }
+}
+
+/// A running telemetry ingest endpoint and the reports it has accepted.
+#[derive(Debug)]
+pub struct TelemetryIngest {
+    endpoint: Url,
+    options: TelemetryStackOptions,
+    reports: Mutex<mpsc::UnboundedReceiver<NodeReportEvent>>,
+    /// Holds the node identity file for the stack's lifetime, so a system test never writes a
+    /// `telemetry-id` into the developer's home directory.
+    id_dir: TempDir,
+    server: JoinHandle<()>,
+}
+
+impl Drop for TelemetryIngest {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+impl TelemetryIngest {
+    /// Binds an ephemeral loopback port and serves the ingest router on it.
+    pub async fn start(options: TelemetryStackOptions) -> Result<Self> {
+        let (reports, receiver) = mpsc::unbounded_channel();
+        let recorder = Arc::new(ChannelRecorder { reports });
+        let proxy = Arc::new(TrustedProxyConfig::new(CLIENT_IP_HEADER.to_string(), Vec::new()));
+        let router = IngestRoutes::router(recorder, proxy);
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .wrap_err("Failed to bind the telemetry ingest listener")?;
+        let address =
+            listener.local_addr().wrap_err("Failed to read the telemetry ingest address")?;
+        let server = tokio::spawn(async move {
+            let service = router.into_make_service_with_connect_info::<SocketAddr>();
+            if let Err(error) = axum::serve(listener, service).await {
+                tracing::warn!(target: "telemetry", %error, "telemetry ingest server stopped");
+            }
+        });
+
+        Ok(Self {
+            endpoint: Url::parse(&format!("http://{address}{NODE_REPORT_PATH}"))
+                .wrap_err("Failed to build the telemetry ingest endpoint URL")?,
+            options,
+            reports: Mutex::new(receiver),
+            id_dir: TempDir::new().wrap_err("Failed to create the telemetry identity directory")?,
+            server,
+        })
+    }
+
+    /// Returns the URL nodes POST reports to.
+    pub const fn endpoint(&self) -> &Url {
+        &self.endpoint
+    }
+
+    /// Returns the path the reporting node persists its telemetry identity to.
+    pub fn id_path(&self) -> PathBuf {
+        self.id_dir.path().join("telemetry-id")
+    }
+
+    /// Builds the telemetry configuration for a consensus node reporting to this endpoint.
+    pub fn node_config(&self, version: String, network: String) -> TelemetryNodeConfig {
+        let client = TelemetryConfig {
+            report_interval: self.options.report_interval,
+            sample_interval: self.options.sample_interval,
+            ..TelemetryConfig::new(self.id_path(), Some(self.endpoint.clone()))
+        };
+        let node_config = NodeConfigReport {
+            prune_mode: None,
+            p2p_enabled: true,
+            discovery_enabled: false,
+            sequencer_enabled: false,
+            supervisor_enabled: false,
+            flashblocks_enabled: false,
+            metrics_enabled: false,
+            experimental_flags: Vec::new(),
+            report_interval_secs: self.options.report_interval.as_secs(),
+            sample_interval_secs: self.options.sample_interval.as_secs(),
+        };
+        TelemetryNodeConfig::new(client, version, network, node_config)
+    }
+
+    /// Waits for the next report the node sends, up to `timeout`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no report arrives in time, or if the ingest endpoint has shut down.
+    pub async fn next_report(&self, timeout: Duration) -> Result<NodeReportEvent> {
+        let mut reports = self.reports.lock().await;
+        tokio::time::timeout(timeout, reports.recv())
+            .await
+            .wrap_err_with(|| format!("No telemetry report arrived within {timeout:?}"))?
+            .ok_or_eyre("The telemetry ingest endpoint shut down")
+    }
+
+    /// Waits up to `timeout` for a report satisfying `predicate`, discarding earlier ones.
+    ///
+    /// The first report a node sends is built one interval after startup, when the chain may
+    /// still be at genesis and peers may not have connected. Tests that assert on live values
+    /// wait for a report that carries them rather than for the first one to arrive.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no matching report arrives in time.
+    pub async fn next_report_matching(
+        &self,
+        timeout: Duration,
+        predicate: impl Fn(&NodeReportEvent) -> bool,
+    ) -> Result<NodeReportEvent> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_eyre("No matching telemetry report arrived before the deadline")?;
+            let event = self.next_report(remaining).await?;
+            if predicate(&event) {
+                return Ok(event);
+            }
+        }
+    }
+}

--- a/etc/systems/tests/telemetry.rs
+++ b/etc/systems/tests/telemetry.rs
@@ -1,0 +1,85 @@
+//! End-to-end system test for node telemetry.
+//!
+//! Runs the whole loop unmocked: the client consensus node's telemetry actor reads live engine
+//! and p2p state, builds a `node_report`, POSTs it over HTTP to the stack's ingest endpoint, and
+//! the ingest handler parses it back into the shared wire type. Nothing here asserts against a
+//! test double, so a schema drift between the client and the service fails this test.
+
+use std::time::Duration;
+
+use base_system_tests::{SystemTestStackBuilder, TelemetryStackOptions};
+use base_telemetry_types::{NODE_REPORT_SCHEMA_VERSION, NodeLayer, NodeRole};
+use eyre::Result;
+
+/// L2 chain ID for this test binary, distinct from every other system test's.
+const L2_CHAIN_ID: u64 = 84_538_471;
+/// How often the node under test reports.
+const REPORT_INTERVAL: Duration = Duration::from_secs(3);
+/// How long to wait for a report carrying live chain and peer values.
+///
+/// Generous relative to the reporting interval: the first report is built before the chain has
+/// necessarily advanced, so this has to cover several cycles.
+const REPORT_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// A validator reports live head, peer, and hardware values to the ingest endpoint.
+#[tokio::test]
+async fn test_a_validator_reports_live_heads_and_peers() -> Result<()> {
+    let system = SystemTestStackBuilder::new()
+        .with_l2_chain_id(L2_CHAIN_ID)
+        .with_telemetry(TelemetryStackOptions::new().with_report_interval(REPORT_INTERVAL))
+        .build()
+        .await?;
+
+    // The first cycle can fire before the chain advances or the p2p handshake completes, and a
+    // report of zeroes at startup is correct behavior rather than a failure.
+    let event = system
+        .telemetry()
+        .next_report_matching(REPORT_TIMEOUT, |event| {
+            event.report.heads.unsafe_block > 0 && event.report.net_health.peer_count > 0
+        })
+        .await?;
+    let report = &event.report;
+
+    assert_eq!(report.schema_version, NODE_REPORT_SCHEMA_VERSION);
+    assert_eq!(report.client.layer, NodeLayer::Consensus);
+    assert_eq!(report.client.role, NodeRole::Validator);
+    assert_eq!(report.client.l2_chain_id, L2_CHAIN_ID);
+    assert_eq!(report.config.report_interval_secs, REPORT_INTERVAL.as_secs());
+
+    assert!(report.heads.unsafe_block > 0, "the validator should have followed the chain");
+    assert!(
+        Some(report.heads.unsafe_block) >= report.heads.safe_block,
+        "the safe head can never lead the unsafe head"
+    );
+    assert!(
+        report.net_health.peer_count > 0,
+        "the validator is connected to the builder consensus node"
+    );
+    assert!(
+        report.hardware.cpu_cores.is_some_and(|cores| cores > 0),
+        "hardware collection should report a core count"
+    );
+    assert!(!report.telemetry_id.is_nil(), "every report carries a minted identity");
+
+    // The node reports over loopback and advertises no routable address, so ingest falls back
+    // to the observed edge IP.
+    assert!(event.reported_ip.is_loopback(), "the report arrived over loopback");
+
+    // Reporting is a loop, not a one-shot. The second report proves the actor survives a
+    // completed cycle, and that the identity is stable across cycles rather than reminted.
+    let next = system.telemetry().next_report(REPORT_TIMEOUT).await?;
+    assert_eq!(
+        next.report.telemetry_id, report.telemetry_id,
+        "the telemetry identity must be stable across reports"
+    );
+    assert!(
+        next.report.heads.unsafe_block >= report.heads.unsafe_block,
+        "the reported unsafe head must not go backwards"
+    );
+    assert!(
+        next.report.client.uptime_secs >= report.client.uptime_secs,
+        "uptime must advance across reports"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Backport of #4641 to `releases/v1.3.0`.

## What this is

Opt-out telemetry from the consensus node to a collector the Base team runs: version adoption, head lag, hardware shape, and peer counts. See #4641 for the full design writeup and review discussion.

## Why backport it

The v1.3.0 line is what is actually running. Landing this only on `main` means the change cannot be exercised against a real network until the next minor release, which is the whole point of shipping an MVP.

## What changed relative to #4641

One conflict, in `crates/consensus/service/src/lib.rs`: the release branch does not export `ShadowFunding`, so the re-export list here is the release branch's set plus the four new `Telemetry*` symbols. Nothing else — the other 55 files apply verbatim.

## Nothing sends anything by default

The actor is `None` unless `--telemetry.endpoint` is set. Merging this cannot cause any node to report anywhere; enabling it is a separate config change.

## Verification

Run against this branch:

- `cargo test -p base -p base-cli-utils -p base-consensus-node -p base-telemetry-client -p base-telemetry-service -p base-telemetry-types` — passes
- `cargo clippy --all-targets` on the same set — clean
- `cargo +nightly fmt --all --check` — clean

`base telemetry preview` prints the exact payload a node would send, so the collected fields are reviewable without running a node.
