### PR TITLE
feat(challenger-e2e): add crate scaffold and full-game proposal checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,6 +3481,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-challenger-e2e"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "clap",
+ "eyre",
+ "humantime",
+ "reqwest 0.13.4",
+ "url",
+]
+
+[[package]]
 name = "base-cli-utils"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ base-snapshotter = { path = "crates/infra/snapshotter" }
 websocket-proxy = { path = "crates/infra/websocket-proxy" }
 base-telemetry-service = { path = "crates/infra/telemetry" }
 base-shadow-metrics = { path = "crates/infra/shadow-metrics" }
+base-challenger-e2e = { path = "crates/infra/challenger-e2e" }
 base-zk-benchmarks = { path = "crates/infra/zk-benchmarks" }
 base-zk-fork-dispute = { path = "crates/infra/zk-fork-dispute" }
 

--- a/crates/infra/challenger-e2e/Cargo.toml
+++ b/crates/infra/challenger-e2e/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "base-challenger-e2e"
+description = "Behavioural end-to-end test of the challenger against an ephemeral L1 fork"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+eyre.workspace = true
+url.workspace = true
+reqwest.workspace = true
+humantime.workspace = true
+alloy-primitives.workspace = true
+clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/infra/challenger-e2e/README.md
+++ b/crates/infra/challenger-e2e/README.md
@@ -1,0 +1,21 @@
+# `base-challenger-e2e`
+
+Behavioural end-to-end test of the challenger.
+
+Forks the target L1 into a pod-local Anvil, hands the fork to a real
+`base-challenger` binary running alongside it, and asserts on what that
+challenger does — first that it leaves valid games alone, then that it
+disputes every classifier path we can stage honestly on that same fork.
+
+This crate currently carries two pieces of that test:
+
+- [`Config`] — the `BASE_CHALLENGER_*` variables are shared with the challenger
+  under test, so the driver forks exactly the L1 the challenger is configured
+  against. The `CHALLENGER_E2E_*` variables belong to the driver alone.
+- [`Scrape`] — a Prometheus text-exposition reader for the challenger's
+  `/metrics`. Assertions are made against the challenger's own counters rather
+  than against chain state alone.
+
+The driver that consumes them lands in a follow-up PR, which replaces this
+README with the full argument for why the test is honest and what each path
+asserts.

--- a/crates/infra/challenger-e2e/src/config.rs
+++ b/crates/infra/challenger-e2e/src/config.rs
@@ -11,7 +11,7 @@ use alloy_primitives::Address;
 use clap::Parser;
 use url::Url;
 
