### PR TITLE
ci: install protobuf for macos basectl release builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,6 +69,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libclang-dev pkg-config protobuf-compiler
 
+      - name: Install system dependencies (macOS)
+        if: matrix.target.os == 'macos' && matrix.binary == 'basectl'
+        run: brew install protobuf
+
       - name: Install Go for basectl
         if: matrix.binary == 'basectl'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0


### PR DESCRIPTION
## Summary
- install Homebrew protobuf for macOS basectl release builds so sp1-prover-types can find protoc
- keep the install scoped to `matrix.target.os == 'macos' && matrix.binary == 'basectl'`

## Failure analysis
- In run 33442805766, job 99654974558 / macOS arm64 basectl failed while compiling `sp1-prover-types v6.3.0` because `protoc` was not installed. The log says `Could not find protoc` and recommends `brew install protobuf` on macOS.
- In the same run, job 99654974474 / Linux arm64 base reached `Compiling base v1.3.0 (/home/runner/work/base/base/bin/base)` and then exited with `The runner has received a shutdown signal` / exit code 143. I did not see a Rust compiler or linker error in that log. The job metadata shows it ran on `ubuntu-24.04-arm` from 2026-08-31T21:44:28Z to 2026-08-31T22:16:58Z, so this looks like runner cancellation/shutdown and should be rerun.

## Validation
- `git diff --check`
