### PR TITLE
feat(shadow-metrics): add recent shadow blocks endpoint

### DIFF
--- a/crates/execution/shadow-indexer-db/src/repo.rs
+++ b/crates/execution/shadow-indexer-db/src/repo.rs
@@ -298,6 +298,40 @@ impl ShadowBlockRepo {
         Ok(row.map(|(updated_at, number)| ShadowBlockCursor { updated_at, number }))
     }
 
+    /// Lists the most recent resolved shadow blocks, newest first.
+    ///
+    /// Only rows that have gained a canonical hash are returned, matching the
+    /// single-block summary endpoint: an unresolved row is not yet a confirmed
+    /// shadow replacement. `before` excludes rows at or above that block number,
+    /// so the caller pages backwards by passing the last number it saw.
+    ///
+    /// # Errors
+    /// Returns an error when the query fails.
+    pub async fn list_recent(
+        &self,
+        limit: i64,
+        before: Option<i64>,
+    ) -> Result<Vec<ShadowSummaryRow>> {
+        let rows = query_as::<_, ShadowSummaryRow>(
+            "SELECT number, hash, canonical_hash, \
+             payload->>'builder_version' AS builder_version, \
+             payload#>'{block,block,header,header}' AS header, \
+             payload#>'{block,block,body,transactions}' AS transactions \
+             FROM shadow_blocks \
+             WHERE canonical_hash IS NOT NULL \
+               AND ($1::BIGINT IS NULL OR number < $1) \
+             ORDER BY number DESC \
+             LIMIT $2",
+        )
+        .bind(before)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await
+        .context("failed to list recent shadow blocks")?;
+
+        Ok(rows)
+    }
+
     /// Lists reorged-out shadow candidates replaced by the canonical block with `canonical_hash`.
     ///
     /// # Errors