-/// Runtime configuration for [`crate::ChallengerE2e`].
+/// Runtime configuration for the challenger E2E driver.
 #[derive(Debug, Parser)]
 #[command(name = "challenger-e2e", version, about, long_about = None)]
 pub struct Config {

--- a/crates/infra/challenger-e2e/src/config.rs
+++ b/crates/infra/challenger-e2e/src/config.rs
@@ -1,0 +1,98 @@
+//! Environment-driven configuration for the challenger E2E driver.
+//!
+//! The `BASE_CHALLENGER_*` variables are shared with the challenger under test
+//! — both containers source the same config-service mapping — so the driver
+//! forks exactly the L1 the challenger is configured against. The
+//! `CHALLENGER_E2E_*` variables belong to the driver alone.
+
+use std::time::Duration;
+
+use alloy_primitives::Address;
+use clap::Parser;
+use url::Url;
+
+/// Runtime configuration for [`crate::ChallengerE2e`].
+#[derive(Debug, Parser)]
+#[command(name = "challenger-e2e", version, about, long_about = None)]
+pub struct Config {
+    /// L1 RPC that Anvil forks. Only ever read from.
+    #[arg(long = "l1-eth-rpc", env = "BASE_CHALLENGER_L1_ETH_RPC")]
+    pub l1_eth_rpc: Url,
+
+    /// L2 archive RPC used to compute canonical output roots.
+    #[arg(long = "l2-eth-rpc", env = "BASE_CHALLENGER_L2_ETH_RPC")]
+    pub l2_eth_rpc: Url,
+
+    /// Live prover-service JSON-RPC. Used to request a real SNARK of canonical
+    /// roots; never the Anvil fork URL.
+    #[arg(long = "zk-rpc-url", env = "BASE_CHALLENGER_ZK_RPC_URL")]
+    pub zk_rpc_url: Url,
+
+    /// Address of the `DisputeGameFactory` contract on L1.
+    #[arg(long = "dispute-game-factory-addr", env = "BASE_CHALLENGER_DISPUTE_GAME_FACTORY_ADDR")]
+    pub dispute_game_factory_addr: Address,
+
+    /// Game type ID for `AggregateVerifier` dispute games.
+    #[arg(long = "game-type", env = "BASE_CHALLENGER_GAME_TYPE")]
+    pub game_type: u32,
+
+    /// Port Anvil binds to.
+    ///
+    /// Deliberately not 8545: the production challenger config reserves that
+    /// for the keychain signer sidecar.
+    #[arg(long = "anvil-port", env = "CHALLENGER_E2E_ANVIL_PORT", default_value = "18545")]
+    pub anvil_port: u16,
+
+    /// Prometheus endpoint of the challenger under test.
+    #[arg(
+        long = "challenger-metrics-url",
+        env = "CHALLENGER_E2E_CHALLENGER_METRICS_URL",
+        default_value = "http://127.0.0.1:7300/metrics"
+    )]
+    pub challenger_metrics_url: Url,
+
+    /// How far back through factory indices to look for a game to corrupt.
+    #[arg(long = "game-lookback", env = "CHALLENGER_E2E_GAME_LOOKBACK", default_value = "50")]
+    pub game_lookback: u64,
+
+    /// Budget for spawning the fork and for the challenger's first scan.
+    #[arg(
+        long = "startup-timeout",
+        env = "CHALLENGER_E2E_STARTUP_TIMEOUT",
+        default_value = "5m",
+        value_parser = humantime::parse_duration
+    )]
+    pub startup_timeout: Duration,
+
+    /// How long the fork is left healthy before it is corrupted.
+    ///
+    /// Must span several challenger poll intervals, otherwise the positive
+    /// case proves nothing.
+    #[arg(
+        long = "quiet-window",
+        env = "CHALLENGER_E2E_QUIET_WINDOW",
+        default_value = "90s",
+        value_parser = humantime::parse_duration
+    )]
+    pub quiet_window: Duration,
+
+    /// Budget for the challenger to dispute the corrupted game.
+    ///
+    /// Sized for the ZK fallback path, which waits on a real SNARK proof.
+    #[arg(
+        long = "dispute-timeout",
+        env = "CHALLENGER_E2E_DISPUTE_TIMEOUT",
+        default_value = "45m",
+        value_parser = humantime::parse_duration
+    )]
+    pub dispute_timeout: Duration,
+
+    /// Interval between driver polls of the fork and the metrics endpoint.
+    #[arg(
+        long = "poll-interval",
+        env = "CHALLENGER_E2E_POLL_INTERVAL",
+        default_value = "5s",
+        value_parser = humantime::parse_duration
+    )]
+    pub poll_interval: Duration,
+}

--- a/crates/infra/challenger-e2e/src/lib.rs
+++ b/crates/infra/challenger-e2e/src/lib.rs
@@ -1,7 +1,4 @@
-//! Behavioural end-to-end test of the challenger against an ephemeral L1 fork.
-//!
-//! This crate currently carries the driver's configuration and its Prometheus
-//! scraper. The driver itself lands separately.
+#![doc = include_str!("../README.md")]
 
 mod config;
 pub use config::Config;

--- a/crates/infra/challenger-e2e/src/lib.rs
+++ b/crates/infra/challenger-e2e/src/lib.rs
@@ -1,0 +1,10 @@
+//! Behavioural end-to-end test of the challenger against an ephemeral L1 fork.
+//!
+//! This crate currently carries the driver's configuration and its Prometheus
+//! scraper. The driver itself lands separately.
+
+mod config;
+pub use config::Config;
+
+mod metrics;
+pub use metrics::Scrape;

