### PR TITLE
fix(flashblocks): anchor pending state to the canonical tip

### DIFF
--- a/crates/execution/flashblocks-node/tests/state.rs
+++ b/crates/execution/flashblocks-node/tests/state.rs
@@ -839,3 +839,108 @@ async fn test_same_block_append_refreshes_pending_header() {
         "same-block append must publish a fresh header with updated transactions_root"
     );
 }
+
+/// Advances the node past `pending`'s anchor without telling the state processor, reproducing
+/// the queue-lag shape from the 2026-08-20 mainnet incident where canonical and flashblock
+/// updates piled up in the shared unbounded queue while the node kept following the chain.
+async fn advance_tip_without_processing(test: &mut FlashblocksBuilderTestHarness, blocks: u64) {
+    for _ in 0..blocks {
+        test.new_canonical_block_without_processing(vec![]).await;
+    }
+}
+
+#[tokio::test]
+async fn test_stale_pending_dropped_once_node_advances_past_it() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+    assert_eq!(
+        test.flashblocks
+            .get_pending_blocks()
+            .get_block(true)
+            .expect("pending tracks block 1")
+            .header
+            .number,
+        1
+    );
+
+    advance_tip_without_processing(&mut test, 7).await;
+    assert_eq!(test.node.latest_block().number, 7);
+
+    // A backlogged flashblock for block 1 must not keep the genesis-anchored overlay live.
+    test.send_flashblock(
+        FlashblockBuilder::new(&test, 1)
+            .with_canonical_block_number(0)
+            .with_transactions(vec![test.build_transaction_to_send_eth(
+                Account::Alice,
+                Account::Bob,
+                100_000,
+            )])
+            .build(),
+    )
+    .await;
+
+    assert!(
+        test.flashblocks.get_pending_blocks().is_none(),
+        "pending must be absent rather than serve an overlay anchored 7 blocks behind the tip"
+    );
+}
+
+#[tokio::test]
+async fn test_stale_base_flashblock_does_not_republish_pending() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+
+    advance_tip_without_processing(&mut test, 7).await;
+    assert_eq!(test.node.latest_block().number, 7);
+
+    // A backlogged base flashblock rebuilds from scratch, so it is the path that kept
+    // republishing stale overlays for hours as the queue drained.
+    test.send_flashblock(FlashblockBuilder::new_base(&test).with_canonical_block_number(0).build())
+        .await;
+
+    assert!(
+        test.flashblocks.get_pending_blocks().is_none(),
+        "a rebuild anchored at genesis must not publish while the node is at block 7"
+    );
+}
+
+#[tokio::test]
+async fn test_pending_recovers_at_current_canonical_tip() {
+    let mut test = FlashblocksBuilderTestHarness::new().await;
+
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+    advance_tip_without_processing(&mut test, 7).await;
+
+    test.send_flashblock(FlashblockBuilder::new_base(&test).with_canonical_block_number(0).build())
+        .await;
+    assert!(test.flashblocks.get_pending_blocks().is_none());
+
+    // Recovery needs no explicit reset: the first flashblock rooted at the tip rebuilds.
+    test.send_flashblock(FlashblockBuilder::new_base(&test).build()).await;
+
+    let recovered = test
+        .flashblocks
+        .get_pending_blocks()
+        .get_block(true)
+        .expect("pending recovers on the current tip");
+    assert_eq!(recovered.header.number, 8, "pending must track the child of block 7");
+
+    test.send_flashblock(
+        FlashblockBuilder::new(&test, 1)
+            .with_transactions(vec![test.build_transaction_to_send_eth(
+                Account::Alice,
+                Account::Bob,
+                100_000,
+            )])
+            .build(),
+    )
+    .await;
+
+    let extended = test
+        .flashblocks
+        .get_pending_blocks()
+        .get_block(true)
+        .expect("recovered pending keeps accepting flashblocks");
+    assert_eq!(extended.header.number, 8);
+    assert_eq!(extended.transactions.len(), 2, "deposit tx from base + Alice->Bob transfer");
+}

--- a/crates/execution/flashblocks/README.md
+++ b/crates/execution/flashblocks/README.md
@@ -15,6 +15,88 @@ Flashblocks state management for Base nodes. Subscribes to flashblocks and combi
 - **`CanonicalBlockReconciler`**: Reconciles flashblock state with canonical chain updates.
 - **`ReorgDetector`**: Detects chain reorganizations affecting pending state.
 
