### PR TITLE
feat(snapshotter): publish tip chunks via chunk_files [backport #4494 to releases/v1.3.0]

### DIFF
--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -102,8 +102,9 @@ pub struct SnapshotterConfig {
 
     /// Number of completed timestamped snapshot run directories to retain remotely.
     ///
-    /// Older `{prefix}/{timestamp}/` directories are deleted after a successful
-    /// upload. The append-only `{prefix}/static_files/` directory is never pruned.
+    /// Older `{prefix}/{timestamp}/` directories, including their latest static-file
+    /// chunks, are deleted after a successful upload. The append-only
+    /// `{prefix}/static_files/` directory containing finalized chunks is never pruned.
     #[arg(long, env = "SNAPSHOTTER_RETAIN_RUNS", default_value = "3")]
     pub retain_runs: NonZeroUsize,
 

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -29,7 +29,7 @@ pub use snapshot::{
 };
 
 mod upload;
-pub use upload::{SnapshotRun, SnapshotUploader, UploadStrategy};
+pub use upload::{SnapshotRun, SnapshotUploadParams, SnapshotUploader, UploadStrategy};
 
 mod orchestrator;
 pub use orchestrator::Snapshotter;

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -17,7 +17,7 @@ use crate::{
         SnapshotManifestExt,
     },
     tip::TipChecker,
-    upload::SnapshotUploader,
+    upload::{SnapshotUploadParams, SnapshotUploader},
 };
 
 /// Orchestrates the full snapshot flow: stop CL and EL → generate → upload → restart EL and CL.
@@ -196,7 +196,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         let chain_id = self.config.chain_id;
         let block = Some(self.config.block.unwrap_or(latest_block));
         let blocks_per_file = self.config.blocks_per_file;
-        let remote_for_gen = remote_static_files;
+        let remote_for_gen = remote_static_files.clone();
         let previous_chunk_output_files_for_gen = previous_chunk_output_files;
         let upload_proofs = self.config.upload_proofs;
 
@@ -221,8 +221,14 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             bail!("snapshot generation produced no files");
         }
 
-        self.upload_run_directory(&run_output_dir, run_timestamp, files, remote_manifest.as_ref())
-            .await?;
+        self.upload_run_directory(
+            &run_output_dir,
+            run_timestamp,
+            files,
+            remote_manifest.as_ref(),
+            &remote_static_files,
+        )
+        .await?;
 
         info!(output_dir = %run_output_dir.display(), "cleaning up local artifacts");
         if let Err(e) = tokio::fs::remove_dir_all(&run_output_dir).await {
@@ -243,13 +249,20 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         );
 
         let files = SnapshotGenerator::collect_output_files(&run_output_dir)?;
+        let remote_static_files = self.uploader.list_remote_static_files().await?;
         let remote_manifest = self.uploader.fetch_previous_manifest().await?;
         info!(
             has_remote_manifest = remote_manifest.is_some(),
             "fetched previous manifest for blake3 diff"
         );
-        self.upload_run_directory(&run_output_dir, run_timestamp, files, remote_manifest.as_ref())
-            .await
+        self.upload_run_directory(
+            &run_output_dir,
+            run_timestamp,
+            files,
+            remote_manifest.as_ref(),
+            &remote_static_files,
+        )
+        .await
     }
 
     /// Uploads one prepared run directory after generation or from upload-only mode.
@@ -259,6 +272,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         run_timestamp: u64,
         files: Vec<PathBuf>,
         remote_manifest: Option<&SnapshotManifest>,
