### PR TITLE
chore(eip8130): re-pin canonical addresses for collapsed import

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -46,46 +46,46 @@ impl Eip8130Contracts {
 
     /// Account Configuration system contract (`ACCOUNT_CONFIG_ADDRESS`). The
     /// protocol reads actor/account state directly from this contract's storage.
-    pub const ACCOUNT_CONFIG: Address = address!("0x8130297f0DBDcFAf948368Ec9D8D4D58bC7100ac");
+    pub const ACCOUNT_CONFIG: Address = address!("0x813012Bd8D971928475235BBac6F0488c4A100AC");
 
     /// Per-contract mined CREATE2 salt for [`Self::ACCOUNT_CONFIG`], yielding its
     /// `0x8130…` vanity address.
     pub const ACCOUNT_CONFIG_SALT: B256 =
-        b256!("0x4532130eeecf79d53e3a4dc69e4d6f4f87bc9aa359c8942993d7b7b1432e3c4c");
+        b256!("0xd5fe4abe7c2e23a731e7835e5e0ab0445758c8de819e8dd180528e7dcddd79c0");
 
     /// keccak256 of the `ACCOUNT_CONFIG` deployment init code (for CREATE2
     /// derivation and bytecode-drift detection).
     pub const ACCOUNT_CONFIG_INIT_CODE_HASH: B256 =
-        b256!("0x909d1f65c75dddbc9bbdb852b44dae144f0f48e98417b5e564f9a92ac28a6561");
+        b256!("0x60fe45aa9ff559770214f6488ec559057fdefff4fead53ecd8e3711802bbdf9f");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Account implementations (init code embeds `ACCOUNT_CONFIG`)
     // ─────────────────────────────────────────────────────────────────────────
 
     /// Default wallet implementation, used as the target of default EOA delegation.
-    pub const DEFAULT_ACCOUNT: Address = address!("0x8130f934D3D3B962d928B574d5341c7c97E4AdEF");
+    pub const DEFAULT_ACCOUNT: Address = address!("0x81305170f491e4E313ee37C6A27d1E4A6B76aDEf");
 
     /// Per-contract mined CREATE2 salt for [`Self::DEFAULT_ACCOUNT`].
     pub const DEFAULT_ACCOUNT_SALT: B256 =
-        b256!("0x00000000000000000000000000000000000000000000000000000001ac07d4e2");
+        b256!("0x000000000000000000000000000000000000000000000000000000011360fcfe");
 
     /// keccak256 of the `DEFAULT_ACCOUNT` deployment init code.
     pub const DEFAULT_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0xbb640b1f4cc889b64440d8a07a5d1577247aec7fb1996a617224e8a9f30df6ca");
+        b256!("0x3ff654b7c4a56715cfbdfbdb9a5829bf18d28618c167834db2e0b98652f09f2e");
 
     /// Canonical high-rate payer account implementation
     /// (`CanonicalHighRatePayerAccount`). Wallets that block ETH transfers when
     /// locked, granting higher EIP-8130 mempool access (rate limits).
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT: Address =
-        address!("0x813065610C51316A3F9498784Fc038E4b640Fa57");
+        address!("0x81303Fb4E3d037a8649c2Dc7A968Da336c20fA57");
 
     /// Per-contract mined CREATE2 salt for [`Self::CANONICAL_HIGH_RATE_PAYER_ACCOUNT`].
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT_SALT: B256 =
-        b256!("0x0000000000000000000000000000000000000000000000000000000173ed1462");
+        b256!("0x000000000000000000000000000000000000000000000000000000016413f8b0");
 
     /// keccak256 of the `CANONICAL_HIGH_RATE_PAYER_ACCOUNT` deployment init code.
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0xc12fc0cce1ac362ab0c5073bea285004a6a34f00644ebdd5a068904d5d1b8078");
+        b256!("0xeca6026c72f4fbc315cf71e2be26bc7a6fe651f2c3c8e7c2519ff23ed5ba96e5");
 
     /// keccak256 of the ERC-1167 minimal-proxy *runtime* bytecode whose
     /// implementation is [`Self::CANONICAL_HIGH_RATE_PAYER_ACCOUNT`]:
@@ -97,7 +97,7 @@ impl Eip8130Contracts {
     /// Used to recognize high-rate payer accounts by codehash (e.g. mempool
     /// admission) without resolving an EIP-7702 delegation target.
     pub const CANONICAL_HIGH_RATE_PAYER_PROXY_CODE_HASH: B256 =
-        b256!("0x6cba95b9880aae4d0540f0f42ae50e423ba969552244dc3c80f2d4c45c4431c1");
+        b256!("0xf0379ea075edd442fb30c0bd253734fd2f364ed682e1f63e05bfbb954c67c8cb");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Canonical authenticators (accepted on the EIP-8130 block-validation path)
@@ -134,15 +134,15 @@ impl Eip8130Contracts {
     /// Delegated-validation (1-hop) authenticator contract (init code embeds
     /// `ACCOUNT_CONFIG`).
     pub const DELEGATE_AUTHENTICATOR: Address =
-        address!("0x81300AF9F2E3C620eD0F666fb114bEF50cedADE1");
+        address!("0x81301AA52202f8C6b79Cde660440E3c6A7c5ade1");
 
     /// Per-contract mined CREATE2 salt for [`Self::DELEGATE_AUTHENTICATOR`].
     pub const DELEGATE_AUTHENTICATOR_SALT: B256 =
-        b256!("0x00000000000000000000000000000000000000000000000000000000695d3247");
+        b256!("0x000000000000000000000000000000000000000000000000000000012b221529");
 
     /// keccak256 of the `DELEGATE_AUTHENTICATOR` deployment init code.
     pub const DELEGATE_AUTHENTICATOR_INIT_CODE_HASH: B256 =
-        b256!("0xdc379a77f7ef26ccea53ffbf6281d96502af1d05d1b0f1c41d78812b78520d8e");
+        b256!("0x0fa70638e780cea7b2a6305f13b2155e9dfb211e4e31f57a14863031c9c65035");
 
     /// The canonical authenticator allowlist: the deployed `IAuthenticator`
     /// contracts a compliant node accepts on the EIP-8130 block-validation path.

--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -46,46 +46,46 @@ impl Eip8130Contracts {
 
     /// Account Configuration system contract (`ACCOUNT_CONFIG_ADDRESS`). The
     /// protocol reads actor/account state directly from this contract's storage.
-    pub const ACCOUNT_CONFIG: Address = address!("0x813079205F4cFCC0bE8166be1C7F863Db8A700AC");
+    pub const ACCOUNT_CONFIG: Address = address!("0x8130297f0DBDcFAf948368Ec9D8D4D58bC7100ac");
 
     /// Per-contract mined CREATE2 salt for [`Self::ACCOUNT_CONFIG`], yielding its
     /// `0x8130…` vanity address.
     pub const ACCOUNT_CONFIG_SALT: B256 =
-        b256!("0x544ebe415c98e81edc2101578e9389396d270c2af154129832b643549b08a819");
+        b256!("0x4532130eeecf79d53e3a4dc69e4d6f4f87bc9aa359c8942993d7b7b1432e3c4c");
 
     /// keccak256 of the `ACCOUNT_CONFIG` deployment init code (for CREATE2
     /// derivation and bytecode-drift detection).
     pub const ACCOUNT_CONFIG_INIT_CODE_HASH: B256 =
-        b256!("0x70eb4641a426e42492d0730a934d831dbe0963321fb55860d6246c35145349da");
+        b256!("0x909d1f65c75dddbc9bbdb852b44dae144f0f48e98417b5e564f9a92ac28a6561");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Account implementations (init code embeds `ACCOUNT_CONFIG`)
     // ─────────────────────────────────────────────────────────────────────────
 
     /// Default wallet implementation, used as the target of default EOA delegation.
-    pub const DEFAULT_ACCOUNT: Address = address!("0x8130f53536097991a3AD949D9a1D76E1b666aDEf");
+    pub const DEFAULT_ACCOUNT: Address = address!("0x8130f934D3D3B962d928B574d5341c7c97E4AdEF");
 
     /// Per-contract mined CREATE2 salt for [`Self::DEFAULT_ACCOUNT`].
     pub const DEFAULT_ACCOUNT_SALT: B256 =
-        b256!("0x000000000000000000000000000000000000000000000000000000030924c784");
+        b256!("0x00000000000000000000000000000000000000000000000000000001ac07d4e2");
 
     /// keccak256 of the `DEFAULT_ACCOUNT` deployment init code.
     pub const DEFAULT_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0xf99c7ecb38528e8f0b209f476b3cbbba8f4f8f83161e9e54945e9a041ee8ee2b");
+        b256!("0xbb640b1f4cc889b64440d8a07a5d1577247aec7fb1996a617224e8a9f30df6ca");
 
     /// Canonical high-rate payer account implementation
     /// (`CanonicalHighRatePayerAccount`). Wallets that block ETH transfers when
     /// locked, granting higher EIP-8130 mempool access (rate limits).
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT: Address =
-        address!("0x8130A75698ace565afeae1fa36a327248D93fA57");
+        address!("0x813065610C51316A3F9498784Fc038E4b640Fa57");
 
     /// Per-contract mined CREATE2 salt for [`Self::CANONICAL_HIGH_RATE_PAYER_ACCOUNT`].
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT_SALT: B256 =
-        b256!("0x00000000000000000000000000000000000000000000000000000001f53faf75");
+        b256!("0x0000000000000000000000000000000000000000000000000000000173ed1462");
 
     /// keccak256 of the `CANONICAL_HIGH_RATE_PAYER_ACCOUNT` deployment init code.
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0x92cddd461fb1c1ab9297cef0ff86ed2d59d9c14a6399c5e71d262e5e2dade5c4");
+        b256!("0xc12fc0cce1ac362ab0c5073bea285004a6a34f00644ebdd5a068904d5d1b8078");
 
     /// keccak256 of the ERC-1167 minimal-proxy *runtime* bytecode whose
     /// implementation is [`Self::CANONICAL_HIGH_RATE_PAYER_ACCOUNT`]:
@@ -97,7 +97,7 @@ impl Eip8130Contracts {
     /// Used to recognize high-rate payer accounts by codehash (e.g. mempool
     /// admission) without resolving an EIP-7702 delegation target.
     pub const CANONICAL_HIGH_RATE_PAYER_PROXY_CODE_HASH: B256 =
-        b256!("0x029d2e31f6309cdefe6a1514785cd001d123ecf88fd79e4ba2e3801fd8b81cf9");
+        b256!("0x6cba95b9880aae4d0540f0f42ae50e423ba969552244dc3c80f2d4c45c4431c1");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Canonical authenticators (accepted on the EIP-8130 block-validation path)
@@ -134,15 +134,15 @@ impl Eip8130Contracts {
     /// Delegated-validation (1-hop) authenticator contract (init code embeds
     /// `ACCOUNT_CONFIG`).
     pub const DELEGATE_AUTHENTICATOR: Address =
-        address!("0x8130fB676B7e718AE6a097b62eA271915B9bade1");
+        address!("0x81300AF9F2E3C620eD0F666fb114bEF50cedADE1");
 
     /// Per-contract mined CREATE2 salt for [`Self::DELEGATE_AUTHENTICATOR`].
     pub const DELEGATE_AUTHENTICATOR_SALT: B256 =
-        b256!("0x00000000000000000000000000000000000000000000000000000000115250c1");
+        b256!("0x00000000000000000000000000000000000000000000000000000000695d3247");
 
     /// keccak256 of the `DELEGATE_AUTHENTICATOR` deployment init code.
     pub const DELEGATE_AUTHENTICATOR_INIT_CODE_HASH: B256 =
-        b256!("0x027ef6d7ad2f6f84b9aece32ca0db7aba30e1e83890a6a82fc6a357a4e2c8679");
+        b256!("0xdc379a77f7ef26ccea53ffbf6281d96502af1d05d1b0f1c41d78812b78520d8e");
 
     /// The canonical authenticator allowlist: the deployed `IAuthenticator`
     /// contracts a compliant node accepts on the EIP-8130 block-validation path.

--- a/crates/common/consensus/src/transaction/eip8130/addresses.rs
+++ b/crates/common/consensus/src/transaction/eip8130/addresses.rs
@@ -46,46 +46,46 @@ impl Eip8130Contracts {
 
     /// Account Configuration system contract (`ACCOUNT_CONFIG_ADDRESS`). The
     /// protocol reads actor/account state directly from this contract's storage.
-    pub const ACCOUNT_CONFIG: Address = address!("0x813011b7a5f25f8433Ac1E0993DE06CB2d1500Ac");
+    pub const ACCOUNT_CONFIG: Address = address!("0x813079205F4cFCC0bE8166be1C7F863Db8A700AC");
 
     /// Per-contract mined CREATE2 salt for [`Self::ACCOUNT_CONFIG`], yielding its
     /// `0x8130…` vanity address.
     pub const ACCOUNT_CONFIG_SALT: B256 =
-        b256!("0xecfbe92b1e12c2f5b6593225a9a2783106f355ed82b1475873b072dbc50e01ca");
+        b256!("0x544ebe415c98e81edc2101578e9389396d270c2af154129832b643549b08a819");
 
     /// keccak256 of the `ACCOUNT_CONFIG` deployment init code (for CREATE2
     /// derivation and bytecode-drift detection).
     pub const ACCOUNT_CONFIG_INIT_CODE_HASH: B256 =
-        b256!("0x9536faebef20bb8cfabc70cf8717ef49e49f9c7d14e3621e8a1c6000e33d8670");
+        b256!("0x70eb4641a426e42492d0730a934d831dbe0963321fb55860d6246c35145349da");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Account implementations (init code embeds `ACCOUNT_CONFIG`)
     // ─────────────────────────────────────────────────────────────────────────
 
     /// Default wallet implementation, used as the target of default EOA delegation.
-    pub const DEFAULT_ACCOUNT: Address = address!("0x813035E3fc4a102CE2b4a73D78a25D1Ea5AFadEf");
+    pub const DEFAULT_ACCOUNT: Address = address!("0x8130f53536097991a3AD949D9a1D76E1b666aDEf");
 
     /// Per-contract mined CREATE2 salt for [`Self::DEFAULT_ACCOUNT`].
     pub const DEFAULT_ACCOUNT_SALT: B256 =
-        b256!("0x00000000000000000000000000000000000000000000000000000001d896d087");
+        b256!("0x000000000000000000000000000000000000000000000000000000030924c784");
 
     /// keccak256 of the `DEFAULT_ACCOUNT` deployment init code.
     pub const DEFAULT_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0xa7da1ddce58d2f90c0e6a56473a036ff5379d3812ed751d1e8567d0301d31a7f");
+        b256!("0xf99c7ecb38528e8f0b209f476b3cbbba8f4f8f83161e9e54945e9a041ee8ee2b");
 
     /// Canonical high-rate payer account implementation
     /// (`CanonicalHighRatePayerAccount`). Wallets that block ETH transfers when
     /// locked, granting higher EIP-8130 mempool access (rate limits).
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT: Address =
-        address!("0x8130D6819734515f958965eFd2d212541d44FA57");
+        address!("0x8130A75698ace565afeae1fa36a327248D93fA57");
 
     /// Per-contract mined CREATE2 salt for [`Self::CANONICAL_HIGH_RATE_PAYER_ACCOUNT`].
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT_SALT: B256 =
-        b256!("0x000000000000000000000000000000000000000000000000000000030b4ce9ef");
+        b256!("0x00000000000000000000000000000000000000000000000000000001f53faf75");
 
     /// keccak256 of the `CANONICAL_HIGH_RATE_PAYER_ACCOUNT` deployment init code.
     pub const CANONICAL_HIGH_RATE_PAYER_ACCOUNT_INIT_CODE_HASH: B256 =
-        b256!("0x68734881f5eac22f7cfc977fc0fac19c3d80929f1a4b1c0199bafb6614418287");
+        b256!("0x92cddd461fb1c1ab9297cef0ff86ed2d59d9c14a6399c5e71d262e5e2dade5c4");
 
     /// keccak256 of the ERC-1167 minimal-proxy *runtime* bytecode whose
     /// implementation is [`Self::CANONICAL_HIGH_RATE_PAYER_ACCOUNT`]:
@@ -97,7 +97,7 @@ impl Eip8130Contracts {
     /// Used to recognize high-rate payer accounts by codehash (e.g. mempool
     /// admission) without resolving an EIP-7702 delegation target.
     pub const CANONICAL_HIGH_RATE_PAYER_PROXY_CODE_HASH: B256 =
-        b256!("0x891026e0ed34e33136cc7cc0019710cd57e0c21e7ea9e1a090539fe85fec8798");
+        b256!("0x029d2e31f6309cdefe6a1514785cd001d123ecf88fd79e4ba2e3801fd8b81cf9");
 
     // ─────────────────────────────────────────────────────────────────────────
     // Canonical authenticators (accepted on the EIP-8130 block-validation path)
@@ -134,15 +134,15 @@ impl Eip8130Contracts {
     /// Delegated-validation (1-hop) authenticator contract (init code embeds
     /// `ACCOUNT_CONFIG`).
     pub const DELEGATE_AUTHENTICATOR: Address =
-        address!("0x8130015119757e0b1F9985F723091a851598Ade1");
+        address!("0x8130fB676B7e718AE6a097b62eA271915B9bade1");
 
     /// Per-contract mined CREATE2 salt for [`Self::DELEGATE_AUTHENTICATOR`].
     pub const DELEGATE_AUTHENTICATOR_SALT: B256 =
-        b256!("0x0000000000000000000000000000000000000000000000000000000221fb1b0f");
+        b256!("0x00000000000000000000000000000000000000000000000000000000115250c1");
 
     /// keccak256 of the `DELEGATE_AUTHENTICATOR` deployment init code.
     pub const DELEGATE_AUTHENTICATOR_INIT_CODE_HASH: B256 =
-        b256!("0xa63cc2b8d524a19583b6dc9588e45ea8ee93aa9226fcaba53917062fe6d5681b");
+        b256!("0x027ef6d7ad2f6f84b9aece32ca0db7aba30e1e83890a6a82fc6a357a4e2c8679");
 
     /// The canonical authenticator allowlist: the deployed `IAuthenticator`
     /// contracts a compliant node accepts on the EIP-8130 block-validation path.


### PR DESCRIPTION
## Summary
- Re-pins the canonical EIP-8130 system-contract addresses to match [eip-8130 PR #100](https://github.com/base/eip-8130/pull/100), whose finalized head (`Make RevokeActor idempotent and regenerate vanity salts`) re-mines the vanity salts.
- Changed contracts (address + CREATE2 salt + init-code hash re-pinned together): `ACCOUNT_CONFIG` (Keystore), `DEFAULT_ACCOUNT`, `CANONICAL_HIGH_RATE_PAYER_ACCOUNT`, `DELEGATE_AUTHENTICATOR`. Also updates the high-rate-payer ERC-1167 proxy code hash.
- `P256_AUTHENTICATOR` and `WEBAUTHN_AUTHENTICATOR` are unchanged (their bytecode did not change).

### New pins
| Contract | Address |
| --- | --- |
| `ACCOUNT_CONFIG` (Keystore) | `0x813012Bd8D971928475235BBac6F0488c4A100AC` |
| `DEFAULT_ACCOUNT` | `0x81305170f491e4E313ee37C6A27d1E4A6B76aDEf` |
| `CANONICAL_HIGH_RATE_PAYER_ACCOUNT` | `0x81303Fb4E3d037a8649c2Dc7A968Da336c20fA57` |
| `DELEGATE_AUTHENTICATOR` | `0x81301AA52202f8C6b79Cde660440E3c6A7c5ade1` |
| `P256_AUTHENTICATOR` (unchanged) | `0x8130C89F65750431b564A4730397552a11CeA256` |
| `WEBAUTHN_AUTHENTICATOR` (unchanged) | `0x813007b6b1b48E75D91dEc5927ab515d12a0F1d0` |

All addresses/salts/hashes were regenerated from PR #100's finalized `Deploy.s.sol` (`forge script --sig addresses()` plus init-code-hash logging).

## Test plan
- [x] `cargo test -p base-common-consensus eip8130::addresses` — the `addresses_match_create2_derivation` drift guard confirms every `(address, salt, init_code_hash)` triple is self-consistent under CREATE2, and the ERC-1167 proxy code-hash tests pass.