### PR TITLE
feat(challenger-e2e): drive a real challenger against an ephemeral L1 fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3472,12 +3472,28 @@ dependencies = [
 name = "base-challenger-e2e"
 version = "0.0.0"
 dependencies = [
+ "alloy-node-bindings",
  "alloy-primitives",
+ "alloy-provider",
+ "alloy-signer-local 2.4.1",
+ "base-proof-contracts",
  "clap",
  "eyre",
  "humantime",
  "reqwest 0.13.4",
+ "tokio",
+ "tracing",
  "url",
+]
+
+[[package]]
+name = "base-challenger-e2e-bin"
+version = "0.0.0"
+dependencies = [
+ "base-challenger-e2e",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bin/challenger-e2e/Cargo.toml
+++ b/bin/challenger-e2e/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "base-challenger-e2e-bin"
+description = "Standalone challenger E2E binary for K8s CronJob execution"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "base-challenger-e2e"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+tracing = { workspace = true }
+base-challenger-e2e = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }

--- a/bin/challenger-e2e/README.md
+++ b/bin/challenger-e2e/README.md
@@ -3,6 +3,9 @@
 Challenger behavioural end-to-end test binary for Base.
 
 Parses CLI arguments and delegates to `base_challenger_e2e::ChallengerE2e::run()`,
-which forks the target L1 into a pod-local Anvil, corrupts dispute games the
-live challenger has already accepted, and asserts that the challenger sidecar
-disputes them. Intended for K8s Job execution.
+which forks the target L1 into a pod-local Anvil, releases the challenger
+sidecar onto that fork, and asserts the challenger scans it without disputing
+anything while every game on it is still valid. Intended for K8s Job execution.
+
+Corrupting games and asserting the dispute paths is layered on top of the same
+harness; see the `base-challenger-e2e` crate README for the current scope.

--- a/bin/challenger-e2e/README.md
+++ b/bin/challenger-e2e/README.md
@@ -1,0 +1,8 @@
+# `base-challenger-e2e-bin`
+
+Challenger behavioural end-to-end test binary for Base.
+
+Parses CLI arguments and delegates to `base_challenger_e2e::ChallengerE2e::run()`,
+which forks the target L1 into a pod-local Anvil, corrupts dispute games the
+live challenger has already accepted, and asserts that the challenger sidecar
+disputes them. Intended for K8s Job execution.

--- a/bin/challenger-e2e/src/main.rs
+++ b/bin/challenger-e2e/src/main.rs
@@ -1,0 +1,17 @@
+//! Standalone challenger E2E binary for K8s `CronJob` execution.
+
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt().json().with_env_filter(EnvFilter::from_default_env()).init();
+
+    tracing::info!("starting challenger E2E test");
+
+    if let Err(e) = base_challenger_e2e::ChallengerE2e::run().await {
+        tracing::error!(error = %e, error_debug = ?e, "challenger E2E test failed");
+        std::process::exit(1);
+    }
+
+    tracing::info!("challenger E2E test passed");
+}

--- a/crates/infra/challenger-e2e/Cargo.toml
+++ b/crates/infra/challenger-e2e/Cargo.toml
@@ -14,7 +14,13 @@ workspace = true
 [dependencies]
 eyre.workspace = true
 url.workspace = true
+tracing.workspace = true
 reqwest.workspace = true
 humantime.workspace = true
+alloy-provider.workspace = true
 alloy-primitives.workspace = true
+alloy-signer-local.workspace = true
+alloy-node-bindings.workspace = true
+base-proof-contracts.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["time"] }

--- a/crates/infra/challenger-e2e/README.md
+++ b/crates/infra/challenger-e2e/README.md
@@ -22,15 +22,28 @@ them cannot exercise the challenger at all.
 
 1. **The challenger comes up.** `base_challenger_up` is 1 and at least one scan
    has completed.
-2. **The challenger leaves valid games alone.** Over
-   `CHALLENGER_E2E_QUIET_WINDOW`, `base_challenger_games_scanned_total`
-   advances while `games_invalid_total`, `nullify_tx_submitted_total` and
-   `challenge_tx_submitted_total` stay flat. Nothing on the fork has been
-   corrupted, so a challenger that disputes anything here is disputing a valid
-   game.
+2. **The challenger leaves valid games alone.** `games_invalid_total`,
+   `nullify_tx_submitted_total` and `challenge_tx_submitted_total` must be zero
+   outright on the first post-scan scrape, and must still be zero after
+   `CHALLENGER_E2E_QUIET_WINDOW`. Nothing on the fork has been corrupted, so a
+   challenger that disputes anything here is disputing a valid game.
+
+   The baseline is checked absolutely rather than as a delta because
+   `games_scanned_total` is incremented for the whole scanned range *before*
+   any candidate is validated — a challenger that disputed during startup would
+   otherwise be absorbed into the baseline and pass.
+
+   Progress over the window is asserted on
+   `base_challenger_validation_latency_seconds_count`, not on
+   `games_scanned_total`. The latter counts attempted factory indices and
+   advances even when every game query fails; the histogram is only touched
+   from inside the validator, once per candidate game, so it is the only metric
+   that shows a game was actually looked at.
 
 `base_challenger_validation_errors_total` is reported rather than fatal — it is
-usually the L2 RPC rather than the challenger.
+usually the L2 RPC rather than the challenger. A storm severe enough to matter
+fails the assertion above instead, since a game whose roots cannot be computed
+is never validated.
 
 ## Required environment
 

--- a/crates/infra/challenger-e2e/README.md
+++ b/crates/infra/challenger-e2e/README.md
@@ -10,8 +10,9 @@ This crate currently covers the positive case: the challenger comes up against
 the fork, scans it, and disputes nothing. The dispute paths are staged on top
 of the same harness.
 
-Key **A** (driver) signs setup only. Key **B** (challenger) is the only key
-that may ever dispute. Both are generated per run and never leave the pod.
+The challenger key is generated per run and never leaves the pod. It is the
+only key on the fork that may dispute; the dispute paths add a second key that
+signs their setup and nothing else.
 
 ## What it asserts
 

