### PR TITLE
fix(system-tests): stabilize in-process stack setup

### DIFF
--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -164,7 +164,7 @@ build-image target='base' profile='dev':
 
 # Prepares Docker images needed for system tests
 pull-images:
-    docker build --load -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
+    docker build --load -t system-test-setup:local -f etc/docker/Dockerfile.devnet .
     docker pull ghcr.io/paradigmxyz/reth:v1.11.4
     docker pull sigp/lighthouse:v8.0.1
 
@@ -191,7 +191,7 @@ _install-nextest:
 
 [private]
 _build-setup-image:
-    docker build --load -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
+    docker build --load -t system-test-setup:local -f etc/docker/Dockerfile.devnet .
 
 [private]
 _build-rust-images group profile='dev':

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -164,7 +164,7 @@ build-image target='base' profile='dev':
 
 # Prepares Docker images needed for system tests
 pull-images:
-    docker build --load -t system-test-setup:local -f etc/docker/Dockerfile.devnet .
+    docker build --load -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
     docker pull ghcr.io/paradigmxyz/reth:v1.11.4
     docker pull sigp/lighthouse:v8.0.1
 
@@ -191,7 +191,7 @@ _install-nextest:
 
 [private]
 _build-setup-image:
-    docker build --load -t system-test-setup:local -f etc/docker/Dockerfile.devnet .
+    docker build --load -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
 
 [private]
 _build-rust-images group profile='dev':

