### PR TITLE
feat(evm2): Add The Base Precompile Set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3619,6 +3619,7 @@ dependencies = [
  "base-common-evm",
  "base-common-genesis",
  "base-common-l1-fees",
+ "base-common-precompiles",
  "evm2",
  "revm",
 ]

--- a/crates/common/evm2/Cargo.toml
+++ b/crates/common/evm2/Cargo.toml
@@ -31,6 +31,8 @@ alloy-primitives.workspace = true
 # and alloy crates the tests use are already in [dependencies]; Cargo unifies features across both
 # sections, so only the dev-only crates are listed here.
 base-common-evm = { workspace = true, features = ["blst", "c-kzg", "portable", "secp256k1", "std"] }
+# base — the revm precompile set, as the source of truth for the precompile-cap parity test.
+base-common-precompiles.workspace = true
 # base — the revm transition hooks + fork schedule, for the transition-parity harness.
 base-common-chains.workspace = true
 

--- a/crates/common/evm2/src/lib.rs
+++ b/crates/common/evm2/src/lib.rs
@@ -18,6 +18,8 @@ pub use transaction::BaseTxEnvelope;
 mod handler;
 pub use handler::BaseTxHandlerHooks;
 
+mod precompiles;
+
 mod executor;
 pub use executor::{
     BaseBlockExecutionCtx, BaseBlockExecutor, BlockExecutionResult, BlockGasLimitExceeded,

--- a/crates/common/evm2/src/precompiles.rs
+++ b/crates/common/evm2/src/precompiles.rs
@@ -36,7 +36,7 @@ const BLS_PAIRING_JOVIAN_MAX: usize = 156_672;
 macro_rules! capped_precompile {
     ($(#[$attr:meta])* $name:ident, $max:expr, $halt:ident, $inner:path) => {
         $(#[$attr])*
-        fn $name(
+        pub fn $name(
             _evm: &mut Evm<'_, BaseEvmTypes>,
             message: &Message<BaseEvmTypes>,
             gas: &mut GasTracker,
@@ -50,64 +50,64 @@ macro_rules! capped_precompile {
     };
 }
 
-capped_precompile!(
-    /// bn254 pairing with the Granite input cap.
-    run_bn254_pair_granite,
-    BN254_PAIR_GRANITE_MAX,
-    Bn254PairLength,
-    bn254::pair::run_istanbul
-);
-capped_precompile!(
-    /// bn254 pairing with the Jovian input cap.
-    run_bn254_pair_jovian,
-    BN254_PAIR_JOVIAN_MAX,
-    Bn254PairLength,
-    bn254::pair::run_istanbul
-);
-capped_precompile!(
-    /// BLS12-381 G1 MSM with the Isthmus input cap.
-    run_bls_g1_msm_isthmus,
-    BLS_G1_MSM_ISTHMUS_MAX,
-    Bls12381G1MsmInputLength,
-    bls12_381::g1_msm::run
-);
-capped_precompile!(
-    /// BLS12-381 G1 MSM with the Jovian input cap.
-    run_bls_g1_msm_jovian,
-    BLS_G1_MSM_JOVIAN_MAX,
-    Bls12381G1MsmInputLength,
-    bls12_381::g1_msm::run
-);
-capped_precompile!(
-    /// BLS12-381 G2 MSM with the Isthmus input cap.
-    run_bls_g2_msm_isthmus,
-    BLS_G2_MSM_ISTHMUS_MAX,
-    Bls12381G2MsmInputLength,
-    bls12_381::g2_msm::run
-);
-capped_precompile!(
-    /// BLS12-381 G2 MSM with the Jovian input cap.
-    run_bls_g2_msm_jovian,
-    BLS_G2_MSM_JOVIAN_MAX,
-    Bls12381G2MsmInputLength,
-    bls12_381::g2_msm::run
-);
-capped_precompile!(
-    /// BLS12-381 pairing with the Isthmus input cap.
-    run_bls_pairing_isthmus,
-    BLS_PAIRING_ISTHMUS_MAX,
-    Bls12381PairingInputLength,
-    bls12_381::pairing::run
-);
-capped_precompile!(
-    /// BLS12-381 pairing with the Jovian input cap.
-    run_bls_pairing_jovian,
-    BLS_PAIRING_JOVIAN_MAX,
-    Bls12381PairingInputLength,
-    bls12_381::pairing::run
-);
-
 impl BaseEvmTypes {
+    capped_precompile!(
+        /// bn254 pairing with the Granite input cap.
+        run_bn254_pair_granite,
+        BN254_PAIR_GRANITE_MAX,
+        Bn254PairLength,
+        bn254::pair::run_istanbul
+    );
+    capped_precompile!(
+        /// bn254 pairing with the Jovian input cap.
+        run_bn254_pair_jovian,
+        BN254_PAIR_JOVIAN_MAX,
+        Bn254PairLength,
+        bn254::pair::run_istanbul
+    );
+    capped_precompile!(
+        /// BLS12-381 G1 MSM with the Isthmus input cap.
+        run_bls_g1_msm_isthmus,
+        BLS_G1_MSM_ISTHMUS_MAX,
+        Bls12381G1MsmInputLength,
+        bls12_381::g1_msm::run
+    );
+    capped_precompile!(
+        /// BLS12-381 G1 MSM with the Jovian input cap.
+        run_bls_g1_msm_jovian,
+        BLS_G1_MSM_JOVIAN_MAX,
+        Bls12381G1MsmInputLength,
+        bls12_381::g1_msm::run
+    );
+    capped_precompile!(
+        /// BLS12-381 G2 MSM with the Isthmus input cap.
+        run_bls_g2_msm_isthmus,
+        BLS_G2_MSM_ISTHMUS_MAX,
+        Bls12381G2MsmInputLength,
+        bls12_381::g2_msm::run
+    );
+    capped_precompile!(
+        /// BLS12-381 G2 MSM with the Jovian input cap.
+        run_bls_g2_msm_jovian,
+        BLS_G2_MSM_JOVIAN_MAX,
+        Bls12381G2MsmInputLength,
+        bls12_381::g2_msm::run
+    );
+    capped_precompile!(
+        /// BLS12-381 pairing with the Isthmus input cap.
+        run_bls_pairing_isthmus,
+        BLS_PAIRING_ISTHMUS_MAX,
+        Bls12381PairingInputLength,
+        bls12_381::pairing::run
+    );
+    capped_precompile!(
+        /// BLS12-381 pairing with the Jovian input cap.
+        run_bls_pairing_jovian,
+        BLS_PAIRING_JOVIAN_MAX,
+        Bls12381PairingInputLength,
+        bls12_381::pairing::run
+    );
+
     /// Returns the Base precompile set for `spec`.
     ///
     /// Starts from the stock Ethereum set for the mapped EVM2 spec ([`Precompiles::base`]) and
@@ -137,13 +137,13 @@ impl BaseEvmTypes {
             map.insert(Precompile::new(
                 BN254_PAIR_ADDRESS,
                 PrecompileId::Bn254Pairing,
-                run_bn254_pair_jovian,
+                Self::run_bn254_pair_jovian,
             ));
         } else if at(BaseUpgrade::Granite) {
             map.insert(Precompile::new(
                 BN254_PAIR_ADDRESS,
                 PrecompileId::Bn254Pairing,
-                run_bn254_pair_granite,
+                Self::run_bn254_pair_granite,
             ));
         }
 
@@ -152,33 +152,33 @@ impl BaseEvmTypes {
             map.insert(Precompile::new(
                 BLS12_G1_MSM_ADDRESS,
                 PrecompileId::Bls12G1Msm,
-                run_bls_g1_msm_jovian,
+                Self::run_bls_g1_msm_jovian,
             ));
             map.insert(Precompile::new(
                 BLS12_G2_MSM_ADDRESS,
                 PrecompileId::Bls12G2Msm,
-                run_bls_g2_msm_jovian,
+                Self::run_bls_g2_msm_jovian,
             ));
             map.insert(Precompile::new(
                 BLS12_PAIRING_ADDRESS,
                 PrecompileId::Bls12Pairing,
-                run_bls_pairing_jovian,
+                Self::run_bls_pairing_jovian,
             ));
         } else if at(BaseUpgrade::Isthmus) {
             map.insert(Precompile::new(
                 BLS12_G1_MSM_ADDRESS,
                 PrecompileId::Bls12G1Msm,
-                run_bls_g1_msm_isthmus,
+                Self::run_bls_g1_msm_isthmus,
             ));
             map.insert(Precompile::new(
                 BLS12_G2_MSM_ADDRESS,
                 PrecompileId::Bls12G2Msm,
-                run_bls_g2_msm_isthmus,
+                Self::run_bls_g2_msm_isthmus,
             ));
             map.insert(Precompile::new(
                 BLS12_PAIRING_ADDRESS,
                 PrecompileId::Bls12Pairing,
-                run_bls_pairing_isthmus,
+                Self::run_bls_pairing_isthmus,
             ));
         }
 
@@ -243,7 +243,7 @@ mod tests {
         let mut evm = evm(BaseUpgrade::Granite);
         // One byte over the Granite cap halts before doing any pairing work.
         let over = message(vec![0u8; BN254_PAIR_GRANITE_MAX + 1]);
-        let err = run_bn254_pair_granite(&mut evm, &over, &mut gas).unwrap_err();
+        let err = BaseEvmTypes::run_bn254_pair_granite(&mut evm, &over, &mut gas).unwrap_err();
         assert_eq!(err.as_halt(), Some(&PrecompileHalt::Bn254PairLength));
     }
 
@@ -254,7 +254,7 @@ mod tests {
         let mut gas = GasTracker::new(u64::MAX);
         let mut evm = evm(BaseUpgrade::Jovian);
         let over = message(vec![0u8; BN254_PAIR_JOVIAN_MAX + 1]);
-        let err = run_bn254_pair_jovian(&mut evm, &over, &mut gas).unwrap_err();
+        let err = BaseEvmTypes::run_bn254_pair_jovian(&mut evm, &over, &mut gas).unwrap_err();
         assert_eq!(err.as_halt(), Some(&PrecompileHalt::Bn254PairLength));
     }
 
@@ -263,7 +263,7 @@ mod tests {
         let mut gas = GasTracker::new(u64::MAX);
         let mut evm = evm(BaseUpgrade::Isthmus);
         let over = message(vec![0u8; BLS_PAIRING_ISTHMUS_MAX + 1]);
-        let err = run_bls_pairing_isthmus(&mut evm, &over, &mut gas).unwrap_err();
+        let err = BaseEvmTypes::run_bls_pairing_isthmus(&mut evm, &over, &mut gas).unwrap_err();
         assert_eq!(err.as_halt(), Some(&PrecompileHalt::Bls12381PairingInputLength));
     }
 

--- a/crates/common/evm2/src/precompiles.rs
+++ b/crates/common/evm2/src/precompiles.rs
@@ -1,0 +1,65 @@
+//! Base precompile set selection.
+
+use base_common_genesis::BaseUpgrade;
+use evm2::{Precompiles, precompiles::P256VERIFY};
+
+use crate::{BaseEvmTypes, BaseSpecId};
+
+impl BaseEvmTypes {
+    /// Returns the Base precompile set for `spec`.
+    ///
+    /// Starts from the stock Ethereum set for the mapped EVM2 spec ([`Precompiles::base`]) and
+    /// layers the Base-specific differences on top. Base enables RIP-7212 `P256VERIFY`
+    /// (secp256r1, `0x100`) from **Fjord**, ahead of its upstream Osaka introduction; from
+    /// **Azul** (which maps to Osaka) the Osaka-priced `P256VERIFY` is already installed by
+    /// [`Precompiles::base`], so the earlier-priced variant is only bridged for Fjord..<Azul.
+    ///
+    /// The Base-specific bn254 pairing input caps (Granite/Jovian), the Isthmus/Jovian BLS12-381
+    /// variants, and the Beryl/Cobalt dynamic precompiles (B20 factory, registries, `TxContext`,
+    /// `NonceManager`) are not yet ported and remain follow-up work.
+    pub fn precompiles(spec: BaseSpecId) -> Precompiles<Self> {
+        let upgrade = spec.upgrade();
+        let mut precompiles = Precompiles::base(spec.into());
+        if (upgrade as u8) >= (BaseUpgrade::Fjord as u8)
+            && (upgrade as u8) < (BaseUpgrade::Azul as u8)
+        {
+            precompiles.as_map_mut().insert(P256VERIFY());
+        }
+        precompiles
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+
+    use super::*;
+
+    /// The RIP-7212 secp256r1 `P256VERIFY` precompile address.
+    const P256_ADDRESS: alloy_primitives::Address =
+        address!("0x0000000000000000000000000000000000000100");
+
+    #[test]
+    fn p256_absent_before_fjord() {
+        let mut precompiles = BaseEvmTypes::precompiles(BaseSpecId::new(BaseUpgrade::Ecotone));
+        assert!(!precompiles.as_map_mut().contains(&P256_ADDRESS), "no P256 before Fjord");
+    }
+
+    #[test]
+    fn p256_present_from_fjord() {
+        for upgrade in [BaseUpgrade::Fjord, BaseUpgrade::Granite, BaseUpgrade::Isthmus] {
+            let mut precompiles = BaseEvmTypes::precompiles(BaseSpecId::new(upgrade));
+            assert!(
+                precompiles.as_map_mut().contains(&P256_ADDRESS),
+                "P256 present at {upgrade:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn p256_present_at_azul_via_osaka() {
+        // Azul maps to Osaka, where `Precompiles::base` already installs the Osaka-priced P256.
+        let mut precompiles = BaseEvmTypes::precompiles(BaseSpecId::new(BaseUpgrade::Azul));
+        assert!(precompiles.as_map_mut().contains(&P256_ADDRESS), "P256 present at Azul");
+    }
+}

--- a/crates/common/evm2/src/precompiles.rs
+++ b/crates/common/evm2/src/precompiles.rs
@@ -1,43 +1,188 @@
 //! Base precompile set selection.
 
+use alloy_primitives::{Address, address};
 use base_common_genesis::BaseUpgrade;
-use evm2::{Precompiles, precompiles::P256VERIFY};
+use evm2::{
+    Evm, Precompiles,
+    interpreter::{GasTracker, Message},
+    precompiles::{
+        P256VERIFY, Precompile, PrecompileHalt, PrecompileId, PrecompileResult, bls12_381, bn254,
+    },
+};
 
 use crate::{BaseEvmTypes, BaseSpecId};
+
+// Precompile addresses whose Base variants override the stock Ethereum entries.
+const BN254_PAIR_ADDRESS: Address = address!("0x0000000000000000000000000000000000000008");
+const BLS12_G1_MSM_ADDRESS: Address = address!("0x000000000000000000000000000000000000000c");
+const BLS12_G2_MSM_ADDRESS: Address = address!("0x000000000000000000000000000000000000000e");
+const BLS12_PAIRING_ADDRESS: Address = address!("0x000000000000000000000000000000000000000f");
+
+// Base bn254 pairing input caps (bytes): Granite introduces the cap, Jovian tightens it.
+const BN254_PAIR_GRANITE_MAX: usize = 112_687;
+const BN254_PAIR_JOVIAN_MAX: usize = 81_984;
+
+// Base BLS12-381 input caps (bytes): Isthmus introduces them, Jovian tightens them.
+const BLS_G1_MSM_ISTHMUS_MAX: usize = 513_760;
+const BLS_G1_MSM_JOVIAN_MAX: usize = 288_960;
+const BLS_G2_MSM_ISTHMUS_MAX: usize = 488_448;
+const BLS_G2_MSM_JOVIAN_MAX: usize = 278_784;
+const BLS_PAIRING_ISTHMUS_MAX: usize = 235_008;
+const BLS_PAIRING_JOVIAN_MAX: usize = 156_672;
+
+/// Defines an input-capped precompile that halts when the input exceeds `$max` and otherwise
+/// delegates to the stock evm2 precompile `$inner`. Mirrors the OP-stack precompile variants that
+/// bound calldata size at Granite/Isthmus/Jovian.
+macro_rules! capped_precompile {
+    ($(#[$attr:meta])* $name:ident, $max:expr, $halt:ident, $inner:path) => {
+        $(#[$attr])*
+        fn $name(
+            _evm: &mut Evm<'_, BaseEvmTypes>,
+            message: &Message<BaseEvmTypes>,
+            gas: &mut GasTracker,
+        ) -> PrecompileResult {
+            let input = message.input.as_ref();
+            if input.len() > $max {
+                return Err(PrecompileHalt::$halt.into());
+            }
+            $inner(input, gas)
+        }
+    };
+}
+
+capped_precompile!(
+    /// bn254 pairing with the Granite input cap.
+    run_bn254_pair_granite, BN254_PAIR_GRANITE_MAX, Bn254PairLength, bn254::pair::run_istanbul
+);
+capped_precompile!(
+    /// bn254 pairing with the Jovian input cap.
+    run_bn254_pair_jovian, BN254_PAIR_JOVIAN_MAX, Bn254PairLength, bn254::pair::run_istanbul
+);
+capped_precompile!(
+    /// BLS12-381 G1 MSM with the Isthmus input cap.
+    run_bls_g1_msm_isthmus, BLS_G1_MSM_ISTHMUS_MAX, Bls12381G1MsmInputLength, bls12_381::g1_msm::run
+);
+capped_precompile!(
+    /// BLS12-381 G1 MSM with the Jovian input cap.
+    run_bls_g1_msm_jovian, BLS_G1_MSM_JOVIAN_MAX, Bls12381G1MsmInputLength, bls12_381::g1_msm::run
+);
+capped_precompile!(
+    /// BLS12-381 G2 MSM with the Isthmus input cap.
+    run_bls_g2_msm_isthmus, BLS_G2_MSM_ISTHMUS_MAX, Bls12381G2MsmInputLength, bls12_381::g2_msm::run
+);
+capped_precompile!(
+    /// BLS12-381 G2 MSM with the Jovian input cap.
+    run_bls_g2_msm_jovian, BLS_G2_MSM_JOVIAN_MAX, Bls12381G2MsmInputLength, bls12_381::g2_msm::run
+);
+capped_precompile!(
+    /// BLS12-381 pairing with the Isthmus input cap.
+    run_bls_pairing_isthmus, BLS_PAIRING_ISTHMUS_MAX, Bls12381PairingInputLength, bls12_381::pairing::run
+);
+capped_precompile!(
+    /// BLS12-381 pairing with the Jovian input cap.
+    run_bls_pairing_jovian, BLS_PAIRING_JOVIAN_MAX, Bls12381PairingInputLength, bls12_381::pairing::run
+);
 
 impl BaseEvmTypes {
     /// Returns the Base precompile set for `spec`.
     ///
     /// Starts from the stock Ethereum set for the mapped EVM2 spec ([`Precompiles::base`]) and
-    /// layers the Base-specific differences on top. Base enables RIP-7212 `P256VERIFY`
-    /// (secp256r1, `0x100`) from **Fjord**, ahead of its upstream Osaka introduction; from
-    /// **Azul** (which maps to Osaka) the Osaka-priced `P256VERIFY` is already installed by
-    /// [`Precompiles::base`], so the earlier-priced variant is only bridged for Fjord..<Azul.
+    /// layers the Base-specific differences on top:
     ///
-    /// The Base-specific bn254 pairing input caps (Granite/Jovian), the Isthmus/Jovian BLS12-381
-    /// variants, and the Beryl/Cobalt dynamic precompiles (B20 factory, registries, `TxContext`,
-    /// `NonceManager`) are not yet ported and remain follow-up work.
+    /// - **Fjord** enables RIP-7212 `P256VERIFY` (secp256r1, `0x100`), ahead of its upstream Osaka
+    ///   introduction; from **Azul** (which maps to Osaka) the Osaka-priced variant is already
+    ///   installed by [`Precompiles::base`].
+    /// - **Granite** caps the bn254 pairing (`0x08`) input; **Jovian** tightens the cap.
+    /// - **Isthmus** caps the BLS12-381 G1/G2 MSM and pairing (`0x0c`/`0x0e`/`0x0f`) inputs;
+    ///   **Jovian** tightens those caps.
+    ///
+    /// The Beryl/Cobalt dynamic precompiles (B20 factory, registries, `TxContext`, `NonceManager`)
+    /// remain follow-up work.
     pub fn precompiles(spec: BaseSpecId) -> Precompiles<Self> {
         let upgrade = spec.upgrade();
+        let at = |fork: BaseUpgrade| (upgrade as u8) >= (fork as u8);
         let mut precompiles = Precompiles::base(spec.into());
-        if (upgrade as u8) >= (BaseUpgrade::Fjord as u8)
-            && (upgrade as u8) < (BaseUpgrade::Azul as u8)
-        {
-            precompiles.as_map_mut().insert(P256VERIFY());
+        let map = precompiles.as_map_mut();
+
+        if at(BaseUpgrade::Fjord) && !at(BaseUpgrade::Azul) {
+            map.insert(P256VERIFY());
         }
+
+        // bn254 pairing input cap: Jovian tightens the Granite cap.
+        if at(BaseUpgrade::Jovian) {
+            map.insert(Precompile::new(
+                BN254_PAIR_ADDRESS,
+                PrecompileId::Bn254Pairing,
+                run_bn254_pair_jovian,
+            ));
+        } else if at(BaseUpgrade::Granite) {
+            map.insert(Precompile::new(
+                BN254_PAIR_ADDRESS,
+                PrecompileId::Bn254Pairing,
+                run_bn254_pair_granite,
+            ));
+        }
+
+        // BLS12-381 MSM/pairing input caps: present from Isthmus (Prague BLS), tightened at Jovian.
+        if at(BaseUpgrade::Jovian) {
+            map.insert(Precompile::new(
+                BLS12_G1_MSM_ADDRESS,
+                PrecompileId::Bls12G1Msm,
+                run_bls_g1_msm_jovian,
+            ));
+            map.insert(Precompile::new(
+                BLS12_G2_MSM_ADDRESS,
+                PrecompileId::Bls12G2Msm,
+                run_bls_g2_msm_jovian,
+            ));
+            map.insert(Precompile::new(
+                BLS12_PAIRING_ADDRESS,
+                PrecompileId::Bls12Pairing,
+                run_bls_pairing_jovian,
+            ));
+        } else if at(BaseUpgrade::Isthmus) {
+            map.insert(Precompile::new(
+                BLS12_G1_MSM_ADDRESS,
+                PrecompileId::Bls12G1Msm,
+                run_bls_g1_msm_isthmus,
+            ));
+            map.insert(Precompile::new(
+                BLS12_G2_MSM_ADDRESS,
+                PrecompileId::Bls12G2Msm,
+                run_bls_g2_msm_isthmus,
+            ));
+            map.insert(Precompile::new(
+                BLS12_PAIRING_ADDRESS,
+                PrecompileId::Bls12Pairing,
+                run_bls_pairing_isthmus,
+            ));
+        }
+
         precompiles
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::address;
+    use evm2::{env::BlockEnv, evm::InMemoryDB};
 
     use super::*;
 
     /// The RIP-7212 secp256r1 `P256VERIFY` precompile address.
-    const P256_ADDRESS: alloy_primitives::Address =
-        address!("0x0000000000000000000000000000000000000100");
+    const P256_ADDRESS: Address = address!("0x0000000000000000000000000000000000000100");
+
+    /// Builds a minimal EVM at `upgrade` (the capped precompile fns ignore the EVM, but their
+    /// signature requires one).
+    fn evm(upgrade: BaseUpgrade) -> Evm<'static, BaseEvmTypes> {
+        let spec = BaseSpecId::new(upgrade);
+        Evm::new(
+            spec,
+            BlockEnv::<BaseEvmTypes>::default(),
+            BaseEvmTypes::tx_registry(),
+            InMemoryDB::default(),
+            Precompiles::base(spec.into()),
+        )
+    }
 
     #[test]
     fn p256_absent_before_fjord() {
@@ -61,5 +206,52 @@ mod tests {
         // Azul maps to Osaka, where `Precompiles::base` already installs the Osaka-priced P256.
         let mut precompiles = BaseEvmTypes::precompiles(BaseSpecId::new(BaseUpgrade::Azul));
         assert!(precompiles.as_map_mut().contains(&P256_ADDRESS), "P256 present at Azul");
+    }
+
+    /// Builds a message carrying `input` bytes, for driving a precompile.
+    fn message(input: Vec<u8>) -> Message<BaseEvmTypes> {
+        Message::<BaseEvmTypes> { input: input.into(), ..Default::default() }
+    }
+
+    #[test]
+    fn bn254_pairing_granite_cap_halts_oversized_input() {
+        let mut gas = GasTracker::new(u64::MAX);
+        let mut evm = evm(BaseUpgrade::Granite);
+        // One byte over the Granite cap halts before doing any pairing work.
+        let over = message(vec![0u8; BN254_PAIR_GRANITE_MAX + 1]);
+        let err = run_bn254_pair_granite(&mut evm, &over, &mut gas).unwrap_err();
+        assert_eq!(err.as_halt(), Some(&PrecompileHalt::Bn254PairLength));
+    }
+
+    #[test]
+    fn bn254_pairing_jovian_cap_halts_oversized_input() {
+        // The Jovian cap is tighter than Granite: an input between the two caps is allowed under
+        // Granite but halts under the Jovian variant.
+        let mut gas = GasTracker::new(u64::MAX);
+        let mut evm = evm(BaseUpgrade::Jovian);
+        let over = message(vec![0u8; BN254_PAIR_JOVIAN_MAX + 1]);
+        let err = run_bn254_pair_jovian(&mut evm, &over, &mut gas).unwrap_err();
+        assert_eq!(err.as_halt(), Some(&PrecompileHalt::Bn254PairLength));
+    }
+
+    #[test]
+    fn bls_pairing_isthmus_cap_halts_oversized_input() {
+        let mut gas = GasTracker::new(u64::MAX);
+        let mut evm = evm(BaseUpgrade::Isthmus);
+        let over = message(vec![0u8; BLS_PAIRING_ISTHMUS_MAX + 1]);
+        let err = run_bls_pairing_isthmus(&mut evm, &over, &mut gas).unwrap_err();
+        assert_eq!(err.as_halt(), Some(&PrecompileHalt::Bls12381PairingInputLength));
+    }
+
+    #[test]
+    fn base_precompiles_install_bn254_and_bls_caps() {
+        // Granite installs the bn254 pairing cap; Isthmus additionally installs the BLS caps.
+        let mut isthmus = BaseEvmTypes::precompiles(BaseSpecId::new(BaseUpgrade::Isthmus));
+        let map = isthmus.as_map_mut();
+        for address in
+            [BN254_PAIR_ADDRESS, BLS12_G1_MSM_ADDRESS, BLS12_G2_MSM_ADDRESS, BLS12_PAIRING_ADDRESS]
+        {
+            assert!(map.contains(&address), "expected a precompile at {address}");
+        }
     }
 }

--- a/crates/common/evm2/src/precompiles.rs
+++ b/crates/common/evm2/src/precompiles.rs
@@ -52,35 +52,59 @@ macro_rules! capped_precompile {
 
 capped_precompile!(
     /// bn254 pairing with the Granite input cap.
-    run_bn254_pair_granite, BN254_PAIR_GRANITE_MAX, Bn254PairLength, bn254::pair::run_istanbul
+    run_bn254_pair_granite,
+    BN254_PAIR_GRANITE_MAX,
+    Bn254PairLength,
+    bn254::pair::run_istanbul
 );
 capped_precompile!(
     /// bn254 pairing with the Jovian input cap.
-    run_bn254_pair_jovian, BN254_PAIR_JOVIAN_MAX, Bn254PairLength, bn254::pair::run_istanbul
+    run_bn254_pair_jovian,
+    BN254_PAIR_JOVIAN_MAX,
+    Bn254PairLength,
+    bn254::pair::run_istanbul
 );
 capped_precompile!(
     /// BLS12-381 G1 MSM with the Isthmus input cap.
-    run_bls_g1_msm_isthmus, BLS_G1_MSM_ISTHMUS_MAX, Bls12381G1MsmInputLength, bls12_381::g1_msm::run
+    run_bls_g1_msm_isthmus,
+    BLS_G1_MSM_ISTHMUS_MAX,
+    Bls12381G1MsmInputLength,
+    bls12_381::g1_msm::run
 );
 capped_precompile!(
     /// BLS12-381 G1 MSM with the Jovian input cap.
-    run_bls_g1_msm_jovian, BLS_G1_MSM_JOVIAN_MAX, Bls12381G1MsmInputLength, bls12_381::g1_msm::run
+    run_bls_g1_msm_jovian,
+    BLS_G1_MSM_JOVIAN_MAX,
+    Bls12381G1MsmInputLength,
+    bls12_381::g1_msm::run
 );
 capped_precompile!(
     /// BLS12-381 G2 MSM with the Isthmus input cap.
-    run_bls_g2_msm_isthmus, BLS_G2_MSM_ISTHMUS_MAX, Bls12381G2MsmInputLength, bls12_381::g2_msm::run
+    run_bls_g2_msm_isthmus,
+    BLS_G2_MSM_ISTHMUS_MAX,
+    Bls12381G2MsmInputLength,
+    bls12_381::g2_msm::run
 );
 capped_precompile!(
     /// BLS12-381 G2 MSM with the Jovian input cap.
-    run_bls_g2_msm_jovian, BLS_G2_MSM_JOVIAN_MAX, Bls12381G2MsmInputLength, bls12_381::g2_msm::run
+    run_bls_g2_msm_jovian,
+    BLS_G2_MSM_JOVIAN_MAX,
+    Bls12381G2MsmInputLength,
+    bls12_381::g2_msm::run
 );
 capped_precompile!(
     /// BLS12-381 pairing with the Isthmus input cap.
-    run_bls_pairing_isthmus, BLS_PAIRING_ISTHMUS_MAX, Bls12381PairingInputLength, bls12_381::pairing::run
+    run_bls_pairing_isthmus,
+    BLS_PAIRING_ISTHMUS_MAX,
+    Bls12381PairingInputLength,
+    bls12_381::pairing::run
 );
 capped_precompile!(
     /// BLS12-381 pairing with the Jovian input cap.
-    run_bls_pairing_jovian, BLS_PAIRING_JOVIAN_MAX, Bls12381PairingInputLength, bls12_381::pairing::run
+    run_bls_pairing_jovian,
+    BLS_PAIRING_JOVIAN_MAX,
+    Bls12381PairingInputLength,
+    bls12_381::pairing::run
 );
 
 impl BaseEvmTypes {

--- a/crates/common/evm2/src/precompiles.rs
+++ b/crates/common/evm2/src/precompiles.rs
@@ -244,6 +244,23 @@ mod tests {
     }
 
     #[test]
+    fn cap_constants_match_the_revm_reference() {
+        // Pin every input cap to the revm `base-common-precompiles` source of truth so the two
+        // engines can never silently diverge on the OP-stack calldata-size bounds.
+        assert_eq!(BN254_PAIR_GRANITE_MAX, base_common_precompiles::GRANITE_MAX_INPUT_SIZE);
+        assert_eq!(BN254_PAIR_JOVIAN_MAX, base_common_precompiles::JOVIAN_MAX_INPUT_SIZE);
+        assert_eq!(BLS_G1_MSM_ISTHMUS_MAX, base_common_precompiles::ISTHMUS_G1_MSM_MAX_INPUT_SIZE);
+        assert_eq!(BLS_G1_MSM_JOVIAN_MAX, base_common_precompiles::JOVIAN_G1_MSM_MAX_INPUT_SIZE);
+        assert_eq!(BLS_G2_MSM_ISTHMUS_MAX, base_common_precompiles::ISTHMUS_G2_MSM_MAX_INPUT_SIZE);
+        assert_eq!(BLS_G2_MSM_JOVIAN_MAX, base_common_precompiles::JOVIAN_G2_MSM_MAX_INPUT_SIZE);
+        assert_eq!(
+            BLS_PAIRING_ISTHMUS_MAX,
+            base_common_precompiles::ISTHMUS_PAIRING_MAX_INPUT_SIZE
+        );
+        assert_eq!(BLS_PAIRING_JOVIAN_MAX, base_common_precompiles::JOVIAN_PAIRING_MAX_INPUT_SIZE);
+    }
+
+    #[test]
     fn base_precompiles_install_bn254_and_bls_caps() {
         // Granite installs the bn254 pairing cap; Isthmus additionally installs the BLS caps.
         let mut isthmus = BaseEvmTypes::precompiles(BaseSpecId::new(BaseUpgrade::Isthmus));


### PR DESCRIPTION
## Summary

Adds the Base-specific precompile set to base-common-evm2, including the Fjord P256VERIFY precompile and the bn254 and BLS input-size caps. The precompiles are pinned to the revm base-common-evm reference so both engines accept and reject the same inputs. This is the second PR in the EVM2-integration stack, built on the block-executor completeness work.