--- a/crates/infra/challenger-e2e/README.md
+++ b/crates/infra/challenger-e2e/README.md
@@ -16,9 +16,13 @@ that may ever dispute. Both are generated per run and never leave the pod.
 ## What it asserts
 
 One process, one fork, two TEE-only in-progress games (newest-first, lookback
-50, at least one intermediate root). The run bails if fewer than two such games
-exist — they are the games the dispute paths will corrupt, so a fork without
-them cannot exercise the challenger at all.
+50, at least one intermediate root, all above the anchor game). The run bails if
+fewer than two such games exist — they are the games the dispute paths will
+corrupt, so a fork without them cannot exercise the challenger at all.
+
+The anchor bound is not cosmetic: the scanner starts at one past the anchor
+game's factory index, so a game at or before the anchor is one the challenger
+will never look at, however invalid it is made.
 
 1. **The challenger comes up.** `base_challenger_up` is 1 and at least one scan
    has completed.
@@ -34,16 +38,16 @@ them cannot exercise the challenger at all.
    otherwise be absorbed into the baseline and pass.
 
    Progress over the window is asserted on
-   `base_challenger_validation_latency_seconds_count`, not on
-   `games_scanned_total`. The latter counts attempted factory indices and
-   advances even when every game query fails; the histogram is only touched
-   from inside the validator, once per candidate game, so it is the only metric
-   that shows a game was actually looked at.
+   `validation_latency_seconds_count` minus `validation_errors_total`, not on
+   `games_scanned_total`. The last counts attempted factory indices and
+   advances even when every game query fails. The histogram is closer — it is
+   only touched from inside the validator — but its latency is recorded from a
+   drop guard, so it too counts attempts rather than successes. Subtracting the
+   error counter, which the validator increments exactly once per failed call,
+   leaves the games the challenger actually managed to check.
 
-`base_challenger_validation_errors_total` is reported rather than fatal — it is
-usually the L2 RPC rather than the challenger. A storm severe enough to matter
-fails the assertion above instead, since a game whose roots cannot be computed
-is never validated.
+Validation errors below that threshold are reported rather than fatal — they
+are usually the L2 RPC rather than the challenger.
 
 ## Required environment
 
@@ -58,6 +62,7 @@ is pointed at and talks to the same prover-service.
 | `BASE_CHALLENGER_ZK_RPC_URL` | Yes | Live prover-service JSON-RPC (not the fork) |
 | `BASE_CHALLENGER_DISPUTE_GAME_FACTORY_ADDR` | Yes | `DisputeGameFactory` on L1 |
 | `BASE_CHALLENGER_GAME_TYPE` | Yes | `AggregateVerifier` game type |
+| `BASE_CHALLENGER_ANCHOR_STATE_REGISTRY_ADDR` | Yes | `AnchorStateRegistry` on L1; read to find the scanner's lower bound |
 | `CHALLENGER_E2E_ANVIL_PORT` | No (default `18545`) | Fork port; not 8545, which the production challenger reserves for its signer sidecar |
 | `CHALLENGER_E2E_CHALLENGER_METRICS_URL` | No (default `http://127.0.0.1:7300/metrics`) | Prometheus endpoint of the challenger under test |
 | `CHALLENGER_E2E_GAME_LOOKBACK` | No (default `50`) | Factory indices searched for two games |

--- a/crates/infra/challenger-e2e/README.md
+++ b/crates/infra/challenger-e2e/README.md
@@ -4,18 +4,73 @@ Behavioural end-to-end test of the challenger.
 
 Forks the target L1 into a pod-local Anvil, hands the fork to a real
 `base-challenger` binary running alongside it, and asserts on what that
-challenger does — first that it leaves valid games alone, then that it
-disputes every classifier path we can stage honestly on that same fork.
+challenger does.
 
-This crate currently carries two pieces of that test:
+This crate currently covers the positive case: the challenger comes up against
+the fork, scans it, and disputes nothing. The dispute paths are staged on top
+of the same harness.
 
-- [`Config`] — the `BASE_CHALLENGER_*` variables are shared with the challenger
-  under test, so the driver forks exactly the L1 the challenger is configured
-  against. The `CHALLENGER_E2E_*` variables belong to the driver alone.
-- [`Scrape`] — a Prometheus text-exposition reader for the challenger's
-  `/metrics`. Assertions are made against the challenger's own counters rather
-  than against chain state alone.
+Key **A** (driver) signs setup only. Key **B** (challenger) is the only key
+that may ever dispute. Both are generated per run and never leave the pod.
 