--- a/crates/infra/challenger-e2e/src/metrics.rs
+++ b/crates/infra/challenger-e2e/src/metrics.rs
@@ -1,0 +1,101 @@
+//! Minimal Prometheus text-exposition scraper for the challenger under test.
+
+use eyre::{Context, Result};
+use url::Url;
+
+/// One scrape of a Prometheus `/metrics` endpoint.
+///
+/// Series are kept as `(name, labels, value)` rather than parsed into a typed
+/// model; the driver only ever sums counters and reads gauges.
+#[derive(Debug, Default)]
+pub struct Scrape {
+    series: Vec<(String, String, f64)>,
+}
+
+impl Scrape {
+    /// Fetches and parses the endpoint.
+    pub async fn fetch(url: &Url) -> Result<Self> {
+        let body = reqwest::get(url.clone())
+            .await
+            .with_context(|| format!("failed to scrape {url}"))?
+            .error_for_status()
+            .with_context(|| format!("{url} returned an error status"))?
+            .text()
+            .await
+            .with_context(|| format!("failed to read the response body from {url}"))?;
+        Ok(Self::parse(&body))
+    }
+
+    /// Sum of every series sharing `name`, or `0.0` when the metric is absent.
+    ///
+    /// Absent-as-zero is what makes the assertions readable: a counter that has
+    /// never been incremented is not exported at all, and that is the same
+    /// thing as "it did not happen".
+    pub fn sum(&self, name: &str) -> f64 {
+        // Every string contains "", so this matches the name alone.
+        self.label_sum(name, "")
+    }
+
+    /// Sum of every series sharing `name` whose label set mentions `label`.
+    ///
+    /// A substring match keeps the caller free of label-ordering and quoting
+    /// concerns; label values in this crate's metrics are distinct enough that
+    /// it cannot alias.
+    pub fn label_sum(&self, name: &str, label: &str) -> f64 {
+        self.series
+            .iter()
+            .filter(|(series_name, labels, _)| series_name == name && labels.contains(label))
+            .map(|(.., value)| value)
+            .sum()
+    }
+
+    fn parse(body: &str) -> Self {
+        let series = body
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .filter_map(|line| {
+                // Prometheus allows an optional timestamp after the value.
+                let (key, rest) = line.split_once(' ')?;
+                let value = rest.split_whitespace().next()?.parse::<f64>().ok()?;
+                let (name, labels) = key
+                    .split_once('{')
+                    .map_or((key, ""), |(name, labels)| (name, labels.trim_end_matches('}')));
+                Some((name.to_string(), labels.to_string(), value))
+            })
+            .collect();
+        Self { series }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Scrape;
+
+    #[test]
+    fn parses_counters_gauges_and_labels() {
+        let scrape = Scrape::parse(
+            r#"
+            # HELP base_challenger_up Challenger is running
+            # TYPE base_challenger_up gauge
+            base_challenger_up 1
+            base_challenger_games_scanned_total 42
+            base_challenger_nullify_tx_outcome_total{status="success"} 3
+            base_challenger_nullify_tx_outcome_total{status="reverted"} 2
+            "#,
+        );
+
+        assert_eq!(scrape.sum("base_challenger_up"), 1.0);
+        assert_eq!(scrape.sum("base_challenger_games_scanned_total"), 42.0);
+        assert_eq!(scrape.sum("base_challenger_nullify_tx_outcome_total"), 5.0);
+        assert_eq!(scrape.label_sum("base_challenger_nullify_tx_outcome_total", "reverted"), 2.0);
+        // A counter that never fired is not exported, and reads as zero.
+        assert_eq!(scrape.sum("base_challenger_challenge_tx_submitted_total"), 0.0);
+    }
+
+    #[test]
+    fn ignores_optional_prometheus_timestamp() {
+        let scrape = Scrape::parse("base_challenger_up 1 1710000000000\n");
+        assert_eq!(scrape.sum("base_challenger_up"), 1.0);
+    }
+}

--- a/crates/infra/zk-fork-dispute/src/checkpoint.rs
+++ b/crates/infra/zk-fork-dispute/src/checkpoint.rs
@@ -21,11 +21,19 @@ use crate::config::Config;
 #[derive(Debug, Clone, Copy)]
 pub struct Checkpoint {
     /// 0-based invalid intermediate index.
+    ///
+    /// Unused by the proof journal for a full-game [`Self::proposal`] proof;
+    /// kept so session IDs stay unique per constructed checkpoint.
     pub index: u64,
     /// Inclusive L2 start block for the proof range.
     pub start_block: u64,
     /// Number of L2 blocks to prove.
     pub block_count: u64,
+    /// Intermediate root interval committed by the proof.
+    ///
+    /// Equal to [`Self::block_count`] for a single-checkpoint dispute proof.
+    /// Smaller than `block_count` when proving a full game for `verifyProposalProof`.
+    pub interval: u64,
     /// Canonical output root expected by the dispute call.
     pub expected_root: B256,
 }
@@ -33,8 +41,8 @@ pub struct Checkpoint {
 impl Checkpoint {
     /// Exclusive end block of the proof range.
     ///
-    /// Unchecked add is safe: values are only constructed via [`Self::from_roots`],
-    /// which validates the sum with `checked_add`.
+    /// Unchecked add is safe: values are only constructed via [`Self::from_roots`]
+    /// and [`Self::proposal`], which validate the sum with `checked_add`.
     pub const fn target_block(self) -> u64 {
         self.start_block + self.block_count
     }
@@ -117,6 +125,41 @@ impl Checkpoint {
         bail!("no invalid intermediate root found for game {}", config.game_address)
     }
 
+    /// Builds a checkpoint covering the game's full canonical range, unpatched.
+    ///
+    /// The proof journal matches the roots already stored on the game, which is
+    /// what `verifyProposalProof` reconstructs.
+    pub async fn proposal(
+        config: &Config,
+        verifier: &AggregateVerifierContractClient,
+    ) -> Result<Self> {
+        let roots = verifier.intermediate_output_roots(config.game_address).await?;
+        if roots.is_empty() {
+            bail!("game {} has no intermediate output roots", config.game_address);
+        }
+
+        let starting_block = verifier.starting_block_number(config.game_address).await?;
+        let interval =
+            Self::infer_interval(config.game_address, verifier, starting_block, roots.len())
+                .await?;
+        let root_count = u64::try_from(roots.len())
+            .map_err(|_| eyre!("intermediate root count does not fit u64"))?;
+        let block_count =
+            interval.checked_mul(root_count).ok_or_else(|| eyre!("proposal range overflow"))?;
+        // Upholds the invariant `target_block` relies on for its unchecked add.
+        starting_block
+            .checked_add(block_count)
+            .ok_or_else(|| eyre!("proposal target block overflow"))?;
+
+        Ok(Self {
+            index: 0,
+            start_block: starting_block,
+            block_count,
+            interval,
+            expected_root: roots[roots.len() - 1],
+        })
+    }
+
     /// Requests a SNARK PLONK proof for this checkpoint and returns dispute-ready bytes.
     ///
     /// Pins the schedule to the game's final L2 block, which may be after [`Self::target_block`],
@@ -140,6 +183,7 @@ impl Checkpoint {
             prover_service_url = %config.prover_service_url,
             start_block = self.start_block,
             target_block = self.target_block(),
+            interval = self.interval,
             l1_head = %l1_head,
             schedule_l2_block_number = game_l2_block_number,
             "requesting SNARK PLONK proof"
@@ -151,7 +195,7 @@ impl Checkpoint {
                 number_of_blocks_to_prove: self.block_count,
                 sequence_window: None,
                 l1_head: Some(l1_head),
-                intermediate_root_interval: Some(self.block_count),
+                intermediate_root_interval: Some(self.interval),
                 schedule_l2_block_number: Some(game_l2_block_number),
                 zk_vm: ZkVm::Sp1,
                 zk_backend: config.zk_backend,
@@ -232,7 +276,7 @@ impl Checkpoint {
             .ok_or_else(|| eyre!("target block overflow"))?;
         let start_block =
             target_block.checked_sub(interval).ok_or_else(|| eyre!("start block underflow"))?;
-        Ok(Self { index, start_block, block_count: interval, expected_root })
+        Ok(Self { index, start_block, block_count: interval, interval, expected_root })
     }
 
     async fn infer_interval(


### PR DESCRIPTION
## What changed?

First half of #4191, split for review size. Adds the `base-challenger-e2e` crate's non-driver parts plus the one `zk-fork-dispute` change the driver needs. Nothing here runs yet — the driver lands in the follow-up.

**`crates/infra/zk-fork-dispute/src/checkpoint.rs`** (+48/−4)

- `Checkpoint` gains an `interval` field. The proof's `intermediate_root_interval` was hardcoded to `block_count`, which is only correct for a single-checkpoint dispute proof. `from_roots` keeps setting `interval == block_count`, so that path is byte-identical.
- New `Checkpoint::proposal()` builds a checkpoint over a game's **full canonical range, unpatched** — the shape `verifyProposalProof` reconstructs. It reads the game's intermediate roots and starting block, infers the interval, and validates `start + count` with `checked_add` so `target_block`'s unchecked add stays sound.

**`crates/infra/challenger-e2e/`** (new crate, ~230 lines)

- `config.rs` — clap/env config. `BASE_CHALLENGER_*` is shared with the challenger under test so the driver forks exactly the L1 the challenger is configured against; `CHALLENGER_E2E_*` belongs to the driver.
- `metrics.rs` — Prometheus text-exposition scraper. Series stay as `(name, labels, value)`; the driver only sums counters and reads gauges.
- `Cargo.toml` / `lib.rs` / workspace member entry / `Cargo.lock`.

## Why?

#4191 was 1128 lines across two crates with two different sets of owners. This half is reviewable on its own: the `checkpoint.rs` change is self-contained (`Checkpoint` is only ever constructed inside that file, `starting_block_number` already exists on `main`), and the config/scraper are ordinary leaf code.

`Checkpoint::proposal()` has **no caller in this PR** — the driver in the follow-up is its only consumer. Flagging that up front so it doesn't read as dead code.

## How to test?

```sh
cargo test   -p base-zk-fork-dispute -p base-challenger-e2e --all-targets
cargo clippy -p base-zk-fork-dispute -p base-challenger-e2e --all-targets -- -D warnings
```

Then confirm the dispute path is unchanged — `from_roots` must still produce `interval == block_count`:

```sh
grep -n 'interval, expected_root' crates/infra/zk-fork-dispute/src/checkpoint.rs
```

Config and scraper are covered by unit tests in the follow-up PR, which is where their consumer lives.

## Notes to reviewers

- Replaces #4191. Follow-up: the driver PR, stacked on this branch.
- Nothing in the workspace depends on `base-challenger-e2e`; it is a leaf built only by the consuming `base-proofs` Dockerfile.
