### PR TITLE
docs: bump the node image pin example to v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker compose up --build
 NETWORK_ENV=.env.sepolia docker compose up --build
 
 # Pin a published image (no compile):
-NODE_TAG=v1.2.6 docker compose up
+NODE_TAG=v1.3.0 docker compose up
 ```
 
 See the [docs](https://docs.base.org/base-chain/node-operators/run-a-base-node) for hardware requirements, snapshots, Flashblocks, and historical proofs.


### PR DESCRIPTION
## Summary
Update the README `NODE_TAG` pin example from `v1.2.6` to `v1.3.0` so it matches the current published `ghcr.io/base/node` tag.

Made with [Cursor](https://cursor.com)