-The driver that consumes them lands in a follow-up PR, which replaces this
-README with the full argument for why the test is honest and what each path
-asserts.
+## What it asserts
+
+One process, one fork, two TEE-only in-progress games (newest-first, lookback
+50, at least one intermediate root). The run bails if fewer than two such games
+exist — they are the games the dispute paths will corrupt, so a fork without
+them cannot exercise the challenger at all.
+
+1. **The challenger comes up.** `base_challenger_up` is 1 and at least one scan
+   has completed.
+2. **The challenger leaves valid games alone.** Over
+   `CHALLENGER_E2E_QUIET_WINDOW`, `base_challenger_games_scanned_total`
+   advances while `games_invalid_total`, `nullify_tx_submitted_total` and
+   `challenge_tx_submitted_total` stay flat. Nothing on the fork has been
+   corrupted, so a challenger that disputes anything here is disputing a valid
+   game.
+
+`base_challenger_validation_errors_total` is reported rather than fatal — it is
+usually the L2 RPC rather than the challenger.
+
+## Required environment
+
+`BASE_CHALLENGER_*` is shared with the challenger under test — both read the
+same config-service mapping, so the driver forks exactly the L1 the challenger
+is pointed at and talks to the same prover-service.
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `BASE_CHALLENGER_L1_ETH_RPC` | Yes | L1 the fork is taken from; only ever read |
+| `BASE_CHALLENGER_L2_ETH_RPC` | Yes | L2 archive RPC for canonical output roots |
+| `BASE_CHALLENGER_ZK_RPC_URL` | Yes | Live prover-service JSON-RPC (not the fork) |
+| `BASE_CHALLENGER_DISPUTE_GAME_FACTORY_ADDR` | Yes | `DisputeGameFactory` on L1 |
+| `BASE_CHALLENGER_GAME_TYPE` | Yes | `AggregateVerifier` game type |
+| `CHALLENGER_E2E_ANVIL_PORT` | No (default `18545`) | Fork port; not 8545, which the production challenger reserves for its signer sidecar |
+| `CHALLENGER_E2E_CHALLENGER_METRICS_URL` | No (default `http://127.0.0.1:7300/metrics`) | Prometheus endpoint of the challenger under test |
+| `CHALLENGER_E2E_GAME_LOOKBACK` | No (default `50`) | Factory indices searched for two games |
+| `CHALLENGER_E2E_STARTUP_TIMEOUT` | No (default `5m`) | Budget for the fork and the first scan |
+| `CHALLENGER_E2E_QUIET_WINDOW` | No (default `90s`) | Positive-case observation window |
+| `CHALLENGER_E2E_DISPUTE_TIMEOUT` | No (default `45m`) | Budget for each SNARK / dispute; sized for a real proof |
+| `CHALLENGER_E2E_POLL_INTERVAL` | No (default `5s`) | Driver poll interval |
+
+`anvil` must be on `PATH`. The challenger under test must be reachable on
+`CHALLENGER_E2E_CHALLENGER_METRICS_URL` and must be configured with a local
+private key rather than a signer sidecar, since the driver supplies the key
+through the env file.
+
+## Usage
+
+```toml
+[dependencies]
+base-challenger-e2e = { workspace = true }
+```
+
+```rust,ignore
+use base_challenger_e2e::ChallengerE2e;
+
+ChallengerE2e::run().await?;
+```
+
+The `base-challenger-e2e` binary wraps this for K8s `CronJob` execution; the pod
+topology it expects lives in `protocols/base-proofs`, in
+`chart/challenger-e2e`.

--- a/crates/infra/challenger-e2e/src/challenger_e2e.rs
+++ b/crates/infra/challenger-e2e/src/challenger_e2e.rs
@@ -7,8 +7,9 @@ use alloy_primitives::{Address, U256, hex};
 use alloy_provider::{Provider, RootProvider};
 use alloy_signer_local::PrivateKeySigner;
 use base_proof_contracts::{
-    AggregateVerifierClient, AggregateVerifierContractClient, DisputeGameFactoryClient,
-    DisputeGameFactoryContractClient, GameStatus,
+    AggregateVerifierClient, AggregateVerifierContractClient, AnchorStateRegistryClient,
+    AnchorStateRegistryContractClient, DisputeGameFactoryClient, DisputeGameFactoryContractClient,
+    GameStatus,
 };
 use clap::Parser;
 use eyre::{Context, Result, bail, ensure, eyre};
