### PR TITLE
fix(precompiles): activation registry rejects nonzero value from Cobalt (BOP-599)

### DIFF
--- a/crates/common/precompiles/src/activation/abi.rs
+++ b/crates/common/precompiles/src/activation/abi.rs
@@ -39,6 +39,9 @@ sol! {
         /// The new admin address is zero.
         error ZeroAdminAddress();
 
+        /// ETH was attached to a call targeting a nonpayable activation-registry selector.
+        error NonPayable();
+
         /// Returns true when `feature` is activated.
         function isActivated(bytes32 feature) external view returns (bool);
 

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -2,6 +2,7 @@
 
 use alloy_primitives::Bytes;
 use alloy_sol_types::SolCall;
+use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
@@ -18,8 +19,15 @@ impl ActivationRegistryStorage<'_> {
         ctx: StorageCtx<'_>,
         calldata: &[u8],
         admin_config: ActivationAdminConfig,
+        upgrade: BaseUpgrade,
     ) -> PrecompileResult {
-        self.dispatch_with_observer(ctx, calldata, admin_config, NoopPrecompileCallObserver)
+        self.dispatch_with_observer(
+            ctx,
+            calldata,
+            admin_config,
+            upgrade,
+            NoopPrecompileCallObserver,
+        )
     }
 
     /// ABI-dispatches activation registry calldata with an observer.
@@ -28,6 +36,7 @@ impl ActivationRegistryStorage<'_> {
         ctx: StorageCtx<'_>,
         calldata: &[u8],
         admin_config: ActivationAdminConfig,
+        upgrade: BaseUpgrade,
         observer: O,
     ) -> PrecompileResult
     where
@@ -35,6 +44,15 @@ impl ActivationRegistryStorage<'_> {
     {
         let mut recorder =
             BerylCallRecorder::start(observer, BerylMetricLabels::activation_call(calldata));
+        // Activation-registry selectors are all nonpayable; reject attached ETH from Cobalt
+        // onward. Pre-Cobalt (Beryl) preserves the historical accept-and-strand behavior so
+        // replay of live-installed activation calls remains byte-identical.
+        if upgrade >= BaseUpgrade::Cobalt && !ctx.call_value().is_zero() {
+            return recorder.record_base_error_result(
+                ctx,
+                BasePrecompileError::revert(IActivationRegistry::NonPayable {}),
+            );
+        }
         if let Err(error) = recorder.deduct_calldata_gas(ctx, calldata) {
             return recorder.record_base_error_result(ctx, error);
         }
@@ -82,8 +100,9 @@ impl ActivationRegistryStorage<'_> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, Bytes, address};
-    use alloy_sol_types::SolCall;
+    use alloy_primitives::{Address, B256, Bytes, U256, address};
+    use alloy_sol_types::{SolCall, SolError};
+    use base_common_genesis::BaseUpgrade;
     use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
 
     use crate::{ActivationAdminConfig, ActivationRegistryStorage, IActivationRegistry};
@@ -106,7 +125,12 @@ mod tests {
             storage.set_caller(ADMIN);
 
             let output = StorageCtx::enter(&mut storage, |ctx| {
-                ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, STATIC_ADMIN_CONFIG)
+                ActivationRegistryStorage::new(ctx).dispatch(
+                    ctx,
+                    &calldata,
+                    STATIC_ADMIN_CONFIG,
+                    BaseUpgrade::Beryl,
+                )
             })
             .expect("unknown selector must be returned as a revert");
 
@@ -128,10 +152,71 @@ mod tests {
             Bytes::from(IActivationRegistry::setAdminCall { newAdmin: NEW_ADMIN }.abi_encode());
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, STATE_ADMIN_CONFIG)
+            ActivationRegistryStorage::new(ctx).dispatch(
+                ctx,
+                &calldata,
+                STATE_ADMIN_CONFIG,
+                BaseUpgrade::Cobalt,
+            )
         })
         .expect("setAdmin must not fatally error");
 
         assert!(output.is_success(), "setAdmin must succeed once state-backed admin is enabled");