--- a/crates/infra/shadow-metrics/src/api.rs
+++ b/crates/infra/shadow-metrics/src/api.rs
@@ -223,15 +223,19 @@ struct RecentShadowBlocksQuery {
 
 const DEFAULT_RECENT_LIMIT: i64 = 25;
 
+/// No upper bound: this endpoint is consumed server-to-server. Absent falls back
+/// to the default; anything below 1 floors at 1 so a malformed value cannot make
+/// Postgres reject the query.
+fn resolve_recent_limit(limit: Option<i64>) -> i64 {
+    limit.unwrap_or(DEFAULT_RECENT_LIMIT).max(1)
+}
+
 /// The most recent resolved shadow blocks, newest first, paged backwards by `before`.
-///
-/// No upper bound on `limit`: this endpoint is consumed server-to-server. `limit`
-/// only floors at 1 so a malformed value cannot make Postgres reject the query.
 async fn get_recent_shadow_blocks(
     State(state): State<ApiState>,
     Query(query): Query<RecentShadowBlocksQuery>,
 ) -> Result<Json<Vec<ShadowBlockSummary>>, ApiError> {
-    let limit = query.limit.unwrap_or(DEFAULT_RECENT_LIMIT).max(1);
+    let limit = resolve_recent_limit(query.limit);
 
     let repo = state.repo()?;
     let shadows = repo.list_recent(limit, query.before).await?;
@@ -518,6 +522,14 @@ mod tests {
             header: Json(row.payload.block.header().clone()),
             transactions: Json(row.payload.block.body().transactions.clone()),
         }
+    }
+
+    #[test]
+    fn resolve_recent_limit_defaults_and_floors() {
+        assert_eq!(resolve_recent_limit(None), DEFAULT_RECENT_LIMIT);
+        assert_eq!(resolve_recent_limit(Some(50)), 50);
+        assert_eq!(resolve_recent_limit(Some(0)), 1);
+        assert_eq!(resolve_recent_limit(Some(-5)), 1);
     }
 
     #[test]

--- a/crates/infra/shadow-metrics/src/api.rs
+++ b/crates/infra/shadow-metrics/src/api.rs
@@ -36,6 +36,7 @@ pub fn api_router(store: Option<ShadowMetricsStore>) -> Router {
     let repo = store.map(|store| ShadowBlockRepo::new(store.pool().clone()));
     Router::new()
         .route("/shadow-candidates", get(get_shadow_candidates_batch))
+        .route("/shadow-blocks", get(get_recent_shadow_blocks))
         .route("/blocks/{id}", get(get_block))
         .route("/blocks/{id}/shadow-candidates", get(get_shadow_candidates))
         .route("/shadow-blocks/{id}", get(get_shadow_block))
@@ -212,6 +213,37 @@ async fn get_shadow_candidates_batch(
         "served batch shadow candidates"
     );
     Ok(Json(result))
+}
+
+#[derive(Debug, Deserialize)]
+struct RecentShadowBlocksQuery {
+    limit: Option<i64>,
+    before: Option<i64>,
+}
+
+const DEFAULT_RECENT_LIMIT: i64 = 25;
+
+/// The most recent resolved shadow blocks, newest first, paged backwards by `before`.
+///
+/// No upper bound on `limit`: this endpoint is consumed server-to-server. `limit`
+/// only floors at 1 so a malformed value cannot make Postgres reject the query.
+async fn get_recent_shadow_blocks(
+    State(state): State<ApiState>,
+    Query(query): Query<RecentShadowBlocksQuery>,
+) -> Result<Json<Vec<ShadowBlockSummary>>, ApiError> {
+    let limit = query.limit.unwrap_or(DEFAULT_RECENT_LIMIT).max(1);
+
+    let repo = state.repo()?;
+    let shadows = repo.list_recent(limit, query.before).await?;
+    tracing::info!(
+        target: "shadow_metrics::api",
+        endpoint = "recent-shadow-blocks",
+        limit,
+        before = query.before,
+        count = shadows.len(),
+        "served recent shadow blocks"
+    );
+    Ok(Json(shadows.iter().map(shadow_block_summary).collect::<Vec<_>>()))
 }
 
 /// A single reorged-out shadow block summary addressed by shadow block hash.

--- a/crates/infra/shadow-metrics/src/api.rs
+++ b/crates/infra/shadow-metrics/src/api.rs
@@ -227,9 +227,7 @@ const DEFAULT_RECENT_LIMIT: i64 = 25;
 /// to the default; anything below 1 floors at 1 so a malformed value cannot make
 /// Postgres reject the query.
 fn resolve_recent_limit(limit: Option<i64>) -> i64 {
-fn resolve_recent_limit(limit: Option<i64>) -> i64 {
-    limit.unwrap_or(DEFAULT_RECENT_LIMIT).clamp(1, 1000)
-}
+    limit.unwrap_or(DEFAULT_RECENT_LIMIT).max(1)
 }
 
 /// The most recent resolved shadow blocks, newest first, paged backwards by `before`.

--- a/crates/infra/shadow-metrics/src/api.rs
+++ b/crates/infra/shadow-metrics/src/api.rs
@@ -222,12 +222,13 @@ struct RecentShadowBlocksQuery {
 }
 
 const DEFAULT_RECENT_LIMIT: i64 = 25;
+const MAX_RECENT_LIMIT: i64 = 1000;
 
-/// No upper bound: this endpoint is consumed server-to-server. Absent falls back
-/// to the default; anything below 1 floors at 1 so a malformed value cannot make
-/// Postgres reject the query.
+/// Absent falls back to the default; the result is clamped to [1, MAX] so a
+/// malformed low value cannot make Postgres reject the query and an oversized
+/// value cannot force an unbounded scan.
 fn resolve_recent_limit(limit: Option<i64>) -> i64 {
-    limit.unwrap_or(DEFAULT_RECENT_LIMIT).max(1)
+    limit.unwrap_or(DEFAULT_RECENT_LIMIT).clamp(1, MAX_RECENT_LIMIT)
 }
 
 /// The most recent resolved shadow blocks, newest first, paged backwards by `before`.
@@ -525,11 +526,12 @@ mod tests {
     }
 
     #[test]
-    fn resolve_recent_limit_defaults_and_floors() {
+    fn resolve_recent_limit_defaults_and_clamps() {
         assert_eq!(resolve_recent_limit(None), DEFAULT_RECENT_LIMIT);
         assert_eq!(resolve_recent_limit(Some(50)), 50);
         assert_eq!(resolve_recent_limit(Some(0)), 1);
         assert_eq!(resolve_recent_limit(Some(-5)), 1);
+        assert_eq!(resolve_recent_limit(Some(MAX_RECENT_LIMIT + 1)), MAX_RECENT_LIMIT);
     }
 
     #[test]

--- a/crates/infra/shadow-metrics/src/api.rs
+++ b/crates/infra/shadow-metrics/src/api.rs
@@ -227,7 +227,9 @@ const DEFAULT_RECENT_LIMIT: i64 = 25;
 /// to the default; anything below 1 floors at 1 so a malformed value cannot make
 /// Postgres reject the query.
 fn resolve_recent_limit(limit: Option<i64>) -> i64 {
-    limit.unwrap_or(DEFAULT_RECENT_LIMIT).max(1)
+fn resolve_recent_limit(limit: Option<i64>) -> i64 {
+    limit.unwrap_or(DEFAULT_RECENT_LIMIT).clamp(1, 1000)
+}
 }
 
 /// The most recent resolved shadow blocks, newest first, paged backwards by `before`.

--- a/etc/systems/tests/shadow_metrics_reader.rs
+++ b/etc/systems/tests/shadow_metrics_reader.rs
@@ -559,3 +559,32 @@ async fn resumes_from_persisted_cursor_after_restart() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn list_recent_returns_resolved_rows_newest_first_and_pages_by_before() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    let repo = ShadowBlockRepo::new(database.pool.clone());
+    repo.flush(&reorged([
+        ShadowBlockFixture::new(300).into_row(0x01, Some(0x11)),
+        ShadowBlockFixture::new(301).into_row(0x02, None),
+        ShadowBlockFixture::new(302).into_row(0x03, Some(0x12)),
+        ShadowBlockFixture::new(303).into_row(0x04, Some(0x13)),
+    ]))
+    .await?;
+
+    let page1 = repo.list_recent(2, None).await?;
+    assert_eq!(
+        page1.iter().map(|row| row.number).collect::<Vec<_>>(),
+        [303, 302],
+        "newest resolved rows first, capped by limit"
+    );
+
+    let page2 = repo.list_recent(2, Some(page1.last().expect("page1 not empty").number)).await?;
+    assert_eq!(
+        page2.iter().map(|row| row.number).collect::<Vec<_>>(),
+        [300],
+        "before excludes the cursor row and the unresolved 301 is skipped"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Adds `GET /shadow-blocks?limit&before` returning resolved shadow blocks newest-first, backing a dense shadow-block list in internal-explorer. `list_recent` pages backwards by block number and returns only rows that have gained a canonical hash, matching the single-block summary. Consumed server-to-server, so no upper bound on `limit`.