### PR TITLE
ci: avoid redundant PR base fetches

### DIFF
--- a/.depot/workflows/ci-core.yml
+++ b/.depot/workflows/ci-core.yml
@@ -2,7 +2,8 @@ name: CI Core
 on:
   workflow_call:
     inputs:
-      base_ref:
+      diff_base:
+        description: Git revision used as the base for affected-crate comparisons
         required: false
         type: string
         default: ""
@@ -103,7 +104,7 @@ jobs:
     name: Build
     runs-on: depot-ubuntu-24.04-8
     env:
-      BASE_REF: ${{ inputs.base_ref }}
+      DIFF_BASE: ${{ inputs.diff_base }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -111,10 +112,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: ${{ inputs.base_ref != '' && 0 || 1 }}
-      - name: Fetch base branch
-        if: inputs.base_ref != ''
-        run: git fetch origin "$BASE_REF":refs/remotes/origin/"$BASE_REF"
+          fetch-depth: ${{ inputs.diff_base != '' && 2 || 1 }}
       - uses: ./.depot/actions/setup
         with:
           native-deps: "true"
@@ -126,7 +124,7 @@ jobs:
     name: Clippy
     runs-on: depot-ubuntu-24.04-8
     env:
-      BASE_REF: ${{ inputs.base_ref }}
+      DIFF_BASE: ${{ inputs.diff_base }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -134,10 +132,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: ${{ inputs.base_ref != '' && 0 || 1 }}
-      - name: Fetch base branch
-        if: inputs.base_ref != ''
-        run: git fetch origin "$BASE_REF":refs/remotes/origin/"$BASE_REF"
+          fetch-depth: ${{ inputs.diff_base != '' && 2 || 1 }}
       - uses: ./.depot/actions/setup
         with:
           native-deps: "true"
@@ -149,7 +144,7 @@ jobs:
     name: Test
     runs-on: depot-ubuntu-24.04-8
     env:
-      BASE_REF: ${{ inputs.base_ref }}
+      DIFF_BASE: ${{ inputs.diff_base }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -157,10 +152,7 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: ${{ inputs.base_ref != '' && 0 || 1 }}
-      - name: Fetch base branch
-        if: inputs.base_ref != ''
-        run: git fetch origin "$BASE_REF":refs/remotes/origin/"$BASE_REF"
+          fetch-depth: ${{ inputs.diff_base != '' && 2 || 1 }}
       - uses: ./.depot/actions/setup
         with:
           native-deps: "true"

--- a/.depot/workflows/ci-merge-queue.yml
+++ b/.depot/workflows/ci-merge-queue.yml
@@ -19,7 +19,6 @@ jobs:
     uses: ./.depot/workflows/ci-core.yml
     with:
       allow_registry_login: true
-      base_ref: ""
       build_command: just build::ci
       clippy_command: just check::clippy-ci
       run_system_tests: true

--- a/.depot/workflows/ci-pr.yml
+++ b/.depot/workflows/ci-pr.yml
@@ -16,11 +16,11 @@ jobs:
       # The tested PR merge commit stores its exact base as the first parent.
       diff_base: HEAD^1
       build_command: >-
-        just build::affected-ci "$DIFF_BASE"
+        just build::affected-ci "${DIFF_BASE:?}"
       clippy_command: >-
-        just check::clippy-affected-ci "$DIFF_BASE"
+        just check::clippy-affected-ci "${DIFF_BASE:?}"
       run_system_tests: false
       run_sigsegv: false
       test_command: >-
-        just test-affected-ci "$DIFF_BASE"
+        just test-affected-ci "${DIFF_BASE:?}"
     secrets: inherit

--- a/.depot/workflows/ci-pr.yml
+++ b/.depot/workflows/ci-pr.yml
@@ -13,13 +13,14 @@ jobs:
     uses: ./.depot/workflows/ci-core.yml
     with:
       allow_registry_login: ${{ github.event.pull_request.head.repo.fork != true }}
-      base_ref: ${{ github.base_ref || 'main' }}
+      # The tested PR merge commit stores its exact base as the first parent.
+      diff_base: HEAD^1
       build_command: >-
-        just build::affected-ci "origin/${{ github.base_ref || 'main' }}"
+        just build::affected-ci "$DIFF_BASE"
       clippy_command: >-
-        just check::clippy-affected-ci "origin/${{ github.base_ref || 'main' }}"
+        just check::clippy-affected-ci "$DIFF_BASE"
       run_system_tests: false
       run_sigsegv: false
       test_command: >-
-        just test-affected-ci "origin/${{ github.base_ref || 'main' }}"
+        just test-affected-ci "$DIFF_BASE"
     secrets: inherit


### PR DESCRIPTION
## Summary

Removes an extra `Fetch base branch` step after `actions/checkout`, replacing it with a depth-two checkout for pull requests and depth-one checkout for merge-queue jobs.

## Test plan
- [x] Parse the modified workflow YAML files
- [x] Run `git diff --check`
- [x] Run `just actions::lint-ci`
- [x] Push a commit with changes to a crate and ensure `affected-ci` detects the affected crates correctly