+## Pending State
+
+`StateProcessor` merges two inputs into a single pending snapshot: the flashblock stream from the
+builder and the node's canonical block notifications. Both arrive as `StateUpdate` values on one
+unbounded queue and are applied in order, so the processor's view of the chain falls behind the
+node's real tip whenever applying updates is slower than receiving them.
+
+### The invariant
+
+A published snapshot either tracks flashblocks anchored near the node's current canonical tip, or
+there is no snapshot at all.
+
+This matters because consumers execute against `PendingBlocks::canonical_block_number`, the
+canonical block the overlay is layered on. While that block stays close to the tip, callers read
+the node's in-memory canonical state. An overlay stranded on an old anchor forces them onto
+historical state instead, which is slow enough to starve the processor that produced the overlay
+and keep it stranded. `max_pending_blocks_depth` (CLI `--max-pending-blocks-depth`, default 3)
+bounds how far behind the tip the anchor may sit.
+
+Bounding the distance rather than requiring the anchor to equal the tip is deliberate. When
+flashblocks for the next block arrive before the processor has applied the current canonical
+block, pending legitimately spans blocks at or below the tip while still extending past it, and
+that state is correct and useful. A small window keeps it alive and absorbs the delay between a
+canonical notification and the block becoming visible through the provider, so the processor does
+not need to track which updates raced with which.
+
+### Enforcement
+
+Three checks maintain the invariant. Each reads the tip from the provider rather than trusting the
+height of the queued update, because a lagging queue reports a stale height and makes every guard
+evaluate against a chain position the node left long ago.
+
+- Before an update is dispatched, a snapshot anchored more than `max_pending_blocks_depth` blocks
+  behind the tip is dropped. This bounds staleness to a single update interval no matter how large
+  the queue has grown. Canonical notifications keep arriving even when the flashblock stream
+  stalls, and if both stall the node is not advancing, so the snapshot is not stale.
+- Flashblocks whose block the node has already canonicalized are skipped before execution. They
+  cannot produce a publishable snapshot, and executing them anyway lets a backlog starve the fresh
+  payloads queued behind it.
+- Every build path publishes through `publish_pending_blocks`, which re-reads the tip and refuses
+  to publish a snapshot that is anchored too far back or no longer extends past the tip. Because it
+  is the single funnel, this holds for the reorg and depth-limit rebuilds as well as for ordinary
+  sequential appends.
+
+Recovery needs no separate mechanism. Once pending is absent, the next index-0 flashblock rooted at
+the current tip rebuilds a snapshot through the ordinary build path.
+
+### Canonical reconciliation
+
+When a canonical block is applied, `ReorgDetector` compares the transactions pending had tracked
+for that block against the block's actual transactions. If pending exists,
+`CanonicalBlockReconciler` then chooses one of:
+
+- **`CatchUp`**: canonical reached or passed pending's latest block. Pending is cleared.
+- **`HandleReorg`**: the transaction sets differ. Flashblocks beyond the canonical block are
+  re-executed from canonical state without reusing the existing pending state.
+- **`DepthLimitExceeded`**: pending retains more than `max_pending_blocks_depth` blocks that the
+  canonical chain has already covered. Pending is rebuilt from the canonical block forward.
+- **`Continue`**: no conflict. The existing pending state is extended.
+
+An empty tracked set means pending held no flashblocks for that block rather than that the block
+was empty, since every L2 block carries an L1 attributes deposit. That case is not a reorg, and
+treating it as one would rebuild the whole snapshot for a block that needs no work.
+
+Reconciliation compares against the greater of the notified block height and the provider tip.
+Using only the notified height leaves `CatchUp` and `DepthLimitExceeded` unable to fire while
+pending drifts away from the tip, because both thresholds move with the stale queue.
+
+Flashblocks that arrive before their parent canonical block is visible are buffered in a bounded
+cache and replayed once it lands.
+
+### Observability
+
+- `pending_drop_stale`: snapshots dropped for being anchored too far behind the tip.
+- `flashblock_superseded`: flashblocks skipped because their block was already canonical.
+- `pending_clear_catchup`, `pending_clear_reorg`: clears by reconciliation outcome.
+- `pending_snapshot_height`, `pending_snapshot_fb_index`: current snapshot position.
+
+Sustained `pending_drop_stale` means the processor cannot keep up with its queue. Pending is
+correct in that state, since it is absent rather than stale, but flashblock-backed RPC responses
+fall back to canonical data.
+
 ## RPC Extensions
 
 This crate provides pending-state-aware Ethereum RPC implementations used by

--- a/crates/execution/flashblocks/README.md
+++ b/crates/execution/flashblocks/README.md
@@ -48,17 +48,34 @@ not need to track which updates raced with which.
 
 ### Enforcement
 
-Three checks maintain the invariant. Each reads the tip from the provider rather than trusting the
-height of the queued update, because a lagging queue reports a stale height and makes every guard
-evaluate against a chain position the node left long ago.
+Guards run in two places, and that split is what bounds staleness.
+
+**On the receiving tasks.** `on_canonical_block_received` and `on_flashblock_received` run on the
+subscription tasks rather than on the processor, so they keep working while the processor is inside
+a single expensive update. They use the notified block height directly instead of reading the
+provider.
+
+- A canonical notification records the new height and immediately drops the published snapshot if
+  it is anchored more than `max_pending_blocks_depth` behind it. Because this runs at chain speed,
+  a snapshot cannot stay readable through a long apply. The drop is a compare-and-swap against the
+  snapshot that was judged, so a snapshot the processor published concurrently, which is
+  necessarily anchored on a later tip, is left alone.
+- A flashblock for a block at or below the last notified canonical height is dropped before it is
+  queued, so the queue never accumulates work that could not produce a publishable snapshot.
+
+The recorded height is the one most recently notified rather than the highest ever seen, so a reorg
+that lowers the tip does not suppress flashblocks built on the replacement chain.
+
+**In the processor.** These read the tip from the provider rather than trusting the height of the
+queued update, because a lagging queue reports a stale height and makes a guard evaluate against a
+chain position the node left long ago.
 
 - Before an update is dispatched, a snapshot anchored more than `max_pending_blocks_depth` blocks
-  behind the tip is dropped. This bounds staleness to a single update interval no matter how large
-  the queue has grown. Canonical notifications keep arriving even when the flashblock stream
-  stalls, and if both stall the node is not advancing, so the snapshot is not stale.
-- Flashblocks whose block the node has already canonicalized are skipped before execution. They
-  cannot produce a publishable snapshot, and executing them anyway lets a backlog starve the fresh
-  payloads queued behind it.
+  behind the tip is dropped. This covers advances the notification path did not report, such as the
+  gap between a canonical notification and the block becoming visible through the provider.
+- Flashblocks whose block the node has already canonicalized are skipped before execution. This
+  catches payloads that were fresh when queued and went stale while waiting, and cached payloads
+  replayed after a canonical block arrives.
 - Every build path publishes through `publish_pending_blocks`, which re-reads the tip and refuses
   to publish a snapshot that is anchored too far back or no longer extends past the tip. Because it
   is the single funnel, this holds for the reorg and depth-limit rebuilds as well as for ordinary
@@ -69,21 +86,20 @@ the current tip rebuilds a snapshot through the ordinary build path.
 
 ### Limits
 
-These checks run when an update is applied, so they bound how stale a snapshot can be by the
-duration of one unit of work rather than by the depth of the queue. A snapshot published while the
-tip was current stays readable while the processor is inside a long apply, and the tip may advance
-underneath it during that time. Consumers that cannot tolerate this must check freshness themselves
-at the point of use, comparing their own view of the tip against `canonical_block_number` and
-`parent_hash`; the processor cannot do it for them, because it is not running at the moment they
-read.
+Freshness is bounded by canonical notification delivery rather than by processor progress, but it
+is still not evaluated at the moment a consumer reads. A consumer that cannot tolerate a snapshot
+going stale between the last notification and its own read must compare its view of the tip against
+`canonical_block_number` and `parent_hash` itself.
 