@@ -37,9 +38,17 @@ const DISPUTE_COUNTERS: [&str; 3] = [
 /// Count series of the challenger's validation-latency histogram.
 ///
 /// Recorded once per call to the validator's `validate_output_roots`, which is
-/// reached per candidate game, so this is the only metric that shows the
-/// challenger got past the factory and looked at a game.
+/// reached once per candidate game.
 const VALIDATIONS: &str = "base_challenger_validation_latency_seconds_count";
+
+/// Failed validations, one per failed [`VALIDATIONS`] call.
+///
+/// `validate_output_roots` records its latency from a drop guard, so the
+/// histogram counts attempts rather than successes. It increments this counter
+/// exactly once on the way out of a failure — the `?` returns on the first
+/// error it observes — so the difference of the two is the number of games the
+/// challenger actually validated.
+const VALIDATION_ERRORS: &str = "base_challenger_validation_errors_total";
 
 /// Behavioural end-to-end test of the challenger.
 ///
@@ -70,10 +79,15 @@ impl ChallengerE2e {
             provider.clone(),
         );
         let verifier = AggregateVerifierContractClient::new(provider.clone());
+        let anchor_registry = AnchorStateRegistryContractClient::new(
+            config.anchor_state_registry_addr,
+            provider.clone(),
+        );
 
         // Chosen before the challenger boots, so the quiet window below is
         // measured against a fork that already contains the target games.
-        let (game_a, game_b) = Self::select_games(&config, &factory, &verifier).await?;
+        let (game_a, game_b) =
+            Self::select_games(&config, &factory, &verifier, &anchor_registry).await?;
 
         Self::release_challenger(&fork_url, &challenger)?;
         Self::await_first_scan(&config).await?;
@@ -130,6 +144,7 @@ impl ChallengerE2e {
         config: &Config,
         factory: &DisputeGameFactoryContractClient,
         verifier: &AggregateVerifierContractClient,
+        anchor_registry: &AnchorStateRegistryContractClient,
     ) -> Result<(Address, Address)> {
         let game_count = factory.game_count().await?;
         if game_count == 0 {
@@ -137,9 +152,20 @@ impl ChallengerE2e {
         }
         let floor = game_count.saturating_sub(config.game_lookback);
 
+        // The challenger scans from one past the anchor game's factory index,
+        // so anything at or before it is invisible to the challenger no matter
+        // what state it is in. Walking newest-first means stopping at the
+        // anchor is the whole lower bound.
+        let anchor_game = anchor_registry.anchor_snapshot().await?.anchor_game;
+
         let mut selected = Vec::with_capacity(2);
         for index in (floor..game_count).rev() {
             let game = factory.game_at_index(index).await?;
+            // ZERO is the starting anchor, where the challenger scans from 0.
+            if anchor_game != Address::ZERO && game.proxy == anchor_game {
+                info!(anchor_game = %anchor_game, factory_index = index, "reached the anchor");
+                break;
+            }
             if game.game_type != config.game_type {
                 continue;
             }
@@ -182,8 +208,9 @@ impl ChallengerE2e {
             return Ok((*game_a, *game_b));
         }
         bail!(
-            "need two in-progress, uncountered games of type {} in the newest {} factory \
-             indices, found {}; the fork source may be behind or the proposer may be stalled",
+            "need two in-progress, uncountered games of type {} above the anchor in the newest \
+             {} factory indices, found {}; the fork source may be behind, the proposer may be \
+             stalled, or the anchor may have advanced past them",
             config.game_type,
             game_count - floor,
             selected.len()
@@ -269,16 +296,20 @@ impl ChallengerE2e {
 
         // `games_scanned_total` counts attempted factory indices and is
         // incremented even when every game query fails, so it cannot show that
-        // any game was actually looked at. The validation histogram is only
-        // touched from inside `validate_output_roots`, which is reached per
-        // candidate game, so its count is the positive signal.
-        let validated = after.sum(VALIDATIONS) - before.sum(VALIDATIONS);
+        // any game was actually looked at. The validation histogram is closer
+        // but still counts attempts, because its latency is recorded from a
+        // drop guard that fires on the error path too. Subtracting the error
+        // counter leaves the validations that actually computed a root.
+        let attempted = after.sum(VALIDATIONS) - before.sum(VALIDATIONS);
+        let failed = after.sum(VALIDATION_ERRORS) - before.sum(VALIDATION_ERRORS);
+        let validated = attempted - failed;
         let scanned = after.sum("base_challenger_games_scanned_total")
             - before.sum("base_challenger_games_scanned_total");
         ensure!(
             validated > 0.0,
-            "the challenger validated no game in {:?} ({scanned} indices scanned); it is \
-             reaching the factory but not the games, so a quiet window proves nothing",
+            "the challenger completed no validation in {:?} ({attempted} attempted, {failed} \
+             failed, {scanned} indices scanned); a quiet window over games it never managed to \
+             check proves nothing",
             config.quiet_window
         );
 
@@ -290,14 +321,11 @@ impl ChallengerE2e {
             );
         }
 
-        // Validation errors are usually the L2 RPC rather than the challenger,
-        // so they are reported rather than fatal. A storm severe enough to
-        // matter fails the assertion above instead, because a game whose roots
-        // cannot be computed is never validated.
-        let errors = after.sum("base_challenger_validation_errors_total")
-            - before.sum("base_challenger_validation_errors_total");
-        if errors > 0.0 {
-            warn!(validation_errors = errors, "the challenger reported validation errors");
+        // Some failures are tolerable — they are usually the L2 RPC rather than
+        // the challenger — so they are reported rather than fatal. A storm that
+        // swallows every game fails the assertion above instead.
+        if failed > 0.0 {
+            warn!(validation_errors = failed, "the challenger reported validation errors");
         }
 
         info!(

--- a/crates/infra/challenger-e2e/src/challenger_e2e.rs
+++ b/crates/infra/challenger-e2e/src/challenger_e2e.rs
@@ -1,0 +1,336 @@
+//! Drives a real challenger binary against a throwaway fork of the target L1.
+
+use std::{path::Path, time::Duration};
+
+use alloy_node_bindings::{Anvil, AnvilInstance};
+use alloy_primitives::{Address, U256, hex};
+use alloy_provider::{Provider, RootProvider};
+use alloy_signer_local::PrivateKeySigner;
+use base_proof_contracts::{
+    AggregateVerifierClient, AggregateVerifierContractClient, DisputeGameFactoryClient,
+    DisputeGameFactoryContractClient, GameStatus,
+};
+use clap::Parser;
+use eyre::{Context, Result, bail, ensure, eyre};
+use tracing::{info, warn};
+use url::Url;
+
+use crate::{config::Config, metrics::Scrape};
+
+/// Wei granted to each throwaway account on the fork. Orders of magnitude more
+/// than a dispute costs, and worthless outside the pod.
+const FUNDING_WEI: u128 = 100_000_000_000_000_000_000;
+
+/// Handshake file the driver writes to release the challenger sidecar, which
+/// blocks on it appearing. The sidecar hardcodes the same path, so this was
+/// never independently configurable.
+const CHALLENGER_ENV_FILE: &str = "/shared/challenger.env";
+
+/// Behavioural end-to-end test of the challenger.
+///
+/// See the crate README for the full argument; the short version is that the
+/// fork is built from a real chain and the games under test were created and
+/// verified on that chain, so nothing the challenger sees is stubbed.
+#[derive(Debug)]
+pub struct ChallengerE2e;
+
+impl ChallengerE2e {
+    /// Runs the test to completion. An `Ok` return means the challenger passed.
+    pub async fn run() -> Result<()> {
+        let config = Config::parse();
+
+        // Two distinct accounts: A (driver) signs setup only, B is the
+        // challenger. Both are generated per run and never leave the pod.
+        let driver = PrivateKeySigner::random();
+        let challenger = PrivateKeySigner::random();
+
+        // Held until the end of run(); the fork dies with this binding.
+        let anvil = Self::spawn_fork(&config)?;
+        let fork_url = anvil.endpoint_url();
+        let provider: RootProvider = RootProvider::new_http(fork_url.clone());
+        Self::fund(&provider, &[driver.address(), challenger.address()]).await?;
+
+        let factory = DisputeGameFactoryContractClient::new(
+            config.dispute_game_factory_addr,
+            provider.clone(),
+        );
+        let verifier = AggregateVerifierContractClient::new(provider.clone());
+
+        // Chosen before the challenger boots, so the quiet window below is
+        // measured against a fork that already contains the target games.
+        let (game_a, game_b) = Self::select_games(&config, &factory, &verifier).await?;
+
+        Self::release_challenger(&fork_url, &challenger)?;
+        Self::await_first_scan(&config).await?;
+
+        Self::assert_quiet_on_valid_games(&config).await?;
+
+        info!(
+            game_a = %game_a,
+            game_b = %game_b,
+            "the fork holds two disputable games and the challenger left both alone"
+        );
+        Ok(())
+    }
+
+    fn spawn_fork(config: &Config) -> Result<AnvilInstance> {
+        info!(fork_source = %config.l1_eth_rpc, port = config.anvil_port, "spawning L1 fork");
+        Anvil::new()
+            .fork(config.l1_eth_rpc.as_str())
+            .port(config.anvil_port)
+            .timeout(u64::try_from(config.startup_timeout.as_millis()).unwrap_or(u64::MAX))
+            // A cold fork issues a burst of archive reads; the default client-side
+            // throttle turns that into a startup timeout.
+            .arg("--no-rate-limit")
+            .try_spawn()
+            .context("failed to spawn anvil; the binary must be on PATH")
+    }
+
+    async fn fund(provider: &RootProvider, addresses: &[Address]) -> Result<()> {
+        for address in addresses {
+            provider
+                .client()
+                .request::<_, ()>("anvil_setBalance", (address, U256::from(FUNDING_WEI)))
+                .await
+                .with_context(|| format!("anvil_setBalance failed for {address}"))?;
+        }
+        Ok(())
+    }
+
+    /// Picks the two newest in-progress TEE-only games the challenger will
+    /// classify as disputable once their roots stop matching L2.
+    ///
+    /// Selecting them here rather than later is what makes the quiet window a
+    /// real assertion: the games the challenger must ignore are the same ones
+    /// it will later be asked to dispute. Scanning newest-first also keeps the
+    /// range recent, which matters because the L2 RPC is a live node and may
+    /// have pruned the state behind an older game.
+    async fn select_games(
+        config: &Config,
+        factory: &DisputeGameFactoryContractClient,
+        verifier: &AggregateVerifierContractClient,
+    ) -> Result<(Address, Address)> {
+        let game_count = factory.game_count().await?;
+        if game_count == 0 {
+            bail!("factory {} has no games on the fork", config.dispute_game_factory_addr);
+        }
+        let floor = game_count.saturating_sub(config.game_lookback);
+
+        let mut selected = Vec::with_capacity(2);
+        for index in (floor..game_count).rev() {
+            let game = factory.game_at_index(index).await?;
+            if game.game_type != config.game_type {
+                continue;
+            }
+            if verifier.status(game.proxy).await? != GameStatus::InProgress {
+                continue;
+            }
+            // A TEE-only, uncountered game is the challenger's Path 1. Games
+            // that already carry a ZK proof or a counter are mid-dispute and
+            // would confuse the assertions below.
+            if verifier.tee_prover(game.proxy).await? == Address::ZERO {
+                continue;
+            }
+            if verifier.zk_prover(game.proxy).await? != Address::ZERO {
+                continue;
+            }
+            if verifier.countered_index(game.proxy).await? != 0 {
+                continue;
+            }
+            // Corrupting a game means rewriting one of its intermediate roots,
+            // so a game without any is not disputable by this test.
+            let root_count = verifier.intermediate_output_roots(game.proxy).await?.len();
+            if root_count == 0 {
+                continue;
+            }
+
+            info!(
+                game = %game.proxy,
+                factory_index = index,
+                root_count,
+                slot = selected.len(),
+                "selected game"
+            );
+            selected.push(game.proxy);
+            if selected.len() == 2 {
+                break;
+            }
+        }
+
+        if let [game_a, game_b] = selected.as_slice() {
+            return Ok((*game_a, *game_b));
+        }
+        bail!(
+            "need two in-progress, uncountered games of type {} in the newest {} factory \
+             indices, found {}; the fork source may be behind or the proposer may be stalled",
+            config.game_type,
+            game_count - floor,
+            selected.len()
+        )
+    }
+
+    /// Hands the fork and a funded key to the challenger sidecar, which is
+    /// blocked on this file appearing.
+    ///
+    /// Written via a rename so the sidecar can never source a partial file.
+    fn release_challenger(fork_url: &Url, signer: &PrivateKeySigner) -> Result<()> {
+        // Sourced after /envmapper/mapping.env, so these override the
+        // config-service values for the run.
+        let contents = format!(
+            "export BASE_CHALLENGER_L1_ETH_RPC={fork_url}\n\
+             export BASE_CHALLENGER_PRIVATE_KEY={}\n",
+            hex::encode_prefixed(signer.to_bytes())
+        );
+
+        let path = Path::new(CHALLENGER_ENV_FILE);
+        let staging = path.with_extension("tmp");
+        std::fs::write(&staging, contents)
+            .with_context(|| format!("failed to write {}", staging.display()))?;
+        std::fs::rename(&staging, path)
+            .with_context(|| format!("failed to publish {}", path.display()))?;
+
+        info!(
+            challenger_address = %signer.address(),
+            env_file = %path.display(),
+            "released the challenger onto the fork"
+        );
+        Ok(())
+    }
+
+    /// Waits until the challenger is up and has completed a scan.
+    async fn await_first_scan(config: &Config) -> Result<()> {
+        Self::poll_until(
+            config,
+            config.startup_timeout,
+            "the challenger to complete a scan",
+            || async {
+                let scrape = Scrape::fetch(&config.challenger_metrics_url).await?;
+                Ok((scrape.sum("base_challenger_up") >= 1.0
+                    && scrape.sum("base_challenger_games_scanned_total") > 0.0)
+                    .then_some(()))
+            },
+        )
+        .await
+    }
+
+    /// Positive case: a challenger that disputes valid games fails here.
+    ///
+    /// Nothing on the fork has been corrupted yet, so every game the
+    /// challenger can see is one it must leave alone.
+    async fn assert_quiet_on_valid_games(config: &Config) -> Result<()> {
+        let before = Scrape::fetch(&config.challenger_metrics_url).await?;
+        info!(window = ?config.quiet_window, "observing the challenger against an unmodified fork");
+        tokio::time::sleep(config.quiet_window).await;
+        let after = Scrape::fetch(&config.challenger_metrics_url).await?;
+
+        let scanned = after.sum("base_challenger_games_scanned_total")
+            - before.sum("base_challenger_games_scanned_total");
+        ensure!(
+            scanned > 0.0,
+            "the challenger scanned no games in {:?}; it is not making progress against the fork",
+            config.quiet_window
+        );
+
+        for metric in [
+            "base_challenger_games_invalid_total",
+            "base_challenger_nullify_tx_submitted_total",
+            "base_challenger_challenge_tx_submitted_total",
+        ] {
+            let delta = after.sum(metric) - before.sum(metric);
+            ensure!(
+                delta == 0.0,
+                "{metric} advanced by {delta} while every game on the fork was valid"
+            );
+        }
+
+        // Validation errors are usually the L2 RPC rather than the challenger,
+        // so they are reported rather than fatal. A persistent storm shows up
+        // as a dispute timeout below, which repeats this number.
+        let errors = after.sum("base_challenger_validation_errors_total")
+            - before.sum("base_challenger_validation_errors_total");
+        if errors > 0.0 {
+            warn!(validation_errors = errors, "the challenger reported validation errors");
+        }
+
+        info!(games_scanned = scanned, "the challenger left every valid game alone");
+        Ok(())
+    }
+
+    /// Appends the challenger's failure counters to a dispute timeout, which is
+    /// otherwise indistinguishable from "nothing happened".
+    async fn annotate_timeout(error: eyre::Report, config: &Config) -> eyre::Report {
+        let Ok(scrape) = Scrape::fetch(&config.challenger_metrics_url).await else {
+            return error;
+        };
+        error.wrap_err(format!(
+            "challenger counters at timeout: invalid={} validation_errors={} \
+             nullify_submitted={} nullify_reverted={} challenge_submitted={} \
+             challenge_reverted={} pending_proofs={}",
+            scrape.sum("base_challenger_games_invalid_total"),
+            scrape.sum("base_challenger_validation_errors_total"),
+            scrape.sum("base_challenger_nullify_tx_submitted_total"),
+            scrape.label_sum("base_challenger_nullify_tx_outcome_total", "reverted"),
+            scrape.sum("base_challenger_challenge_tx_submitted_total"),
+            scrape.label_sum("base_challenger_challenge_tx_outcome_total", "reverted"),
+            scrape.sum("base_challenger_pending_proofs"),
+        ))
+    }
+
+    /// Polls `check` every `poll_interval` until it yields a value or `budget`
+    /// elapses.
+    async fn poll_until<T, F, Fut>(
+        config: &Config,
+        budget: Duration,
+        waiting_for: &str,
+        mut check: F,
+    ) -> Result<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<Option<T>>>,
+    {
+        let mut last_error = None;
+        match tokio::time::timeout(budget, async {
+            loop {
+                match check().await {
+                    Ok(Some(value)) => return Ok(value),
+                    Ok(None) => {}
+                    // The fork and the challenger are both starting up; a read
+                    // that fails now routinely succeeds on the next tick.
+                    Err(error) => {
+                        warn!(error = %error, "poll failed; retrying");
+                        last_error = Some(error);
+                    }
+                }
+                tokio::time::sleep(config.poll_interval).await;
+            }
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                let msg = format!("timed out after {budget:?} waiting for {waiting_for}");
+                let error = match last_error {
+                    Some(error) => error.wrap_err(msg),
+                    None => eyre!("{msg}"),
+                };
+                Err(Self::annotate_timeout(error, config).await)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn private_key_env_is_0x_hex_and_round_trips() {
+        let signer = PrivateKeySigner::random();
+        let encoded = hex::encode_prefixed(signer.to_bytes());
+        assert!(encoded.starts_with("0x"), "{encoded}");
+        assert_eq!(encoded.len(), 66);
+        assert!(encoded[2..].chars().all(|c| c.is_ascii_hexdigit()));
+        let parsed: PrivateKeySigner = encoded.parse().expect("challenger clap parse");
+        assert_eq!(parsed.address(), signer.address());
+    }
+}

--- a/crates/infra/challenger-e2e/src/challenger_e2e.rs
+++ b/crates/infra/challenger-e2e/src/challenger_e2e.rs
@@ -63,16 +63,15 @@ impl ChallengerE2e {
     pub async fn run() -> Result<()> {
         let config = Config::parse();
 
-        // Two distinct accounts: A (driver) signs setup only, B is the
-        // challenger. Both are generated per run and never leave the pod.
-        let driver = PrivateKeySigner::random();
+        // Generated per run and never leaves the pod. The dispute paths add a
+        // second account that signs their setup; this one only ever disputes.
         let challenger = PrivateKeySigner::random();
 
         // Held until the end of run(); the fork dies with this binding.
         let anvil = Self::spawn_fork(&config)?;
         let fork_url = anvil.endpoint_url();
         let provider: RootProvider = RootProvider::new_http(fork_url.clone());
-        Self::fund(&provider, &[driver.address(), challenger.address()]).await?;
+        Self::fund(&provider, &[challenger.address()]).await?;
 
         let factory = DisputeGameFactoryContractClient::new(
             config.dispute_game_factory_addr,

--- a/crates/infra/challenger-e2e/src/challenger_e2e.rs
+++ b/crates/infra/challenger-e2e/src/challenger_e2e.rs
@@ -26,6 +26,21 @@ const FUNDING_WEI: u128 = 100_000_000_000_000_000_000;
 /// never independently configurable.
 const CHALLENGER_ENV_FILE: &str = "/shared/challenger.env";
 
+/// Counters that must stay at zero for as long as every game on the fork is
+/// valid. Checked absolutely at the baseline and as a delta over the window.
+const DISPUTE_COUNTERS: [&str; 3] = [
+    "base_challenger_games_invalid_total",
+    "base_challenger_nullify_tx_submitted_total",
+    "base_challenger_challenge_tx_submitted_total",
+];
+
+/// Count series of the challenger's validation-latency histogram.
+///
+/// Recorded once per call to the validator's `validate_output_roots`, which is
+/// reached per candidate game, so this is the only metric that shows the
+/// challenger got past the factory and looked at a game.
+const VALIDATIONS: &str = "base_challenger_validation_latency_seconds_count";
+
 /// Behavioural end-to-end test of the challenger.
 ///
 /// See the crate README for the full argument; the short version is that the
@@ -74,7 +89,13 @@ impl ChallengerE2e {
     }
 
     fn spawn_fork(config: &Config) -> Result<AnvilInstance> {
-        info!(fork_source = %config.l1_eth_rpc, port = config.anvil_port, "spawning L1 fork");
+        // Host only. Provider URLs routinely carry the API key in the path or
+        // the query string, and this log ships to a shared aggregator.
+        info!(
+            fork_source = config.l1_eth_rpc.host_str().unwrap_or("<no host>"),
+            port = config.anvil_port,
+            "spawning L1 fork"
+        );
         Anvil::new()
             .fork(config.l1_eth_rpc.as_str())
             .port(config.anvil_port)
@@ -176,8 +197,15 @@ impl ChallengerE2e {
     fn release_challenger(fork_url: &Url, signer: &PrivateKeySigner) -> Result<()> {
         // Sourced after /envmapper/mapping.env, so these override the
         // config-service values for the run.
+        //
+        // The unsets are load-bearing. `--private-key` and `--signer-endpoint`
+        // are `conflicts_with` in the shared signer CLI, and clap counts an
+        // env-sourced value as present, so a mapping that carries the
+        // production sidecar variables makes the challenger refuse to start.
         let contents = format!(
-            "export BASE_CHALLENGER_L1_ETH_RPC={fork_url}\n\
+            "unset BASE_CHALLENGER_SIGNER_ENDPOINT\n\
+             unset BASE_CHALLENGER_SIGNER_ADDRESS\n\
+             export BASE_CHALLENGER_L1_ETH_RPC={fork_url}\n\
              export BASE_CHALLENGER_PRIVATE_KEY={}\n",
             hex::encode_prefixed(signer.to_bytes())
         );
@@ -219,23 +247,42 @@ impl ChallengerE2e {
     /// challenger can see is one it must leave alone.
     async fn assert_quiet_on_valid_games(config: &Config) -> Result<()> {
         let before = Scrape::fetch(&config.challenger_metrics_url).await?;
+
+        // Cumulative, not a delta. `games_scanned_total` is incremented for the
+        // whole scanned range before any candidate is validated, so a scan that
+        // has already completed can have disputed something before this
+        // baseline was taken; a delta comparison would absorb it into `before`
+        // and pass.
+        for metric in DISPUTE_COUNTERS {
+            let total = before.sum(metric);
+            ensure!(
+                total == 0.0,
+                "{metric} is already {total} on the first completed scan; the challenger \
+                 disputed something before the observation window opened, or the fork source \
+                 carries a genuinely invalid game"
+            );
+        }
+
         info!(window = ?config.quiet_window, "observing the challenger against an unmodified fork");
         tokio::time::sleep(config.quiet_window).await;
         let after = Scrape::fetch(&config.challenger_metrics_url).await?;
 
+        // `games_scanned_total` counts attempted factory indices and is
+        // incremented even when every game query fails, so it cannot show that
+        // any game was actually looked at. The validation histogram is only
+        // touched from inside `validate_output_roots`, which is reached per
+        // candidate game, so its count is the positive signal.
+        let validated = after.sum(VALIDATIONS) - before.sum(VALIDATIONS);
         let scanned = after.sum("base_challenger_games_scanned_total")
             - before.sum("base_challenger_games_scanned_total");
         ensure!(
-            scanned > 0.0,
-            "the challenger scanned no games in {:?}; it is not making progress against the fork",
+            validated > 0.0,
+            "the challenger validated no game in {:?} ({scanned} indices scanned); it is \
+             reaching the factory but not the games, so a quiet window proves nothing",
             config.quiet_window
         );
 
-        for metric in [
-            "base_challenger_games_invalid_total",
-            "base_challenger_nullify_tx_submitted_total",
-            "base_challenger_challenge_tx_submitted_total",
-        ] {
+        for metric in DISPUTE_COUNTERS {
             let delta = after.sum(metric) - before.sum(metric);
             ensure!(
                 delta == 0.0,
@@ -244,15 +291,20 @@ impl ChallengerE2e {
         }
 
         // Validation errors are usually the L2 RPC rather than the challenger,
-        // so they are reported rather than fatal. A persistent storm shows up
-        // as a dispute timeout below, which repeats this number.
+        // so they are reported rather than fatal. A storm severe enough to
+        // matter fails the assertion above instead, because a game whose roots
+        // cannot be computed is never validated.
         let errors = after.sum("base_challenger_validation_errors_total")
             - before.sum("base_challenger_validation_errors_total");
         if errors > 0.0 {
             warn!(validation_errors = errors, "the challenger reported validation errors");
         }
 
-        info!(games_scanned = scanned, "the challenger left every valid game alone");
+        info!(
+            games_validated = validated,
+            indices_scanned = scanned,
+            "the challenger left every valid game alone"
+        );
         Ok(())
     }
 

--- a/crates/infra/challenger-e2e/src/config.rs
+++ b/crates/infra/challenger-e2e/src/config.rs
@@ -11,7 +11,7 @@ use alloy_primitives::Address;
 use clap::Parser;
 use url::Url;
 
-/// Runtime configuration for the challenger E2E driver.
+/// Runtime configuration for [`crate::ChallengerE2e`].
 #[derive(Debug, Parser)]
 #[command(name = "challenger-e2e", version, about, long_about = None)]
 pub struct Config {

--- a/crates/infra/challenger-e2e/src/config.rs
+++ b/crates/infra/challenger-e2e/src/config.rs
@@ -36,6 +36,14 @@ pub struct Config {
     #[arg(long = "game-type", env = "BASE_CHALLENGER_GAME_TYPE")]
     pub game_type: u32,
 
+    /// `AnchorStateRegistry` on L1.
+    ///
+    /// Read only to find the anchor game's factory index. The challenger scans
+    /// from one past it, so a game at or before the anchor is one it will never
+    /// look at.
+    #[arg(long = "anchor-state-registry-addr", env = "BASE_CHALLENGER_ANCHOR_STATE_REGISTRY_ADDR")]
+    pub anchor_state_registry_addr: Address,
+
     /// Port Anvil binds to.
     ///
     /// Deliberately not 8545: the production challenger config reserves that

--- a/crates/infra/challenger-e2e/src/lib.rs
+++ b/crates/infra/challenger-e2e/src/lib.rs
@@ -5,3 +5,6 @@ pub use config::Config;
 
 mod metrics;
 pub use metrics::Scrape;
+
+mod challenger_e2e;
+pub use challenger_e2e::ChallengerE2e;

--- a/crates/infra/challenger-e2e/src/metrics.rs
+++ b/crates/infra/challenger-e2e/src/metrics.rs
@@ -1,7 +1,26 @@
 //! Minimal Prometheus text-exposition scraper for the challenger under test.
 
+use std::{sync::LazyLock, time::Duration};
+
 use eyre::{Context, Result};
+use reqwest::Client;
 use url::Url;
+
+/// Client for every scrape, built once so the connection pool is reused across
+/// the several hundred polls a run makes.
+///
+/// The timeout is the point of it. Every caller is either inside a poll loop
+/// that retries, or is annotating a failure that has already happened, so a
+/// stalled endpoint must surface as an error rather than parking the run —
+/// and `reqwest`'s default client has no timeout at all.
+static CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    // Not `unwrap_or_default`: the default client has no timeout, so a silent
+    // fallback would reintroduce exactly the hang this exists to prevent.
+    Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("the reqwest TLS backend failed to initialise")
+});
 
 /// One scrape of a Prometheus `/metrics` endpoint.
 ///
@@ -15,7 +34,9 @@ pub struct Scrape {
 impl Scrape {
     /// Fetches and parses the endpoint.
     pub async fn fetch(url: &Url) -> Result<Self> {
-        let body = reqwest::get(url.clone())
+        let body = CLIENT
+            .get(url.clone())
+            .send()
             .await
             .with_context(|| format!("failed to scrape {url}"))?
             .error_for_status()

--- a/deny.toml
+++ b/deny.toml
@@ -225,6 +225,9 @@ skip = [
     "alloy-consensus",
     "alloy-consensus-any",
     "alloy-eips",
+    # alloy-node-bindings (anvil harness for base-challenger-e2e) pins an older
+    # alloy-hardforks than the rest of the workspace.
+    "alloy-hardforks",
     "alloy-json-rpc",
     "alloy-network",
     "alloy-network-primitives",


### PR DESCRIPTION
Stacked on #4780. Split out of #4781 so each half is reviewable on its own; this is the harness plus the positive case, #4781 is now only the dispute paths.

## What changed?

`ChallengerE2e::run()` and the `base-challenger-e2e` binary that wraps it for `CronJob` execution.

- **Fork.** Spawns a pod-local Anvil forked from `BASE_CHALLENGER_L1_ETH_RPC`, funds two throwaway keys generated per run — A (driver, signs setup only) and B (challenger, the only key permitted to dispute).
- **Game selection.** Walks the newest `CHALLENGER_E2E_GAME_LOOKBACK` factory indices for two in-progress, uncountered, TEE-only games of the configured game type with at least one intermediate output root. Bails with a diagnostic if fewer than two exist.
- **Handshake.** Writes `/shared/challenger.env` via a rename (so the sidecar can never source a partial file) with the fork URL and B's key. The challenger sidecar blocks on that file appearing.
- **Positive case.** Waits for `base_challenger_up == 1` and a completed scan, then holds `CHALLENGER_E2E_QUIET_WINDOW` and asserts `games_scanned_total` advances while `games_invalid_total`, `nullify_tx_submitted_total` and `challenge_tx_submitted_total` stay flat.

Plus `poll_until` (used by every wait in both halves) and `annotate_timeout`, which appends the challenger's failure counters to a timeout — otherwise a timeout is indistinguishable from "nothing happened".

## Why?

The challenger is a bot that spends money and nullifies proofs. Unit tests cover the classifier against mocks; nothing covers the deployed binary against a real chain. The gate this feeds is: a zeronet challenger image cannot be promoted to sepolia unless it has been shown to behave correctly on a throwaway fork of the L1 it will actually run against.

Forking rather than deploying a fresh chain is what makes it honest. The games were created and verified on the real chain before the fork point, so the `TEEVerifier`, the `TEEProverRegistry` and the game bytecode are all real.

The positive case is the half that catches the expensive failure mode. A challenger that disputes valid games burns gas and nullifies honest proposals; there is no assertion anywhere else in the repo that the deployed binary leaves a valid chain alone.

## How to test?

```
cargo +nightly fmt --all -- --check
BASE_SUCCINCT_ELF_STUB=1 cargo clippy -p base-challenger-e2e -p base-challenger-e2e-bin \
  --all-features --all-targets -- -D warnings
cargo test -p base-challenger-e2e
```

To run it end to end you need a challenger pod; the topology lives in `protocols/base-proofs` under `chart/challenger-e2e`. Locally, against a chain you have RPC for:

```
anvil --version            # must be on PATH
export BASE_CHALLENGER_L1_ETH_RPC=... BASE_CHALLENGER_L2_ETH_RPC=... \
       BASE_CHALLENGER_ZK_RPC_URL=... \
       BASE_CHALLENGER_DISPUTE_GAME_FACTORY_ADDR=... BASE_CHALLENGER_GAME_TYPE=...
cargo run -p base-challenger-e2e-bin
```

Expect it to log `selected game` twice, then block on the handshake until a challenger is reachable at `CHALLENGER_E2E_CHALLENGER_METRICS_URL`.

To see the positive case fail as intended, point `CHALLENGER_E2E_CHALLENGER_METRICS_URL` at a challenger that is actively disputing: `games_invalid_total advanced by N while every game on the fork was valid`.