### PR TITLE
fix(system-tests): shut down tx forwarding stacks

### DIFF
--- a/etc/systems/src/l2/shadow_sequencer.rs
+++ b/etc/systems/src/l2/shadow_sequencer.rs
@@ -151,4 +151,11 @@ impl ShadowSequencer {
     pub fn rpc_url(&self) -> Result<Url> {
         self.builder.rpc_url()
     }
+
+    /// Stops the shadow consensus task and gracefully shuts down its execution node.
+    pub async fn shutdown(self) -> Result<()> {
+        let Self { builder, consensus } = self;
+        drop(consensus);
+        builder.shutdown().await.wrap_err("Failed to shut down shadow builder")
+    }
 }

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -138,6 +138,14 @@ impl L2ClientConsensus {
             Self::Follow(consensus) => Some(consensus.rollup_config()),
         }
     }
+
+    /// Stops the client consensus task.
+    pub async fn shutdown(self) {
+        match self {
+            Self::Validator(consensus) => drop(consensus),
+            Self::Follow(consensus) => consensus.shutdown().await,
+        }
+    }
 }
 
 /// A complete L2 network stack composed of Builder + Consensus + Batcher.
@@ -593,5 +601,30 @@ impl L2Stack {
     /// Returns the follow-mode client consensus rollup configuration, when enabled.
     pub fn client_follow_rollup_config(&self) -> Option<&RollupConfig> {
         self.client_consensus.follow_rollup_config()
+    }
+
+    /// Stops the in-process L2 services and gracefully shuts down execution runtimes.
+    pub async fn shutdown(self) -> Result<()> {
+        let Self {
+            builder,
+            builder_consensus,
+            batcher,
+            client,
+            client_consensus,
+            shadow_sequencers,
+        } = self;
+
+        for shadow in shadow_sequencers {
+            shadow.shutdown().await.wrap_err("Failed to shut down shadow sequencer")?;
+        }
+
+        client_consensus.shutdown().await;
+        drop(batcher);
+        drop(builder_consensus);
+
+        client.shutdown().await.wrap_err("Failed to shut down L2 client")?;
+        builder.shutdown().await.wrap_err("Failed to shut down L2 builder")?;
+
+        Ok(())
     }
 }

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -272,6 +272,38 @@ impl SystemTestStack {
             l2_client_consensus_rpc: self.l2_stack().client_consensus_rpc_url().to_string(),
         })
     }
+
+    /// Stops in-process services before container-backed L1 resources are dropped.
+    pub async fn shutdown(self) -> Result<()> {
+        let Self {
+            _temp_dir,
+            #[cfg(feature = "upgrade-signal")]
+                l2_chain_id: _,
+            l1_genesis,
+            l2_deployment,
+            l1_stack,
+            l2_stack,
+            l1_rpc_proxy,
+            #[cfg(feature = "upgrade-signal")]
+            upgrade_signal,
+            #[cfg(feature = "upgrade-signal")]
+            _runtime_upgrade_signal_guard,
+        } = self;
+
+        let result = l2_stack.shutdown().await.wrap_err("Failed to shut down L2 stack");
+
+        #[cfg(feature = "upgrade-signal")]
+        drop(upgrade_signal);
+        drop(l1_rpc_proxy);
+        drop(l1_stack);
+        drop(l2_deployment);
+        drop(l1_genesis);
+        drop(_temp_dir);
+        #[cfg(feature = "upgrade-signal")]
+        drop(_runtime_upgrade_signal_guard);
+
+        result
+    }
 }
 
 /// Builder for creating a new `SystemTestStack`.

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -210,6 +210,8 @@ async fn test_insert_validated_transaction_single() -> Result<()> {
     assert_eq!(receipt.inner.from, sender);
     assert_eq!(receipt.inner.to, Some(recipient));
 
+    system.shutdown().await?;
+
     Ok(())
 }
 
@@ -311,6 +313,8 @@ async fn test_tx_forwarding_pipeline_system() -> Result<()> {
     assert_eq!(receipt.inner.from, sender);
     assert_eq!(receipt.inner.to, Some(recipient));
 
+    system.shutdown().await?;
+
     Ok(())
 }
 
@@ -373,6 +377,8 @@ async fn test_matching_validity_predicates_are_forwarded_and_included() -> Resul
         "the validity metadata must not alter the signed transaction's state transition"
     );
 
+    system.shutdown().await?;
+
     Ok(())
 }
 
@@ -409,6 +415,8 @@ async fn test_eip8130_validity_transaction_is_included_by_native_builder() -> Re
     let receipt = builder_provider.wait_for_receipt(tx_hash, TX_RECEIPT_TIMEOUT).await?;
     assert_eq!(receipt.inner.transaction_hash, tx_hash);
     assert!(receipt.inner.inner.status());
+
+    system.shutdown().await?;
 
     Ok(())
 }
@@ -475,6 +483,8 @@ async fn test_validity_transaction_lands_after_balance_predicate_becomes_true() 
         "validity transaction landed before the state change that satisfied it"
     );
     assert!(builder_provider.get_balance(watched).await? >= U256::from(1));
+
+    system.shutdown().await?;
 
     Ok(())
 }
@@ -596,6 +606,8 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
         "recoverable storage predicate mismatch should remain pending"
     );
 
+    system.shutdown().await?;
+
     Ok(())
 }
 
@@ -651,6 +663,8 @@ async fn test_invalid_validity_batches_are_rejected_at_mempool_ingress() -> Resu
 
     assert!(client_provider.get_transaction_by_hash(tx_hash).await?.is_none());
     assert!(builder_provider.get_transaction_by_hash(tx_hash).await?.is_none());
+
+    system.shutdown().await?;
 
     Ok(())
 }
@@ -789,6 +803,8 @@ async fn test_tx_forwarding_pipeline_system_high_load() -> Result<()> {
         included_count, total_txs,
         "Expected all {total_txs} transactions to be included, got {included_count}"
     );
+
+    system.shutdown().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add explicit async shutdown for system-test L2 stacks and shadow sequencers
- call the shutdown path from tx-forwarding system tests after successful assertions
- prevent tx-forwarding tests from hanging during implicit teardown after the test body completes

## Root cause
CI run https://github.com/base/base/runs/99643661922 timed out six tx-forwarding system tests at nextest's 360s timeout. Local reproduction showed the test body completed successfully, including receipt verification, then the process hung while dropping the in-process stack. The L2 execution nodes already had explicit async shutdown methods, but the top-level stack did not call them.

## Verification
- just devnet _build-contracts
- cargo test --locked -p base-system-tests --profile ci test_tx_forwarding_pipeline_system -- --exact --nocapture
- cargo nextest run -P ci --locked -p base-system-tests --cargo-profile ci --test tx_forwarding --no-fail-fast
- cargo nextest run -P ci --locked -p base-system-tests --cargo-profile ci --test tx_forwarding test_tx_forwarding_pipeline_system_high_load
- cargo check --locked -p base-system-tests
- cargo check --locked -p base-system-tests --no-default-features
- cargo fmt --check
- git diff --check