-For the same reason, the height comparison does not detect that the anchor block itself was reorged
-out, since the replacement sits at the same height. That is caught when `ReorgDetector` sees the
-replaced block's transactions, or by a consumer comparing `parent_hash`.
+The height comparison does not detect that the anchor block was reorged out, because the
+replacement sits at the same height. That is caught when `ReorgDetector` sees the replaced block's
+transactions, or by a consumer comparing `parent_hash`. Detecting it here would mean checking the
+anchor's hash against canonical history, which is a statement about whether a payload's declared
+parent is real and belongs in payload validation.
 
-The update queue is unbounded. Skipping superseded flashblocks makes it drain far faster than the
-work it replaced, so lag tends to correct itself rather than compound, but sustained overload still
-grows memory. A hard bound on the queue is separate work.
+The update queue is unbounded. Dropping superseded flashblocks before they are queued removes the
+backlog shape that let lag compound, but a sustained burst of payloads that are all ahead of the
+tip still grows memory. A hard bound on the queue is separate work.
 
 ### Canonical reconciliation
 

--- a/crates/execution/flashblocks/README.md
+++ b/crates/execution/flashblocks/README.md
@@ -31,8 +31,13 @@ This matters because consumers execute against `PendingBlocks::canonical_block_n
 canonical block the overlay is layered on. While that block stays close to the tip, callers read
 the node's in-memory canonical state. An overlay stranded on an old anchor forces them onto
 historical state instead, which is slow enough to starve the processor that produced the overlay
-and keep it stranded. `max_pending_blocks_depth` (CLI `--max-pending-blocks-depth`, default 3)
-bounds how far behind the tip the anchor may sit.
+and keep it stranded.
+
+`max_pending_blocks_depth` (CLI `--max-pending-blocks-depth`, default 3) sets the bound. It is
+measured from the earliest pending block, matching the depth `CanonicalBlockReconciler` already
+uses, so the reconciler never builds a snapshot that the tip checks then discard. The anchor is
+the block below the earliest pending block, so it may sit up to `max_pending_blocks_depth + 1`
+blocks behind the tip.
 
 Bounding the distance rather than requiring the anchor to equal the tip is deliberate. When
 flashblocks for the next block arrive before the processor has applied the current canonical
@@ -61,6 +66,24 @@ evaluate against a chain position the node left long ago.
 
 Recovery needs no separate mechanism. Once pending is absent, the next index-0 flashblock rooted at
 the current tip rebuilds a snapshot through the ordinary build path.
+
+### Limits
+
+These checks run when an update is applied, so they bound how stale a snapshot can be by the
+duration of one unit of work rather than by the depth of the queue. A snapshot published while the
+tip was current stays readable while the processor is inside a long apply, and the tip may advance
+underneath it during that time. Consumers that cannot tolerate this must check freshness themselves
+at the point of use, comparing their own view of the tip against `canonical_block_number` and
+`parent_hash`; the processor cannot do it for them, because it is not running at the moment they
+read.
+
+For the same reason, the height comparison does not detect that the anchor block itself was reorged
+out, since the replacement sits at the same height. That is caught when `ReorgDetector` sees the
+replaced block's transactions, or by a consumer comparing `parent_hash`.
+
+The update queue is unbounded. Skipping superseded flashblocks makes it drain far faster than the
+work it replaced, so lag tends to correct itself rather than compound, but sustained overload still
+grows memory. A hard bound on the queue is separate work.
 
 ### Canonical reconciliation
 

--- a/crates/execution/flashblocks/src/metrics.rs
+++ b/crates/execution/flashblocks/src/metrics.rs
@@ -20,6 +20,10 @@ base_metrics::define_metrics! {
     pending_clear_catchup: counter,
     #[describe("Number of times pending snapshot was cleared because of reorg")]
     pending_clear_reorg: counter,
+    #[describe("Number of times a pending snapshot was dropped because it did not extend the canonical tip")]
+    pending_drop_stale: counter,
+    #[describe("Number of flashblock updates skipped because their block was already canonical")]
+    flashblock_superseded: counter,
     #[describe("Pending snapshot flashblock index (current)")]
     pending_snapshot_fb_index: gauge,
     #[describe("Pending snapshot block number (current)")]

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -403,10 +403,11 @@ where
         // Determine the reconciliation strategy. Reorg detection compares against the block
         // we were notified about, but reconciliation must use the node's real canonical height
         // so a lagging queue cannot hide that pending has drifted away from the tip.
+        let canonical_number = self.effective_canonical_number(block.number);
         let strategy = CanonicalBlockReconciler::reconcile(
             Some(pending_blocks.earliest_block_number()),
             Some(pending_blocks.latest_block_number()),
-            self.effective_canonical_number(block.number),
+            canonical_number,
             self.max_depth,
             reorg_detected,
         );
@@ -416,7 +417,8 @@ where
                 debug!(
                     message = "pending snapshot cleared because canonical caught up",
                     latest_pending_block = pending_blocks.latest_block_number(),
-                    canonical_block = block.number,
+                    notified_block = block.number,
+                    canonical_block = canonical_number,
                 );
                 Metrics::pending_clear_catchup().increment(1);
                 Metrics::pending_snapshot_fb_index()
@@ -432,8 +434,10 @@ where
                 );
                 Metrics::pending_clear_reorg().increment(1);
 
-                // If there is a reorg, we re-process all future flashblocks without reusing the existing pending state
-                flashblocks.retain(|flashblock| flashblock.metadata.block_number > block.number);
+                // Rebuild from the real tip, not the notified height: under queue lag those
+                // two differ, and re-executing the already-canonical range cannot publish.
+                flashblocks
+                    .retain(|flashblock| flashblock.metadata.block_number > canonical_number);
                 self.build_pending_state(None, &flashblocks)
             }
             ReconciliationStrategy::DepthLimitExceeded { depth, max_depth } => {
@@ -443,7 +447,8 @@ where
                     max_depth = max_depth,
                 );
 
-                flashblocks.retain(|flashblock| flashblock.metadata.block_number > block.number);
+                flashblocks
+                    .retain(|flashblock| flashblock.metadata.block_number > canonical_number);
                 self.build_pending_state(None, &flashblocks)
             }
             ReconciliationStrategy::Continue => {

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -172,11 +172,13 @@ where
     /// Returns the published snapshot, dropping it first if it is stranded too far behind the
     /// canonical tip to become usable again.
     ///
-    /// Calling this once per update is what bounds staleness. However far the queue has fallen
-    /// behind, a stranded overlay survives only until the next update arrives, and canonical
-    /// notifications keep arriving even when the flashblocks stream stalls. Snapshots that
-    /// merely stopped extending the tip are left for [`Self::process_canonical_block`] to
-    /// reconcile, so its catch-up path keeps reporting.
+    /// `FlashblocksState` drops stranded overlays as canonical notifications arrive, which is
+    /// what keeps staleness bounded by chain progress rather than by how long a single update
+    /// takes to apply. This check covers the advances that path did not report: notifications
+    /// carry the committed height, while the provider may already be further along, and the
+    /// two differ during the window between a notification and the block becoming visible.
+    /// Snapshots that merely stopped extending the tip are left for
+    /// [`Self::process_canonical_block`] to reconcile, so its catch-up path keeps reporting.
     fn take_tip_anchored_pending(&self) -> Option<Arc<PendingBlocks>> {
         let pending_blocks = self.pending_blocks.load_full()?;
 
@@ -301,6 +303,9 @@ where
     /// Executing a flashblock for an already-canonical block cannot produce a publishable
     /// snapshot, and doing it anyway is what let the queue lag sustain itself: the backlog
     /// of superseded payloads consumed the processor while fresh payloads waited behind them.
+    /// `FlashblocksState` rejects payloads that are already superseded when they arrive, so
+    /// what reaches here is a payload that was fresh when queued and went stale while waiting,
+    /// or one replayed from the cache after its canonical block landed.
     async fn apply_flashblock(
         &self,
         prev_pending_blocks: Option<Arc<PendingBlocks>>,

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -88,6 +88,108 @@ where
         *self.lock_live_state() = Some(LivePendingState { db, state_overrides });
     }
 
+    /// Returns `true` when the node has already canonicalized the flashblock's block.
+    fn is_superseded(&self, flashblock: &Flashblock) -> bool {
+        self.client.best_block_number().is_ok_and(|best| flashblock.metadata.block_number <= best)
+    }
+
+    /// Returns the canonical height to reconcile against.
+    ///
+    /// Canonical and flashblock updates share one unbounded queue applied FIFO, so the height
+    /// of a queued notification can be far behind the height the node has actually reached.
+    /// Taking the greater of the two keeps reconciliation anchored to the real chain.
+    fn effective_canonical_number(&self, notified: BlockNumber) -> BlockNumber {
+        match self.client.best_block_number() {
+            Ok(best) => notified.max(best),
+            Err(e) => {
+                warn!(
+                    message = "could not read canonical tip, reconciling against notified block",
+                    notified_block = notified,
+                    error = %e,
+                );
+                notified
+            }
+        }
+    }
+
+    /// Returns `true` when `pending_blocks` is anchored within `max_depth` of the node's
+    /// canonical tip.
+    ///
+    /// Consumers execute against [`PendingBlocks::canonical_block_number`], so an overlay
+    /// anchored far behind the tip makes them walk a historical trie. The `max_depth`
+    /// allowance is the same bound [`CanonicalBlockReconciler`] applies, and it absorbs the
+    /// normal delay between a canonical notification and provider visibility.
+    fn is_anchored_near_tip(&self, pending_blocks: &PendingBlocks) -> bool {
+        let best = match self.client.best_block_number() {
+            Ok(best) => best,
+            Err(e) => {
+                warn!(message = "could not read canonical tip, keeping pending state", error = %e);
+                return true;
+            }
+        };
+
+        let blocks_behind_tip = best.saturating_sub(pending_blocks.earliest_block_number());
+        if blocks_behind_tip > self.max_depth {
+            debug!(
+                message = "pending snapshot anchored too far behind canonical tip, dropping",
+                canonical_tip = best,
+                earliest_pending_block = pending_blocks.earliest_block_number(),
+                latest_pending_block = pending_blocks.latest_block_number(),
+                max_depth = self.max_depth,
+            );
+            return false;
+        }
+
+        true
+    }
+
+    /// Returns `true` when `pending_blocks` is usable as live pending state, meaning it is
+    /// anchored near the tip and still extends past it.
+    fn extends_canonical_tip(&self, pending_blocks: &PendingBlocks) -> bool {
+        if !self.is_anchored_near_tip(pending_blocks) {
+            return false;
+        }
+
+        self.client.best_block_number().is_ok_and(|best| {
+            if pending_blocks.latest_block_number() > best {
+                return true;
+            }
+            debug!(
+                message = "pending snapshot no longer extends canonical tip, dropping",
+                canonical_tip = best,
+                latest_pending_block = pending_blocks.latest_block_number(),
+            );
+            false
+        })
+    }
+
+    /// Returns the published snapshot, dropping it first if it is anchored too far behind the
+    /// canonical tip to ever be usable again.
+    ///
+    /// Calling this once per update is what bounds staleness. However far the queue has fallen
+    /// behind, an overlay stranded on an old anchor survives only until the next update
+    /// arrives, and canonical notifications keep arriving even when the flashblocks stream
+    /// stalls. Snapshots that merely stopped extending the tip are left for
+    /// [`Self::process_canonical_block`] to reconcile, so its catch-up path keeps reporting.
+    fn take_tip_anchored_pending(&self) -> Option<Arc<PendingBlocks>> {
+        let pending_blocks = self.pending_blocks.load_full()?;
+        if self.is_anchored_near_tip(&pending_blocks) {
+            return Some(pending_blocks);
+        }
+
+        Metrics::pending_drop_stale().increment(1);
+        self.clear_live_state();
+        self.pending_blocks.store(None);
+
+        None
+    }
+
+    /// Publishes a freshly built snapshot, unless it no longer extends the canonical tip.
+    ///
+    /// Every build path funnels through here, so this is the one place that has to enforce
+    /// the invariant: pending state either tracks flashblocks on the node's current canonical
+    /// tip or is absent. That holds no matter which path produced the snapshot, and it makes
+    /// recovery automatic, because the next tip-rooted flashblock rebuilds from `None`.
     fn publish_pending_blocks(
         &self,
         mut pending_blocks_builder: PendingBlocksBuilder,
@@ -99,6 +201,13 @@ where
         pending_blocks_builder.with_state_overrides(state_overrides.clone());
 
         let pending_blocks = Arc::new(pending_blocks_builder.build()?);
+
+        if !self.extends_canonical_tip(&pending_blocks) {
+            Metrics::pending_drop_stale().increment(1);
+            self.clear_live_state();
+            return Ok(None);
+        }
+
         self.set_live_state(db, state_overrides);
 
         Ok(Some(pending_blocks))
@@ -130,7 +239,7 @@ where
     /// Processes updates from the queue until the channel closes.
     pub async fn start(&self) {
         while let Some(update) = self.rx.lock().await.recv().await {
-            let prev_pending_blocks = self.pending_blocks.load_full();
+            let prev_pending_blocks = self.take_tip_anchored_pending();
             match update {
                 StateUpdate::Canonical(block) => {
                     debug!(message = "processing canonical block", block_number = block.number);
@@ -150,7 +259,7 @@ where
                                     cached_count = cached.len(),
                                 );
                                 for flashblock in cached {
-                                    let fb_prev = self.pending_blocks.load_full();
+                                    let fb_prev = self.take_tip_anchored_pending();
                                     self.apply_flashblock(fb_prev, flashblock).await;
                                 }
                             }
@@ -172,11 +281,26 @@ where
         }
     }
 
+    /// Applies a flashblock, unless the node has already canonicalized its block.
+    ///
+    /// Executing a flashblock for an already-canonical block cannot produce a publishable
+    /// snapshot, and doing it anyway is what let the queue lag sustain itself: the backlog
+    /// of superseded payloads consumed the processor while fresh payloads waited behind them.
     async fn apply_flashblock(
         &self,
         prev_pending_blocks: Option<Arc<PendingBlocks>>,
         flashblock: Flashblock,
     ) {
+        if self.is_superseded(&flashblock) {
+            debug!(
+                message = "skipping flashblock for already canonical block",
+                block_number = flashblock.metadata.block_number,
+                flashblock_index = flashblock.index,
+            );
+            Metrics::flashblock_superseded().increment(1);
+            return;
+        }
+
         let start_time = Instant::now();
         match self.process_flashblock(prev_pending_blocks, &flashblock) {
             Ok(new_pending_blocks) => {
@@ -256,11 +380,13 @@ where
         let reorg_result = ReorgDetector::detect(&tracked_txn_hashes, &block_txn_hashes);
         let reorg_detected = reorg_result.is_reorg();
 
-        // Determine the reconciliation strategy
+        // Determine the reconciliation strategy. Reorg detection compares against the block
+        // we were notified about, but reconciliation must use the node's real canonical height
+        // so a lagging queue cannot hide that pending has drifted away from the tip.
         let strategy = CanonicalBlockReconciler::reconcile(
             Some(pending_blocks.earliest_block_number()),
             Some(pending_blocks.latest_block_number()),
-            block.number,
+            self.effective_canonical_number(block.number),
             self.max_depth,
             reorg_detected,
         );

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -88,9 +88,28 @@ where
         *self.lock_live_state() = Some(LivePendingState { db, state_overrides });
     }
 
+    /// Returns the node's canonical tip, or `None` when the provider cannot report it.
+    ///
+    /// Every tip check treats `None` as unknown and leaves pending state as it is, so a
+    /// provider hiccup degrades to the behaviour from before tip anchoring instead of
+    /// dropping a snapshot that may well be current. This is the only place that decides that
+    /// policy, so the checks below cannot disagree about it.
+    fn canonical_tip(&self) -> Option<BlockNumber> {
+        match self.client.best_block_number() {
+            Ok(best) => Some(best),
+            Err(e) => {
+                warn!(
+                    message = "could not read canonical tip, leaving pending state unchanged",
+                    error = %e,
+                );
+                None
+            }
+        }
+    }
+
     /// Returns `true` when the node has already canonicalized the flashblock's block.
     fn is_superseded(&self, flashblock: &Flashblock) -> bool {
-        self.client.best_block_number().is_ok_and(|best| flashblock.metadata.block_number <= best)
+        self.canonical_tip().is_some_and(|best| flashblock.metadata.block_number <= best)
     }
 
     /// Returns the canonical height to reconcile against.
@@ -99,43 +118,50 @@ where
     /// of a queued notification can be far behind the height the node has actually reached.
     /// Taking the greater of the two keeps reconciliation anchored to the real chain.
     fn effective_canonical_number(&self, notified: BlockNumber) -> BlockNumber {
-        match self.client.best_block_number() {
-            Ok(best) => notified.max(best),
-            Err(e) => {
-                warn!(
-                    message = "could not read canonical tip, reconciling against notified block",
-                    notified_block = notified,
-                    error = %e,
-                );
-                notified
-            }
-        }
+        self.canonical_tip().map_or(notified, |best| notified.max(best))
     }
 
-    /// Returns `true` when `pending_blocks` is anchored within `max_depth` of the node's
-    /// canonical tip.
+    /// Returns `true` when `pending_blocks` is anchored within `max_depth` blocks of canonical
+    /// height `best`.
     ///
     /// Consumers execute against [`PendingBlocks::canonical_block_number`], so an overlay
-    /// anchored far behind the tip makes them walk a historical trie. The `max_depth`
-    /// allowance is the same bound [`CanonicalBlockReconciler`] applies, and it absorbs the
-    /// normal delay between a canonical notification and provider visibility.
-    fn is_anchored_near_tip(&self, pending_blocks: &PendingBlocks) -> bool {
-        let best = match self.client.best_block_number() {
-            Ok(best) => best,
-            Err(e) => {
-                warn!(message = "could not read canonical tip, keeping pending state", error = %e);
-                return true;
-            }
-        };
+    /// anchored far behind the tip makes them walk historical state. The distance is measured
+    /// from the earliest pending block so that this bound is the one
+    /// [`CanonicalBlockReconciler`] already applies, which means the reconciler never builds a
+    /// snapshot that this check then throws away. The anchor itself is the block below that, so
+    /// it may sit up to `max_depth + 1` blocks behind `best`.
+    fn is_anchored_near(&self, pending_blocks: &PendingBlocks, best: BlockNumber) -> bool {
+        best.saturating_sub(pending_blocks.earliest_block_number()) <= self.max_depth
+    }
 
-        let blocks_behind_tip = best.saturating_sub(pending_blocks.earliest_block_number());
-        if blocks_behind_tip > self.max_depth {
+    /// Returns `true` when `pending_blocks` is usable as live pending state, meaning it is
+    /// anchored near the tip and still extends past it.
+    ///
+    /// This deliberately compares heights only. Detecting that the anchor itself was reorged
+    /// out means comparing its hash against canonical history, which is a statement about
+    /// whether an incoming payload's declared parent is real, so it belongs in payload
+    /// validation rather than in a staleness check on already-published state. Fork-stranded
+    /// pending is caught here when [`ReorgDetector`] sees the replaced block's transactions,
+    /// and by consumers, which must compare their parent hash against
+    /// [`PendingBlocks::parent_hash`] before reusing cached execution results.
+    fn extends_canonical_tip(&self, pending_blocks: &PendingBlocks) -> bool {
+        let Some(best) = self.canonical_tip() else { return true };
+
+        if !self.is_anchored_near(pending_blocks, best) {
             debug!(
                 message = "pending snapshot anchored too far behind canonical tip, dropping",
                 canonical_tip = best,
                 earliest_pending_block = pending_blocks.earliest_block_number(),
-                latest_pending_block = pending_blocks.latest_block_number(),
                 max_depth = self.max_depth,
+            );
+            return false;
+        }
+
+        if pending_blocks.latest_block_number() <= best {
+            debug!(
+                message = "pending snapshot no longer extends canonical tip, dropping",
+                canonical_tip = best,
+                latest_pending_block = pending_blocks.latest_block_number(),
             );
             return false;
         }
@@ -143,40 +169,29 @@ where
         true
     }
 
-    /// Returns `true` when `pending_blocks` is usable as live pending state, meaning it is
-    /// anchored near the tip and still extends past it.
-    fn extends_canonical_tip(&self, pending_blocks: &PendingBlocks) -> bool {
-        if !self.is_anchored_near_tip(pending_blocks) {
-            return false;
-        }
-
-        self.client.best_block_number().is_ok_and(|best| {
-            if pending_blocks.latest_block_number() > best {
-                return true;
-            }
-            debug!(
-                message = "pending snapshot no longer extends canonical tip, dropping",
-                canonical_tip = best,
-                latest_pending_block = pending_blocks.latest_block_number(),
-            );
-            false
-        })
-    }
-
-    /// Returns the published snapshot, dropping it first if it is anchored too far behind the
-    /// canonical tip to ever be usable again.
+    /// Returns the published snapshot, dropping it first if it is stranded too far behind the
+    /// canonical tip to become usable again.
     ///
     /// Calling this once per update is what bounds staleness. However far the queue has fallen
-    /// behind, an overlay stranded on an old anchor survives only until the next update
-    /// arrives, and canonical notifications keep arriving even when the flashblocks stream
-    /// stalls. Snapshots that merely stopped extending the tip are left for
-    /// [`Self::process_canonical_block`] to reconcile, so its catch-up path keeps reporting.
+    /// behind, a stranded overlay survives only until the next update arrives, and canonical
+    /// notifications keep arriving even when the flashblocks stream stalls. Snapshots that
+    /// merely stopped extending the tip are left for [`Self::process_canonical_block`] to
+    /// reconcile, so its catch-up path keeps reporting.
     fn take_tip_anchored_pending(&self) -> Option<Arc<PendingBlocks>> {
         let pending_blocks = self.pending_blocks.load_full()?;
-        if self.is_anchored_near_tip(&pending_blocks) {
+
+        let Some(best) = self.canonical_tip() else { return Some(pending_blocks) };
+        if self.is_anchored_near(&pending_blocks, best) {
             return Some(pending_blocks);
         }
 
+        debug!(
+            message = "pending snapshot anchored too far behind canonical tip, dropping",
+            canonical_tip = best,
+            earliest_pending_block = pending_blocks.earliest_block_number(),
+            latest_pending_block = pending_blocks.latest_block_number(),
+            max_depth = self.max_depth,
+        );
         Metrics::pending_drop_stale().increment(1);
         self.clear_live_state();
         self.pending_blocks.store(None);

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -179,7 +179,7 @@ where
     /// two differ during the window between a notification and the block becoming visible.
     /// Snapshots that merely stopped extending the tip are left for
     /// [`Self::process_canonical_block`] to reconcile, so its catch-up path keeps reporting.
-    fn take_tip_anchored_pending(&self) -> Option<Arc<PendingBlocks>> {
+    fn load_pending_or_drop_stale(&self) -> Option<Arc<PendingBlocks>> {
         let pending_blocks = self.pending_blocks.load_full()?;
 
         let Some(best) = self.canonical_tip() else { return Some(pending_blocks) };
@@ -256,7 +256,7 @@ where
     /// Processes updates from the queue until the channel closes.
     pub async fn start(&self) {
         while let Some(update) = self.rx.lock().await.recv().await {
-            let prev_pending_blocks = self.take_tip_anchored_pending();
+            let prev_pending_blocks = self.load_pending_or_drop_stale();
             match update {
                 StateUpdate::Canonical(block) => {
                     debug!(message = "processing canonical block", block_number = block.number);
@@ -276,7 +276,7 @@ where
                                     cached_count = cached.len(),
                                 );
                                 for flashblock in cached {
-                                    let fb_prev = self.take_tip_anchored_pending();
+                                    let fb_prev = self.load_pending_or_drop_stale();
                                     self.apply_flashblock(fb_prev, flashblock).await;
                                 }
                             }

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -1,6 +1,9 @@
 //! Flashblocks state management.
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use alloy_consensus::Header;
 use arc_swap::{ArcSwapOption, Guard};
@@ -18,6 +21,7 @@ use tokio::sync::{
 
 use crate::{
     FlashblocksAPI, FlashblocksReceiver, PendingBlocks,
+    metrics::Metrics,
     processor::{StateProcessor, StateUpdate},
 };
 
@@ -32,6 +36,7 @@ pub struct FlashblocksState {
     rx: Arc<Mutex<mpsc::UnboundedReceiver<StateUpdate>>>,
     flashblock_sender: Sender<Arc<PendingBlocks>>,
     max_pending_blocks_depth: u64,
+    last_canonical_block: AtomicU64,
 }
 
 impl FlashblocksState {
@@ -50,6 +55,7 @@ impl FlashblocksState {
             rx: Arc::new(Mutex::new(rx)),
             flashblock_sender,
             max_pending_blocks_depth,
+            last_canonical_block: AtomicU64::new(0),
         }
     }
 
@@ -78,9 +84,53 @@ impl FlashblocksState {
         });
     }
 
+    /// Drops the published snapshot when it is anchored more than `max_pending_blocks_depth`
+    /// blocks behind `canonical_block_number`.
+    ///
+    /// [`StateProcessor`] enforces the same bound, but only once it reaches the matching queue
+    /// entry. Repeating it on the task that receives the notification is what keeps staleness
+    /// bounded by chain progress rather than by processor progress: a snapshot cannot stay
+    /// readable through a long apply merely because the processor has not dequeued the
+    /// notification yet.
+    fn drop_pending_behind(&self, canonical_block_number: u64) {
+        let published = self.pending_blocks.load();
+        let Some(stale) = published.as_ref() else { return };
+
+        // Measured from the earliest pending block so this matches the bound the processor and
+        // the reconciler apply, and the three cannot disagree about which snapshots survive.
+        let earliest_pending_block = stale.earliest_block_number();
+        if canonical_block_number.saturating_sub(earliest_pending_block)
+            <= self.max_pending_blocks_depth
+        {
+            return;
+        }
+
+        // Clear only the snapshot that was judged. The processor publishes concurrently, and
+        // anything it published after the load above is anchored on a later tip than this one.
+        // Losing this race costs nothing, because an absent snapshot is always safe to serve.
+        let current = self.pending_blocks.compare_and_swap(&published, None);
+        if !current.as_ref().is_some_and(|current| Arc::ptr_eq(current, stale)) {
+            return;
+        }
+
+        debug!(
+            message = "dropping pending snapshot anchored too far behind the canonical tip",
+            canonical_block_number,
+            earliest_pending_block,
+            max_depth = self.max_pending_blocks_depth,
+        );
+        Metrics::pending_drop_stale().increment(1);
+    }
+
     /// Handles a canonical block being received.
     pub fn on_canonical_block_received(&self, block: RecoveredBlock<BaseBlock>) {
         let block_number = block.number;
+
+        // Deliberately not `fetch_max`: a reorg can move the tip down, and keeping the higher
+        // height would suppress every flashblock built on the replacement chain.
+        self.last_canonical_block.store(block_number, Ordering::Relaxed);
+        self.drop_pending_behind(block_number);
+
         match self.queue.send(StateUpdate::Canonical(block)) {
             Ok(_) => {
                 info!(message = "added canonical block to processing queue", block_number)
@@ -96,6 +146,19 @@ impl FlashblocksReceiver for FlashblocksState {
     fn on_flashblock_received(&self, flashblock: Flashblock) {
         let flashblock_index = flashblock.index;
         let block_number = flashblock.metadata.block_number;
+
+        // Rejecting superseded payloads here keeps them out of the queue entirely, so a backlog
+        // cannot grow on work that could never produce a publishable snapshot. The processor
+        // repeats the check for payloads that were fresh on arrival but went stale while queued.
+        if block_number <= self.last_canonical_block.load(Ordering::Relaxed) {
+            debug!(
+                message = "dropping flashblock for an already canonical block",
+                block_number, flashblock_index,
+            );
+            Metrics::flashblock_superseded().increment(1);
+            return;
+        }
+
         match self.queue.send(StateUpdate::Flashblock(flashblock)) {
             Ok(_) => {
                 debug!(
@@ -133,5 +196,133 @@ impl FlashblocksState {
     /// tests to inject a pre-built `PendingBlocks` state.
     pub fn set_pending_blocks_for_testing(&self, pending_blocks: Option<PendingBlocks>) {
         self.pending_blocks.store(pending_blocks.map(Arc::new));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::{Block, BlockBody, Sealed};
+    use alloy_primitives::{Address, B256, Bloom, Bytes, U256};
+    use alloy_rpc_types_engine::PayloadId;
+    use base_common_flashblocks::{
+        ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Metadata,
+    };
+
+    use super::*;
+    use crate::PendingBlocksBuilder;
+
+    const MAX_DEPTH: u64 = 3;
+
+    fn flashblock_for_block(block_number: u64) -> Flashblock {
+        Flashblock {
+            payload_id: PayloadId::default(),
+            index: 0,
+            base: Some(ExecutionPayloadBaseV1 {
+                parent_beacon_block_root: B256::ZERO,
+                parent_hash: B256::ZERO,
+                fee_recipient: Address::ZERO,
+                prev_randao: B256::ZERO,
+                block_number,
+                gas_limit: 30_000_000,
+                timestamp: 1_700_000_000,
+                extra_data: Bytes::default(),
+                base_fee_per_gas: U256::from(1_000_000_000u64),
+            }),
+            diff: ExecutionPayloadFlashblockDeltaV1 {
+                state_root: B256::ZERO,
+                receipts_root: B256::ZERO,
+                logs_bloom: Bloom::default(),
+                gas_used: 21_000,
+                block_hash: B256::ZERO,
+                transactions: vec![],
+                withdrawals: vec![],
+                withdrawals_root: B256::ZERO,
+                blob_gas_used: None,
+            },
+            metadata: Metadata::new(block_number),
+        }
+    }
+
+    /// Builds a snapshot whose earliest pending block is `block_number`, which is the height
+    /// the staleness bound is measured from.
+    fn pending_anchored_at(block_number: u64) -> PendingBlocks {
+        let mut builder = PendingBlocksBuilder::new();
+        builder.with_flashblocks([flashblock_for_block(block_number)]);
+        builder.with_header(Sealed::new_unchecked(
+            Header { number: block_number, ..Default::default() },
+            B256::ZERO,
+        ));
+        builder.build().expect("pending fixture builds")
+    }
+
+    fn canonical_block(block_number: u64) -> RecoveredBlock<BaseBlock> {
+        RecoveredBlock::new_unhashed(
+            Block {
+                header: Header { number: block_number, ..Default::default() },
+                body: BlockBody::default(),
+            },
+            vec![],
+        )
+    }
+
+    /// The processor is never started here, so only the notification path can clear the
+    /// snapshot. That is the property that bounds staleness while the processor is busy.
+    #[test]
+    fn canonical_notification_drops_stale_pending_without_the_processor() {
+        let state = FlashblocksState::new(MAX_DEPTH);
+        state.set_pending_blocks_for_testing(Some(pending_anchored_at(1)));
+
+        state.on_canonical_block_received(canonical_block(1 + MAX_DEPTH + 1));
+
+        assert!(
+            state.get_pending_blocks().is_none(),
+            "a snapshot anchored past max_pending_blocks_depth must not survive the notification"
+        );
+    }
+
+    #[test]
+    fn canonical_notification_keeps_pending_within_max_depth() {
+        let state = FlashblocksState::new(MAX_DEPTH);
+        state.set_pending_blocks_for_testing(Some(pending_anchored_at(1)));
+
+        state.on_canonical_block_received(canonical_block(1 + MAX_DEPTH));
+
+        assert!(
+            state.get_pending_blocks().is_some(),
+            "normal lag must not clear pending, or every notification would drop live state"
+        );
+    }
+
+    #[tokio::test]
+    async fn superseded_flashblock_never_enters_the_queue() {
+        let state = FlashblocksState::new(MAX_DEPTH);
+        state.on_canonical_block_received(canonical_block(7));
+
+        state.on_flashblock_received(flashblock_for_block(3));
+
+        let mut rx = state.rx.lock().await;
+        assert!(
+            matches!(rx.try_recv(), Ok(StateUpdate::Canonical(_))),
+            "the canonical notification itself is still queued for reconciliation"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "a flashblock for an already canonical block must not consume queue capacity"
+        );
+    }
+
+    #[tokio::test]
+    async fn flashblock_ahead_of_canonical_enters_the_queue() {
+        let state = FlashblocksState::new(MAX_DEPTH);
+        state.on_canonical_block_received(canonical_block(7));
+
+        state.on_flashblock_received(flashblock_for_block(8));
+
+        let mut rx = state.rx.lock().await;
+        assert!(matches!(rx.try_recv(), Ok(StateUpdate::Canonical(_))));
+        assert!(
+            matches!(rx.try_recv(), Ok(StateUpdate::Flashblock(_))),
+            "flashblocks extending the tip must still reach the processor"
+        );
     }
 }

--- a/crates/execution/flashblocks/src/validation.rs
+++ b/crates/execution/flashblocks/src/validation.rs
@@ -129,10 +129,18 @@ impl ReorgDetector {
     /// Compares tracked vs canonical transaction hashes to detect reorgs.
     ///
     /// Returns `ReorgDetected` if counts differ, hashes differ, or order differs.
+    ///
+    /// An empty tracked set means pending held no flashblocks for the canonical block, so
+    /// there is nothing to compare against and no reorg is reported. Every L2 block carries
+    /// an L1 attributes deposit, so a tracked block is never legitimately empty.
     pub fn detect(
         tracked_tx_hashes: &[B256],
         canonical_tx_hashes: &[B256],
     ) -> ReorgDetectionResult {
+        if tracked_tx_hashes.is_empty() {
+            return ReorgDetectionResult::NoReorg;
+        }
+
         if tracked_tx_hashes != canonical_tx_hashes {
             ReorgDetectionResult::ReorgDetected {
                 tracked_count: tracked_tx_hashes.len(),
@@ -170,6 +178,12 @@ pub struct CanonicalBlockReconciler;
 
 impl CanonicalBlockReconciler {
     /// Returns the appropriate [`ReconciliationStrategy`] based on pending vs canonical state.
+    ///
+    /// `canonical_block_number` must be the node's effective canonical height, not just the
+    /// height of the block being reconciled. Callers that pass a queued notification height
+    /// evaluate every guard here in whatever frame of reference the queue has fallen behind
+    /// to, so neither `CatchUp` nor `DepthLimitExceeded` fires while pending drifts away
+    /// from the real tip.
     ///
     /// Priority: `NoPendingState` → `CatchUp` → `HandleReorg` → `DepthLimitExceeded` → `Continue`
     pub const fn reconcile(
@@ -295,8 +309,10 @@ mod tests {
     // Reorg cases - different counts
     #[case(&[0x01, 0x02, 0x03], &[0x01, 0x02], ReorgDetectionResult::ReorgDetected { tracked_count: 3, canonical_count: 2 })]
     #[case(&[0x01], &[0x01, 0x02, 0x03], ReorgDetectionResult::ReorgDetected { tracked_count: 1, canonical_count: 3 })]
-    #[case(&[], &[0x01], ReorgDetectionResult::ReorgDetected { tracked_count: 0, canonical_count: 1 })]
     #[case(&[0x01], &[], ReorgDetectionResult::ReorgDetected { tracked_count: 1, canonical_count: 0 })]
+    // An untracked canonical block is not a reorg: pending simply held no flashblocks for it.
+    #[case(&[], &[0x01], ReorgDetectionResult::NoReorg)]
+    #[case(&[], &[0x01, 0x02, 0x03], ReorgDetectionResult::NoReorg)]
     #[case(&[0x01, 0x01, 0x02], &[0x01, 0x02], ReorgDetectionResult::ReorgDetected { tracked_count: 3, canonical_count: 2 })]
     // Reorg cases - same count, different hashes
     #[case(&[0x01, 0x02], &[0x03, 0x04], ReorgDetectionResult::ReorgDetected { tracked_count: 2, canonical_count: 2 })]


### PR DESCRIPTION
Smaller fix for the 8/20 pending-state incident (IM-28968) than #4705.

Reconciliation was using the canonical height from the queue, not the node's actual tip. That queue is an unbounded FIFO of mixed canonical and flashblock updates, so once apply fell behind, CatchUp/DepthLimit never fired and `base_meterBundle` kept executing against a historical overlay.

This checks the real tip and drops pending if it's more than `--max-pending-blocks-depth` (default 3) behind. Superseded flashblocks are skipped instead of executed. The same checks run on the subscription tasks, so a snapshot can't stay readable just because the processor is stuck in one apply. Missing pending is fine; the next base flashblock on the current tip rebuilds it.

Not in this PR: a hard queue bound, or detecting a same-height reorg of the anchor by hash.

## Test plan

- `cargo test -p base-flashblocks --lib`
- `cargo test -p base-flashblocks-node --test state` — the three new tests reproduce the lag by advancing the provider tip without notifying the processor; they fail without the processor change
- local docker devnet on this commit: client pending stayed on the child of latest, `pending_drop_stale` ticked once at startup and then didn't climb

type=routine
risk=low
impact=sev5