### PR TITLE
feat(txpool): unify tip-per-gas ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,6 +4631,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer 2.4.1",
  "alloy-signer-local 2.4.1",
+ "alloy-sol-types",
  "async-trait",
  "base-common-chains",
  "base-common-consensus",

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -38,10 +38,11 @@ const DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE_MIB: u64 = 64;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum TxpoolOrdering {
-    /// Order by coinbase tip (fee-based, higher tip = higher priority).
+    /// Order by unified tip-per-gas (higher bid = higher priority).
     ///
-    /// This is the default ordering strategy that prioritizes transactions
-    /// based on the priority fee (tip) they offer to the block producer.
+    /// Standard transactions use `priorityFeePerGas`. EIP-8130 transactions
+    /// with a static coinbase tip use `tip / gasLimit`. Equal bids prefer
+    /// fewer validity predicates.
     #[default]
     CoinbaseTip,
     /// Order by receive timestamp (FIFO, earlier = higher priority).
@@ -360,7 +361,7 @@ pub struct RollupArgs {
     /// Transaction ordering strategy for the mempool.
     ///
     /// Determines how transactions are prioritized when building blocks.
-    /// - `coinbase-tip`: Order by priority fee (higher tip = higher priority). Default.
+    /// - `coinbase-tip`: Order by tip-per-gas (priority fee, or EIP-8130 coinbase tip / gas limit). Default.
     /// - `timestamp`: Order by receive time (FIFO, earlier = higher priority).
     #[arg(long = "rollup.txpool-ordering", default_value = "coinbase-tip")]
     pub txpool_ordering: TxpoolOrdering,

--- a/crates/execution/txpool/Cargo.toml
+++ b/crates/execution/txpool/Cargo.toml
@@ -61,6 +61,7 @@ jsonrpsee = { workspace = true, features = ["http-client", "server", "macros"] }
 
 [dev-dependencies]
 alloy-signer.workspace = true
+alloy-sol-types.workspace = true
 alloy-signer-local.workspace = true
 reth-tasks.workspace = true
 base-test-utils.workspace = true

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -42,7 +42,10 @@ pub use transaction::{
 };
 
 mod ordering;
-pub use ordering::{BaseOrdering, BestTransactionPriority, TimestampOrdering};
+pub use ordering::{
+    BaseOrdering, BasePriority, BestTransactionPriority, TimestampOrdering, UnifiedTipOrdering,
+    UnifiedTipPriority,
+};
 
 mod parking;
 pub use parking::{

--- a/crates/execution/txpool/src/ordering.rs
+++ b/crates/execution/txpool/src/ordering.rs
@@ -138,10 +138,10 @@ impl PartialOrd for UnifiedTipPriority {
 
 impl Ord for UnifiedTipPriority {
     fn cmp(&self, other: &Self) -> Ordering {
-        // `tip * gas` fits in U256: a larger product would already overflow the
-        // transaction's total fee spend.
-        let left = self.tip * U256::from(other.gas);
-        let right = other.tip * U256::from(self.gas);
+        // Saturate at U256::MAX so a pathological tip*gas product ranks as
+        // the highest bid instead of wrapping.
+        let left = self.tip.saturating_mul(U256::from(other.gas));
+        let right = other.tip.saturating_mul(U256::from(self.gas));
         left.cmp(&right).then_with(|| self.predicates.cmp(&other.predicates))
     }
 }
@@ -149,9 +149,10 @@ impl Ord for UnifiedTipPriority {
 /// Unified tip-per-gas ordering for standard and EIP-8130 transactions.
 ///
 /// Uses [`CoinbaseTip::decode`] when the transaction is a statically-analyzable
-/// EIP-8130 coinbase tip; otherwise ranks by `effective_tip_per_gas`. Same bid
-/// prefers fewer validity predicates, so standard transactions beat equally
-/// priced advanced transactions.
+/// EIP-8130 coinbase tip; otherwise ranks by `effective_tip_per_gas`. Returns
+/// [`Priority::None`] when `max_fee_per_gas < base_fee`, including for a
+/// decoded coinbase tip. Same bid prefers fewer validity predicates, so
+/// standard transactions beat equally priced advanced transactions.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct UnifiedTipOrdering<T = BasePooledTransaction>(PhantomData<T>);
@@ -180,6 +181,9 @@ where
         transaction: &Self::Transaction,
         base_fee: u64,
     ) -> Priority<Self::PriorityValue> {
+        let Some(effective_tip) = transaction.effective_tip_per_gas(base_fee) else {
+            return Priority::None;
+        };
         let predicates = transaction.validity_predicates().len();
         if let Some(signed) = transaction.as_eip8130()
             && let Some(tip) = CoinbaseTip::decode(signed.tx(), transaction.sender())
@@ -190,9 +194,7 @@ where
                 predicates,
             ));
         }
-        transaction.effective_tip_per_gas(base_fee).map_or(Priority::None, |tip| {
-            Priority::Value(UnifiedTipPriority::new(U256::from(tip), 1, predicates))
-        })
+        Priority::Value(UnifiedTipPriority::new(U256::from(effective_tip), 1, predicates))
     }
 }
 