+    }
+
+    #[test]
+    fn dispatch_rejects_call_with_nonzero_value_at_cobalt() {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+        storage.set_call_value(U256::from(1u64));
+
+        // A read-only, unauthenticated selector — the exact path an attacker uses to strand ETH.
+        let calldata =
+            IActivationRegistry::isActivatedCall { feature: B256::ZERO }.abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).dispatch(
+                ctx,
+                &calldata,
+                STATE_ADMIN_CONFIG,
+                BaseUpgrade::Cobalt,
+            )
+        })
+        .expect("nonzero value must revert, not fatally error");
+
+        assert!(output.is_revert());
+        assert_eq!(
+            output.bytes,
+            Bytes::from(IActivationRegistry::NonPayable {}.abi_encode()),
+        );
+    }
+
+    #[test]
+    fn dispatch_accepts_nonzero_value_before_cobalt() {
+        // Consensus safety: pre-Cobalt (Beryl) must NOT emit the new NonPayable revert, otherwise
+        // replay of live-installed activation calls that carried ETH would diverge.
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_caller(ADMIN);
+        storage.set_call_value(U256::from(1u64));
+
+        let calldata =
+            IActivationRegistry::isActivatedCall { feature: B256::ZERO }.abi_encode();
+
+        let output = StorageCtx::enter(&mut storage, |ctx| {
+            ActivationRegistryStorage::new(ctx).dispatch(
+                ctx,
+                &calldata,
+                STATIC_ADMIN_CONFIG,
+                BaseUpgrade::Beryl,
+            )
+        })
+        .expect("Beryl replay must not fatally error on nonzero value");
+
+        assert!(output.is_success(), "pre-Cobalt must accept nonzero value (legacy behavior)");
+        assert_ne!(
+            output.bytes,
+            Bytes::from(IActivationRegistry::NonPayable {}.abi_encode()),
+            "pre-Cobalt must never emit NonPayable",
+        );
     }
 }

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -171,8 +171,7 @@ mod tests {
         storage.set_call_value(U256::from(1u64));
 
         // A read-only, unauthenticated selector — the exact path an attacker uses to strand ETH.
-        let calldata =
-            IActivationRegistry::isActivatedCall { feature: B256::ZERO }.abi_encode();
+        let calldata = IActivationRegistry::isActivatedCall { feature: B256::ZERO }.abi_encode();
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
             ActivationRegistryStorage::new(ctx).dispatch(
@@ -185,10 +184,7 @@ mod tests {
         .expect("nonzero value must revert, not fatally error");
 
         assert!(output.is_revert());
-        assert_eq!(
-            output.bytes,
-            Bytes::from(IActivationRegistry::NonPayable {}.abi_encode()),
-        );
+        assert_eq!(output.bytes, Bytes::from(IActivationRegistry::NonPayable {}.abi_encode()));
     }
 
     #[test]
@@ -199,8 +195,7 @@ mod tests {
         storage.set_caller(ADMIN);
         storage.set_call_value(U256::from(1u64));
 
-        let calldata =
-            IActivationRegistry::isActivatedCall { feature: B256::ZERO }.abi_encode();
+        let calldata = IActivationRegistry::isActivatedCall { feature: B256::ZERO }.abi_encode();
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
             ActivationRegistryStorage::new(ctx).dispatch(

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// Entry point for the activation registry precompile.
-#[precompile(args(admin_config: ActivationAdminConfig))]
+#[precompile(args(admin_config: ActivationAdminConfig, upgrade: BaseUpgrade))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ActivationRegistry;
 
@@ -75,6 +75,7 @@ impl ActivationRegistry {
                 ctx,
                 &calldata,
                 admin_config,
+                upgrade,
                 observer,
             )
             }

--- a/crates/common/precompiles/src/activation/storage.rs
+++ b/crates/common/precompiles/src/activation/storage.rs
@@ -248,6 +248,7 @@ impl ActivationRegistryStorage<'_> {
 mod tests {
     use alloy_primitives::{Address, B256, U256, address, keccak256, uint};
     use alloy_sol_types::{SolCall, SolEvent};
+    use base_common_genesis::BaseUpgrade;
     use base_precompile_storage::{
         BasePrecompileError, HashMapStorageProvider, PrecompileOutput, Result, StorageCtx,
         StorageKey,
@@ -722,7 +723,12 @@ mod tests {
         let calldata = IActivationRegistry::deactivateCall { feature: FEATURE }.abi_encode();
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, STATIC_ADMIN_CONFIG)
+            ActivationRegistryStorage::new(ctx).dispatch(
+                ctx,
+                &calldata,
+                STATIC_ADMIN_CONFIG,
+                BaseUpgrade::Beryl,
+            )
         })
         .expect("dispatch must not fatally error");
 
@@ -743,7 +749,12 @@ mod tests {
         let calldata = IActivationRegistry::activateCall { feature: FEATURE }.abi_encode();
 
         let output = StorageCtx::enter(&mut storage, |ctx| {
-            ActivationRegistryStorage::new(ctx).dispatch(ctx, &calldata, STATIC_ADMIN_CONFIG)
+            ActivationRegistryStorage::new(ctx).dispatch(
+                ctx,
+                &calldata,
+                STATIC_ADMIN_CONFIG,
+                BaseUpgrade::Beryl,
+            )
         })
         .expect("dispatch must not fatally error");
 


### PR DESCRIPTION
## Summary

- Adds `NonPayable()` to `IActivationRegistry` and rejects nonzero `call_value` at the top of `dispatch_with_observer`, mirroring the guard `nonce`, `tx_context`, `policy`, `b20_asset`, `b20_stablecoin`, and `b20_factory` already install.
- Threads the active `BaseUpgrade` through the activation dispatcher and gates the new guard behind `upgrade >= BaseUpgrade::Cobalt`. Pre-Cobalt (Beryl) behavior is byte-identical — no consensus divergence on replay.

## Context

Cantina finding #12 (Low, Jay). `dispatch_with_observer` never inspected `ctx.call_value()`. Since `isActivated` / `checkActivated` require no authorization, any caller could reach a successful dispatch while carrying ETH, stranding value at the precompile address with no bytecode able to recover it. This also broke a crate-wide invariant: activation was the sole precompile whose interface didn't even define `NonPayable`.

Because this changes revert behavior on live-installed precompile calls, it is execution-consensus-affecting. The guard is therefore inert for `upgrade < BaseUpgrade::Cobalt`.

## Approach

- `abi.rs`: added `error NonPayable();` to `sol! interface IActivationRegistry`. New selector, no impact on existing decoding.
- `dispatch.rs`: `dispatch` / `dispatch_with_observer` now accept `upgrade: BaseUpgrade`. Guard runs immediately after `BerylCallRecorder::start`, before `deduct_calldata_gas`, matching `b20_stablecoin/dispatch.rs`.
- `precompile.rs`: extended the `#[precompile(args(...))]` attribute so the macro-generated `precompile(...)` forwards `upgrade`; the manual `precompile_with_observer` closure also forwards it.
- `storage.rs`: two SSTORE-refund tests updated to pass `BaseUpgrade::Beryl`.

## Test plan

- [x] `cargo test -p base-common-precompiles activation::` — 33 tests pass, including new `dispatch_rejects_call_with_nonzero_value_at_cobalt` and `dispatch_accepts_nonzero_value_before_cobalt` (consensus-safety guard).
- [x] `cargo test -p base-common-precompiles` — 669 unit + 39 integration tests pass.
- [x] `cargo clippy -p base-common-precompiles --all-targets -- -D warnings` clean.

## Links

- Linear: [BOP-599](https://linear.app/coinbase/issue/BOP-599)
- Cantina: [finding #12](https://cantina.xyz/code/3a3e0d24-1cb7-474c-87ef-f0ad2350b5c4/findings/12)