### PR TITLE
fix(ci): use lld for rust service Docker builds

### DIFF
--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -4,7 +4,7 @@ FROM public.ecr.aws/docker/library/rust:${RUST_VERSION}-trixie AS rust-builder-b
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      git libclang-dev libssl-dev pkg-config curl build-essential cmake \
+      git libclang-dev libssl-dev pkg-config curl build-essential cmake lld \
       protobuf-compiler libprotobuf-dev && \
     rm -rf /var/lib/apt/lists/*
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
@@ -13,6 +13,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 ENV RUSTC_WRAPPER=sccache
 ENV SCCACHE_DIR=/sccache
 ENV CARGO_INCREMENTAL=0
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=lld"
 
 FROM rust-builder-base AS zk-builder-base
 RUN apt-get update && \


### PR DESCRIPTION
## Summary

- install `lld` in the Rust services Docker builder image
- set Docker Rust builds to pass `-fuse-ld=lld`

## Why

The arm64 Build and Push node job was failing while linking `base-consensus`:

```text
ckzg.c:(.text.bytes_from_g1+0x0): undefined reference to `blst_p1_compress'
```

The failing linker line placed the static Rust `blst` rlib before `-lckzg`, then `libckzg.a` referenced `blst_*` symbols later. GNU ld does not resolve that static archive back-reference in this ordering. Using lld avoids the ordering-sensitive failure for these Docker Rust builds.

## Verification

- `git diff --check`
- Depot arm64 `base` bake passed with this Dockerfile fix before rebasing: `g6q5mkmzzh`
- Rebased arm64 Depot bake `h74n6xphjb` passed the previously failing `base-consensus` link point; I canceled it during a long final optimized link after the original failure no longer reproduced
- Local amd64 Docker build passed before the final lld-only change, and `base-reth-node --help` smoke test succeeded