+        remote_static_files: &HashMap<String, u64>,
     ) -> Result<()> {
         if files.is_empty() {
             bail!("snapshot run directory produced no files")
@@ -271,14 +285,15 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             serde_json::from_slice(&manifest_bytes).context("failed to parse run manifest.json")?;
 
         self.uploader
-            .upload(
-                run_output_dir,
-                &files,
-                run_timestamp,
-                self.config.retain_runs.get(),
-                &local_manifest,
+            .upload(SnapshotUploadParams {
+                output_dir: run_output_dir,
+                files: &files,
+                timestamp: run_timestamp,
+                retain_runs: self.config.retain_runs.get(),
+                local_manifest: &local_manifest,
                 remote_manifest,
-            )
+                remote_static_files,
+            })
             .await
             .with_context(|| {
                 format!(

--- a/crates/infra/snapshotter/src/snapshot.rs
+++ b/crates/infra/snapshotter/src/snapshot.rs
@@ -28,9 +28,6 @@ use crate::progress::{
 /// Default blocks per static file segment.
 const DEFAULT_BLOCKS_PER_FILE: u64 = 500_000;
 
-/// Number of extra chunks beyond the tip to compress as a safety buffer.
-const EXTRA_CHUNKS_BUFFER: u64 = 2;
-
 /// Maximum number of chunks allowed before bailing to prevent OOM.
 /// At 500k blocks per file, 100k chunks covers 50 billion blocks.
 const MAX_CHUNKS: u64 = 100_000;
@@ -54,8 +51,8 @@ pub trait SnapshotManifestExt {
     /// - `filename` does not match the `{component}-{start}-{end}.tar.zst` pattern,
     /// - the component is not present in the manifest or is not a chunked component,
     /// - the chunk index is out of range, or
-    /// - the chunk's hash list is empty (which happens for chunks that were skipped
-    ///   at generation time — see the tip+buffer invariant in `compute_skip_ranges`).
+    /// - the chunk's hash list is empty (which happens when no prior metadata was
+    ///   available for a chunk skipped during generation).
     ///
     /// Callers should treat `None` as "no comparable hash available" and fall
     /// through to re-upload.
@@ -63,6 +60,9 @@ pub trait SnapshotManifestExt {
 
     /// Returns the full per-file metadata for a static-file chunk archive.
     fn chunk_output_files_for_file(&self, filename: &str) -> Option<Vec<OutputFileChecksum>>;
+
+    /// Returns whether `filename` is the latest chunk for its component.
+    fn is_latest_chunk_file(&self, filename: &str) -> bool;
 }
 
 impl SnapshotManifestExt for SnapshotManifest {
@@ -92,6 +92,20 @@ impl SnapshotManifestExt for SnapshotManifest {
             return None;
         }
         Some(entries.clone())
+    }
+
+    fn is_latest_chunk_file(&self, filename: &str) -> bool {
+        let Some((component, start, end)) = ChunkFilename::parse(filename) else {
+            return false;
+        };
+        let Some(ComponentManifest::Chunked(meta)) = self.components.get(&component) else {
+            return false;
+        };
+        let Some((latest_start, latest_end)) = latest_chunk_range(meta) else {
+            return false;
+        };
+
+        start == latest_start && end == latest_end
     }
 }
 
@@ -415,19 +429,19 @@ impl SnapshotGenerator {
         Ok(files)
     }
 
-    /// Determines which chunk ranges can be skipped based on what already exists
-    /// remotely. Keeps the tip chunk and `EXTRA_CHUNKS_BUFFER` additional chunks.
+    /// Determines which finalized chunk ranges can be skipped based on what already
+    /// exists remotely. Keeps only the latest chunk in the timestamped run directory.
     pub fn compute_skip_ranges(
         remote_filenames: &HashSet<&str>,
         block: u64,
         blocks_per_file: u64,
     ) -> Result<HashSet<(u64, u64)>> {
         let num_chunks = block.div_ceil(blocks_per_file);
-        let keep_from = num_chunks.saturating_sub(1 + EXTRA_CHUNKS_BUFFER);
+        let latest_chunk = num_chunks.saturating_sub(1);
 
         let mut skip = HashSet::new();
         for i in 0..num_chunks {
-            if i >= keep_from {
+            if i >= latest_chunk {
                 continue;
             }
             let start = i * blocks_per_file;
@@ -472,6 +486,17 @@ impl ChunkFilename {
         let start = parts[1].parse::<u64>().ok()?;
         Some((parts[2].to_string(), start, end))
     }
+}
+
+/// Returns the block range for a chunked component's latest archive.
+fn latest_chunk_range(meta: &ChunkedArchive) -> Option<(u64, u64)> {
+    let latest_start = meta
+        .total_blocks
+        .checked_sub(1)?
+        .checked_div(meta.blocks_per_file)?
+        .checked_mul(meta.blocks_per_file)?;
+    let latest_end = latest_start.checked_add(meta.blocks_per_file - 1)?;
+    Some((latest_start, latest_end))
 }
 
 /// Infers the snapshot block from the highest header static file range.
@@ -907,32 +932,29 @@ mod tests {
             remote.insert(ChunkFilename::format(key, 1_500_000, 1_999_999));
         }
 
-        // block=2_000_000, blocks_per_file=500_000 → 4 chunks (indices 0-3)
-        // tip = chunk 3, buffer = 2 → keep chunks 1,2,3 → skip chunk 0
+        // block=2_000_000, blocks_per_file=500_000 → 4 chunks (indices 0-3).
+        // Only chunk 3 remains mutable; chunks 0, 1, and 2 are finalized.
         let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
         let skip = SnapshotGenerator::compute_skip_ranges(&refs, 2_000_000, 500_000).unwrap();
 
         assert!(skip.contains(&(0, 499_999)), "chunk 0 should be skipped");
-        assert!(!skip.contains(&(500_000, 999_999)), "chunk 1 should NOT be skipped (in buffer)");
-        assert!(
-            !skip.contains(&(1_000_000, 1_499_999)),
-            "chunk 2 should NOT be skipped (in buffer)"
-        );
-        assert!(!skip.contains(&(1_500_000, 1_999_999)), "chunk 3 (tip) should NOT be skipped");
+        assert!(skip.contains(&(500_000, 999_999)), "chunk 1 should be skipped");
+        assert!(skip.contains(&(1_000_000, 1_499_999)), "chunk 2 should be skipped");
+        assert!(!skip.contains(&(1_500_000, 1_999_999)), "chunk 3 (tip) should not be skipped");
     }
 
     #[test]
-    fn compute_skip_ranges_keeps_all_when_few_chunks() {
+    fn compute_skip_ranges_keeps_only_latest_chunk_when_few_chunks() {
         let mut remote = HashSet::new();
         for &(key, _) in CHUNKED_COMPONENTS {
             remote.insert(ChunkFilename::format(key, 0, 499_999));
             remote.insert(ChunkFilename::format(key, 500_000, 999_999));
         }
 
-        // block=1_000_000 → 2 chunks, tip + buffer(2) = 3 → keep all
+        // block=1_000_000 → 2 chunks; only chunk 1 remains mutable.
         let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
         let skip = SnapshotGenerator::compute_skip_ranges(&refs, 1_000_000, 500_000).unwrap();
-        assert!(skip.is_empty(), "should keep all chunks when count <= tip + buffer");
+        assert_eq!(skip, HashSet::from([(0, 499_999)]), "only the latest chunk should be kept");
     }
 
     #[test]
@@ -954,6 +976,48 @@ mod tests {
         assert!(
             !skip.contains(&(0, 499_999)),
             "should not skip range if not all components are present remotely"
+        );
+    }
+
+    #[test]
+    fn is_latest_chunk_file_identifies_only_the_final_chunk() {
+        let mut components = BTreeMap::new();
+        components.insert(
+            "headers".to_string(),
+            ComponentManifest::Chunked(ChunkedArchive {
+                blocks_per_file: 500_000,
+                total_blocks: 1_000_000,
+                chunk_sizes: vec![1, 1],
+                chunk_decompressed_sizes: vec![1, 1],
+                chunk_output_files: vec![vec![], vec![]],
+                chunk_files: vec![],
+            }),
+        );
+        let manifest = SnapshotManifest {
+            block: 1_000_000,
+            chain_id: 8453,
+            storage_version: 2,
+            timestamp: 0,
+            base_url: None,
+            reth_version: None,
+            components,
+        };
+
+        assert!(
+            manifest.is_latest_chunk_file("headers-500000-999999.tar.zst"),
+            "latest chunk should be identified"
+        );
+        assert!(
+            !manifest.is_latest_chunk_file("headers-0-499999.tar.zst"),
+            "finalized chunk should not be identified as latest"
+        );
+        assert!(
+            !manifest.is_latest_chunk_file("headers-500000-999998.tar.zst"),
+            "wrong range end should not be identified as latest"
+        );
+        assert!(
+            !manifest.is_latest_chunk_file("state.tar.zst"),
+            "single archive should not be identified as a latest chunk"
         );
     }
 
@@ -1166,7 +1230,11 @@ mod tests {
         );
         assert!(
             filenames.contains(&"headers-500000-999999.tar.zst".to_string()),
-            "buffer range should be compressed"
+            "range without a shared remote archive should be compressed"
+        );
+        assert!(
+            filenames.contains(&"headers-1000000-1499999.tar.zst".to_string()),
+            "range without a shared remote archive should be compressed"
         );
         assert!(
             filenames.contains(&"headers-1500000-1999999.tar.zst".to_string()),

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -2,14 +2,13 @@
 //!
 //! Artifacts are split into two areas within the bucket:
 //!
-//! - `{prefix}/static_files/` — static file chunks that are immutable for finalized
-//!   block ranges. Only the tip chunk changes between snapshots. The uploader
-//!   compares the per-file BLAKE3 hashes recorded in the previous run's
-//!   `manifest.json` against the freshly generated manifest, and skips chunks
-//!   whose hashes match.
+//! - `{prefix}/static_files/` — static file chunks for finalized block ranges. The uploader
+//!   compares the per-file BLAKE3 hashes recorded in the previous run's `manifest.json`
+//!   against the freshly generated manifest, and skips chunks whose hashes match.
 //!
-//! - `{prefix}/{date}/` — per-run directory for mdbx state, rocksdb indices, proofs, and the
-//!   manifest. These are always re-uploaded since they change every snapshot.
+//! - `{prefix}/{date}/` — per-run directory for mdbx state, rocksdb indices, proofs, the
+//!   manifest, and the latest static-file chunk for every component. Keeping the mutable chunk
+//!   beside the manifest prevents it from being overwritten while a downloader uses that manifest.
 
 use std::{
     collections::HashMap,
@@ -30,7 +29,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     progress::{UploadProgress, UploadStage},
-    snapshot::{ChunkFilename, SnapshotManifest, SnapshotManifestExt},
+    snapshot::{ChunkFilename, ComponentManifest, SnapshotManifest, SnapshotManifestExt},
 };
 
 /// Maximum number of concurrent file uploads.
@@ -61,6 +60,25 @@ pub struct SnapshotRun {
     pub manifest_key: String,
 }
 
+/// Inputs for [`SnapshotUploader::upload`].
+#[derive(Debug, Clone, Copy)]
+pub struct SnapshotUploadParams<'a> {
+    /// Directory containing the generated archives and `manifest.json`.
+    pub output_dir: &'a Path,
+    /// Generated artifact paths to upload.
+    pub files: &'a [PathBuf],
+    /// Unix timestamp used as the run directory name.
+    pub timestamp: u64,
+    /// Number of completed run directories to retain after upload.
+    pub retain_runs: usize,
+    /// Freshly generated local manifest.
+    pub local_manifest: &'a SnapshotManifest,
+    /// Previous run's published manifest, if any.
+    pub remote_manifest: Option<&'a SnapshotManifest>,
+    /// Shared `static_files/` listing from [`SnapshotUploader::list_remote_static_files`].
+    pub remote_static_files: &'a HashMap<String, u64>,
+}
+
 /// Determines whether a snapshot component is re-uploaded every run
 /// or can be skipped when the remote copy already matches.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,18 +88,29 @@ pub enum UploadStrategy {
     /// Upload to `static_files/`, skipping if the per-file BLAKE3 hashes
     /// recorded in the previous run's manifest match the freshly generated ones.
     DiffByHash,
+    /// Upload the latest static-file chunk to the timestamped run directory.
+    LatestChunk,
 }
 
 impl UploadStrategy {
     /// Classifies a snapshot filename into its upload strategy.
     ///
     /// Static file chunks follow the pattern `{component}-{start}-{end}.tar.zst`
-    /// (e.g. `headers-0-499999.tar.zst`). These are immutable for finalized block
-    /// ranges and only the tip chunk changes between snapshots.
+    /// (e.g. `headers-0-499999.tar.zst`). Finalized chunks are deduplicated in
+    /// `static_files/`; the latest chunk is kept beside the timestamped manifest.
     ///
     /// Everything else (state, rocksdb, proofs, manifest) is always uploaded.
     pub fn classify(filename: &str) -> Self {
         if ChunkFilename::parse(filename).is_some() { Self::DiffByHash } else { Self::AlwaysUpload }
+    }
+
+    /// Classifies a snapshot filename using its manifest to identify the latest chunk.
+    pub fn classify_with_manifest(filename: &str, manifest: &SnapshotManifest) -> Self {
+        if manifest.is_latest_chunk_file(filename) {
+            Self::LatestChunk
+        } else {
+            Self::classify(filename)
+        }
     }
 }
 
@@ -255,37 +284,34 @@ impl SnapshotUploader {
 
     /// Uploads snapshot artifacts with diff-based optimization.
     ///
-    /// Static file chunks go to `{prefix}/static_files/` and are skipped when
-    /// their per-file BLAKE3 hashes (recorded in `local_manifest`) match those
-    /// from `remote_manifest`. State, rocksdb, proofs, and manifest go to
-    /// `{prefix}/{timestamp}/` and are always re-uploaded. `manifest.json` is
-    /// uploaded last as the "snapshot complete" signal.
-    pub async fn upload(
-        &self,
-        output_dir: &Path,
-        files: &[PathBuf],
-        timestamp: u64,
-        retain_runs: usize,
-        local_manifest: &SnapshotManifest,
-        remote_manifest: Option<&SnapshotManifest>,
-    ) -> Result<String> {
+    /// Finalized static file chunks go to `{prefix}/static_files/` and are skipped
+    /// only when their per-file BLAKE3 hashes (recorded in `local_manifest`) match
+    /// `remote_manifest` and the archive exists in shared storage. The latest chunk
+    /// of each component, state, rocksdb, proofs, and manifest go to
+    /// `{prefix}/{timestamp}/`. `manifest.json` is uploaded last as the "snapshot complete"
+    /// signal.
+    ///
+    /// `remote_static_files` is the shared-storage listing from
+    /// [`Self::list_remote_static_files`]; callers that already listed for generation
+    /// should reuse that map instead of listing again.
+    pub async fn upload(&self, params: SnapshotUploadParams<'_>) -> Result<String> {
         let static_prefix = self.static_files_prefix();
-        let run_prefix = self.run_prefix(timestamp);
+        let run_prefix = self.run_prefix(params.timestamp);
 
         info!(
             run_prefix = %run_prefix,
             static_prefix = %static_prefix,
-            file_count = files.len(),
+            file_count = params.files.len(),
             bucket = %self.bucket,
             "uploading snapshot artifacts"
         );
 
-        let manifest_path = output_dir.join("manifest.json");
+        let manifest_path = params.output_dir.join("manifest.json");
         let mut static_uploads = Vec::new();
         let mut run_uploads = Vec::new();
         let mut skipped = 0u64;
 
-        for file in files {
+        for file in params.files {
             if file == &manifest_path {
                 continue;
             }
@@ -296,18 +322,25 @@ impl SnapshotUploader {
                 .to_string_lossy()
                 .to_string();
 
-            let strategy = UploadStrategy::classify(&file_name);
+            let strategy =
+                UploadStrategy::classify_with_manifest(&file_name, params.local_manifest);
 
             match strategy {
                 UploadStrategy::DiffByHash => {
-                    let local_hashes = local_manifest.chunk_hashes_for_file(&file_name);
+                    let local_hashes = params.local_manifest.chunk_hashes_for_file(&file_name);
                     let remote_hashes =
-                        remote_manifest.and_then(|m| m.chunk_hashes_for_file(&file_name));
+                        params.remote_manifest.and_then(|m| m.chunk_hashes_for_file(&file_name));
                     match (&local_hashes, &remote_hashes) {
-                        (Some(local), Some(remote)) if local == remote => {
-                            debug!(file = %file_name, "skipping static file (blake3 matches)");
+                        (Some(local), Some(remote))
+                            if local == remote
+                                && params.remote_static_files.contains_key(&file_name) =>
+                        {
+                            debug!(file = %file_name, "skipping finalized static file (blake3 matches shared object)");
                             skipped += 1;
                             continue;
+                        }
+                        (Some(local), Some(remote)) if local == remote => {
+                            debug!(file = %file_name, "uploading finalized static file missing from shared storage");
                         }
                         (Some(_), Some(_)) => {
                             debug!(file = %file_name, "re-uploading static file (blake3 mismatch)");
@@ -318,7 +351,7 @@ impl SnapshotUploader {
                     }
                     static_uploads.push(file.clone());
                 }
-                UploadStrategy::AlwaysUpload => {
+                UploadStrategy::LatestChunk | UploadStrategy::AlwaysUpload => {
                     run_uploads.push(file.clone());
                 }
             }
@@ -359,9 +392,9 @@ impl SnapshotUploader {
                 .await?;
 
             let published_manifest = build_published_manifest(
-                local_manifest,
-                self.public_static_files_base_url().as_deref(),
-                timestamp,
+                params.local_manifest,
+                self.public_snapshot_base_url().as_deref(),
+                params.timestamp,
             )?;
             self.upload_manifest(&manifest_key, published_manifest, progress_ref).await?;
             Ok::<(), anyhow::Error>(())
@@ -382,8 +415,8 @@ impl SnapshotUploader {
             return Err(error);
         }
 
-        if let Err(e) = self.prune_old_runs(retain_runs).await {
-            warn!(error = %e, retain_runs, "failed to prune old snapshot runs");
+        if let Err(e) = self.prune_old_runs(params.retain_runs).await {
+            warn!(error = %e, retain_runs = params.retain_runs, "failed to prune old snapshot runs");
         }
 
         info!(
@@ -413,13 +446,13 @@ impl SnapshotUploader {
         }
     }
 
-    /// Returns the public base URL for top-level static files, if configured.
-    fn public_static_files_base_url(&self) -> Option<String> {
+    /// Returns the public HTTP base URL for snapshot downloads (snapshot root, not `static_files/`).
+    fn public_snapshot_base_url(&self) -> Option<String> {
         let base = self.public_base_url.as_deref()?.trim_end_matches('/');
         Some(if self.prefix.is_empty() {
-            format!("{base}/static_files")
+            base.to_string()
         } else {
-            format!("{base}/{}/static_files", self.prefix)
+            format!("{base}/{}", self.prefix)
         })
     }
 
@@ -1005,28 +1038,49 @@ fn retry_delay_secs(attempt: usize) -> u64 {
     retry_delay(attempt).as_secs()
 }
 
-/// Builds the single published manifest for a run.
+/// Builds the published manifest for a run.
 ///
-/// Chunked archives are served from top-level `static_files/` via `base_url`, while
-/// the always-changing `state` and `rocksdb_indices` archives stay in the timestamped
-/// run directory and are referenced through `../{timestamp}/...` file paths.
-///
-/// `proofs` is also uploaded into the run directory, but its `file` field is left as
-/// a bare filename (`proofs.tar.zst`). The proofs downloader resolves the archive as a
-/// sibling of `manifest.json` and rejects path traversal (`..`).
+/// `base_url` points at the snapshot root (`{public_base}/{prefix}`). Finalized static-file
+/// chunks use `static_files/{archive}` in [`ChunkedArchive::chunk_files`]; tip chunks and
+/// state/rocksdb use `{timestamp}/{archive}`. Proofs stays a bare sibling filename for
+/// `ProofsDownloader`.
 fn build_published_manifest(
     local_manifest: &SnapshotManifest,
-    public_static_files_base_url: Option<&str>,
+    public_snapshot_base_url: Option<&str>,
     timestamp: u64,
 ) -> Result<Vec<u8>> {
     let mut manifest = local_manifest.clone();
-    manifest.base_url = public_static_files_base_url.map(str::to_owned);
+    manifest.base_url = public_snapshot_base_url.map(str::to_owned);
 
     for (component_name, component) in &mut manifest.components {
-        if let reth_cli_commands::download::manifest::ComponentManifest::Single(single) = component
-            && matches!(component_name.as_str(), "state" | "rocksdb_indices")
-        {
-            single.file = format!("../{timestamp}/{}", single.file);
+        match component {
+            ComponentManifest::Single(single)
+                if matches!(component_name.as_str(), "state" | "rocksdb_indices") =>
+            {
+                single.file = format!("{timestamp}/{}", single.file);
+            }
+            ComponentManifest::Chunked(chunked) => {
+                let num_chunks = chunked.num_chunks();
+                let mut chunk_files = Vec::with_capacity(num_chunks as usize);
+                for i in 0..num_chunks {
+                    let start = i
+                        .checked_mul(chunked.blocks_per_file)
+                        .context("block range overflow in published chunk_files")?;
+                    let end = chunked
+                        .blocks_per_file
+                        .checked_sub(1)
+                        .and_then(|offset| start.checked_add(offset))
+                        .context("block range overflow in published chunk_files")?;
+                    let archive_name = ChunkFilename::format(component_name, start, end);
+                    if i.checked_add(1) == Some(num_chunks) {
+                        chunk_files.push(format!("{timestamp}/{archive_name}"));
+                    } else {
+                        chunk_files.push(format!("static_files/{archive_name}"));
+                    }
+                }
+                chunked.chunk_files = chunk_files;
+            }
+            _ => {}
         }
     }
 
@@ -1078,12 +1132,10 @@ mod tests {
     }
 
     #[test]
-    fn build_published_manifest_leaves_proofs_file_as_sibling() {
+    fn build_published_manifest_sets_chunk_files_and_leaves_proofs_as_sibling() {
         use std::collections::BTreeMap;
 
-        use reth_cli_commands::download::manifest::{
-            ComponentManifest, SingleArchive, SnapshotManifest,
-        };
+        use crate::snapshot::{ChunkedArchive, SingleArchive};
 
         let mut components = BTreeMap::new();
         components.insert(
@@ -1106,9 +1158,20 @@ mod tests {
                 output_files: vec![],
             }),
         );
+        components.insert(
+            "headers".to_string(),
+            ComponentManifest::Chunked(ChunkedArchive {
+                blocks_per_file: 500_000,
+                total_blocks: 1_000_000,
+                chunk_sizes: vec![100, 200],
+                chunk_decompressed_sizes: vec![1_000, 2_000],
+                chunk_output_files: vec![vec![], vec![]],
+                chunk_files: vec![],
+            }),
+        );
 
         let local = SnapshotManifest {
-            block: 1,
+            block: 1_000_000,
             chain_id: 8453,
             storage_version: 2,
             timestamp: 1_700_000_000,
@@ -1117,21 +1180,30 @@ mod tests {
             components,
         };
 
-        let published = build_published_manifest(
-            &local,
-            Some("https://example.com/static_files"),
-            1_700_000_000,
-        )
-        .unwrap();
+        let published =
+            build_published_manifest(&local, Some("https://example.com/mainnet"), 1_700_000_000)
+                .unwrap();
         let manifest: serde_json::Value = serde_json::from_slice(&published).unwrap();
 
         assert_eq!(
-            manifest["components"]["state"]["file"], "../1700000000/state.tar.zst",
-            "state should be rewritten relative to static_files base_url"
+            manifest["base_url"], "https://example.com/mainnet",
+            "base_url should point at snapshot root"
+        );
+        assert_eq!(
+            manifest["components"]["state"]["file"], "1700000000/state.tar.zst",
+            "state should be rewritten under the timestamp directory"
         );
         assert_eq!(
             manifest["components"]["proofs"]["file"], "proofs.tar.zst",
             "proofs must remain a sibling of manifest.json for ProofsDownloader"
+        );
+        assert_eq!(
+            manifest["components"]["headers"]["chunk_files"],
+            serde_json::json!([
+                "static_files/headers-0-499999.tar.zst",
+                "1700000000/headers-500000-999999.tar.zst",
+            ]),
+            "headers chunk_files should split finalized and tip paths under root base_url"
         );
     }
 

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use base_snapshotter::{
     ChunkedArchive, ComponentManifest, ContainerManager, DockerContainerManager,
     ManifestGenerationParams, OutputFileChecksum, SnapshotGenerator, SnapshotManifest,
-    SnapshotUploader, TipChecker, TipStatus,
+    SnapshotUploadParams, SnapshotUploader, TipChecker, TipStatus,
 };
 use bollard::{
     Docker,
@@ -30,6 +30,26 @@ use serial_test::serial;
 
 mod common;
 use common::TestHarness;
+
+/// Builds [`SnapshotUploadParams`] for e2e uploads that retain 100 runs.
+const fn upload_params<'a>(
+    output_dir: &'a Path,
+    files: &'a [PathBuf],
+    timestamp: u64,
+    local_manifest: &'a SnapshotManifest,
+    remote_manifest: Option<&'a SnapshotManifest>,
+    remote_static_files: &'a HashMap<String, u64>,
+) -> SnapshotUploadParams<'a> {
+    SnapshotUploadParams {
+        output_dir,
+        files,
+        timestamp,
+        retain_runs: 100,
+        local_manifest,
+        remote_manifest,
+        remote_static_files,
+    }
+}
 
 struct MockContainerManager {
     running: AtomicBool,
@@ -352,8 +372,16 @@ async fn upload_artifacts_to_minio() -> Result<()> {
     let files = create_fake_snapshot(&output_dir, 1_000_000)?;
     let local_manifest = parse_local_manifest(&output_dir)?;
 
-    let upload_prefix =
-        uploader.upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, None).await?;
+    let upload_prefix = uploader
+        .upload(upload_params(
+            &output_dir,
+            &files,
+            1_700_000_000,
+            &local_manifest,
+            None,
+            &HashMap::new(),
+        ))
+        .await?;
     assert_eq!(upload_prefix, "mainnet/1700000000", "run prefix should be date-based");
 
     let s3 = &harness.storage_client;
@@ -375,12 +403,12 @@ async fn upload_artifacts_to_minio() -> Result<()> {
     assert_eq!(manifest["block"], 1_000_000, "manifest block mismatch");
     assert_eq!(manifest["chain_id"], 8453, "manifest chain_id mismatch");
     assert_eq!(
-        manifest["base_url"], "https://snapshots.example.com/mainnet/static_files",
-        "manifest should point chunk downloads at top-level static_files"
+        manifest["base_url"], "https://snapshots.example.com/mainnet",
+        "manifest base_url should point at snapshot root"
     );
     assert_eq!(
-        manifest["components"]["state"]["file"], "../1700000000/state.tar.zst",
-        "manifest should point state back to the dated run dir"
+        manifest["components"]["state"]["file"], "1700000000/state.tar.zst",
+        "manifest should point state at the timestamped run dir"
     );
     assert_eq!(
         manifest["components"]["proofs"]["file"], "proofs.tar.zst",
@@ -390,20 +418,39 @@ async fn upload_artifacts_to_minio() -> Result<()> {
     let components = manifest["components"].as_object().expect("components should be an object");
     assert_eq!(components.len(), 9, "should have all 9 component types");
 
-    // Verify static file chunks go to {prefix}/static_files/
+    assert_eq!(
+        manifest["components"]["headers"]["chunk_files"],
+        serde_json::json!([
+            "static_files/headers-0-499999.tar.zst",
+            "1700000000/headers-500000-999999.tar.zst",
+        ]),
+        "headers chunk_files should split finalized and tip paths"
+    );
+
+    // Verify finalized chunks are shared while the latest chunk stays beside the manifest.
     for component in ["headers", "transactions", "receipts"] {
-        for chunk_idx in 0..2u64 {
-            let start = chunk_idx * 500_000;
-            let end = (chunk_idx + 1) * 500_000 - 1;
-            let key = format!("mainnet/static_files/{component}-{start}-{end}.tar.zst");
-            let body = get_object_bytes(s3, bucket, &key).await?;
-            let expected = format!("fake-{component}-chunk-{chunk_idx}");
-            assert_eq!(
-                body,
-                expected.as_bytes(),
-                "{component} chunk {chunk_idx} should be in static_files/"
-            );
-        }
+        let finalized_key = format!("mainnet/static_files/{component}-0-499999.tar.zst");
+        let finalized_body = get_object_bytes(s3, bucket, &finalized_key).await?;
+        assert_eq!(
+            finalized_body,
+            format!("fake-{component}-chunk-0").as_bytes(),
+            "{component} finalized chunk should be in static_files/"
+        );
+
+        let latest_key = format!("mainnet/1700000000/{component}-500000-999999.tar.zst");
+        let latest_body = get_object_bytes(s3, bucket, &latest_key).await?;
+        assert_eq!(
+            latest_body,
+            format!("fake-{component}-chunk-1").as_bytes(),
+            "{component} latest chunk should be in the timestamped directory"
+        );
+
+        let latest_shared_key = format!("mainnet/static_files/{component}-500000-999999.tar.zst");
+        let latest_shared = s3.head_object().bucket(bucket).key(&latest_shared_key).send().await;
+        assert!(
+            latest_shared.is_err(),
+            "{component} latest chunk must not be written to static_files/"
+        );
     }
 
     Ok(())
@@ -425,8 +472,16 @@ async fn upload_with_empty_prefix() -> Result<()> {
     let files = create_fake_snapshot(&output_dir, 100)?;
     let local_manifest = parse_local_manifest(&output_dir)?;
 
-    let upload_prefix =
-        uploader.upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, None).await?;
+    let upload_prefix = uploader
+        .upload(upload_params(
+            &output_dir,
+            &files,
+            1_700_000_000,
+            &local_manifest,
+            None,
+            &HashMap::new(),
+        ))
+        .await?;
     assert_eq!(upload_prefix, "1700000000", "empty prefix should produce bare date");
 
     let s3 = &harness.storage_client;
@@ -445,21 +500,30 @@ async fn upload_with_empty_prefix() -> Result<()> {
     let manifest: serde_json::Value = serde_json::from_slice(&manifest_body)?;
     assert_eq!(manifest["block"], 100, "manifest should be in date dir");
     assert_eq!(
-        manifest["base_url"], "https://snapshots.example.com/static_files",
-        "manifest should point chunk downloads at top-level static_files"
+        manifest["base_url"], "https://snapshots.example.com",
+        "manifest base_url should point at snapshot root"
     );
     assert_eq!(
-        manifest["components"]["state"]["file"], "../1700000000/state.tar.zst",
-        "manifest should point state back to the dated run dir"
+        manifest["components"]["state"]["file"], "1700000000/state.tar.zst",
+        "manifest should point state at the timestamped run dir"
     );
     assert_eq!(
         manifest["components"]["proofs"]["file"], "proofs.tar.zst",
         "proofs must remain a sibling of manifest.json for ProofsDownloader"
     );
 
-    let headers_body =
-        get_object_bytes(s3, bucket, "static_files/headers-0-499999.tar.zst").await?;
-    assert_eq!(headers_body, b"fake-headers-chunk-0", "headers chunk 0 should be in static_files/");
+    assert_eq!(
+        manifest["components"]["headers"]["chunk_files"],
+        serde_json::json!(["1700000000/headers-0-499999.tar.zst"]),
+        "single-chunk headers should live under the timestamp directory"
+    );
+
+    let headers_body = get_object_bytes(s3, bucket, "1700000000/headers-0-499999.tar.zst").await?;
+    assert_eq!(headers_body, b"fake-headers-chunk-0", "latest headers chunk should be in date dir");
+
+    let shared_headers =
+        s3.head_object().bucket(bucket).key("static_files/headers-0-499999.tar.zst").send().await;
+    assert!(shared_headers.is_err(), "latest headers chunk must not be in static_files/");
 
     Ok(())
 }
@@ -525,8 +589,8 @@ async fn diff_upload_skips_chunks_when_blake3_matches() -> Result<()> {
         None,
     );
 
-    // Pre-seed static_files/ with the prior run's chunks and a previous manifest.json
-    // at {prefix}/1699000000/manifest.json. Both use the same hash seed.
+    // Pre-seed shared finalized chunks and a previous manifest at
+    // {prefix}/1699000000/manifest.json. Both use the same hash seed.
     let prev_manifest = manifest_with_seeded_hashes(1_000_000, 500_000, DIFF_TEST_COMPONENTS, "v1");
     s3.put_object()
         .bucket(bucket)
@@ -536,17 +600,13 @@ async fn diff_upload_skips_chunks_when_blake3_matches() -> Result<()> {
         .await?;
 
     for &component in DIFF_TEST_COMPONENTS {
-        for chunk_idx in 0..2u64 {
-            let start = chunk_idx * 500_000;
-            let end = start + 499_999;
-            let key = format!("diff-match/static_files/{component}-{start}-{end}.tar.zst");
-            s3.put_object()
-                .bucket(bucket)
-                .key(&key)
-                .body(aws_sdk_s3::primitives::ByteStream::from(b"old-bytes".to_vec()))
-                .send()
-                .await?;
-        }
+        let key = format!("diff-match/static_files/{component}-0-499999.tar.zst");
+        s3.put_object()
+            .bucket(bucket)
+            .key(&key)
+            .body(aws_sdk_s3::primitives::ByteStream::from(b"old-bytes".to_vec()))
+            .send()
+            .await?;
     }
 
     // Generate a new run that produces the SAME hashes (same seed) but with
@@ -560,23 +620,36 @@ async fn diff_upload_skips_chunks_when_blake3_matches() -> Result<()> {
     let remote_manifest = uploader.fetch_previous_manifest().await?;
     assert!(remote_manifest.is_some(), "should find the pre-seeded previous manifest");
 
+    let remote_static_files = uploader.list_remote_static_files().await?;
     uploader
-        .upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, remote_manifest.as_ref())
+        .upload(upload_params(
+            &output_dir,
+            &files,
+            1_700_000_000,
+            &local_manifest,
+            remote_manifest.as_ref(),
+            &remote_static_files,
+        ))
         .await?;
 
-    // Verify: pre-seeded chunks were NOT overwritten (skipped due to blake3 match).
+    // Verify: matching finalized chunks were not overwritten, while the latest chunks
+    // were written to the timestamped run directory.
     for &component in DIFF_TEST_COMPONENTS {
-        for chunk_idx in 0..2u64 {
-            let start = chunk_idx * 500_000;
-            let end = start + 499_999;
-            let key = format!("diff-match/static_files/{component}-{start}-{end}.tar.zst");
-            let body = get_object_bytes(s3, bucket, &key).await?;
-            assert_eq!(
-                body.as_slice(),
-                b"old-bytes",
-                "chunk {component} {chunk_idx} should have been skipped (blake3 match)"
-            );
-        }
+        let finalized_key = format!("diff-match/static_files/{component}-0-499999.tar.zst");
+        let finalized_body = get_object_bytes(s3, bucket, &finalized_key).await?;
+        assert_eq!(
+            finalized_body.as_slice(),
+            b"old-bytes",
+            "{component} finalized chunk should be skipped when blake3 matches"
+        );
+
+        let latest_key = format!("diff-match/1700000000/{component}-500000-999999.tar.zst");
+        let latest_body = get_object_bytes(s3, bucket, &latest_key).await?;
+        assert_eq!(
+            latest_body.as_slice(),
+            b"new-bytes",
+            "{component} latest chunk should be uploaded beside the manifest"
+        );
     }
 
     let manifest_body = get_object_bytes(s3, bucket, "diff-match/1700000000/manifest.json").await?;
@@ -589,6 +662,93 @@ async fn diff_upload_skips_chunks_when_blake3_matches() -> Result<()> {
             .iter()
             .all(|entry| entry.as_array().is_some_and(|files| !files.is_empty())),
         "download manifest should preserve output-file metadata for skipped chunks"
+    );
+
+    Ok(())
+}
+
+/// Verifies a former tip is uploaded to shared storage after the next range opens.
+#[tokio::test]
+#[serial]
+async fn finalizing_previous_latest_chunk_uploads_it_to_shared_storage() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let s3 = &harness.storage_client;
+    let bucket = &harness.bucket_name;
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "finalize-tip".to_string(),
+        None,
+    );
+
+    let first_tmp = tempfile::tempdir()?;
+    let first_output_dir = first_tmp.path().join("output");
+    let first_files = seeded_snapshot(
+        &first_output_dir,
+        500_000,
+        500_000,
+        &["headers"],
+        "v1",
+        b"first-tip-bytes",
+    )?;
+    let first_manifest = parse_local_manifest(&first_output_dir)?;
+    uploader
+        .upload(upload_params(
+            &first_output_dir,
+            &first_files,
+            1_700_000_000,
+            &first_manifest,
+            None,
+            &HashMap::new(),
+        ))
+        .await?;
+
+    let first_tip =
+        get_object_bytes(s3, bucket, "finalize-tip/1700000000/headers-0-499999.tar.zst").await?;
+    assert_eq!(
+        first_tip.as_slice(),
+        b"first-tip-bytes",
+        "first run should store its latest chunk beside the manifest"
+    );
+
+    let second_tmp = tempfile::tempdir()?;
+    let second_output_dir = second_tmp.path().join("output");
+    let second_files = seeded_snapshot(
+        &second_output_dir,
+        1_000_000,
+        500_000,
+        &["headers"],
+        "v1",
+        b"second-run-bytes",
+    )?;
+    let second_manifest = parse_local_manifest(&second_output_dir)?;
+    let remote_manifest = uploader.fetch_previous_manifest().await?;
+    uploader
+        .upload(upload_params(
+            &second_output_dir,
+            &second_files,
+            1_700_000_001,
+            &second_manifest,
+            remote_manifest.as_ref(),
+            &HashMap::new(),
+        ))
+        .await?;
+
+    let finalized =
+        get_object_bytes(s3, bucket, "finalize-tip/static_files/headers-0-499999.tar.zst").await?;
+    assert_eq!(
+        finalized.as_slice(),
+        b"second-run-bytes",
+        "the former latest chunk must be promoted to shared storage once finalized"
+    );
+
+    let second_tip =
+        get_object_bytes(s3, bucket, "finalize-tip/1700000001/headers-500000-999999.tar.zst")
+            .await?;
+    assert_eq!(
+        second_tip.as_slice(),
+        b"second-run-bytes",
+        "second run should keep its latest chunk beside its manifest"
     );
 
     Ok(())
@@ -621,17 +781,13 @@ async fn diff_upload_reuploads_on_blake3_mismatch_even_when_size_matches() -> Re
         .await?;
 
     for &component in DIFF_TEST_COMPONENTS {
-        for chunk_idx in 0..2u64 {
-            let start = chunk_idx * 500_000;
-            let end = start + 499_999;
-            let key = format!("diff-mismatch/static_files/{component}-{start}-{end}.tar.zst");
-            s3.put_object()
-                .bucket(bucket)
-                .key(&key)
-                .body(aws_sdk_s3::primitives::ByteStream::from(b"corrupted-bytes-x".to_vec()))
-                .send()
-                .await?;
-        }
+        let key = format!("diff-mismatch/static_files/{component}-0-499999.tar.zst");
+        s3.put_object()
+            .bucket(bucket)
+            .key(&key)
+            .body(aws_sdk_s3::primitives::ByteStream::from(b"corrupted-bytes-x".to_vec()))
+            .send()
+            .await?;
     }
 
     // New run reports DIFFERENT hashes (seed "v2") for the same chunk filenames.
@@ -656,22 +812,34 @@ async fn diff_upload_reuploads_on_blake3_mismatch_even_when_size_matches() -> Re
     let remote_manifest = uploader.fetch_previous_manifest().await?;
 
     uploader
-        .upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, remote_manifest.as_ref())
+        .upload(upload_params(
+            &output_dir,
+            &files,
+            1_700_000_000,
+            &local_manifest,
+            remote_manifest.as_ref(),
+            &HashMap::new(),
+        ))
         .await?;
 
-    // Verify every chunk was re-uploaded with the fresh bytes.
+    // Verify finalized chunks are re-uploaded on a BLAKE3 mismatch, while latest chunks
+    // are isolated in the timestamped run directory.
     for &component in DIFF_TEST_COMPONENTS {
-        for chunk_idx in 0..2u64 {
-            let start = chunk_idx * 500_000;
-            let end = start + 499_999;
-            let key = format!("diff-mismatch/static_files/{component}-{start}-{end}.tar.zst");
-            let body = get_object_bytes(s3, bucket, &key).await?;
-            assert_eq!(
-                body.as_slice(),
-                b"healthy-bytes-yyy",
-                "chunk {component} {chunk_idx} should have been re-uploaded despite size match"
-            );
-        }
+        let finalized_key = format!("diff-mismatch/static_files/{component}-0-499999.tar.zst");
+        let finalized_body = get_object_bytes(s3, bucket, &finalized_key).await?;
+        assert_eq!(
+            finalized_body.as_slice(),
+            b"healthy-bytes-yyy",
+            "{component} finalized chunk should be re-uploaded despite matching size"
+        );
+
+        let latest_key = format!("diff-mismatch/1700000000/{component}-500000-999999.tar.zst");
+        let latest_body = get_object_bytes(s3, bucket, &latest_key).await?;
+        assert_eq!(
+            latest_body.as_slice(),
+            b"healthy-bytes-yyy",
+            "{component} latest chunk should be uploaded beside the manifest"
+        );
     }
 
     Ok(())
@@ -699,12 +867,31 @@ async fn diff_upload_uploads_everything_on_first_run() -> Result<()> {
     assert!(remote_manifest.is_none(), "fresh bucket should have no previous manifest");
 
     uploader
-        .upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, remote_manifest.as_ref())
+        .upload(upload_params(
+            &output_dir,
+            &files,
+            1_700_000_000,
+            &local_manifest,
+            remote_manifest.as_ref(),
+            &HashMap::new(),
+        ))
         .await?;
 
     let body =
-        get_object_bytes(s3, bucket, "first-run/static_files/headers-0-499999.tar.zst").await?;
-    assert_eq!(body.as_slice(), b"fresh-chunk", "static file should be uploaded on first run");
+        get_object_bytes(s3, bucket, "first-run/1700000000/headers-0-499999.tar.zst").await?;
+    assert_eq!(
+        body.as_slice(),
+        b"fresh-chunk",
+        "latest static file should be uploaded beside manifest"
+    );
+
+    let shared_chunk = s3
+        .head_object()
+        .bucket(bucket)
+        .key("first-run/static_files/headers-0-499999.tar.zst")
+        .send()
+        .await;
+    assert!(shared_chunk.is_err(), "latest static file must not be uploaded to shared storage");
 
     Ok(())
 }
@@ -714,8 +901,8 @@ async fn diff_upload_uploads_everything_on_first_run() -> Result<()> {
 #[tokio::test]
 #[serial]
 async fn selective_compression_skips_finalized_chunks() -> Result<()> {
-    // Create a real datadir with mdbx + 4 header chunk ranges
-    // block=2M, bpf=500k → 4 chunks, tip=chunk3, buffer=2 → skip chunk 0
+    // Create a real datadir with mdbx + 4 header chunk ranges.
+    // block=2M, bpf=500k → 4 chunks; only chunk 3 remains mutable.
     let source = tempfile::tempdir()?;
     let db_dir = source.path().join("db");
     std::fs::create_dir_all(&db_dir)?;
@@ -738,7 +925,7 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         }
     }
 
-    // Simulate all chunked components existing remotely for range 0-499999
+    // Simulate all chunked components existing remotely for every finalized range.
     let chunk_components = [
         "headers",
         "transactions",
@@ -749,7 +936,11 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
     ];
     let mut remote: HashMap<String, u64> = HashMap::new();
     for component in chunk_components {
-        remote.insert(format!("{component}-0-499999.tar.zst"), 0);
+        for chunk_idx in 0..3u64 {
+            let start = chunk_idx * 500_000;
+            let end = start + 499_999;
+            remote.insert(format!("{component}-{start}-{end}.tar.zst"), 0);
+        }
     }
 
     let output = tempfile::tempdir()?;
@@ -769,29 +960,33 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         .filter_map(|f| f.file_name().map(|n| n.to_string_lossy().to_string()))
         .collect();
 
-    // Skipped range: chunk 0 should NOT be compressed (all components exist remotely)
+    // Every finalized range should be skipped when its complete component set exists remotely.
+    for component in chunk_components {
+        for chunk_idx in 0..3u64 {
+            let start = chunk_idx * 500_000;
+            let end = start + 499_999;
+            assert!(
+                !filenames.contains(&format!("{component}-{start}-{end}.tar.zst")),
+                "{component} finalized range {chunk_idx} should not produce an archive"
+            );
+        }
+    }
+
+    // Only the final chunk should be compressed for every component.
     for component in chunk_components {
         assert!(
-            !filenames.contains(&format!("{component}-0-499999.tar.zst")),
-            "{component} finalized range should not produce an archive"
+            filenames.contains(&format!("{component}-1500000-1999999.tar.zst")),
+            "{component} latest chunk should produce an archive"
         );
     }
 
-    // Buffer + tip ranges: should be compressed
-    for component in chunk_components {
-        assert!(
-            filenames.contains(&format!("{component}-500000-999999.tar.zst")),
-            "{component} tip range should produce an archive"
-        );
-    }
-
-    // Always-upload: state + manifest
+    // Always-upload: state + manifest.
     assert!(filenames.contains(&"state.tar.zst".to_string()), "state should always be produced");
     assert!(filenames.contains(&"manifest.json".to_string()), "manifest should always be produced");
 
-    // Verify tip archive is a valid compressed file (not empty)
-    let tip_path = output.path().join("headers-500000-999999.tar.zst");
-    assert!(std::fs::metadata(&tip_path)?.len() > 0, "tip archive should not be empty");
+    // Verify latest archive is a valid compressed file (not empty).
+    let tip_path = output.path().join("headers-1500000-1999999.tar.zst");
+    assert!(std::fs::metadata(&tip_path)?.len() > 0, "latest archive should not be empty");
 
     Ok(())
 }
@@ -841,8 +1036,16 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
     );
 
     let local_manifest = parse_local_manifest(output.path())?;
-    let upload_prefix =
-        uploader.upload(output.path(), &files, 1_700_000_000, 100, &local_manifest, None).await?;
+    let upload_prefix = uploader
+        .upload(upload_params(
+            output.path(),
+            &files,
+            1_700_000_000,
+            &local_manifest,
+            None,
+            &HashMap::new(),
+        ))
+        .await?;
     assert_eq!(upload_prefix, "proofs-gen/1700000000");
 
     let s3 = &harness.storage_client;
@@ -858,8 +1061,8 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
         "published proofs file must be a sibling of manifest.json"
     );
     assert_eq!(
-        manifest["components"]["state"]["file"], "../1700000000/state.tar.zst",
-        "state should still use the relative run-dir path"
+        manifest["components"]["state"]["file"], "1700000000/state.tar.zst",
+        "state should use the timestamped run-dir path"
     );
     assert!(
         manifest["components"]["proofs"]["output_files"].as_array().is_some_and(|files| files
@@ -924,9 +1127,17 @@ async fn always_upload_overwrites_existing_state_rocksdb_and_proofs() -> Result<
         output_dir.join("rocksdb_indices.tar.zst"),
         output_dir.join("state.tar.zst"),
     ];
+    let empty_manifest = empty_manifest(2_000_000);
 
     let upload_prefix = uploader
-        .upload(&output_dir, &files, 1_700_000_000, 100, &empty_manifest(2_000_000), None)
+        .upload(upload_params(
+            &output_dir,
+            &files,
+            1_700_000_000,
+            &empty_manifest,
+            None,
+            &HashMap::new(),
+        ))
         .await?;
     assert_eq!(upload_prefix, "overwrite-test/1700000000");
 
@@ -1166,8 +1377,16 @@ async fn e2e_stop_upload_restart_real_container() -> Result<()> {
         "e2e-test".to_string(),
         None,
     );
-    let upload_prefix =
-        uploader.upload(&output_dir, &files, 1_700_000_000, 100, &local_manifest, None).await?;
+    let upload_prefix = uploader
+        .upload(upload_params(
+            &output_dir,
+            &files,
+            1_700_000_000,
+            &local_manifest,
+            None,
+            &HashMap::new(),
+        ))
+        .await?;
 
     let manifest_body = get_object_bytes(
         &harness.storage_client,


### PR DESCRIPTION
## Summary
- Backport #4494 to `releases/v1.3.0`.
- Upload the latest static-file chunk into each timestamped run directory to avoid mismatches with in-flight downloads.
- Publish stock-reth-compatible `chunk_files` paths and remove the Base-only `latest_static_file_archives` extension.

## Test plan
- [x] `cargo test -p base-snapshotter --lib` (25 passed)
- [x] `cargo fmt --all -- --check`