--- a/etc/systems/src/l1/lighthouse.rs
+++ b/etc/systems/src/l1/lighthouse.rs
@@ -178,6 +178,7 @@ fn beacon_command(execution_endpoint: &str) -> Vec<String> {
         format!("--http-port={LIGHTHOUSE_HTTP_PORT}"),
         "--http-allow-origin=*".to_string(),
         "--target-peers=0".to_string(),
+        "--supernode".to_string(),
         format!("--execution-endpoint={execution_endpoint}"),
         format!("--execution-jwt={LIGHTHOUSE_JWT_PATH}"),
     ]

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -146,6 +146,7 @@ impl InProcessBuilder {
         );
         let builder_config = BuilderConfig {
             block_time: config.block_time,
+            block_time_leeway: Duration::from_secs(20),
             flashblocks_ws_addr: SocketAddr::new(Ipv4Addr::LOCALHOST.into(), flashblocks_port),
             flashblocks_interval: Duration::from_millis(200),
             ..Default::default()

--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -355,6 +355,15 @@ impl InProcessConsensus {
         Ok(())
     }
 
+    /// Stops the sequencer via the `admin_stopSequencer` RPC.
+    pub async fn stop_sequencer(&self) -> Result<()> {
+        let client = HttpClientBuilder::default()
+            .build(self.rpc_url().as_str())
+            .wrap_err("Failed to build RPC client")?;
+        client.admin_stop_sequencer().await.wrap_err("Failed to stop sequencer via RPC")?;
+        Ok(())
+    }
+
     /// Returns the RPC URL for this consensus node (localhost).
     pub fn rpc_url(&self) -> Url {
         Url::parse(&format!("http://{}:{}", self.rpc_addr.ip(), self.rpc_addr.port()))

--- a/etc/systems/src/l2/in_process_consensus.rs
+++ b/etc/systems/src/l2/in_process_consensus.rs
@@ -30,7 +30,7 @@ use base_upgrade_signal::{
     UpgradeSignalRuntimeApplier,
 };
 use eyre::{Result, WrapErr};
-use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use tempfile::TempDir;
 use tokio::{
     task::JoinHandle,
@@ -95,6 +95,7 @@ pub struct InProcessConsensusConfig {
 /// A running in-process consensus node.
 pub struct InProcessConsensus {
     rpc_addr: SocketAddr,
+    rpc_client: HttpClient,
     p2p_tcp_port: u16,
     peer_id: String,
     _checkpoint_dir: TempDir,
@@ -277,8 +278,13 @@ impl InProcessConsensus {
             }
         }
 
+        let rpc_client = HttpClientBuilder::default()
+            .build(format!("http://{rpc_addr}"))
+            .wrap_err("Failed to build RPC client")?;
+
         Ok(Self {
             rpc_addr,
+            rpc_client,
             p2p_tcp_port,
             peer_id,
             _checkpoint_dir: checkpoint_dir,
@@ -291,13 +297,9 @@ impl InProcessConsensus {
     /// Retries the connection attempt because the P2P layer may not be fully ready immediately
     /// after the RPC endpoint becomes reachable.
     pub async fn connect_peer(&self, multiaddr: &str) -> Result<()> {
-        let client = HttpClientBuilder::default()
-            .build(self.rpc_url().as_str())
-            .wrap_err("Failed to build RPC client")?;
-
         let mut last_err = None;
         for attempt in 0..20 {
-            match client.opp2p_connect_peer(multiaddr.to_string()).await {
+            match self.rpc_client.opp2p_connect_peer(multiaddr.to_string()).await {
                 Ok(()) => {
                     info!(attempts = attempt + 1, "peer connected");
                     return Ok(());
@@ -317,17 +319,13 @@ impl InProcessConsensus {
     /// Use this after connecting peers when the consensus node was started with
     /// `sequencer_stopped: true` to ensure the validator receives all blocks from the start.
     pub async fn start_sequencer(&self) -> Result<()> {
-        let client = HttpClientBuilder::default()
-            .build(self.rpc_url().as_str())
-            .wrap_err("Failed to build RPC client")?;
-
         // The consensus node validates that the provided hash matches the engine's actual unsafe
         // head before activating the sequencer. Poll sync status until the engine is initialized
         // (non-zero unsafe head hash), then pass the real value.
         let mut last_sync_error = None;
         let unsafe_head = timeout(SEQUENCER_UNSAFE_HEAD_TIMEOUT, async {
             loop {
-                match client.sync_status().await {
+                match self.rpc_client.sync_status().await {
                     Ok(status) if status.unsafe_l2.block_info.hash != B256::ZERO => {
                         return status.unsafe_l2.block_info.hash;
                     }
@@ -347,7 +345,7 @@ impl InProcessConsensus {
             eyre::eyre!("Engine unsafe head did not initialize within 60s{suffix}")
         })?;
 
-        client
+        self.rpc_client
             .admin_start_sequencer(unsafe_head)
             .await
             .wrap_err("Failed to start sequencer via RPC")?;
@@ -357,10 +355,10 @@ impl InProcessConsensus {
 
     /// Stops the sequencer via the `admin_stopSequencer` RPC.
     pub async fn stop_sequencer(&self) -> Result<()> {
-        let client = HttpClientBuilder::default()
-            .build(self.rpc_url().as_str())
-            .wrap_err("Failed to build RPC client")?;
-        client.admin_stop_sequencer().await.wrap_err("Failed to stop sequencer via RPC")?;
+        self.rpc_client
+            .admin_stop_sequencer()
+            .await
+            .wrap_err("Failed to stop sequencer via RPC")?;
         Ok(())
     }
 

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -409,6 +409,10 @@ impl L2Stack {
                 .await
                 .wrap_err("Timed out waiting for delayed-shadow catch-up receipt")??;
             }
+            builder_consensus
+                .stop_sequencer()
+                .await
+                .wrap_err("Failed to pause active sequencer for delayed shadow startup")?;
             batcher = Some(
                 InProcessBatcher::start(InProcessBatcherConfig {
                     l1_rpc_url: l1_rpc_url.clone(),
@@ -474,19 +478,25 @@ impl L2Stack {
                 })
                 .await
                 .wrap_err_with(|| format!("Failed to start shadow sequencer {index}"))?;
-                let shadow_start_height = if shadow_config.start_block.is_some() {
+                let shadow_start_safe_height = if shadow_config.start_block.is_some() {
                     Some(
                         RootProvider::<Base>::new_http(builder.rpc_url()?)
-                            .get_block_number()
-                            .await?,
+                            .get_block_by_number(BlockNumberOrTag::Safe)
+                            .await?
+                            .map_or(0, |block| block.header.number),
                     )
                 } else {
                     None
                 };
-                if let Some(shadow_start_height) = shadow_start_height {
+                if let Some(shadow_start_safe_height) = shadow_start_safe_height {
                     let shadow_provider = RootProvider::<Base>::new_http(shadow.rpc_url()?);
                     timeout(Duration::from_secs(30), async {
-                        while shadow_provider.get_block_number().await? < shadow_start_height {
+                        while shadow_provider
+                            .get_block_by_number(BlockNumberOrTag::Safe)
+                            .await?
+                            .map_or(0, |block| block.header.number)
+                            < shadow_start_safe_height
+                        {
                             sleep(Duration::from_millis(100)).await;
                         }
                         Ok::<_, eyre::Error>(())
@@ -494,6 +504,9 @@ impl L2Stack {
                     .await
                     .wrap_err("Timed out waiting for delayed shadow safe catch-up")??;
                     batcher.as_ref().expect("delayed batcher started").stop();
+                    builder_consensus.start_sequencer().await.wrap_err(
+                        "Failed to resume active sequencer after delayed shadow startup",
+                    )?;
                 }
                 shadow_sequencers.push(shadow);
             }

--- a/etc/systems/src/setup/container.rs
+++ b/etc/systems/src/setup/container.rs
@@ -19,9 +19,9 @@ use crate::{
     network::{ensure_network_exists, network_name},
 };
 
-const SETUP_IMAGE_NAME: &str = "system-test-setup";
+const SETUP_IMAGE_NAME: &str = "devnet-setup";
 const SETUP_IMAGE_TAG: &str = "local";
-const SETUP_IMAGE_REFERENCE: &str = "system-test-setup:local";
+const SETUP_IMAGE_REFERENCE: &str = "devnet-setup:local";
 const SETUP_IMAGE_BUILD_LOCK_DIR: &str = "base-system-test-setup-image-build.lock";
 const SETUP_IMAGE_BUILD_LOCK_TIMEOUT: Duration = Duration::from_secs(600);
 const SETUP_IMAGE_BUILD_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);

--- a/etc/systems/tests/l1_reorg_recovery.rs
+++ b/etc/systems/tests/l1_reorg_recovery.rs
@@ -31,6 +31,7 @@ async fn sequencer_recovers_from_l1_outage_and_deep_reorg() -> Result<()> {
     let system = SystemTestStackBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
+        .with_slot_duration(L1_BLOCK_TIME)
         .with_l1_fault_injection()
         .build()
         .await?;
@@ -169,10 +170,10 @@ async fn wait_for_reorgable_origin(
     timeout(ORIGIN_TIMEOUT, async {
         loop {
             let status = rpc.l2_builder_sync_status().await?;
-            let safe = l1_provider
-                .get_block_by_number(BlockNumberOrTag::Safe)
-                .await?
-                .ok_or_eyre("L1 safe block is missing")?;
+            let Some(safe) = l1_provider.get_block_by_number(BlockNumberOrTag::Safe).await? else {
+                sleep(POLL_INTERVAL).await;
+                continue;
+            };
             let protected_origin = safe.header.number.max(status.finalized_l2.l1_origin.number);
             if status.unsafe_l2.l1_origin.number > protected_origin + REORG_DEPTH {
                 return Ok::<_, eyre::Error>(status);


### PR DESCRIPTION
## Summary

- align the in-process builder payload retention window with the production builder so delayed sealing does not expire transaction-bearing payloads
- run the isolated Lighthouse beacon node as a supernode so Fulu blob reconstruction has all required data columns
- make the L1 reorg scenario use its intended slot duration and tolerate the safe label being temporarily unavailable during startup
- pause active sequencing while a late shadow derives its historical prefix, then resume after the shadow has joined
- build the setup image under the tag consumed by system tests

## Context

The recurring receipt timeouts were not caused by transaction fees or unavailable RPC nodes. The builder accepted and executed the transactions, but L1/batcher pressure delayed sealing past the in-process builder's 500 ms payload leeway. The subsequent payload lookup returned `Unknown payload`, and consensus replaced it with an empty canonical block.

The remaining failures exposed independent test-stack assumptions around PeerDAS blob custody, L1 slot timing, and late-shadow unsafe gossip.