@@ -641,6 +643,13 @@ mod tests {
     fn below_base_fee_standard_tx_has_no_priority() {
         let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
         let tx = eip1559_pooled(1, 10, 1, 21_000);
+        assert_eq!(ordering.priority(&tx, 20), Priority::None);
+    }
+
+    #[test]
+    fn below_base_fee_coinbase_tip_has_no_priority() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let tx = eip8130_pooled(10, 0, 21_000, Some(U256::from(42_000)));
         assert_eq!(ordering.priority(&tx, 20), Priority::None);
     }
 }

--- a/crates/execution/txpool/src/ordering.rs
+++ b/crates/execution/txpool/src/ordering.rs
@@ -11,7 +11,7 @@ use std::{
     time::Instant,
 };
 
-use alloy_primitives::{TxHash, U256, U512};
+use alloy_primitives::{TxHash, U256};
 use base_common_consensus::CoinbaseTip;
 use reth_transaction_pool::{PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction};
 
@@ -138,8 +138,10 @@ impl PartialOrd for UnifiedTipPriority {
 
 impl Ord for UnifiedTipPriority {
     fn cmp(&self, other: &Self) -> Ordering {
-        let left = U512::from(self.tip) * U512::from(other.gas);
-        let right = U512::from(other.tip) * U512::from(self.gas);
+        // `tip * gas` fits in U256: a larger product would already overflow the
+        // transaction's total fee spend.
+        let left = self.tip * U256::from(other.gas);
+        let right = other.tip * U256::from(self.gas);
         left.cmp(&right).then_with(|| self.predicates.cmp(&other.predicates))
     }
 }

--- a/crates/execution/txpool/src/ordering.rs
+++ b/crates/execution/txpool/src/ordering.rs
@@ -1,13 +1,21 @@
-//! Custom ordering for transactions based on timestamp.
+//! Transaction ordering strategies for the Base mempool.
+//!
+//! [`UnifiedTipOrdering`] ranks by tip-per-gas — an EIP-1559 priority fee, or a
+//! statically decoded EIP-8130 coinbase tip over `gas_limit` — and breaks ties
+//! in favor of fewer validity predicates. [`TimestampOrdering`] is FIFO.
 
-use std::{cmp::Reverse, marker::PhantomData, sync::Arc, time::Instant};
-
-use alloy_primitives::TxHash;
-use reth_transaction_pool::{
-    CoinbaseTipOrdering, PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction,
+use std::{
+    cmp::{Ordering, Reverse},
+    marker::PhantomData,
+    sync::Arc,
+    time::Instant,
 };
 
-use crate::{BasePooledTransaction, TimestampedTransaction};
+use alloy_primitives::{TxHash, U256, U512};
+use base_common_consensus::CoinbaseTip;
+use reth_transaction_pool::{PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction};
+
+use crate::{BasePooledTransaction, BasePooledTx, TimestampedTransaction};
 
 /// Complete priority key used when merging best-transaction sources.
 ///
@@ -44,16 +52,16 @@ impl<P: Ord + Clone> BestTransactionPriority<P> {
 /// Each variant holds only the ordering implementation it needs.
 #[derive(Debug)]
 pub enum BaseOrdering<T> {
-    /// Order by coinbase tip (fee-based, higher tip = higher priority).
-    CoinbaseTip(CoinbaseTipOrdering<T>),
+    /// Order by unified tip-per-gas, with fewer validity predicates winning ties.
+    CoinbaseTip(UnifiedTipOrdering<T>),
     /// Order by receive timestamp (FIFO, earlier = higher priority).
     Timestamp(TimestampOrdering<T>),
 }
 
 impl<T> BaseOrdering<T> {
-    /// Creates a new coinbase-tip ordering (fee-based).
+    /// Creates unified tip-per-gas ordering (default pool ranking).
     pub fn coinbase_tip() -> Self {
-        Self::CoinbaseTip(CoinbaseTipOrdering::default())
+        Self::CoinbaseTip(UnifiedTipOrdering::default())
     }
 
     /// Creates a new timestamp ordering (FIFO).
@@ -74,6 +82,147 @@ impl<T> Clone for BaseOrdering<T> {
 impl<T> Default for BaseOrdering<T> {
     fn default() -> Self {
         Self::coinbase_tip()
+    }
+}
+
+/// Tip-per-gas bid with a fewer-predicates tiebreak.
+///
+/// The bid is the rational `tip / gas`. Standard transactions and EIP-8130
+/// transactions without a static coinbase tip use `effective_tip_per_gas` as
+/// `tip` and `gas = 1`. A statically decoded coinbase tip uses that amount as
+/// `tip` and the transaction `gas_limit` as `gas`.
+///
+/// Equality and ordering compare the bid by cross-multiplication, then fewer
+/// predicates. Distinct `(tip, gas)` pairs that represent the same ratio compare
+/// equal.
+#[derive(Debug, Clone, Copy)]
+pub struct UnifiedTipPriority {
+    /// Numerator of the tip-per-gas bid.
+    pub tip: U256,
+    /// Denominator of the tip-per-gas bid (`gas_limit`, or `1` for a priority-fee bid).
+    pub gas: u64,
+    /// Fewer predicates rank higher (`Reverse` so `0` beats `1`).
+    pub predicates: Reverse<u32>,
+}
+
+impl UnifiedTipPriority {
+    /// Builds a priority from a tip amount, gas denominator, and predicate count.
+    pub fn new(tip: U256, gas: u64, predicate_count: usize) -> Self {
+        Self {
+            tip,
+            gas: gas.max(1),
+            predicates: Reverse(u32::try_from(predicate_count).unwrap_or(u32::MAX)),
+        }
+    }
+}
+
+impl Default for UnifiedTipPriority {
+    fn default() -> Self {
+        Self::new(U256::ZERO, 1, 0)
+    }
+}
+
+impl PartialEq for UnifiedTipPriority {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for UnifiedTipPriority {}
+
+impl PartialOrd for UnifiedTipPriority {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for UnifiedTipPriority {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let left = U512::from(self.tip) * U512::from(other.gas);
+        let right = U512::from(other.tip) * U512::from(self.gas);
+        left.cmp(&right).then_with(|| self.predicates.cmp(&other.predicates))
+    }
+}
+
+/// Unified tip-per-gas ordering for standard and EIP-8130 transactions.
+///
+/// Uses [`CoinbaseTip::decode`] when the transaction is a statically-analyzable
+/// EIP-8130 coinbase tip; otherwise ranks by `effective_tip_per_gas`. Same bid
+/// prefers fewer validity predicates, so standard transactions beat equally
+/// priced advanced transactions.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct UnifiedTipOrdering<T = BasePooledTransaction>(PhantomData<T>);
+
+impl<T> Default for UnifiedTipOrdering<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> Clone for UnifiedTipOrdering<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl<T> TransactionOrdering for UnifiedTipOrdering<T>
+where
+    T: BasePooledTx + 'static,
+{
+    type PriorityValue = UnifiedTipPriority;
+    type Transaction = T;
+
+    fn priority(
+        &self,
+        transaction: &Self::Transaction,
+        base_fee: u64,
+    ) -> Priority<Self::PriorityValue> {
+        let predicates = transaction.validity_predicates().len();
+        if let Some(signed) = transaction.as_eip8130()
+            && let Some(tip) = CoinbaseTip::decode(signed.tx(), transaction.sender())
+        {
+            return Priority::Value(UnifiedTipPriority::new(
+                tip,
+                transaction.gas_limit(),
+                predicates,
+            ));
+        }
+        transaction.effective_tip_per_gas(base_fee).map_or(Priority::None, |tip| {
+            Priority::Value(UnifiedTipPriority::new(U256::from(tip), 1, predicates))
+        })
+    }
+}
+
+/// Pool priority value for [`BaseOrdering`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BasePriority {
+    /// Unified tip-per-gas bid plus predicate-count tiebreak.
+    Unified(UnifiedTipPriority),
+    /// Inverted receive timestamp (`u128::MAX - received_at`).
+    Timestamp(u128),
+}
+
+impl Default for BasePriority {
+    fn default() -> Self {
+        Self::Unified(UnifiedTipPriority::default())
+    }
+}
+
+impl PartialOrd for BasePriority {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BasePriority {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Unified(left), Self::Unified(right)) => left.cmp(right),
+            (Self::Timestamp(left), Self::Timestamp(right)) => left.cmp(right),
+            (Self::Unified(_), Self::Timestamp(_)) => Ordering::Less,
+            (Self::Timestamp(_), Self::Unified(_)) => Ordering::Greater,
+        }
     }
 }
 
@@ -118,9 +267,9 @@ where
 
 impl<T> TransactionOrdering for BaseOrdering<T>
 where
-    T: PoolTransaction + TimestampedTransaction + 'static,
+    T: BasePooledTx + TimestampedTransaction + 'static,
 {
-    type PriorityValue = u128;
+    type PriorityValue = BasePriority;
     type Transaction = T;
 
     fn priority(
@@ -129,8 +278,14 @@ where
         base_fee: u64,
     ) -> Priority<Self::PriorityValue> {
         match self {
-            Self::CoinbaseTip(ordering) => ordering.priority(transaction, base_fee),
-            Self::Timestamp(ordering) => ordering.priority(transaction, base_fee),
+            Self::CoinbaseTip(ordering) => match ordering.priority(transaction, base_fee) {
+                Priority::Value(priority) => Priority::Value(BasePriority::Unified(priority)),
+                Priority::None => Priority::None,
+            },
+            Self::Timestamp(ordering) => match ordering.priority(transaction, base_fee) {
+                Priority::Value(priority) => Priority::Value(BasePriority::Timestamp(priority)),
+                Priority::None => Priority::None,
+            },
         }
     }
 }
@@ -138,13 +293,23 @@ where
 #[cfg(test)]
 mod tests {
     use alloy_eips::eip2718::Encodable2718;
-    use base_common_consensus::BaseTransactionSigned;
+    use alloy_primitives::{Address, Bytes, U256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use alloy_sol_types::SolCall;
+    use base_common_chains::ChainConfig;
+    use base_common_consensus::{
+        BasePooledTransaction as ConsensusPooledTransaction, BaseTransactionSigned, Call,
+        Eip8130Signed, IDefaultAccount, Predeploys, TxEip8130,
+    };
     use base_test_utils::Account;
     use reth_primitives_traits::Recovered;
-    use reth_transaction_pool::{TransactionOrdering, test_utils::TransactionBuilder};
+    use reth_transaction_pool::{
+        CoinbaseTipOrdering, PoolTransaction, TransactionOrdering, test_utils::TransactionBuilder,
+    };
 
     use super::*;
-    use crate::BasePooledTransaction;
+    use crate::{BasePooledTransaction, ValidityOperator, ValidityPredicate};
 
     fn create_test_tx(nonce: u64) -> BasePooledTransaction {
         let alice = Account::Alice;
@@ -217,6 +382,80 @@ mod tests {
         let recovered = Recovered::new_unchecked(tx, account.address());
         let len = recovered.encode_2718_len();
         BasePooledTransaction::new_with_received_at(recovered, len, received_at)
+    }
+
+    fn eip1559_pooled(
+        nonce: u64,
+        max_fee_per_gas: u128,
+        max_priority_fee_per_gas: u128,
+        gas_limit: u64,
+    ) -> BasePooledTransaction {
+        let alice = Account::Alice;
+        let bob = Account::Bob;
+        let signed_tx = TransactionBuilder::default()
+            .signer(alice.signer_b256())
+            .chain_id(1)
+            .nonce(nonce)
+            .to(bob.address())
+            .value(1_000)
+            .gas_limit(gas_limit)
+            .max_fee_per_gas(max_fee_per_gas)
+            .max_priority_fee_per_gas(max_priority_fee_per_gas)
+            .into_eip1559();
+        let tx = BaseTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+        let recovered = Recovered::new_unchecked(tx, alice.address());
+        let len = recovered.encode_2718_len();
+        BasePooledTransaction::new(recovered, len)
+    }
+
+    fn encode_execute(target: Address, value: U256) -> Bytes {
+        Bytes::from(
+            IDefaultAccount::executeCall { target, value, data: Default::default() }.abi_encode(),
+        )
+    }
+
+    fn eip8130_pooled(
+        max_fee_per_gas: u128,
+        max_priority_fee_per_gas: u128,
+        gas_limit: u64,
+        coinbase_tip: Option<U256>,
+    ) -> BasePooledTransaction {
+        let signer = PrivateKeySigner::random();
+        let calls = coinbase_tip.map_or_else(Vec::new, |amount| {
+            vec![vec![Call {
+                to: signer.address(),
+                data: encode_execute(Predeploys::SEQUENCER_FEE_VAULT, amount),
+            }]]
+        });
+        let tx = TxEip8130 {
+            chain_id: ChainConfig::mainnet().chain_id,
+            sender: None,
+            nonce_key: U256::ZERO,
+            nonce_sequence: 0,
+            valid_after: 0,
+            valid_before: 0,
+            max_priority_fee_per_gas,
+            max_fee_per_gas,
+            gas_limit,
+            account_changes: Vec::new(),
+            calls,
+            metadata: Bytes::new(),
+            payer: None,
+        };
+        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
+        let signed =
+            Eip8130Signed::new(tx, Bytes::from(signature.as_bytes().to_vec()), Bytes::new());
+        let pooled = ConsensusPooledTransaction::Eip8130(signed);
+        BasePooledTransaction::from_pooled(Recovered::new_unchecked(pooled, signer.address()))
+    }
+
+    fn block_number_predicate() -> ValidityPredicate {
+        ValidityPredicate::BlockNumber {
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: U256::from(1),
+        }
     }
 
     #[test]
@@ -293,13 +532,16 @@ mod tests {
     }
 
     #[test]
-    fn test_base_ordering_default_is_coinbase_tip() {
+    fn test_base_ordering_default_is_unified_tip() {
         let ordering = BaseOrdering::<BasePooledTransaction>::default();
+        let unified = UnifiedTipOrdering::<BasePooledTransaction>::default();
         let tx = create_test_tx(1);
-        let priority = ordering.priority(&tx, 0);
-        let coinbase = CoinbaseTipOrdering::<BasePooledTransaction>::default();
-        let coinbase_priority = coinbase.priority(&tx, 0);
-        assert_eq!(priority, coinbase_priority);
+        match (ordering.priority(&tx, 0), unified.priority(&tx, 0)) {
+            (Priority::Value(BasePriority::Unified(base)), Priority::Value(inner)) => {
+                assert_eq!(base, inner);
+            }
+            other => panic!("expected matching unified priorities, got {other:?}"),
+        }
     }
 
     // NOTE: Same-sender nonce ordering is enforced by the txpool layer, not the
@@ -328,5 +570,75 @@ mod tests {
             priority_0 > priority_1,
             "earlier tx should have higher priority regardless of nonce",
         );
+    }
+
+    #[test]
+    fn standard_tx_ranking_matches_reth_coinbase_tip_order() {
+        let unified = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let reth = CoinbaseTipOrdering::<BasePooledTransaction>::default();
+        let higher = eip1559_pooled(1, 10, 2, 21_000);
+        let lower = eip1559_pooled(2, 10, 1, 21_000);
+
+        assert_eq!(
+            unified.priority(&higher, 0).cmp(&unified.priority(&lower, 0)),
+            reth.priority(&higher, 0).cmp(&reth.priority(&lower, 0)),
+        );
+        assert!(unified.priority(&higher, 0) > unified.priority(&lower, 0));
+    }
+
+    #[test]
+    fn coinbase_tip_per_gas_competes_with_priority_fee() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let standard = eip1559_pooled(1, 10, 2, 21_000);
+        let cheaper_at = eip8130_pooled(10, 0, 21_000, Some(U256::from(21_000)));
+        let richer_at = eip8130_pooled(10, 0, 21_000, Some(U256::from(63_000)));
+
+        assert!(ordering.priority(&standard, 0) > ordering.priority(&cheaper_at, 0));
+        assert!(ordering.priority(&richer_at, 0) > ordering.priority(&standard, 0));
+    }
+
+    #[test]
+    fn fewer_predicates_win_equal_bid() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let standard = eip1559_pooled(1, 10, 2, 21_000);
+        let one_predicate = eip8130_pooled(10, 0, 21_000, Some(U256::from(42_000)))
+            .with_validity_predicates(vec![block_number_predicate()]);
+        let two_predicates = eip8130_pooled(10, 0, 21_000, Some(U256::from(42_000)))
+            .with_validity_predicates(vec![block_number_predicate(), block_number_predicate()]);
+
+        assert!(ordering.priority(&standard, 0) > ordering.priority(&one_predicate, 0));
+        assert!(ordering.priority(&one_predicate, 0) > ordering.priority(&two_predicates, 0));
+    }
+
+    #[test]
+    fn eip8130_without_static_tip_uses_priority_fee() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let standard = eip1559_pooled(1, 10, 3, 21_000);
+        let aa = eip8130_pooled(10, 3, 50_000, None);
+
+        assert_eq!(ordering.priority(&standard, 0), ordering.priority(&aa, 0));
+    }
+
+    #[test]
+    fn equivalent_ratios_compare_equal_before_predicate_tiebreak() {
+        assert_eq!(
+            UnifiedTipPriority::new(U256::from(3u64), 2, 0),
+            UnifiedTipPriority::new(U256::from(6u64), 4, 0),
+        );
+        assert!(
+            UnifiedTipPriority::new(U256::from(3u64), 2, 0)
+                > UnifiedTipPriority::new(U256::from(1u64), 1, 0)
+        );
+        assert!(
+            UnifiedTipPriority::new(U256::from(3u64), 2, 0)
+                > UnifiedTipPriority::new(U256::from(3u64), 2, 1)
+        );
+    }
+
+    #[test]
+    fn below_base_fee_standard_tx_has_no_priority() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let tx = eip1559_pooled(1, 10, 1, 21_000);
+        assert_eq!(ordering.priority(&tx, 20), Priority::None);
     }
 }


### PR DESCRIPTION
## Summary
- Add `UnifiedTipOrdering` so the default `coinbase-tip` pool ranks standard transactions by `effective_tip_per_gas` and EIP-8130 transactions with a static coinbase tip by `tip / gasLimit` (compared as a rational to avoid integer-division loss).
- Break equal bids in favor of fewer validity predicates, so STs beat equally priced ATs and leaner ATs beat heavier ones.
- Completes [BASE-145](https://linear.app/coinbase/issue/BASE-145/implement-unified-priority-scoring-for-sts-priorityfeepergas-and-ats) on top of #4667 (`CoinbaseTip::decode`).

## Test plan
- [ ] `cargo test -p base-execution-txpool --lib ordering`
- [ ] Confirm ST ranking still matches Reth `CoinbaseTipOrdering`
- [ ] Confirm an 8130 coinbase tip of `21_000 / 21_000` loses to a 2 wei priority-fee ST, and `63_000 / 21_000` wins
- [ ] Confirm equal bids prefer 0 predicates over 1 over 2
- [ ] Confirm 8130 without a static tip falls back to priority fee, and `max_fee < base_fee` is `Priority::None`