### PR TITLE
ci: run linux release jobs on depot

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,10 +34,10 @@ jobs:
       matrix:
         target:
           - triple: x86_64-unknown-linux-gnu
-            runner: ubuntu-24.04
+            runner: depot-ubuntu-24.04-16
             os: linux
           - triple: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            runner: depot-ubuntu-24.04-arm-16
             os: linux
           - triple: aarch64-apple-darwin
             runner: macos-14
@@ -160,9 +160,9 @@ jobs:
       matrix:
         settings:
           - arch: linux/amd64
-            runs-on: ubuntu-24.04
+            runs-on: depot-ubuntu-24.04-16
           - arch: linux/arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: depot-ubuntu-24.04-arm-16
         image:
           - target: base
             name: node


### PR DESCRIPTION
## Summary
- move Linux amd64 and arm64 release jobs in this workflow from GitHub-hosted runners to larger Depot runners
- use `depot-ubuntu-24.04-16` for amd64 and `depot-ubuntu-24.04-arm-16` for arm64
- keep the existing cargo build commands unchanged, including the scoped `-lblst` workaround for Linux arm64 binaries

## Failure analysis
- Run 33448995415 job 99674521578 is `build / build-binaries (aarch64-unknown-linux-gnu, ubuntu-24.04-arm, linux, base)`.
- The job starts `cargo rustc --locked --profile maxperf -p "base" --bin "base" -- -C link-arg=-lblst`.
- It reaches `Compiling base v1.3.0 (/home/runner/work/base/base/bin/base)` at 2026-08-31T23:16:53Z, then fails at 2026-08-31T23:36:17Z with `The runner has received a shutdown signal` and exit code 143.
- There is no Rust compiler error, linker error, missing dependency, or `-lblst` failure in the job log. The same run's Linux arm64 `base-consensus` and `basectl` binary jobs succeeded with the existing scoped `-lblst` command.

## Fix rationale
- The failing matrix cell is the largest Linux arm64 Rust binary build and appears to be getting terminated by the hosted arm runner rather than failing deterministically in the build.
- Depot's runner type docs list `depot-ubuntu-24.04-16` and `depot-ubuntu-24.04-arm-16` as 16 CPU / 64 GB RAM runners, so this gives the release workflow's Linux builds more headroom without reducing Cargo parallelism.
- This is scoped to `.github/workflows/build-release.yml`; macOS jobs continue using `macos-14`.

## Validation
- `git diff --check`
- Shell command paths unchanged except for `runs-on` labels; the build scripts remain the same as current `main`.
