### PR TITLE
fix(derive): preserve singular batch parent hashes

### DIFF
--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -71,7 +71,7 @@ where
         Ok(self.config.is_holocene_active(origin.timestamp))
     }
 
-    /// Gets a [`SingleBatch`] from the in-memory buffer.
+    /// Gets a span-derived [`SingleBatch`] from the in-memory buffer and assigns its parent hash.
     pub fn get_single_batch(
         &mut self,
         parent: L2BlockInfo,
@@ -79,8 +79,12 @@ where
     ) -> Result<Option<SingleBatch>, SpanBatchError> {
         trace!(target: "batch_span", buffer_len = self.buffer.len(), "Attempting to get a SingleBatch from buffer");
 
+        let parent_hash = parent.block_info.hash;
         self.try_hydrate_buffer(parent, l1_origins)?;
-        Ok(self.buffer.pop_front())
+        Ok(self.buffer.pop_front().map(|mut batch| {
+            batch.parent_hash = parent_hash;
+            batch
+        }))
     }
 
     /// Hydrates the buffer with single batches derived from the span batch, if there is one
@@ -391,10 +395,15 @@ mod tests {
             panic!("Wrong batch type");
         }
 
-        let batch = stream.next_batch(Default::default(), &mock_origins).await.unwrap();
+        let parent = L2BlockInfo {
+            block_info: BlockInfo { hash: FixedBytes::repeat_byte(0x11), ..Default::default() },
+            ..Default::default()
+        };
+        let batch = stream.next_batch(parent, &mock_origins).await.unwrap();
         if let Batch::Single(single) = batch {
             assert_eq!(single.epoch_num, 1);
             assert_eq!(single.timestamp, 4);
+            assert_eq!(single.parent_hash, parent.block_info.hash);
         } else {
             panic!("Wrong batch type");
         }
