### PR TITLE
feat(builder): expose base_sendRawTransactionValidity on builder nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,6 +3237,7 @@ dependencies = [
  "base-node-runner",
  "base-observability-events",
  "base-test-utils",
+ "base-txpool-rpc",
  "chrono",
  "clap",
  "clap_builder",

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -15,7 +15,7 @@ use base_execution_cli::{
     ExecutionNodeConfigArgs, StandardBaseRethNode, chainspec::chain_value_parser,
 };
 use base_node_runner::BaseNodeRunner;
-use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
 use base_upgrade_signal::UpgradeSignalStartupMode;
 use clap::Args;
 use reth_cli_runner::CliRunner;
@@ -115,6 +115,11 @@ impl SequencerCommand {
             runner.install_ext::<MeteringStoreExtension>(metering_provider);
             runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });
             runner.install_ext::<BuilderApiExtension>(builder_api_config);
+            if builder_api_config.accept_experimental_validity_transactions {
+                runner.install_ext::<SendRawTransactionValidityExtension>(
+                    builder_api_config.max_validity_predicates,
+                );
+            }
             StandardBaseRethNode::install_upgrade_signal_runtime_extension(
                 &mut runner,
                 &rollup_args,

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -13,7 +13,7 @@ use base_execution_cli::{Cli, StandardBaseRethNode};
 use base_node_runner::BaseNodeRunner;
 use base_observability_events::GlobalTransactionEventWriter;
 use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
-use base_txpool_rpc::{TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
 
 type BuilderCli = Cli<Args>;
 
@@ -62,6 +62,11 @@ fn main() {
         runner.install_ext::<MeteringStoreExtension>(metering_provider);
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
         runner.install_ext::<BuilderApiExtension>(builder_api_config);
+        if builder_api_config.accept_experimental_validity_transactions {
+            runner.install_ext::<SendRawTransactionValidityExtension>(
+                builder_api_config.max_validity_predicates,
+            );
+        }
         runner.install_ext::<ShadowIndexerExtension>(shadow_indexer_config);
         StandardBaseRethNode::install_upgrade_signal_runtime_extension(&mut runner, &rollup_args)?;
         runner.add_started_callback(|| {

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -185,8 +185,10 @@ pub struct Args {
     #[arg(long = "builder.enable-resource-metering", default_value = "false")]
     pub enable_resource_metering: bool,
 
-    /// Accept experimental validity-bearing transactions from forwarding nodes.
+    /// Enable experimental validity-bearing transactions on this builder.
     ///
+    /// Registers `base_sendRawTransactionValidity` for direct ingress and accepts
+    /// validity metadata on `base_insertValidatedTransaction` from forwarding nodes.
     /// Predicates are preserved and enforced during block construction.
     #[arg(long = "builder.enable-experimental-validity-transactions", default_value = "false")]
     pub enable_experimental_validity_transactions: bool,

--- a/crates/builder/core/Cargo.toml
+++ b/crates/builder/core/Cargo.toml
@@ -157,6 +157,7 @@ tikv-jemallocator = { workspace = true, optional = true }
 [dev-dependencies]
 # workspace
 base-test-utils.workspace = true
+base-txpool-rpc.workspace = true
 base-builder-core = { path = ".", features = ["test-utils"] }
 
 # reth

--- a/crates/builder/core/tests/rpc.rs
+++ b/crates/builder/core/tests/rpc.rs
@@ -1,17 +1,21 @@
 //! Integration tests for the Builder RPC extension.
 
-use alloy_consensus::TxEip1559;
+use alloy_consensus::{SignableTransaction, TxEip1559};
 use alloy_eips::eip2718::Encodable2718;
-use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, Bytes, Signature, TxHash, TxKind, U256};
 use alloy_rpc_client::RpcClient;
+use alloy_signer::SignerSync;
 use base_builder_core::{BuilderApiExtension, BuilderApiExtensionConfig};
 use base_common_consensus::{BaseTransactionSigned, BaseTypedTransaction, TxDeposit};
+use base_common_rpc_types::BaseTransactionRequest;
 use base_execution_txpool::{
     DEFAULT_MAX_VALIDITY_PREDICATES, NoExtensions, TransactionValidity, ValidatedTransaction,
     ValidityOperator, ValidityPredicate,
 };
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::Account;
+use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityRequest};
 
 /// Sets up a test harness with the `BuilderApiExtension` installed.
 async fn setup(
@@ -40,6 +44,42 @@ fn create_deposit_tx() -> (Address, Bytes) {
     let signed_tx: BaseTransactionSigned = deposit_tx.into();
     let encoded = signed_tx.encoded_2718();
     (sender, Bytes::from(encoded))
+}
+
+/// Sets up a test harness with builder insertion and public validity ingress.
+async fn setup_with_validity_ingress(
+    accept_validity: bool,
+    max_validity_predicates: usize,
+) -> eyre::Result<(TestHarness, RpcClient)> {
+    let config = BuilderApiExtensionConfig::new(accept_validity, max_validity_predicates);
+    let mut builder = TestHarness::builder().with_ext::<BuilderApiExtension>(config);
+    if accept_validity {
+        builder = builder.with_ext::<SendRawTransactionValidityExtension>(max_validity_predicates);
+    }
+    let harness = builder.build().await?;
+    let client = harness.rpc_client()?;
+    Ok((harness, client))
+}
+
+/// Creates a recoverably signed EIP-1559 transaction for public validity ingress.
+fn signed_eip1559_tx(chain_id: u64) -> Bytes {
+    let account = Account::Alice;
+    let request = BaseTransactionRequest::default()
+        .from(account.address())
+        .transaction_type(2u8)
+        .with_gas_limit(21_000)
+        .with_max_fee_per_gas(1_000_000_000)
+        .with_max_priority_fee_per_gas(1_000_000)
+        .with_chain_id(chain_id)
+        .to(Address::ZERO)
+        .with_nonce(0);
+    let transaction = request.build_typed_tx().expect("valid transaction request");
+    let signature = account
+        .signer()
+        .sign_hash_sync(&transaction.signature_hash())
+        .expect("test account should sign transaction");
+
+    transaction.into_signed(signature).encoded_2718().into()
 }
 
 /// Creates an EIP-1559 transaction for testing.
@@ -177,6 +217,72 @@ async fn test_validity_transactions_enforce_configured_limit() -> eyre::Result<(
 
     let result: Result<(), _> =
         client.request("base_insertValidatedTransaction", (transaction,)).await;
+    let error = result.expect_err("builder should reject validity above its configured limit");
+
+    assert!(error.to_string().contains("too many validity predicates"));
+    assert!(error.to_string().contains("maximum 1"));
+    Ok(())
+}
+
+/// Verifies builders do not expose public validity ingress unless explicitly opted in.
+#[tokio::test]
+async fn test_send_raw_transaction_validity_requires_explicit_opt_in() -> eyre::Result<()> {
+    let (disabled_harness, disabled_client) = setup(false, DEFAULT_MAX_VALIDITY_PREDICATES).await?;
+    let disabled: Result<TxHash, _> = disabled_client
+        .request(
+            "base_sendRawTransactionValidity",
+            (SendRawTransactionValidityRequest {
+                tx: signed_eip1559_tx(disabled_harness.chain_id()),
+                validity: Vec::new(),
+            },),
+        )
+        .await;
+    let disabled_error = disabled
+        .expect_err("disabled builder should not expose base_sendRawTransactionValidity")
+        .to_string();
+    assert!(
+        disabled_error.contains("-32601") || disabled_error.to_ascii_lowercase().contains("method"),
+        "expected method-not-found for disabled builder, got: {disabled_error}"
+    );
+
+    let (enabled_harness, enabled_client) =
+        setup_with_validity_ingress(true, DEFAULT_MAX_VALIDITY_PREDICATES).await?;
+    let enabled: Result<TxHash, _> = enabled_client
+        .request(
+            "base_sendRawTransactionValidity",
+            (SendRawTransactionValidityRequest {
+                tx: signed_eip1559_tx(enabled_harness.chain_id()),
+                validity: vec![ValidityPredicate::Balance {
+                    address: Account::Alice.address(),
+                    op: ValidityOperator::Equal,
+                    value: U256::ZERO,
+                }],
+            },),
+        )
+        .await;
+    assert!(enabled.is_ok(), "enabled builder should accept validity ingress: {enabled:?}");
+
+    Ok(())
+}
+
+/// Verifies public validity ingress enforces the builder's configured predicate limit.
+#[tokio::test]
+async fn test_send_raw_transaction_validity_enforces_configured_limit() -> eyre::Result<()> {
+    let (harness, client) = setup_with_validity_ingress(true, 1).await?;
+    let predicate = ValidityPredicate::Balance {
+        address: Account::Alice.address(),
+        op: ValidityOperator::Equal,
+        value: U256::ZERO,
+    };
+    let result: Result<TxHash, _> = client
+        .request(
+            "base_sendRawTransactionValidity",
+            (SendRawTransactionValidityRequest {
+                tx: signed_eip1559_tx(harness.chain_id()),
+                validity: vec![predicate; 2],
+            },),
+        )
+        .await;
     let error = result.expect_err("builder should reject validity above its configured limit");
 
     assert!(error.to_string().contains("too many validity predicates"));

--- a/crates/execution/txpool-rpc/README.md
+++ b/crates/execution/txpool-rpc/README.md
@@ -10,11 +10,12 @@ transaction pool.
 Exposes JSON-RPC APIs for transaction pool administration and transaction lifecycle tracking.
 `AdminTxPoolApiImpl` provides admin-level pool management, while `TransactionStatusApiImpl`
 allows clients to query the current status of individual transactions by hash. The separate
-`SendRawTransactionValidityExtension` registers local mempool ingress through
-`base_sendRawTransactionValidity`; typed validity predicates are preserved while forwarding to
-builders. This endpoint is experimental, but predicates are now evaluated and enforced by the
-builder during block construction: a transaction is only included at a point where all of its
-predicates hold, and it is evicted once it can no longer be included.
+`SendRawTransactionValidityExtension` registers local ingress through
+`base_sendRawTransactionValidity` on both mempool/client nodes and builder nodes. Typed
+validity predicates are preserved in the pool (and while forwarding to builders). This endpoint
+is experimental, but predicates are evaluated and enforced by the builder during block
+construction: a transaction is only included at a point where all of its predicates hold, and
+it is evicted once it can no longer be included.
 
 ## Usage
 

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -422,10 +422,11 @@ that:
    otherwise. Only with this flag set is the `base_sendRawTransactionValidity`
    endpoint registered.
 2. The builder is started with
-   `--builder.enable-experimental-validity-transactions`. If it is not, forwarded
-   transactions that carry predicates are **rejected** ("transaction extensions
-   are disabled"), so a misconfiguration fails loudly rather than silently
-   dropping predicates.
+   `--builder.enable-experimental-validity-transactions`. That flag both
+   registers `base_sendRawTransactionValidity` on the builder and accepts
+   forwarded validity metadata. If it is not set, forwarded transactions that
+   carry predicates are **rejected** ("transaction extensions are disabled"), so
+   a misconfiguration fails loudly rather than silently dropping predicates.
 3. The builder runs the flashblocks build path (the only builder path wired in
    the shipped binaries), which is where predicates are evaluated against state.
 

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -90,7 +90,8 @@ deployment must schedule Cobalt no later than Denim and configure both sides of
 the forwarding path:
 
 - builder: `--builder.enable-experimental-validity-transactions` and
-  `--builder.payload-builder-cutover`
+  `--builder.payload-builder-cutover`. The builder flag also registers
+  `base_sendRawTransactionValidity` for direct ingress.
 - ingress/client: `--enable-experimental-validity-transactions` and a
   `--builder-rpc-urls` endpoint targeting the builder
 

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -16,7 +16,8 @@ use base_execution_txpool::{
     BasePooledTransaction, BuilderApiImpl, BuilderApiServer, DEFAULT_MAX_VALIDITY_PREDICATES,
 };
 use base_node_core::{args::RollupArgs, node::BasePoolBuilder};
-use base_node_runner::{BaseNode, BaseNodeExtension, NodeHooks};
+use base_node_runner::{BaseNode, BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use base_txpool_rpc::SendRawTransactionValidityExtension;
 use eyre::{Result, WrapErr, eyre};
 use reth_db::{
     ClientVersion, DatabaseEnv, init_db,
@@ -56,7 +57,8 @@ pub struct InProcessBuilderConfig {
     pub flashblocks_port: Option<u16>,
     /// Optional fixed Prometheus metrics port (uses random if None).
     pub metrics_port: Option<u16>,
-    /// Whether to accept experimental validity-bearing transactions.
+    /// Whether to accept experimental validity-bearing transactions and expose
+    /// `base_sendRawTransactionValidity`.
     pub enable_experimental_validity_transactions: bool,
     /// Whether to run both payload builders and cut over to basic at Denim.
     pub payload_builder_cutover: bool,
@@ -184,15 +186,22 @@ impl InProcessBuilder {
         let p2p_port = node_config.network.port;
 
         let accept_validity_transactions = config.enable_experimental_validity_transactions;
+        let extra_extensions = config.extra_extensions;
+        let mut hooks = NodeHooks::new();
+        if accept_validity_transactions {
+            hooks = Box::new(SendRawTransactionValidityExtension::from_config(
+                DEFAULT_MAX_VALIDITY_PREDICATES,
+            ))
+            .apply(hooks);
+        }
         let node_builder = NodeBuilder::new(node_config.clone())
             .with_database(db)
             .with_launch_context(runtime.clone())
             .with_types::<BaseNode>();
 
-        let launched = config
-            .extra_extensions
+        let launched = extra_extensions
             .into_iter()
-            .fold(NodeHooks::new(), |hooks, ext| ext.apply(hooks))
+            .fold(hooks, |hooks, ext| ext.apply(hooks))
             .apply_to(
                 node_builder
                     .with_components(

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -79,7 +79,8 @@ pub struct L2StackConfig {
     /// Optional transaction forwarding configuration for the client node.
     /// When set, the client will forward transactions to builder RPC endpoints.
     pub tx_forwarding_config: Option<TxForwardingConfig>,
-    /// Whether both L2 nodes enable experimental validity transaction transport.
+    /// Whether both L2 nodes enable experimental validity transaction transport,
+    /// including `base_sendRawTransactionValidity` on the builder.
     pub enable_experimental_validity_transactions: bool,
     /// Whether the active builder cuts over from flashblocks to basic at Denim.
     pub payload_builder_cutover: bool,

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -1,7 +1,8 @@
 //! System tests for the transaction forwarding pipeline.
 //!
 //! These tests verify that transactions can be forwarded from mempool nodes
-//! to builder nodes via the `base_insertValidatedTransaction` RPC endpoint.
+//! to builder nodes via the `base_insertValidatedTransaction` RPC endpoint, and
+//! that validity transactions can also be submitted directly to the builder.
 
 use std::time::Duration;
 
@@ -378,6 +379,53 @@ async fn test_matching_validity_predicates_are_forwarded_and_included() -> Resul
     );
 
     system.shutdown().await?;
+
+    Ok(())
+}
+
+/// Verifies a validity transaction submitted directly to the builder is included without an
+/// extra mempool-node hop.
+#[tokio::test]
+async fn test_validity_transaction_submitted_directly_to_builder_is_included() -> Result<()> {
+    let system = start_validity_system().await?;
+    let builder_provider = system.l2_builder_provider()?;
+
+    let signer = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_3.private_key)?;
+    let sender = signer.address();
+    builder_provider.wait_for_balance(sender, Duration::from_secs(15)).await?;
+
+    let nonce = builder_provider.get_transaction_count(sender).await?;
+    let recipient: Address = "0x000000000000000000000000000000000000dEaD".parse()?;
+    let recipient_balance_before = builder_provider.get_balance(recipient).await?;
+    let (_, raw_tx, expected_tx_hash) =
+        create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+    let rpc_client = RpcClient::builder().http(system.l2_rpc_url()?);
+    let tx_hash: B256 = rpc_client
+        .request(
+            "base_sendRawTransactionValidity",
+            (SendRawTransactionValidityRequest {
+                tx: raw_tx,
+                validity: vec![ValidityPredicate::Balance {
+                    address: sender,
+                    op: ValidityOperator::GreaterThan,
+                    value: U256::ZERO,
+                }],
+            },),
+        )
+        .await?;
+
+    assert_eq!(tx_hash, expected_tx_hash, "Transaction hash mismatch");
+
+    let receipt = builder_provider.wait_for_receipt(expected_tx_hash, TX_RECEIPT_TIMEOUT).await?;
+    assert_eq!(receipt.inner.transaction_hash, expected_tx_hash);
+    assert!(receipt.inner.block_number.is_some(), "Receipt should have block number");
+    assert_eq!(receipt.inner.from, sender);
+    assert_eq!(receipt.inner.to, Some(recipient));
+    assert_eq!(
+        builder_provider.get_balance(recipient).await?,
+        recipient_balance_before + U256::from(1_000_000_000u64),
+        "direct builder ingress must not alter the signed transaction's state transition"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Registers `base_sendRawTransactionValidity` on builder nodes (`base-builder`, `base sequencer`, and in-process builders) when `--builder.enable-experimental-validity-transactions` is set, so validity transactions can be submitted directly without an extra client/mempool hop.
- The same flag still accepts forwarded validity metadata on `base_insertValidatedTransaction`.
- Adds builder RPC coverage for opt-in and predicate limits, plus a system test that submits a validity transaction straight to the builder and confirms inclusion.

Fixes CHAIN-4890.

## Test plan
- [x] `cargo test -p base-builder-core --test rpc`
- [x] `cargo test -p base-builder-cli --lib`
- [x] `cargo check -p base-builder-bin -p base -p base-system-tests --no-default-features`
- [ ] Run `test_validity_transaction_submitted_directly_to_builder_is_included` in `etc/systems/tests/tx_forwarding.rs` (needs Foundry artifacts)
- [ ] Confirm a builder started with `--builder.enable-experimental-validity-transactions` serves `base_sendRawTransactionValidity` and a builder without the flag returns method-not-found