### PR TITLE
ci: scope aarch64 release link arg to final binary

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -94,8 +94,8 @@ jobs:
           if [ "${{ matrix.target.triple }}" = "aarch64-unknown-linux-gnu" ]; then
             case "${{ matrix.binary }}" in
               base|base-consensus|basectl)
-                export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-lblst"
-                ;;
+                cargo rustc --locked --profile maxperf -p "${{ matrix.binary }}" --bin "${{ matrix.binary }}" -- -C link-arg=-lblst
+                exit
             esac
           fi
           cargo build --locked --profile maxperf --bin "${{ matrix.binary }}"


### PR DESCRIPTION
## Summary
- replace the aarch64 release-job RUSTFLAGS workaround with a cargo rustc invocation
- keep the extra -lblst link arg scoped to the selected final binary only
- avoid passing -lblst to host build scripts before BLST has been built

## Failure analysis
Follow-up release job https://github.com/base/base/actions/runs/33434252927/job/99627011721 failed immediately while compiling host build scripts such as proc-macro2, quote, and serde_core. The merged PR exported RUSTFLAGS=-C link-arg=-lblst for the whole cargo build, so Cargo also passed -lblst to build-script links. At that point the BLST build output path does not exist yet, so ld failed with cannot find -lblst.

Using cargo rustc -p ... --bin ... -- -C link-arg=-lblst leaves dependency and build-script compilation untouched, then applies the additional linker argument only to the final release binary link where the original c-kzg/blst archive-order issue occurs.

## Validation
- git diff --check
- verified commit signature locally
- locally tested the corrected command from a fresh target dir on this x86_64 host:

  ```bash
  CARGO_TARGET_DIR=/tmp/base-release-link-test cargo rustc --locked --profile maxperf -p base-consensus --bin base-consensus -- -C link-arg=-lblst
  ```

  Result:

  ```text
  Finished `maxperf` profile [optimized] target(s) in 4m 30s
  ```

  This is not a native arm64 reproduction, but it does verify the important regression fix: host build scripts compile from scratch without receiving the extra -lblst linker arg, and the extra linker arg is accepted when scoped to the final binary invocation.