### PR TITLE
fix(precompiles): remove incomplete PrecompileProvider impl

### DIFF
--- a/crates/common/evm/README.md
+++ b/crates/common/evm/README.md
@@ -24,7 +24,7 @@ base-common-evm = { workspace = true }
 use base_common_evm::{BaseEvmFactory, BasePrecompiles, BaseSpecId, BaseUpgrade};
 
 let factory = BaseEvmFactory::default();
-let precompiles = BasePrecompiles::new_with_spec(BaseSpecId::new(BaseUpgrade::Isthmus));
+let precompiles = BasePrecompiles::new_with_spec(BaseSpecId::new(BaseUpgrade::Beryl)).install();
 ```
 
 ## License

--- a/crates/common/evm/src/api/builder.rs
+++ b/crates/common/evm/src/api/builder.rs
@@ -13,7 +13,7 @@ use crate::{BaseContext, BaseEvm, BasePrecompiles, BaseSpecId, BerylPrecompileMe
 /// Trait that allows constructing a [`BaseEvm`] from a [`BaseContext`].
 ///
 /// Implemented for [`BaseContext<DB>`] of any database. The resulting [`BaseEvm`]
-/// installs the full [`BasePrecompiles`] map for the active [`BaseSpecId`]; call
+/// installs the full [`PrecompilesMap`] for the active [`BaseSpecId`]; call
 /// [`BaseEvm::with_precompiles`] afterwards to substitute a custom precompile set.
 pub trait Builder: Sized {
     /// The database type of the context.

--- a/crates/common/evm/src/evm.rs
+++ b/crates/common/evm/src/evm.rs
@@ -1,6 +1,6 @@
 use core::ops::{Deref, DerefMut};
 
-use alloy_evm::{Database as AlloyDatabase, Evm, EvmEnv};
+use alloy_evm::{Database as AlloyDatabase, Evm, EvmEnv, precompiles::PrecompilesMap};
 use alloy_primitives::{Address, Bytes};
 use revm::{
     Database as RevmDatabase, DatabaseCommit, ExecuteCommitEvm, ExecuteEvm, InspectCommitEvm,
@@ -25,8 +25,8 @@ use revm::{
 #[cfg(feature = "std")]
 use crate::Eip8130Executor;
 use crate::{
-    BaseContext, BaseHaltReason, BasePrecompiles, BaseSpecId, BaseTransaction,
-    BaseTransactionError, BaseTxTr, handler::BaseHandler,
+    BaseContext, BaseHaltReason, BaseSpecId, BaseTransaction, BaseTransactionError, BaseTxTr,
+    handler::BaseHandler,
 };
 
 /// Type alias for the inner [`RevmEvm`] parameterized with Base-specific context and fixed
@@ -42,14 +42,14 @@ type InnerEvm<DB, I, P> = RevmEvm<
 /// The Base EVM, wrapping [`RevmEvm`] with a [`BaseContext`] and an optional [`Inspector`].
 ///
 /// Parameterized over a database [`DB`], inspector [`I`], and precompile set [`P`]
-/// (defaulting to [`BasePrecompiles`]). All Base-specific context configuration —
+/// (defaulting to [`PrecompilesMap`]). All Base-specific context configuration —
 /// [`BaseSpecId`], [`BaseTransaction`], and [`crate::L1BlockInfo`] — is fixed by [`BaseContext`].
 ///
 /// The `inspect` flag controls whether [`Inspector`] callbacks are invoked during
 /// [`Evm::transact`]. When `false`, the inspector is present in the type but silent,
 /// enabling zero-cost tracing toggling at runtime without type changes.
 #[allow(missing_debug_implementations)] // revm::Context does not implement Debug
-pub struct BaseEvm<DB: RevmDatabase, I, P = BasePrecompiles> {
+pub struct BaseEvm<DB: RevmDatabase, I, P = PrecompilesMap> {
     /// Inner revm EVM with Base-specific context, fixed [`EthInstructions`] and
     /// [`EthFrame`], and generic precompile set [`P`].
     pub(crate) inner: InnerEvm<DB, I, P>,
@@ -93,7 +93,7 @@ impl<DB: RevmDatabase, I, P> BaseEvm<DB, I, P> {
     }
 
     /// Consumes `self` and returns a new [`BaseEvm`] with the given precompile set,
-    /// preserving the inspect flag. Used to substitute [`BasePrecompiles`] with
+    /// preserving the inspect flag. Used to substitute the default [`PrecompilesMap`] with
     /// custom implementations such as FPVM-accelerated precompiles in the proof system.
     pub fn with_precompiles<Q>(self, precompiles: Q) -> BaseEvm<DB, I, Q> {
         BaseEvm { inner: self.inner.with_precompiles(precompiles), inspect: self.inspect }

--- a/crates/common/precompiles/README.md
+++ b/crates/common/precompiles/README.md
@@ -8,11 +8,13 @@ Provides the Base-specific precompile layer used by the Base EVM. The crate sele
 Ethereum and Base precompile table for each supported `BaseUpgrade`, and it also owns the Beryl
 native precompiles that are installed into a dynamic `PrecompilesMap`.
 
-`BasePrecompiles` is the main entry point. It can expose the static precompile table for a fork, or
-build the full installed map used by EVM execution. `BasePrecompileSpec` is the small trait bound
-that lets downstream crates use their own spec wrapper as long as it converts to and from
-`BaseUpgrade`. Most EVM users should still go through the `BasePrecompiles` alias and builders in
-`base-common-evm`, because those are already wired to `BaseSpecId` and install the full map.
+`BasePrecompiles` is the main entry point. It exposes the static precompile table for a fork, and
+`install()` / `install_with_observer()` build the full map used by EVM execution. `BasePrecompiles`
+is not a `PrecompileProvider`; plug the installed `PrecompilesMap` into an EVM, not the selector
+type. `BasePrecompileSpec` is the small trait bound that lets downstream crates use their own spec
+wrapper as long as it converts to and from `BaseUpgrade`. Most EVM users should still go through
+the `BasePrecompiles` alias and builders in `base-common-evm`, because those are already wired to
+`BaseSpecId` and install the full map.
 
 The crate also exports the ABI types, storage adapters, entry points, and shared token traits for
 the native B-20 token system. Those exports cover the activation registry, policy registry, B-20

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -537,6 +537,8 @@ mod tests {
         assert!(precompiles.get(secp256r1::P256VERIFY.address()).is_some());
     }
 
+    // Static table only. Factory, lookup, registries, nonce manager, and tx context
+    // are registered later by install() / install_with_observer().
     #[rstest]
     #[case::beryl(BaseUpgrade::Beryl)]
     #[case::cobalt(BaseUpgrade::Cobalt)]

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -1,17 +1,12 @@
-use alloc::string::String;
-
 use alloy_evm::precompiles::PrecompilesMap;
 use alloy_primitives::Address;
 use base_common_chains::BaseUpgradeExt;
 use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::StorageFeatures;
 use revm::{
-    context::Cfg,
-    context_interface::ContextTr,
-    handler::{EthPrecompiles, PrecompileProvider},
-    interpreter::{CallInputs, InterpreterResult},
+    handler::EthPrecompiles,
     precompile::{self, Precompiles, bn254, modexp, secp256r1},
-    primitives::{AddressSet, OnceLock, hardfork::SpecId},
+    primitives::{OnceLock, hardfork::SpecId},
 };
 
 use crate::{
@@ -20,19 +15,26 @@ use crate::{
     TxContext, UpgradeGatedStorageFeatures, bls12_381, bn254_pair,
 };
 
-/// Base precompile provider.
+/// Static Base precompile table for a [`BasePrecompileSpec`].
+///
+/// This type selects the fork's Ethereum-style precompiles. It is not a
+/// [`revm::handler::PrecompileProvider`]. Call [`Self::install`] or
+/// [`Self::install_with_observer`] to build the executable [`PrecompilesMap`].
 #[derive(Debug, Clone)]
 pub struct BasePrecompiles<S = BaseUpgrade> {
-    /// Inner precompile provider is the same as Ethereum's.
+    /// Inner static Ethereum-style precompile table.
     inner: EthPrecompiles,
-    /// Spec id of the precompile provider.
+    /// Spec id of the precompile table.
     spec: S,
     /// Activation registry admin address.
     activation_admin_address: Option<Address>,
 }
 
 impl<S: BasePrecompileSpec> BasePrecompiles<S> {
-    /// Create a new precompile provider with the given spec.
+    /// Create the static precompile table for the given spec.
+    ///
+    /// The returned value does not include Beryl or later dynamic precompiles.
+    /// Call [`Self::install`] before using the set for EVM execution.
     #[inline]
     pub fn new_with_spec(spec: S) -> Self {
         let precompiles = match spec.upgrade() {
@@ -240,43 +242,6 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
     }
 }
 
-impl<CTX, S> PrecompileProvider<CTX> for BasePrecompiles<S>
-where
-    S: BasePrecompileSpec,
-    CTX: ContextTr<Cfg: Cfg<Spec = S>>,
-{
-    type Output = InterpreterResult;
-
-    #[inline]
-    fn set_spec(&mut self, spec: <CTX::Cfg as Cfg>::Spec) -> bool {
-        if spec == self.spec {
-            return false;
-        }
-        *self =
-            Self::new_with_spec(spec).with_activation_admin_address(self.activation_admin_address);
-        true
-    }
-
-    #[inline]
-    fn run(
-        &mut self,
-        context: &mut CTX,
-        inputs: &CallInputs,
-    ) -> Result<Option<Self::Output>, String> {
-        self.inner.run(context, inputs)
-    }
-
-    #[inline]
-    fn warm_addresses(&self) -> &AddressSet {
-        self.inner.warm_addresses()
-    }
-
-    #[inline]
-    fn contains(&self, address: &Address) -> bool {
-        self.inner.contains(address)
-    }
-}
-
 impl<S: BasePrecompileSpec> Default for BasePrecompiles<S> {
     fn default() -> Self {
         Self::new_with_spec(S::default_precompile_spec())
@@ -298,7 +263,7 @@ mod tests {
 
     use crate::{
         ActivationRegistryStorage, B20FactoryStorage, B20Variant, BasePrecompiles,
-        NonceManagerStorage, TxContextStorage, bls12_381, bn254_pair,
+        NonceManagerStorage, PolicyRegistryStorage, TxContextStorage, bls12_381, bn254_pair,
     };
 
     type TestPrecompiles = BasePrecompiles<BaseUpgrade>;
@@ -570,6 +535,23 @@ mod tests {
 
         assert!(precompiles.get(&bn254::pair::ADDRESS).is_some());
         assert!(precompiles.get(secp256r1::P256VERIFY.address()).is_some());
+    }
+
+    #[rstest]
+    #[case::beryl(BaseUpgrade::Beryl)]
+    #[case::cobalt(BaseUpgrade::Cobalt)]
+    fn new_with_spec_omits_dynamic_precompiles(#[case] spec: BaseUpgrade) {
+        let precompiles = BasePrecompiles::new_with_spec(spec);
+        let static_table = precompiles.precompiles();
+        let (token, _) =
+            B20Variant::Asset.compute_address(Address::repeat_byte(0x11), B256::repeat_byte(0x22));
+
+        assert!(static_table.get(&B20FactoryStorage::ADDRESS).is_none());
+        assert!(static_table.get(&token).is_none());
+        assert!(static_table.get(&PolicyRegistryStorage::ADDRESS).is_none());
+        assert!(static_table.get(&ActivationRegistryStorage::ADDRESS).is_none());
+        assert!(static_table.get(&TxContextStorage::ADDRESS).is_none());
+        assert!(static_table.get(&NonceManagerStorage::ADDRESS).is_none());
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary
- `BasePrecompiles::new_with_spec` only selects the static Ethereum-style table. Implementing `PrecompileProvider` on that type let a downstream EVM silently omit Beryl and Cobalt fork-installed addresses (factory, lookup, registries, nonce manager, transaction context).
- Remove the trait impl so the incomplete selector cannot be plugged in as a provider. Default `BaseEvm` to the installed `PrecompilesMap`, and document that execution must go through `install()` / `install_with_observer()`.
- Add a test that the static table still omits those dynamic addresses until `install()`.

Fixes Cantina #19 / BOP-606.

## Test plan
- [x] `cargo test -p base-common-precompiles --lib`
- [x] `cargo test -p base-common-evm --lib builder::`
- [ ] Confirm first-party builders (`BaseEvmFactory`, `BaseZkvmPrecompiles`) still install the full map
- [ ] Confirm a downstream crate can no longer use `BasePrecompiles` as a `PrecompileProvider`


Made with [Cursor](https://cursor.com)