### PR TITLE
ci: fix release binary build dependencies

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -67,7 +67,13 @@ jobs:
         if: matrix.target.os == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libclang-dev pkg-config
+          sudo apt-get install -y libclang-dev pkg-config protobuf-compiler
+
+      - name: Install Go for basectl
+        if: matrix.binary == 'basectl'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.24.x'
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
@@ -85,6 +91,13 @@ jobs:
 
       - name: Build binary
         run: |
+          if [ "${{ matrix.target.triple }}" = "aarch64-unknown-linux-gnu" ]; then
+            case "${{ matrix.binary }}" in
+              base|base-consensus|basectl)
+                export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-lblst"
+                ;;
+            esac
+          fi
           cargo build --locked --profile maxperf --bin "${{ matrix.binary }}"
 
       - name: Package binary


### PR DESCRIPTION
## Summary
- install protobuf-compiler in release Linux binary jobs so SP1/prost build scripts can find protoc
- install Go 1.24.x for basectl release builds because sp1-recursion-gnark-ffi builds a Go c-archive
- add a targeted Linux arm64 RUSTFLAGS workaround for base/base-consensus/basectl so c-kzg can resolve blst symbols during static linking

## Failure analysis
Release run https://github.com/base/base/actions/runs/33424528855 failed in:
- build-binaries / linux x86_64 / basectl: sp1-prover-types could not find protoc
- build-binaries / linux arm64 / basectl: sp1-prover-types could not find protoc
- build-binaries / macOS arm64 / basectl: sp1-recursion-gnark-ffi panicked because go was not found
- build-binaries / linux arm64 / base-consensus: linker failed with unresolved blst_* symbols referenced by libckzg.a

## Validation
- git diff --check
- local cargo build --locked --profile maxperf --bin basectl progressed past the protoc and Go build-script failures; it later failed in this sandbox because sp1-core-executor-runner tried to write into the read-only local Cargo registry cache