@@ -558,7 +567,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_batch_pass_through() {
-        let data = vec![Ok(Batch::Single(SingleBatch::default()))];
+        let single =
+            SingleBatch { parent_hash: FixedBytes::repeat_byte(0x11), ..Default::default() };
+        let data = vec![Ok(Batch::Single(single.clone()))];
         let config = Arc::new(RollupConfig {
             upgrades: UpgradeConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
@@ -572,7 +583,7 @@ mod tests {
 
         // The next batch should be passed through to the [BatchQueue] stage.
         let batch = stream.next_batch(Default::default(), &[]).await.unwrap();
-        assert!(matches!(batch, Batch::Single(_)));
+        assert_eq!(batch, Batch::Single(single));
         assert_eq!(stream.span_buffer_size(), 0);
         assert!(stream.span.is_none());
     }

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -246,8 +246,7 @@ where
 
         let next_timestamp =
             self.cfg.l2_block_timestamp(parent.block_info.number.saturating_add(1));
-        let denim_active = self.cfg.is_denim_active(next_timestamp);
-        let needs_ancestry_check = denim_active
+        let needs_ancestry_check = self.cfg.is_denim_active(next_timestamp)
             && next_batch.timestamp == next_timestamp
             && next_batch.parent_hash != parent.block_info.hash;
         if needs_ancestry_check {

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -225,7 +225,7 @@ where
 
         // Pull the next batch from the previous stage unless a provider error interrupted its
         // canonical ancestry lookup.
-        let (mut next_batch, inclusion_block) = match self.pending_batch.take() {
+        let (next_batch, inclusion_block) = match self.pending_batch.take() {
             Some(pending_batch) => pending_batch,
             None => {
                 let next_batch = match self.prev.next_batch(parent, self.l1_blocks.as_ref()).await {
@@ -247,10 +247,6 @@ where
         let next_timestamp =
             self.cfg.l2_block_timestamp(parent.block_info.number.saturating_add(1));
         let denim_active = self.cfg.is_denim_active(next_timestamp);
-        if !denim_active {
-            next_batch.parent_hash = parent.block_info.hash;
-        }
-
         let needs_ancestry_check = denim_active
             && next_batch.timestamp == next_timestamp
             && next_batch.parent_hash != parent.block_info.hash;
@@ -541,7 +537,7 @@ mod tests {
         });
         assert!(cfg.is_holocene_active(0));
         let batch = SingleBatch {
-            parent_hash: B256::default(),
+            parent_hash: B256::repeat_byte(1),
             epoch_num: 2,
             epoch_hash: B256::default(),
             timestamp: 4,
@@ -574,8 +570,7 @@ mod tests {
 
         // Grab the next batch.
         let produced_batch = bv.next_batch(parent).await.unwrap();
-        assert_eq!(produced_batch.parent_hash, parent.block_info.hash);
-        assert_eq!(produced_batch, SingleBatch { parent_hash: parent.block_info.hash, ..batch });
+        assert_eq!(produced_batch, batch);
     }
 
     #[tokio::test]
@@ -641,6 +636,57 @@ mod tests {
         assert_eq!(trace_lock.iter().filter(|(l, _)| matches!(l, &Level::DEBUG)).count(), 2);
         assert!(trace_lock[0].1.contains("Advancing batch validator origin"));
         assert!(trace_lock[1].1.contains("Advancing batch validator epoch"));
+    }
+
+    #[tokio::test]
+    async fn test_pre_denim_validator_rejects_stale_parent_after_past_prefix() {
+        let epoch = BlockInfo {
+            number: 10,
+            hash: B256::repeat_byte(0x10),
+            timestamp: 590,
+            ..Default::default()
+        };
+        let inclusion_block = BlockInfo { number: 11, timestamp: 591, ..Default::default() };
+        let parent = L2BlockInfo {
+            block_info: BlockInfo {
+                number: 600,
+                hash: B256::repeat_byte(0x60),
+                timestamp: 600,
+                ..Default::default()
+            },
+            l1_origin: epoch.id(),
+            ..Default::default()
+        };
+        let next_batch = SingleBatch {
+            parent_hash: B256::repeat_byte(0xaa),
+            epoch_num: epoch.number,
+            epoch_hash: epoch.hash,
+            timestamp: 601,
+            ..Default::default()
+        };
+        let past_batch = SingleBatch { timestamp: 600, ..next_batch.clone() };
+        let mut prev = TestNextBatchProvider::new(vec![
+            Ok(Batch::Single(next_batch)),
+            Ok(Batch::Single(past_batch)),
+        ]);
+        prev.origin = Some(inclusion_block);
+        let cfg = Arc::new(RollupConfig {
+            block_time: 1,
+            max_sequencer_drift: 700,
+            seq_window_size: 3_600,
+            upgrades: UpgradeConfig { holocene_time: Some(0), ..Default::default() },
+            ..Default::default()
+        });
+        assert!(!cfg.is_denim_active(601));
+        let mut bv = BatchValidator::new(cfg, prev, TestL2ChainProvider::default());
+        bv.origin = Some(inclusion_block);
+        bv.l1_blocks = vec![epoch, inclusion_block];
+
+        assert_eq!(bv.next_batch(parent).await.unwrap_err(), PipelineError::NotEnoughData.temp());
+        assert!(!bv.prev.flushed);
+
+        assert_eq!(bv.next_batch(parent).await.unwrap_err(), PipelineError::NotEnoughData.temp());
+        assert!(bv.prev.flushed);
     }
 
     #[tokio::test]

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -14,8 +14,8 @@ use crate::{BatchDropReason, BatchValidity, BlockInfo, L2BlockInfo};
 /// Represents a single batch: a single encoded L2 block
 #[derive(Debug, Default, RlpDecodable, RlpEncodable, Clone, PartialEq, Eq)]
 pub struct SingleBatch {
-    /// Block hash of the previous L2 block. `B256::ZERO` if it has not been set by the Batch
-    /// Queue.
+    /// Block hash of the previous L2 block. `B256::ZERO` if a span-derived batch has not yet been
+    /// assigned its parent by the derivation pipeline.
     pub parent_hash: BlockHash,
     /// The batch epoch number. Same as the first L1 block number in the epoch.
     pub epoch_num: u64,


### PR DESCRIPTION
## Problem

A direct singular batch encodes the hash of the L2 parent it was built on. That hash is a consensus-critical fork binding: derivation must reject the batch if it does not match the current safe head.

Before Denim, `BatchValidator` replaced every singular batch's encoded parent hash with the current safe-head hash before calling `SingleBatch::check_batch`. This made the existing parent check tautological.

The bug is observable when an L2 reorg leaves a stale channel on the parent chain and derivation restarts from an agreed safe head in the middle of that channel:

1. Batches before the agreed head are classified as `Past` and skipped without flushing the channel.
2. The stale batch at the next expected timestamp still points to its original, reorged L2 parent.
3. The validator overwrites that parent with the current safe head, allowing the stale suffix to attach to a different fork.

These are not necessarily duplicate batch submissions: they can be validly posted data from an old unsafe branch that remains on L1 after an L2 reorg. A one-second block time does not prevent the issue because the timestamp identifies a height, not the fork at that height.

PR #4783 fixed the related post-Denim case, where several 200 ms blocks can share a whole-second timestamp, but deliberately retained the parent overwrite before Denim. As a result, pre-Denim chains—including one-second L3s—remain affected.

## Solution

Preserve the encoded parent hash for direct singular batches at every fork. The existing `SingleBatch::check_batch` then rejects a stale-fork batch with `ParentHashMismatch`, and `BatchValidator` flushes the invalid channel.

Span-derived singular batches require different handling: their inner parent relationships are implicit after the enclosing span has been validated. This PR therefore assigns the current L2 parent only when a singular batch is popped from `BatchStream`'s span buffer. Direct singular batches bypass that buffer and retain their wire-encoded parent.

The Denim ancestry logic from #4783 remains unchanged. At the next expected timestamp, it still distinguishes a batch built on a canonical ancestor—which can be skipped—from a batch with an unknown or stale-fork parent—which drops and flushes the channel.

## Validation

- Added a one-second pre-Denim regression test covering a `Past` stale-channel prefix followed by a next-timestamp parent mismatch; the prefix is skipped and the stale suffix flushes the channel.
- Verified direct singular batches pass through `BatchStream` without parent mutation.
- Verified singular batches hydrated from a real span receive the current derived parent.
- `cargo test -p base-consensus-derive -- --test-threads=1` (216 passed)
- `cargo clippy -p base-consensus-derive --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`