### PR TITLE
fix(derive): handle stale Denim batches

### DIFF
--- a/crates/consensus/derive/src/stages/batch/batch_provider.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_provider.rs
@@ -46,7 +46,7 @@ where
     /// The batch validator stage of the provider.
     ///
     /// Must be [`None`] if `prev` or `batch_queue` is [`Some`].
-    pub batch_validator: Option<BatchValidator<P>>,
+    pub batch_validator: Option<BatchValidator<P, F>>,
 }
 
 impl<P, F> BatchProvider<P, F>
@@ -66,7 +66,8 @@ where
             // On the first call to `attempt_update`, we need to determine the active stage to
             // initialize the mux with.
             if self.cfg.is_holocene_active(origin.timestamp) {
-                self.batch_validator = Some(BatchValidator::new(Arc::clone(&self.cfg), prev));
+                self.batch_validator =
+                    Some(BatchValidator::new(Arc::clone(&self.cfg), prev, self.provider.clone()));
             } else {
                 self.batch_queue =
                     Some(BatchQueue::new(Arc::clone(&self.cfg), prev, self.provider.clone()));
@@ -75,7 +76,8 @@ where
             // If the batch queue is active and Holocene is also active, transition to the batch
             // validator.
             let batch_queue = self.batch_queue.take().expect("Must have batch queue");
-            let mut bv = BatchValidator::new(Arc::clone(&self.cfg), batch_queue.prev);
+            let mut bv =
+                BatchValidator::new(Arc::clone(&self.cfg), batch_queue.prev, self.provider.clone());
             bv.l1_blocks = batch_queue.l1_blocks;
             bv.origin = batch_queue.origin;
             self.batch_validator = Some(bv);
@@ -208,12 +210,13 @@ mod tests {
     use alloc::{sync::Arc, vec};
 
     use alloy_eips::BlockNumHash;
-    use base_common_genesis::{RollupConfig, SystemConfig, UpgradeConfig};
-    use base_protocol::BlockInfo;
+    use alloy_primitives::B256;
+    use base_common_genesis::{BaseUpgradeConfig, RollupConfig, SystemConfig, UpgradeConfig};
+    use base_protocol::{Batch, BlockInfo, L2BlockInfo, SingleBatch};
 
     use super::BatchProvider;
     use crate::{
-        StageReset,
+        AttributesProvider, PipelineError, StageReset,
         test_utils::{TestL2ChainProvider, TestNextBatchProvider},
         traits::OriginProvider,
     };
@@ -373,5 +376,77 @@ mod tests {
             panic!("Expected BatchValidator");
         };
         assert!(bv.l1_blocks.len() == 1);
+    }
+
+    #[tokio::test]
+    async fn test_denim_validator_skips_same_second_stale_batch() {
+        let origin = BlockInfo { number: 1, hash: B256::repeat_byte(0x11), ..Default::default() };
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                holocene_time: Some(0),
+                base: BaseUpgradeConfig { denim: Some(46), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let parent = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 300,
+                hash: B256::repeat_byte(0x33),
+                timestamp: cfg.l2_block_timestamp(300),
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { number: 0, ..Default::default() },
+            ..Default::default()
+        };
+        assert_eq!(cfg.denim_activation_block_number(), Some(23));
+        assert_eq!(cfg.l2_block_timestamp(298), cfg.l2_block_timestamp(301));
+        let valid = SingleBatch {
+            parent_hash: parent.block_info.hash,
+            epoch_num: origin.number,
+            epoch_hash: origin.hash,
+            timestamp: cfg.l2_block_timestamp(parent.block_info.number + 1),
+            ..Default::default()
+        };
+        let stale_298 =
+            SingleBatch { parent_hash: B256::with_last_byte(297_u64 as u8), ..valid.clone() };
+        let stale_299 =
+            SingleBatch { parent_hash: B256::with_last_byte(298_u64 as u8), ..valid.clone() };
+        let mut prev = TestNextBatchProvider::new(vec![
+            Ok(Batch::Single(valid.clone())),
+            Ok(Batch::Single(stale_299)),
+            Ok(Batch::Single(stale_298)),
+        ]);
+        prev.origin = Some(origin);
+        let l2_provider = TestL2ChainProvider {
+            blocks: (295..parent.block_info.number)
+                .map(|number| L2BlockInfo {
+                    block_info: BlockInfo {
+                        number,
+                        hash: B256::with_last_byte(number as u8),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let mut batch_provider = BatchProvider::new(cfg, prev, l2_provider);
+        batch_provider.attempt_update().unwrap();
+        let validator = batch_provider.batch_validator.as_mut().unwrap();
+        validator.origin = Some(origin);
+        validator.l1_blocks = vec![origin, origin];
+
+        assert_eq!(
+            batch_provider.next_batch(parent).await.unwrap_err(),
+            PipelineError::NotEnoughData.temp()
+        );
+        assert_eq!(
+            batch_provider.next_batch(parent).await.unwrap_err(),
+            PipelineError::NotEnoughData.temp()
+        );
+        assert!(!batch_provider.batch_validator.as_ref().unwrap().prev.flushed);
+        assert_eq!(batch_provider.next_batch(parent).await.unwrap(), valid);
     }
 }

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -1,6 +1,6 @@
 //! Contains the [`BatchValidator`] stage.
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use core::fmt::Debug;
 
 use alloy_eips::BlockNumHash;
@@ -12,7 +12,7 @@ use super::NextBatchProvider;
 use crate::{
     Metrics,
     errors::{PipelineError, PipelineErrorKind, ResetError},
-    traits::{AttributesProvider, OriginAdvancer, OriginProvider, StageReset},
+    traits::{AttributesProvider, L2ChainProvider, OriginAdvancer, OriginProvider, StageReset},
     types::PipelineResult,
 };
 
@@ -22,14 +22,19 @@ use crate::{
 /// [`BatchStream`]: crate::stages::BatchStream
 /// [`AttributesQueue`]: crate::stages::attributes_queue::AttributesQueue
 #[derive(Debug)]
-pub struct BatchValidator<P>
+pub struct BatchValidator<P, F>
 where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
+    F: L2ChainProvider + Debug,
 {
     /// The rollup configuration.
     pub cfg: Arc<RollupConfig>,
     /// The previous stage of the derivation pipeline.
     pub prev: P,
+    /// The L2 chain provider.
+    pub provider: F,
+    /// A candidate and its inclusion block retained while canonical ancestry lookup is retried.
+    pub pending_batch: Option<(SingleBatch, BlockInfo)>,
     /// The L1 origin of the batch sequencer.
     pub origin: Option<BlockInfo>,
     /// A consecutive, time-centric window of L1 Blocks.
@@ -41,13 +46,14 @@ where
     pub l1_blocks: Vec<BlockInfo>,
 }
 
-impl<P> BatchValidator<P>
+impl<P, F> BatchValidator<P, F>
 where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
+    F: L2ChainProvider + Debug,
 {
     /// Create a new [`BatchValidator`] stage.
-    pub const fn new(cfg: Arc<RollupConfig>, prev: P) -> Self {
-        Self { cfg, prev, origin: None, l1_blocks: Vec::new() }
+    pub const fn new(cfg: Arc<RollupConfig>, prev: P, provider: F) -> Self {
+        Self { cfg, prev, provider, pending_batch: None, origin: None, l1_blocks: Vec::new() }
     }
 
     /// Returns `true` if the pipeline origin is behind the parent origin.
@@ -184,9 +190,10 @@ where
 }
 
 #[async_trait]
-impl<P> AttributesProvider for BatchValidator<P>
+impl<P, F> AttributesProvider for BatchValidator<P, F>
 where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
+    F: L2ChainProvider + Send + Debug,
 {
     async fn next_batch(&mut self, parent: L2BlockInfo) -> PipelineResult<SingleBatch> {
         // Update the L1 origin blocks within the stage.
@@ -216,33 +223,70 @@ where
             )));
         }
 
-        // Pull the next batch from the previous stage.
-        let next_batch = match self.prev.next_batch(parent, self.l1_blocks.as_ref()).await {
-            Ok(batch) => batch,
-            Err(PipelineErrorKind::Temporary(PipelineError::Eof)) => {
-                return self.try_derive_empty_batch(&parent);
-            }
-            Err(e) => {
-                return Err(e);
+        // Pull the next batch from the previous stage unless a provider error interrupted its
+        // canonical ancestry lookup.
+        let (mut next_batch, inclusion_block) = match self.pending_batch.take() {
+            Some(pending_batch) => pending_batch,
+            None => {
+                let next_batch = match self.prev.next_batch(parent, self.l1_blocks.as_ref()).await {
+                    Ok(batch) => batch,
+                    Err(PipelineErrorKind::Temporary(PipelineError::Eof)) => {
+                        return self.try_derive_empty_batch(&parent);
+                    }
+                    Err(e) => return Err(e),
+                };
+
+                let Batch::Single(next_batch) = next_batch else {
+                    error!(target: "batch_validator", "BatchValidator received a batch that is not a SingleBatch");
+                    return Err(PipelineError::InvalidBatchType.crit());
+                };
+                (next_batch, stage_origin)
             }
         };
 
-        // The batch must be a single batch - this stage does not support span batches.
-        let Batch::Single(mut next_batch) = next_batch else {
-            error!(
-                target: "batch_validator",
-                "BatchValidator received a batch that is not a SingleBatch"
-            );
-            return Err(PipelineError::InvalidBatchType.crit());
-        };
-        next_batch.parent_hash = parent.block_info.hash;
+        let next_timestamp =
+            self.cfg.l2_block_timestamp(parent.block_info.number.saturating_add(1));
+        let denim_active = self.cfg.is_denim_active(next_timestamp);
+        if !denim_active {
+            next_batch.parent_hash = parent.block_info.hash;
+        }
+
+        let needs_ancestry_check = denim_active
+            && next_batch.timestamp == next_timestamp
+            && next_batch.parent_hash != parent.block_info.hash;
+        if needs_ancestry_check {
+            let same_second_blocks = 1_000 / RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS;
+            let first = parent.block_info.number.saturating_sub(same_second_blocks);
+            for number in (first..parent.block_info.number).rev() {
+                if self.cfg.l2_block_timestamp(number.saturating_add(1)) != next_batch.timestamp {
+                    continue;
+                }
+                let ancestor = match self.provider.l2_block_info_by_number(number).await {
+                    Ok(ancestor) => ancestor,
+                    Err(error) => {
+                        self.pending_batch = Some((next_batch, inclusion_block));
+                        return Err(PipelineError::Provider(error.to_string()).temp());
+                    }
+                };
+                if ancestor.block_info.hash == next_batch.parent_hash {
+                    debug!(
+                        target: "batch_validator",
+                        batch_parent = %next_batch.parent_hash,
+                        safe_head = %parent.block_info.hash,
+                        batch_timestamp = next_batch.timestamp,
+                        "Dropping same-timestamp batch built on a canonical ancestor"
+                    );
+                    return Err(PipelineError::NotEnoughData.temp());
+                }
+            }
+        }
 
         // Check the validity of the single batch before forwarding it.
         match next_batch.check_batch(
             self.cfg.as_ref(),
             self.l1_blocks.as_ref(),
             parent,
-            &stage_origin,
+            &inclusion_block,
         ) {
             BatchValidity::Accept => {
                 info!(target: "batch_validator", epoch_num = next_batch.epoch_num, "Found next batch");
@@ -270,9 +314,10 @@ where
     }
 }
 
-impl<P> OriginProvider for BatchValidator<P>
+impl<P, F> OriginProvider for BatchValidator<P, F>
 where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Debug,
+    F: L2ChainProvider + Debug,
 {
     fn origin(&self) -> Option<BlockInfo> {
         self.prev.origin()
@@ -280,9 +325,10 @@ where
 }
 
 #[async_trait]
-impl<P> OriginAdvancer for BatchValidator<P>
+impl<P, F> OriginAdvancer for BatchValidator<P, F>
 where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
+    F: L2ChainProvider + Send + Debug,
 {
     async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
@@ -290,9 +336,10 @@ where
 }
 
 #[async_trait]
-impl<P> StageReset for BatchValidator<P>
+impl<P, F> StageReset for BatchValidator<P, F>
 where
     P: NextBatchProvider + OriginAdvancer + OriginProvider + StageReset + Send + Debug,
+    F: L2ChainProvider + Send + Debug,
 {
     async fn reset(
         &mut self,
@@ -300,6 +347,7 @@ where
         system_config: SystemConfig,
     ) -> PipelineResult<()> {
         self.prev.reset(l1_origin, system_config).await?;
+        self.pending_batch = None;
         self.origin = self.prev.origin();
         // Include the new origin as an origin to build on.
         // This is only for the initialization case.
@@ -316,6 +364,7 @@ where
     }
 
     async fn flush_channel(&mut self) -> PipelineResult<()> {
+        self.pending_batch = None;
         self.prev.flush_channel().await
     }
 }
@@ -326,14 +375,14 @@ mod tests {
 
     use alloy_eips::BlockNumHash;
     use alloy_primitives::B256;
-    use base_common_genesis::{RollupConfig, SystemConfig, UpgradeConfig};
+    use base_common_genesis::{BaseUpgradeConfig, RollupConfig, SystemConfig, UpgradeConfig};
     use base_protocol::{Batch, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch};
     use tracing::Level;
 
     use crate::{
         AttributesProvider, BatchValidator, NextBatchProvider, OriginAdvancer, PipelineError,
         PipelineErrorKind, PipelineResult, ResetError, StageReset,
-        test_utils::TestNextBatchProvider,
+        test_utils::{TestL2ChainProvider, TestNextBatchProvider},
     };
 
     #[tokio::test]
@@ -341,7 +390,7 @@ mod tests {
         let cfg = Arc::new(RollupConfig::default());
         let mut mock = TestNextBatchProvider::new(vec![]);
         mock.origin = Some(BlockInfo::default());
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
         bv.origin = Some(BlockInfo { number: 1, ..Default::default() });
 
         let mock_parent = L2BlockInfo {
@@ -356,7 +405,7 @@ mod tests {
         let cfg = Arc::new(RollupConfig::default());
         let mut mock = TestNextBatchProvider::new(vec![]);
         mock.origin = Some(BlockInfo::default());
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
 
         // Set up state as if the pipeline was reset with l1_origin = block #1.
         bv.origin = Some(BlockInfo { number: 1, ..Default::default() });
@@ -377,7 +426,7 @@ mod tests {
         let cfg = Arc::new(RollupConfig::default());
         let mut mock = TestNextBatchProvider::new(vec![]);
         mock.origin = Some(BlockInfo { number: 2, ..Default::default() });
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
 
         // Set up state as if the pipeline was reset with l1_origin = block #1.
         bv.origin = Some(BlockInfo { number: 1, ..Default::default() });
@@ -398,7 +447,7 @@ mod tests {
         let cfg = Arc::new(RollupConfig::default());
         let mut mock = TestNextBatchProvider::new(vec![]);
         mock.origin = Some(BlockInfo { number: 2, ..Default::default() });
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
 
         // Set up state as if the pipeline was reset with l1_origin = block #1.
         bv.origin = Some(BlockInfo { number: 1, ..Default::default() });
@@ -423,7 +472,7 @@ mod tests {
             (0..5).map(|_| Ok(Batch::Single(SingleBatch::default()))).collect(),
         );
         mock.origin = Some(BlockInfo::default());
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
         bv.origin = Some(BlockInfo::default());
 
         let mock_parent = L2BlockInfo {
@@ -446,7 +495,7 @@ mod tests {
         let cfg = Arc::new(RollupConfig::default());
         let mut mock = TestNextBatchProvider::new(vec![Ok(Batch::Single(SingleBatch::default()))]);
         mock.origin = Some(BlockInfo { number: 1, ..Default::default() });
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
         bv.origin = Some(BlockInfo::default());
         bv.l1_blocks.push(BlockInfo::default());
 
@@ -466,7 +515,7 @@ mod tests {
         let cfg = Arc::new(RollupConfig::default());
         let mut mock = TestNextBatchProvider::new(vec![Ok(Batch::Span(SpanBatch::default()))]);
         mock.origin = Some(BlockInfo { number: 1, ..Default::default() });
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
         bv.origin = Some(BlockInfo::default());
         bv.l1_blocks.push(BlockInfo::default());
 
@@ -500,7 +549,12 @@ mod tests {
         };
         let parent = L2BlockInfo {
             l1_origin: BlockNumHash { number: 0, ..Default::default() },
-            block_info: BlockInfo { number: 1, timestamp: 2, ..Default::default() },
+            block_info: BlockInfo {
+                number: 1,
+                hash: B256::repeat_byte(1),
+                timestamp: 2,
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -510,7 +564,7 @@ mod tests {
         mock.origin = Some(BlockInfo { number: 1, ..Default::default() });
 
         // Configure batch validator
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
 
         // Reset the pipeline to add the L1 origin to the stage.
         bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default())
@@ -520,7 +574,8 @@ mod tests {
 
         // Grab the next batch.
         let produced_batch = bv.next_batch(parent).await.unwrap();
-        assert_eq!(batch, produced_batch);
+        assert_eq!(produced_batch.parent_hash, parent.block_info.hash);
+        assert_eq!(produced_batch, SingleBatch { parent_hash: parent.block_info.hash, ..batch });
     }
 
     #[tokio::test]
@@ -530,7 +585,7 @@ mod tests {
         let cfg = Arc::new(RollupConfig { seq_window_size: 5, ..Default::default() });
         let mut mock = TestNextBatchProvider::new(vec![]);
         mock.origin = Some(BlockInfo { number: 1, ..Default::default() });
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
 
         // Reset the pipeline to add the L1 origin to the stage.
         bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default())
@@ -563,7 +618,7 @@ mod tests {
         let cfg = Arc::new(RollupConfig { seq_window_size: 5, ..Default::default() });
         let mut mock = TestNextBatchProvider::new(vec![]);
         mock.origin = Some(BlockInfo { number: 1, ..Default::default() });
-        let mut bv = BatchValidator::new(cfg, mock);
+        let mut bv = BatchValidator::new(cfg, mock, TestL2ChainProvider::default());
 
         // Reset the pipeline to add the L1 origin to the stage.
         bv.reset(BlockNumHash { number: 1, ..Default::default() }, SystemConfig::default())
@@ -586,5 +641,60 @@ mod tests {
         assert_eq!(trace_lock.iter().filter(|(l, _)| matches!(l, &Level::DEBUG)).count(), 2);
         assert!(trace_lock[0].1.contains("Advancing batch validator origin"));
         assert!(trace_lock[1].1.contains("Advancing batch validator epoch"));
+    }
+
+    #[tokio::test]
+    async fn test_denim_validator_retries_then_flushes_unknown_parent() {
+        let origin = BlockInfo { number: 1, hash: B256::repeat_byte(0x11), ..Default::default() };
+        let parent = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 3,
+                hash: B256::repeat_byte(0x33),
+                ..Default::default()
+            },
+            l1_origin: BlockNumHash { number: 0, ..Default::default() },
+            ..Default::default()
+        };
+        let batch = SingleBatch {
+            parent_hash: B256::repeat_byte(0xff),
+            epoch_num: origin.number,
+            epoch_hash: origin.hash,
+            ..Default::default()
+        };
+        let mut prev = TestNextBatchProvider::new(vec![Ok(Batch::Single(batch.clone()))]);
+        prev.origin = Some(origin);
+        let cfg = Arc::new(RollupConfig {
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                holocene_time: Some(0),
+                base: BaseUpgradeConfig { denim: Some(0), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut bv = BatchValidator::new(cfg, prev, TestL2ChainProvider::default());
+        bv.origin = Some(origin);
+        bv.l1_blocks = vec![origin, origin];
+
+        assert!(matches!(
+            bv.next_batch(parent).await.unwrap_err(),
+            PipelineErrorKind::Temporary(PipelineError::Provider(_))
+        ));
+        assert_eq!(bv.pending_batch, Some((batch, origin)));
+        assert!(!bv.prev.flushed);
+
+        bv.provider.blocks = (0..parent.block_info.number)
+            .map(|number| L2BlockInfo {
+                block_info: BlockInfo {
+                    number,
+                    hash: B256::with_last_byte(number as u8),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .collect();
+        assert_eq!(bv.next_batch(parent).await.unwrap_err(), PipelineError::NotEnoughData.temp());
+        assert!(bv.pending_batch.is_none());
+        assert!(bv.prev.flushed);
     }
 }

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -259,7 +259,7 @@ where
             let first = parent.block_info.number.saturating_sub(same_second_blocks);
             for number in (first..parent.block_info.number).rev() {
                 if self.cfg.l2_block_timestamp(number.saturating_add(1)) != next_batch.timestamp {
-                    continue;
+                    break;
                 }
                 let ancestor = match self.provider.l2_block_info_by_number(number).await {
                     Ok(ancestor) => ancestor,


### PR DESCRIPTION
## Problem

Denim produces five 200 ms L2 blocks per second, so several consecutive blocks share the same whole-second timestamp. Timestamp validation alone can therefore mistake a stale batch for the next batch.

For example, if the safe head is block 300, the channel may still contain batches built on canonical blocks 297 and 298 whose timestamp also matches block 301. The validator previously replaced each batch's parent hash with block 300's hash, allowing a stale batch to be treated as block 301 and causing the derived chain to diverge (observed as a proof mismatch at block 302).

## Fix

After Denim, preserve each batch's parent hash. When a same-timestamp batch points to a canonical ancestor, discard only that stale batch and continue reading the channel until the batch built on the current safe head is reached. A genuine unknown parent still follows normal invalid-batch handling, and temporary ancestry lookup failures retain the candidate for retry.

Pre-Denim behavior is unchanged.

## Validation

- Added regression coverage for multiple stale same-timestamp batches followed by a valid batch.
- Added coverage for ancestry lookup retry and unknown-parent channel flushing.
- Passed the full derive test suite (215 tests), clippy, and live Nitro proof verification through block 400.