### PR TITLE
fix(precompiles): classify Cobalt policy methods and errors in metrics (Cantina #14 / BOP-601)

### DIFF
--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -6,9 +6,10 @@ use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
-    ActivationAdminConfig, ActivationRegistryStorage, BerylCallRecorder,
+    ActivationAdminConfig, ActivationRegistryStorage,
     IActivationRegistry::{self, IActivationRegistryCalls as C},
-    NoopPrecompileCallObserver, PrecompileCallObserver, PrecompileMetricLabels,
+    NoopPrecompileCallObserver, PrecompileCallObserver, PrecompileCallRecorder,
+    PrecompileMetricLabels,
     macros::decode_precompile_call,
 };
 
@@ -42,8 +43,10 @@ impl ActivationRegistryStorage<'_> {
     where
         O: PrecompileCallObserver,
     {
-        let mut recorder =
-            BerylCallRecorder::start(observer, PrecompileMetricLabels::activation_call(calldata));
+        let mut recorder = PrecompileCallRecorder::start(
+            observer,
+            PrecompileMetricLabels::activation_call(calldata),
+        );
         // Activation-registry selectors are all nonpayable; reject attached ETH from Cobalt
         // onward. Pre-Cobalt (Beryl) preserves the historical accept-and-strand behavior so
         // replay of live-installed activation calls remains byte-identical.

--- a/crates/common/precompiles/src/activation/dispatch.rs
+++ b/crates/common/precompiles/src/activation/dispatch.rs
@@ -6,9 +6,9 @@ use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
-    ActivationAdminConfig, ActivationRegistryStorage, BerylCallRecorder, BerylMetricLabels,
+    ActivationAdminConfig, ActivationRegistryStorage, BerylCallRecorder,
     IActivationRegistry::{self, IActivationRegistryCalls as C},
-    NoopPrecompileCallObserver, PrecompileCallObserver,
+    NoopPrecompileCallObserver, PrecompileCallObserver, PrecompileMetricLabels,
     macros::decode_precompile_call,
 };
 
@@ -43,7 +43,7 @@ impl ActivationRegistryStorage<'_> {
         O: PrecompileCallObserver,
     {
         let mut recorder =
-            BerylCallRecorder::start(observer, BerylMetricLabels::activation_call(calldata));
+            BerylCallRecorder::start(observer, PrecompileMetricLabels::activation_call(calldata));
         // Activation-registry selectors are all nonpayable; reject attached ETH from Cobalt
         // onward. Pre-Cobalt (Beryl) preserves the historical accept-and-strand behavior so
         // replay of live-installed activation calls remains byte-identical.

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -17,10 +17,11 @@ use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx}
 
 use crate::{
     AssetAccounting, AssetCall, AssetVersion, AssetVersions, B20AssetStorage, B20AssetToken,
-    B20PolicyType, B20TokenRole, BerylAuxiliaryMetrics, BerylCallRecorder, BerylMetricLabels,
+    B20PolicyType, B20TokenRole, BerylAuxiliaryMetrics, BerylCallRecorder,
     IB20::{self, IB20Calls as C},
     IB20Asset::{self, IB20AssetCalls as SC},
     NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileCallObserver,
+    PrecompileMetricLabels,
 };
 
 impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
@@ -45,8 +46,10 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
     where
         O: PrecompileCallObserver,
     {
-        let mut recorder =
-            BerylCallRecorder::start(observer.clone(), BerylMetricLabels::b20_asset_call(calldata));
+        let mut recorder = BerylCallRecorder::start(
+            observer.clone(),
+            PrecompileMetricLabels::b20_asset_call(calldata),
+        );
         if !ctx.call_value().is_zero() {
             return recorder
                 .record_base_error_result(ctx, BasePrecompileError::revert(IB20::NonPayable {}));
@@ -589,10 +592,10 @@ mod tests {
 
     use crate::{
         ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, AssetAccounting,
-        AssetV1, AssetVersion, B20AssetStorage, B20AssetToken, B20TokenRole, BerylErrorKind,
-        FakePolicyAccounting, IB20, IB20Asset, InMemoryTokenAccounting, NoopPrecompileCallObserver,
-        PolicyVersion, PrecompileCallMetric, PrecompileCallObserver, PrecompileCallOutcome,
-        PrecompileCallStatus, Token, TokenAccounting,
+        AssetV1, AssetVersion, B20AssetStorage, B20AssetToken, B20TokenRole, FakePolicyAccounting,
+        IB20, IB20Asset, InMemoryTokenAccounting, NoopPrecompileCallObserver, PolicyVersion,
+        PrecompileCallMetric, PrecompileCallObserver, PrecompileCallOutcome, PrecompileCallStatus,
+        PrecompileErrorKind, Token, TokenAccounting,
     };
 
     type TestAssetToken = B20AssetToken<InMemoryTokenAccounting, FakePolicyAccounting>;
@@ -715,7 +718,7 @@ mod tests {
         assert_eq!(calls[0].0.method, "balanceOf");
         assert_eq!(calls[0].0.variant, Some("asset"));
         assert_eq!(calls[0].1.status, PrecompileCallStatus::Revert);
-        assert_eq!(calls[0].1.error, Some(BerylErrorKind::AbiDecode));
+        assert_eq!(calls[0].1.error, Some(PrecompileErrorKind::AbiDecode));
     }
 
     #[test]

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -17,11 +17,11 @@ use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx}
 
 use crate::{
     AssetAccounting, AssetCall, AssetVersion, AssetVersions, B20AssetStorage, B20AssetToken,
-    B20PolicyType, B20TokenRole, BerylAuxiliaryMetrics, BerylCallRecorder,
+    B20PolicyType, B20TokenRole,
     IB20::{self, IB20Calls as C},
     IB20Asset::{self, IB20AssetCalls as SC},
-    NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileCallObserver,
-    PrecompileMetricLabels,
+    NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileAuxiliaryMetrics,
+    PrecompileCallObserver, PrecompileCallRecorder, PrecompileMetricLabels,
 };
 
 impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
@@ -46,7 +46,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
     where
         O: PrecompileCallObserver,
     {
-        let mut recorder = BerylCallRecorder::start(
+        let mut recorder = PrecompileCallRecorder::start(
             observer.clone(),
             PrecompileMetricLabels::b20_asset_call(calldata),
         );
@@ -432,7 +432,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
             // --- Batched mint ---
             SC::batchMint(c) => {
                 observer.record_batch_items(
-                    &BerylAuxiliaryMetrics::b20("asset", "batchMint"),
+                    &PrecompileAuxiliaryMetrics::b20("asset", "batchMint"),
                     c.recipients.len(),
                 );
                 logic.batch_mint(self, caller, c.recipients, c.amounts, privileged)?;
@@ -470,7 +470,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
         let count = announce.internal_calls.len();
         let bytes: usize = announce.internal_calls.iter().map(|call| call.len()).sum();
         observer.record_internal_calls(
-            &BerylAuxiliaryMetrics::b20("asset", "announce"),
+            &PrecompileAuxiliaryMetrics::b20("asset", "announce"),
             count,
             bytes,
         );

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -11,9 +11,9 @@ use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, PrecompileResult, Result, StorageCtx};
 
 use crate::{
-    B20FactoryStorage, B20Variant, BerylAuxiliaryMetrics, BerylCallRecorder, BerylMetricLabels,
-    Factory, FactoryV1, FactoryVersion, FactoryVersions, IB20Factory, NoopPrecompileCallObserver,
-    PrecompileCallObserver,
+    B20FactoryStorage, B20Variant, BerylAuxiliaryMetrics, BerylCallRecorder, Factory, FactoryV1,
+    FactoryVersion, FactoryVersions, IB20Factory, NoopPrecompileCallObserver,
+    PrecompileCallObserver, PrecompileMetricLabels,
 };
 
 impl<'a> B20FactoryStorage<'a> {
@@ -38,8 +38,10 @@ impl<'a> B20FactoryStorage<'a> {
     where
         O: PrecompileCallObserver,
     {
-        let mut recorder =
-            BerylCallRecorder::start(observer.clone(), BerylMetricLabels::factory_call(calldata));
+        let mut recorder = BerylCallRecorder::start(
+            observer.clone(),
+            PrecompileMetricLabels::factory_call(calldata),
+        );
         if !ctx.call_value().is_zero() {
             return recorder.record_base_error_result(
                 ctx,

--- a/crates/common/precompiles/src/b20_factory/dispatch.rs
+++ b/crates/common/precompiles/src/b20_factory/dispatch.rs
@@ -11,9 +11,9 @@ use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, PrecompileResult, Result, StorageCtx};
 
 use crate::{
-    B20FactoryStorage, B20Variant, BerylAuxiliaryMetrics, BerylCallRecorder, Factory, FactoryV1,
-    FactoryVersion, FactoryVersions, IB20Factory, NoopPrecompileCallObserver,
-    PrecompileCallObserver, PrecompileMetricLabels,
+    B20FactoryStorage, B20Variant, Factory, FactoryV1, FactoryVersion, FactoryVersions,
+    IB20Factory, NoopPrecompileCallObserver, PrecompileAuxiliaryMetrics, PrecompileCallObserver,
+    PrecompileCallRecorder, PrecompileMetricLabels,
 };
 
 impl<'a> B20FactoryStorage<'a> {
@@ -38,7 +38,7 @@ impl<'a> B20FactoryStorage<'a> {
     where
         O: PrecompileCallObserver,
     {
-        let mut recorder = BerylCallRecorder::start(
+        let mut recorder = PrecompileCallRecorder::start(
             observer.clone(),
             PrecompileMetricLabels::factory_call(calldata),
         );
@@ -102,7 +102,7 @@ impl<'a> B20FactoryStorage<'a> {
                 let internal_call_bytes = call.initCalls.iter().map(|c| c.len()).sum();
                 let token = logic.create_b20(self, call, address_hash, upgrade)?;
                 observer.record_internal_calls(
-                    &BerylAuxiliaryMetrics::singleton("factory", "createB20"),
+                    &PrecompileAuxiliaryMetrics::singleton("factory", "createB20"),
                     internal_call_count,
                     internal_call_bytes,
                 );

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -14,11 +14,12 @@ use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
-    B20PolicyType, B20StablecoinToken, B20TokenRole, B20Variant, BerylCallRecorder, BerylSelector,
+    B20PolicyType, B20StablecoinToken, B20TokenRole, B20Variant,
     IB20::{self, IB20Calls as C},
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileCallObserver,
-    PrecompileMetricLabels, StablecoinAccounting, StablecoinVersion, StablecoinVersions,
+    PrecompileCallRecorder, PrecompileMetricLabels, PrecompileSelector, StablecoinAccounting,
+    StablecoinVersion, StablecoinVersions,
 };
 
 impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
@@ -43,7 +44,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
     where
         O: PrecompileCallObserver,
     {
-        let mut recorder = BerylCallRecorder::start(
+        let mut recorder = PrecompileCallRecorder::start(
             observer.clone(),
             PrecompileMetricLabels::b20_stablecoin_call(calldata),
         );
@@ -107,7 +108,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
     {
         let logic = version.implementation();
 
-        if let Some(selector) = BerylSelector::selector(calldata)
+        if let Some(selector) = PrecompileSelector::selector(calldata)
             && IB20Stablecoin::IB20StablecoinCalls::valid_selector(selector)
         {
             let call = IB20Stablecoin::IB20StablecoinCalls::abi_decode_validate(calldata).map_err(

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -14,12 +14,11 @@ use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
-    B20PolicyType, B20StablecoinToken, B20TokenRole, B20Variant, BerylCallRecorder,
-    BerylMetricLabels, BerylSelector,
+    B20PolicyType, B20StablecoinToken, B20TokenRole, B20Variant, BerylCallRecorder, BerylSelector,
     IB20::{self, IB20Calls as C},
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileCallObserver,
-    StablecoinAccounting, StablecoinVersion, StablecoinVersions,
+    PrecompileMetricLabels, StablecoinAccounting, StablecoinVersion, StablecoinVersions,
 };
 
 impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
@@ -46,7 +45,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
     {
         let mut recorder = BerylCallRecorder::start(
             observer.clone(),
-            BerylMetricLabels::b20_stablecoin_call(calldata),
+            PrecompileMetricLabels::b20_stablecoin_call(calldata),
         );
         if !ctx.call_value().is_zero() {
             return recorder

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -54,8 +54,8 @@ pub use observer::{EndGuard, NoopPrecompileCallObserver, PrecompileCallObserver}
 mod metrics;
 pub use metrics::{
     BerylAuxiliaryMetrics, BerylCallOutcome, BerylCallRecorder, BerylCallTimer,
-    BerylErrorClassifier, BerylErrorKind, BerylMetricLabels, BerylSelector, CALLDATA_WORD_GAS,
-    PrecompileCallMetric, PrecompileCallOutcome, PrecompileCallStatus,
+    BerylErrorClassifier, BerylSelector, CALLDATA_WORD_GAS, PrecompileCallMetric,
+    PrecompileCallOutcome, PrecompileCallStatus, PrecompileErrorKind, PrecompileMetricLabels,
 };
 
 mod b20_asset;

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -53,9 +53,9 @@ pub use observer::{EndGuard, NoopPrecompileCallObserver, PrecompileCallObserver}
 
 mod metrics;
 pub use metrics::{
-    BerylAuxiliaryMetrics, BerylCallOutcome, BerylCallRecorder, BerylCallTimer,
-    BerylErrorClassifier, BerylSelector, CALLDATA_WORD_GAS, PrecompileCallMetric,
-    PrecompileCallOutcome, PrecompileCallStatus, PrecompileErrorKind, PrecompileMetricLabels,
+    CALLDATA_WORD_GAS, PrecompileAuxiliaryMetrics, PrecompileCallMetric, PrecompileCallOutcome,
+    PrecompileCallRecorder, PrecompileCallStatus, PrecompileCallTimer, PrecompileErrorClassifier,
+    PrecompileErrorKind, PrecompileMetricLabels, PrecompileSelector,
 };
 
 mod b20_asset;

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -112,7 +112,7 @@ pub struct PrecompileCallOutcome {
     /// Total time spent in the Beryl dispatch wrapper, in seconds.
     pub duration_seconds: Option<f64>,
     /// Optional bounded error class.
-    pub error: Option<BerylErrorKind>,
+    pub error: Option<PrecompileErrorKind>,
 }
 
 impl PrecompileCallOutcome {
@@ -120,7 +120,7 @@ impl PrecompileCallOutcome {
     pub fn from_result(
         result: &PrecompileResult,
         duration_seconds: Option<f64>,
-        error: Option<BerylErrorKind>,
+        error: Option<PrecompileErrorKind>,
     ) -> Self {
         match result {
             Ok(output) => Self::from_output(output, duration_seconds, error),
@@ -130,7 +130,7 @@ impl PrecompileCallOutcome {
                 state_gas_used: 0,
                 gas_refunded: 0,
                 duration_seconds,
-                error: Some(BerylErrorKind::from_precompile_error(error)),
+                error: Some(PrecompileErrorKind::from_precompile_error(error)),
             },
         }
     }
@@ -139,13 +139,13 @@ impl PrecompileCallOutcome {
     pub fn from_output(
         output: &PrecompileOutput,
         duration_seconds: Option<f64>,
-        mut error: Option<BerylErrorKind>,
+        mut error: Option<PrecompileErrorKind>,
     ) -> Self {
         let status = if output.is_success() {
             PrecompileCallStatus::Success
         } else if output.is_revert() {
             if error.is_none() {
-                error = Some(BerylErrorKind::from_revert_bytes(&output.bytes));
+                error = Some(PrecompileErrorKind::from_revert_bytes(&output.bytes));
             }
             PrecompileCallStatus::Revert
         } else {
@@ -165,7 +165,7 @@ impl PrecompileCallOutcome {
 
 /// Bounded error-class label for precompile failures.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BerylErrorKind {
+pub enum PrecompileErrorKind {
     /// State mutation was attempted during a static call.
     StaticWrite,
     /// Calldata did not contain a known selector.
@@ -200,7 +200,7 @@ pub enum BerylErrorKind {
     OtherRevert,
 }
 
-impl BerylErrorKind {
+impl PrecompileErrorKind {
     /// Returns the metric label for this error kind.
     pub const fn as_label(self) -> &'static str {
         match self {
@@ -397,11 +397,11 @@ impl BerylErrorClassifier {
     }
 }
 
-/// Method-label helpers for Beryl call observation.
+/// Method-label helpers for native precompile call observation.
 #[derive(Debug, Clone, Copy)]
-pub struct BerylMetricLabels;
+pub struct PrecompileMetricLabels;
 
-impl BerylMetricLabels {
+impl PrecompileMetricLabels {
     /// Returns a B-20 method label from an existing stable call label.
     pub fn b20_method(label: &'static str) -> Cow<'static, str> {
         Cow::Borrowed(
@@ -563,7 +563,7 @@ pub struct BerylCallRecorder<O> {
     observer: O,
     timer: BerylCallTimer,
     call: PrecompileCallMetric,
-    error: Option<BerylErrorKind>,
+    error: Option<PrecompileErrorKind>,
 }
 
 impl<O> BerylCallRecorder<O>
@@ -604,7 +604,7 @@ where
 
     /// Records a Base precompile error before it is converted to a [`PrecompileResult`].
     pub fn record_base_error(&mut self, error: &BasePrecompileError) {
-        self.error = Some(BerylErrorKind::from_base_error(error));
+        self.error = Some(PrecompileErrorKind::from_base_error(error));
     }
 
     /// Records the final result of the precompile call.
@@ -665,15 +665,18 @@ mod tests {
     use base_precompile_storage::{BasePrecompileError, PrecompileError, PrecompileOutput};
 
     use crate::{
-        BerylCallOutcome, BerylCallRecorder, BerylErrorKind, BerylMetricLabels, BerylSelector,
-        CALLDATA_WORD_GAS, IActivationRegistry, IB20, IB20Asset, IB20Factory, IPolicyRegistry,
-        NoopPrecompileCallObserver,
+        BerylCallOutcome, BerylCallRecorder, BerylSelector, CALLDATA_WORD_GAS, IActivationRegistry,
+        IB20, IB20Asset, IB20Factory, IPolicyRegistry, NoopPrecompileCallObserver,
+        PrecompileErrorKind, PrecompileMetricLabels,
     };
 
     #[test]
     fn b20_method_labels_strip_precompile_prefixes() {
-        assert_eq!(BerylMetricLabels::b20_method("precompile-b20-transfer"), "transfer");
-        assert_eq!(BerylMetricLabels::b20_method("precompile-b20-stablecoin-currency"), "currency");
+        assert_eq!(PrecompileMetricLabels::b20_method("precompile-b20-transfer"), "transfer");
+        assert_eq!(
+            PrecompileMetricLabels::b20_method("precompile-b20-stablecoin-currency"),
+            "currency"
+        );
     }
 
     #[test]
@@ -684,44 +687,52 @@ mod tests {
             salt: B256::ZERO,
         }
         .abi_encode();
-        assert_eq!(BerylMetricLabels::factory_method(&factory), "getB20Address");
+        assert_eq!(PrecompileMetricLabels::factory_method(&factory), "getB20Address");
 
         let b20 = IB20::transferCall { to: Address::ZERO, amount: U256::ZERO }.abi_encode();
-        assert_eq!(BerylMetricLabels::b20_asset_method(&b20), "transfer");
+        assert_eq!(PrecompileMetricLabels::b20_asset_method(&b20), "transfer");
     }
 
     #[test]
     fn base_errors_are_classified() {
         assert_eq!(
-            BerylErrorKind::from_base_error(&BasePrecompileError::UnknownFunctionSelector([0; 4])),
-            BerylErrorKind::UnknownSelector
+            PrecompileErrorKind::from_base_error(&BasePrecompileError::UnknownFunctionSelector(
+                [0; 4]
+            )),
+            PrecompileErrorKind::UnknownSelector
         );
         assert_eq!(
-            BerylErrorKind::from_base_error(&BasePrecompileError::StaticCallViolation),
-            BerylErrorKind::StaticWrite
+            PrecompileErrorKind::from_base_error(&BasePrecompileError::StaticCallViolation),
+            PrecompileErrorKind::StaticWrite
         );
     }
 
     #[test]
     fn revert_bytes_are_classified() {
         let unauthorized = IB20::Unauthorized {}.abi_encode().into();
-        assert_eq!(BerylErrorKind::from_revert_bytes(&unauthorized), BerylErrorKind::Unauthorized);
+        assert_eq!(
+            PrecompileErrorKind::from_revert_bytes(&unauthorized),
+            PrecompileErrorKind::Unauthorized
+        );
 
         let policy_not_found = IPolicyRegistry::PolicyNotFound {}.abi_encode().into();
         assert_eq!(
-            BerylErrorKind::from_revert_bytes(&policy_not_found),
-            BerylErrorKind::PolicyMissing
+            PrecompileErrorKind::from_revert_bytes(&policy_not_found),
+            PrecompileErrorKind::PolicyMissing
         );
 
         let admin_storage_disabled =
             IActivationRegistry::AdminStorageNotEnabled {}.abi_encode().into();
         assert_eq!(
-            BerylErrorKind::from_revert_bytes(&admin_storage_disabled),
-            BerylErrorKind::InvalidInput
+            PrecompileErrorKind::from_revert_bytes(&admin_storage_disabled),
+            PrecompileErrorKind::InvalidInput
         );
 
         let zero_admin = IActivationRegistry::ZeroAdminAddress {}.abi_encode().into();
-        assert_eq!(BerylErrorKind::from_revert_bytes(&zero_admin), BerylErrorKind::InvalidInput);
+        assert_eq!(
+            PrecompileErrorKind::from_revert_bytes(&zero_admin),
+            PrecompileErrorKind::InvalidInput
+        );
     }
 
     #[test]
@@ -758,10 +769,10 @@ mod tests {
     #[test]
     fn policy_method_labels_every_canonical_selector() {
         for selector in IPolicyRegistry::IPolicyRegistryCalls::selectors() {
-            let label = BerylMetricLabels::policy_method(&selector);
+            let label = PrecompileMetricLabels::policy_method(&selector);
             assert_ne!(
                 label,
-                BerylMetricLabels::unknown(),
+                PrecompileMetricLabels::unknown(),
                 "policy selector {selector:?} ({}) fell through to unknown",
                 IPolicyRegistry::IPolicyRegistryCalls::name_by_selector(selector)
                     .unwrap_or("<unnamed>"),
@@ -772,27 +783,29 @@ mod tests {
     #[test]
     fn cobalt_policy_method_labels_are_stable() {
         assert_eq!(
-            BerylMetricLabels::policy_method(&IPolicyRegistry::createCompositePolicyCall::SELECTOR),
+            PrecompileMetricLabels::policy_method(
+                &IPolicyRegistry::createCompositePolicyCall::SELECTOR
+            ),
             "createCompositePolicy"
         );
         assert_eq!(
-            BerylMetricLabels::policy_method(&IPolicyRegistry::updateCompositeCall::SELECTOR),
+            PrecompileMetricLabels::policy_method(&IPolicyRegistry::updateCompositeCall::SELECTOR),
             "updateComposite"
         );
         assert_eq!(
-            BerylMetricLabels::policy_method(
+            PrecompileMetricLabels::policy_method(
                 &IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR
             ),
             "compositePolicyChildIds"
         );
         assert_eq!(
-            BerylMetricLabels::policy_method(
+            PrecompileMetricLabels::policy_method(
                 &IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::SELECTOR
             ),
             "MIN_COMPOSITE_CHILD_POLICIES"
         );
         assert_eq!(
-            BerylMetricLabels::policy_method(
+            PrecompileMetricLabels::policy_method(
                 &IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::SELECTOR
             ),
             "MAX_COMPOSITE_CHILD_POLICIES"
@@ -802,35 +815,50 @@ mod tests {
     #[test]
     fn cobalt_errors_classify_as_invalid_input() {
         let child_range = IPolicyRegistry::ChildPoliciesOutsideOfRange {}.abi_encode().into();
-        assert_eq!(BerylErrorKind::from_revert_bytes(&child_range), BerylErrorKind::InvalidInput);
+        assert_eq!(
+            PrecompileErrorKind::from_revert_bytes(&child_range),
+            PrecompileErrorKind::InvalidInput
+        );
 
         let invalid_child =
             IPolicyRegistry::InvalidChildPolicy { childPolicyId: 0 }.abi_encode().into();
-        assert_eq!(BerylErrorKind::from_revert_bytes(&invalid_child), BerylErrorKind::InvalidInput);
+        assert_eq!(
+            PrecompileErrorKind::from_revert_bytes(&invalid_child),
+            PrecompileErrorKind::InvalidInput
+        );
 
         let effective_past =
             IB20Asset::EffectiveAtInPast { effectiveAt: U256::ZERO }.abi_encode().into();
         assert_eq!(
-            BerylErrorKind::from_revert_bytes(&effective_past),
-            BerylErrorKind::InvalidInput
+            PrecompileErrorKind::from_revert_bytes(&effective_past),
+            PrecompileErrorKind::InvalidInput
         );
 
         let effective_far =
             IB20Asset::EffectiveAtTooFar { effectiveAt: U256::ZERO }.abi_encode().into();
-        assert_eq!(BerylErrorKind::from_revert_bytes(&effective_far), BerylErrorKind::InvalidInput);
+        assert_eq!(
+            PrecompileErrorKind::from_revert_bytes(&effective_far),
+            PrecompileErrorKind::InvalidInput
+        );
 
         let update_exists =
             IB20Asset::UIMultiplierUpdateExists { effectiveAt: U256::ZERO }.abi_encode().into();
-        assert_eq!(BerylErrorKind::from_revert_bytes(&update_exists), BerylErrorKind::InvalidInput);
+        assert_eq!(
+            PrecompileErrorKind::from_revert_bytes(&update_exists),
+            PrecompileErrorKind::InvalidInput
+        );
 
         let update_missing = IB20Asset::UIMultiplierUpdateDoesNotExist {}.abi_encode().into();
         assert_eq!(
-            BerylErrorKind::from_revert_bytes(&update_missing),
-            BerylErrorKind::InvalidInput
+            PrecompileErrorKind::from_revert_bytes(&update_missing),
+            PrecompileErrorKind::InvalidInput
         );
 
         let not_seizable = IB20::AccountNotSeizable { account: Address::ZERO }.abi_encode().into();
-        assert_eq!(BerylErrorKind::from_revert_bytes(&not_seizable), BerylErrorKind::InvalidInput);
+        assert_eq!(
+            PrecompileErrorKind::from_revert_bytes(&not_seizable),
+            PrecompileErrorKind::InvalidInput
+        );
     }
 
     #[test]
@@ -838,8 +866,8 @@ mod tests {
         fn assert_classified(name: &str, selector: [u8; 4]) {
             let bytes = Bytes::from(selector.to_vec());
             assert_ne!(
-                BerylErrorKind::from_revert_bytes(&bytes),
-                BerylErrorKind::OtherRevert,
+                PrecompileErrorKind::from_revert_bytes(&bytes),
+                PrecompileErrorKind::OtherRevert,
                 "error selector {selector:?} ({name}) fell through to OtherRevert",
             );
         }

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -313,9 +313,9 @@ impl BerylErrorKind {
                 selector,
             )
             || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::NoPendingAdmin>(selector)
-            || BerylErrorClassifier::is_error_selector::<
-                IPolicyRegistry::ChildPoliciesOutsideOfRange,
-            >(selector)
+            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::ChildPoliciesOutsideOfRange>(
+                selector,
+            )
             || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::InvalidChildPolicy>(
                 selector,
             )
@@ -358,9 +358,9 @@ impl BerylErrorKind {
             || BerylErrorClassifier::is_error_selector::<IActivationRegistry::AlreadyActivated>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<
-                IActivationRegistry::DelegateCallNotAllowed,
-            >(selector)
+            || BerylErrorClassifier::is_error_selector::<IActivationRegistry::DelegateCallNotAllowed>(
+                selector,
+            )
         {
             return Self::InvalidInput;
         }
@@ -772,9 +772,7 @@ mod tests {
     #[test]
     fn cobalt_policy_method_labels_are_stable() {
         assert_eq!(
-            BerylMetricLabels::policy_method(
-                &IPolicyRegistry::createCompositePolicyCall::SELECTOR
-            ),
+            BerylMetricLabels::policy_method(&IPolicyRegistry::createCompositePolicyCall::SELECTOR),
             "createCompositePolicy"
         );
         assert_eq!(
@@ -804,16 +802,11 @@ mod tests {
     #[test]
     fn cobalt_errors_classify_as_invalid_input() {
         let child_range = IPolicyRegistry::ChildPoliciesOutsideOfRange {}.abi_encode().into();
-        assert_eq!(
-            BerylErrorKind::from_revert_bytes(&child_range),
-            BerylErrorKind::InvalidInput
-        );
+        assert_eq!(BerylErrorKind::from_revert_bytes(&child_range), BerylErrorKind::InvalidInput);
 
-        let invalid_child = IPolicyRegistry::InvalidChildPolicy { childPolicyId: 0 }.abi_encode().into();
-        assert_eq!(
-            BerylErrorKind::from_revert_bytes(&invalid_child),
-            BerylErrorKind::InvalidInput
-        );
+        let invalid_child =
+            IPolicyRegistry::InvalidChildPolicy { childPolicyId: 0 }.abi_encode().into();
+        assert_eq!(BerylErrorKind::from_revert_bytes(&invalid_child), BerylErrorKind::InvalidInput);
 
         let effective_past =
             IB20Asset::EffectiveAtInPast { effectiveAt: U256::ZERO }.abi_encode().into();
@@ -824,17 +817,11 @@ mod tests {
 
         let effective_far =
             IB20Asset::EffectiveAtTooFar { effectiveAt: U256::ZERO }.abi_encode().into();
-        assert_eq!(
-            BerylErrorKind::from_revert_bytes(&effective_far),
-            BerylErrorKind::InvalidInput
-        );
+        assert_eq!(BerylErrorKind::from_revert_bytes(&effective_far), BerylErrorKind::InvalidInput);
 
         let update_exists =
             IB20Asset::UIMultiplierUpdateExists { effectiveAt: U256::ZERO }.abi_encode().into();
-        assert_eq!(
-            BerylErrorKind::from_revert_bytes(&update_exists),
-            BerylErrorKind::InvalidInput
-        );
+        assert_eq!(BerylErrorKind::from_revert_bytes(&update_exists), BerylErrorKind::InvalidInput);
 
         let update_missing = IB20Asset::UIMultiplierUpdateDoesNotExist {}.abi_encode().into();
         assert_eq!(
@@ -842,12 +829,8 @@ mod tests {
             BerylErrorKind::InvalidInput
         );
 
-        let not_seizable =
-            IB20::AccountNotSeizable { account: Address::ZERO }.abi_encode().into();
-        assert_eq!(
-            BerylErrorKind::from_revert_bytes(&not_seizable),
-            BerylErrorKind::InvalidInput
-        );
+        let not_seizable = IB20::AccountNotSeizable { account: Address::ZERO }.abi_encode().into();
+        assert_eq!(BerylErrorKind::from_revert_bytes(&not_seizable), BerylErrorKind::InvalidInput);
     }
 
     #[test]

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -1,4 +1,4 @@
-//! Low-cardinality metadata for observing Beryl-native precompile calls.
+//! Low-cardinality metadata for observing native precompile calls.
 
 use alloc::{borrow::Cow, string::ToString};
 #[cfg(feature = "std")]
@@ -12,10 +12,10 @@ use base_precompile_storage::{
 
 use crate::{IActivationRegistry, IB20, IB20Asset, IB20Factory, IB20Stablecoin, IPolicyRegistry};
 
-/// Low-cardinality metadata for one Beryl-native precompile call.
+/// Low-cardinality metadata for one native precompile call.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrecompileCallMetric {
-    /// Beryl precompile surface, such as `factory`, `activation`, `policy`, or `b20`.
+    /// Precompile surface, such as `factory`, `activation`, `policy`, or `b20`.
     pub precompile: &'static str,
     /// ABI method name or `unknown`.
     pub method: Cow<'static, str>,
@@ -95,10 +95,7 @@ impl PrecompileCallStatus {
     }
 }
 
-/// Backwards-compatible alias for Beryl call status labels.
-pub type BerylCallOutcome = PrecompileCallStatus;
-
-/// Final outcome for one Beryl-native precompile call.
+/// Final outcome for one native precompile call.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PrecompileCallOutcome {
     /// Terminal call status.
@@ -109,7 +106,7 @@ pub struct PrecompileCallOutcome {
     pub state_gas_used: i64,
     /// Gas refunded by the precompile.
     pub gas_refunded: i64,
-    /// Total time spent in the Beryl dispatch wrapper, in seconds.
+    /// Total time spent in the precompile dispatch wrapper, in seconds.
     pub duration_seconds: Option<f64>,
     /// Optional bounded error class.
     pub error: Option<PrecompileErrorKind>,
@@ -246,121 +243,148 @@ impl PrecompileErrorKind {
 
     /// Classifies ABI-encoded revert bytes into a bounded metric label.
     pub fn from_revert_bytes(bytes: &Bytes) -> Self {
-        let Some(selector) = BerylSelector::selector(bytes.as_ref()) else {
+        let Some(selector) = PrecompileSelector::selector(bytes.as_ref()) else {
             return Self::OtherRevert;
         };
 
-        if BerylErrorClassifier::is_error_selector::<IActivationRegistry::StaticCallNotAllowed>(
+        if PrecompileErrorClassifier::is_error_selector::<IActivationRegistry::StaticCallNotAllowed>(
             selector,
         ) {
             return Self::StaticWrite;
         }
-        if BerylErrorClassifier::is_error_selector::<IActivationRegistry::FeatureNotActivated>(
+        if PrecompileErrorClassifier::is_error_selector::<IActivationRegistry::FeatureNotActivated>(
             selector,
         ) {
             return Self::FeatureInactive;
         }
-        if BerylErrorClassifier::is_error_selector::<IActivationRegistry::Unauthorized>(selector)
-            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::Unauthorized>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::Unauthorized>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::AccessControlUnauthorizedAccount>(
+        if PrecompileErrorClassifier::is_error_selector::<IActivationRegistry::Unauthorized>(
+            selector,
+        ) || PrecompileErrorClassifier::is_error_selector::<IPolicyRegistry::Unauthorized>(
+            selector,
+        ) || PrecompileErrorClassifier::is_error_selector::<IB20::Unauthorized>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::AccessControlUnauthorizedAccount>(
                 selector,
             )
         {
             return Self::Unauthorized;
         }
-        if BerylErrorClassifier::is_error_selector::<IB20::PolicyForbids>(selector) {
+        if PrecompileErrorClassifier::is_error_selector::<IB20::PolicyForbids>(selector) {
             return Self::PolicyDenied;
         }
-        if BerylErrorClassifier::is_error_selector::<IPolicyRegistry::PolicyNotFound>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::PolicyNotFound>(selector)
+        if PrecompileErrorClassifier::is_error_selector::<IPolicyRegistry::PolicyNotFound>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::PolicyNotFound>(selector)
         {
             return Self::PolicyMissing;
         }
-        if BerylErrorClassifier::is_error_selector::<IB20::ContractPaused>(selector) {
+        if PrecompileErrorClassifier::is_error_selector::<IB20::ContractPaused>(selector) {
             return Self::Paused;
         }
-        if BerylErrorClassifier::is_error_selector::<IB20Factory::TokenAlreadyExists>(selector) {
+        if PrecompileErrorClassifier::is_error_selector::<IB20Factory::TokenAlreadyExists>(selector)
+        {
             return Self::DuplicateCreate;
         }
-        if BerylErrorClassifier::is_error_selector::<IB20Factory::InitCallFailed>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::InternalCallFailed>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::InternalCallMalformed>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::AnnouncementInProgress>(
+        if PrecompileErrorClassifier::is_error_selector::<IB20Factory::InitCallFailed>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::InternalCallFailed>(
+                selector,
+            )
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::InternalCallMalformed>(
+                selector,
+            )
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::AnnouncementInProgress>(
                 selector,
             )
         {
             return Self::InternalCallFailed;
         }
-        if BerylErrorClassifier::is_error_selector::<IB20Factory::InvalidVariant>(selector)
-            || BerylErrorClassifier::is_error_selector::<IActivationRegistry::AdminStorageNotEnabled>(
+        if PrecompileErrorClassifier::is_error_selector::<IB20Factory::InvalidVariant>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<
+                IActivationRegistry::AdminStorageNotEnabled,
+            >(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IActivationRegistry::ZeroAdminAddress>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IActivationRegistry::ZeroAdminAddress>(
+            || PrecompileErrorClassifier::is_error_selector::<IB20Factory::UnsupportedVersion>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IB20Factory::UnsupportedVersion>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Factory::MissingRequiredField>(
+            || PrecompileErrorClassifier::is_error_selector::<IB20Factory::MissingRequiredField>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IB20Factory::InvalidCurrency>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Factory::InvalidDecimals>(selector)
-            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::IncompatiblePolicyType>(
+            || PrecompileErrorClassifier::is_error_selector::<IB20Factory::InvalidCurrency>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::ZeroAddress>(selector)
-            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::BatchSizeTooLarge>(
+            || PrecompileErrorClassifier::is_error_selector::<IB20Factory::InvalidDecimals>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::NoPendingAdmin>(selector)
-            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::ChildPoliciesOutsideOfRange>(
+            || PrecompileErrorClassifier::is_error_selector::<IPolicyRegistry::IncompatiblePolicyType>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::InvalidChildPolicy>(
+            || PrecompileErrorClassifier::is_error_selector::<IPolicyRegistry::ZeroAddress>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::AnnouncementIdAlreadyUsed>(
+            || PrecompileErrorClassifier::is_error_selector::<IPolicyRegistry::BatchSizeTooLarge>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::InvalidMetadataKey>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::InvalidMultiplier>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::EffectiveAtInPast>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::EffectiveAtTooFar>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::UIMultiplierUpdateExists>(
+            || PrecompileErrorClassifier::is_error_selector::<IPolicyRegistry::NoPendingAdmin>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::UIMultiplierUpdateDoesNotExist>(
+            || PrecompileErrorClassifier::is_error_selector::<
+                IPolicyRegistry::ChildPoliciesOutsideOfRange,
+            >(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IPolicyRegistry::InvalidChildPolicy>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::LengthMismatch>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20Asset::EmptyBatch>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::InvalidSender>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::InvalidReceiver>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::InvalidApprover>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::InvalidSpender>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::InvalidAmount>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::EmptyFeatureSet>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::InvalidSupplyCap>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::SupplyCapExceeded>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::InsufficientAllowance>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::InsufficientBalance>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::AccountNotBlocked>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::AccountNotSeizable>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::ExpiredSignature>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::InvalidSigner>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::LastAdminCannotRenounce>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::NotSoleAdmin>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::AccessControlBadConfirmation>(
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::AnnouncementIdAlreadyUsed>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IB20::UnsupportedPolicyType>(selector)
-            || BerylErrorClassifier::is_error_selector::<IB20::NonPayable>(selector)
-            || BerylErrorClassifier::is_error_selector::<IActivationRegistry::AlreadyActivated>(
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::InvalidMetadataKey>(
                 selector,
             )
-            || BerylErrorClassifier::is_error_selector::<IActivationRegistry::DelegateCallNotAllowed>(
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::InvalidMultiplier>(
                 selector,
             )
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::EffectiveAtInPast>(
+                selector,
+            )
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::EffectiveAtTooFar>(
+                selector,
+            )
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::UIMultiplierUpdateExists>(
+                selector,
+            )
+            || PrecompileErrorClassifier::is_error_selector::<
+                IB20Asset::UIMultiplierUpdateDoesNotExist,
+            >(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::LengthMismatch>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20Asset::EmptyBatch>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::InvalidSender>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::InvalidReceiver>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::InvalidApprover>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::InvalidSpender>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::InvalidAmount>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::EmptyFeatureSet>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::InvalidSupplyCap>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::SupplyCapExceeded>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::InsufficientAllowance>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::InsufficientBalance>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::AccountNotBlocked>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::AccountNotSeizable>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::ExpiredSignature>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::InvalidSigner>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::LastAdminCannotRenounce>(
+                selector,
+            )
+            || PrecompileErrorClassifier::is_error_selector::<IB20::NotSoleAdmin>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::AccessControlBadConfirmation>(
+                selector,
+            )
+            || PrecompileErrorClassifier::is_error_selector::<IB20::UnsupportedPolicyType>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IB20::NonPayable>(selector)
+            || PrecompileErrorClassifier::is_error_selector::<IActivationRegistry::AlreadyActivated>(
+                selector,
+            )
+            || PrecompileErrorClassifier::is_error_selector::<
+                IActivationRegistry::DelegateCallNotAllowed,
+            >(selector)
         {
             return Self::InvalidInput;
         }
@@ -371,9 +395,9 @@ impl PrecompileErrorKind {
 
 /// Helpers for extracting ABI selectors from encoded data.
 #[derive(Debug, Clone, Copy)]
-pub struct BerylSelector;
+pub struct PrecompileSelector;
 
-impl BerylSelector {
+impl PrecompileSelector {
     /// Returns the ABI selector from encoded data, if present.
     pub fn selector(bytes: &[u8]) -> Option<[u8; 4]> {
         let bytes = bytes.get(..4)?;
@@ -385,9 +409,9 @@ impl BerylSelector {
 
 /// Helpers for working with ABI error selectors.
 #[derive(Debug, Clone, Copy)]
-pub struct BerylErrorClassifier;
+pub struct PrecompileErrorClassifier;
 
-impl BerylErrorClassifier {
+impl PrecompileErrorClassifier {
     /// Returns whether `selector` belongs to the ABI error type `E`.
     pub fn is_error_selector<E>(selector: [u8; 4]) -> bool
     where
@@ -425,7 +449,7 @@ impl PrecompileMetricLabels {
 
     /// Returns the metric method label for factory calldata.
     pub fn factory_method(calldata: &[u8]) -> Cow<'static, str> {
-        match BerylSelector::selector(calldata) {
+        match PrecompileSelector::selector(calldata) {
             Some(IB20Factory::createB20Call::SELECTOR) => Cow::Borrowed("createB20"),
             Some(IB20Factory::getB20AddressCall::SELECTOR) => Cow::Borrowed("getB20Address"),
             Some(IB20Factory::isB20Call::SELECTOR) => Cow::Borrowed("isB20"),
@@ -445,7 +469,7 @@ impl PrecompileMetricLabels {
 
     /// Returns the metric method label for activation-registry calldata.
     pub fn activation_method(calldata: &[u8]) -> Cow<'static, str> {
-        match BerylSelector::selector(calldata) {
+        match PrecompileSelector::selector(calldata) {
             Some(IActivationRegistry::isActivatedCall::SELECTOR) => Cow::Borrowed("isActivated"),
             Some(IActivationRegistry::checkActivatedCall::SELECTOR) => {
                 Cow::Borrowed("checkActivated")
@@ -465,7 +489,7 @@ impl PrecompileMetricLabels {
 
     /// Returns the metric method label for policy-registry calldata.
     pub fn policy_method(calldata: &[u8]) -> Cow<'static, str> {
-        let Some(selector) = BerylSelector::selector(calldata) else {
+        let Some(selector) = PrecompileSelector::selector(calldata) else {
             return Self::unknown();
         };
         if let Some(method) = IPolicyRegistry::IPolicyRegistryCalls::name_by_selector(selector) {
@@ -481,7 +505,7 @@ impl PrecompileMetricLabels {
 
     /// Returns the metric method label for asset B-20 calldata.
     pub fn b20_asset_method(calldata: &[u8]) -> Cow<'static, str> {
-        let Some(selector) = BerylSelector::selector(calldata) else {
+        let Some(selector) = PrecompileSelector::selector(calldata) else {
             return Self::unknown();
         };
         if let Some(method) = IB20Asset::IB20AssetCalls::name_by_selector(selector) {
@@ -504,7 +528,7 @@ impl PrecompileMetricLabels {
 
     /// Returns the metric method label for stablecoin B-20 calldata.
     pub fn b20_stablecoin_method(calldata: &[u8]) -> Cow<'static, str> {
-        let Some(selector) = BerylSelector::selector(calldata) else {
+        let Some(selector) = PrecompileSelector::selector(calldata) else {
             return Self::unknown();
         };
         if let Some(method) = IB20Stablecoin::IB20StablecoinCalls::name_by_selector(selector) {
@@ -517,14 +541,14 @@ impl PrecompileMetricLabels {
     }
 }
 
-/// Call timer used by Beryl call recorders.
+/// Call timer used by precompile call recorders.
 #[derive(Debug)]
-pub struct BerylCallTimer {
+pub struct PrecompileCallTimer {
     #[cfg(feature = "std")]
     start: Instant,
 }
 
-impl BerylCallTimer {
+impl PrecompileCallTimer {
     /// Starts a new call timer.
     #[cfg(feature = "std")]
     pub fn start() -> Self {
@@ -550,36 +574,36 @@ impl BerylCallTimer {
     }
 }
 
-/// Per-word calldata ingestion cost charged by Beryl native precompile dispatchers.
+/// Per-word calldata ingestion cost charged by native precompile dispatchers.
 ///
 /// Emulates the cost a Solidity predeploy would incur reading its calldata:
 /// `G_copy` (3 gas/word) + `G_memory` (3 gas/word) = 6 gas/word.
 /// Part of the receipts/gas-used commitment: must be identical across all Base execution clients.
 pub const CALLDATA_WORD_GAS: u64 = 6;
 
-/// Per-call recorder for Beryl precompile observations.
+/// Per-call recorder for native precompile observations.
 #[derive(Debug)]
-pub struct BerylCallRecorder<O> {
+pub struct PrecompileCallRecorder<O> {
     observer: O,
-    timer: BerylCallTimer,
+    timer: PrecompileCallTimer,
     call: PrecompileCallMetric,
     error: Option<PrecompileErrorKind>,
 }
 
-impl<O> BerylCallRecorder<O>
+impl<O> PrecompileCallRecorder<O>
 where
     O: crate::PrecompileCallObserver,
 {
     /// Starts a recorder for a precompile call.
     #[cfg(feature = "std")]
     pub fn start(observer: O, call: PrecompileCallMetric) -> Self {
-        Self { observer, timer: BerylCallTimer::start(), call, error: None }
+        Self { observer, timer: PrecompileCallTimer::start(), call, error: None }
     }
 
     /// Starts a recorder for a precompile call.
     #[cfg(not(feature = "std"))]
     pub const fn start(observer: O, call: PrecompileCallMetric) -> Self {
-        Self { observer, timer: BerylCallTimer::start(), call, error: None }
+        Self { observer, timer: PrecompileCallTimer::start(), call, error: None }
     }
 
     /// Updates the current call metadata.
@@ -597,7 +621,7 @@ where
         (calldata.len() as u64).div_ceil(32).saturating_mul(CALLDATA_WORD_GAS)
     }
 
-    /// Deducts the common calldata gas charged by Beryl precompile dispatch.
+    /// Deducts the common calldata gas charged by native precompile dispatch.
     pub fn deduct_calldata_gas(&self, ctx: StorageCtx<'_>, calldata: &[u8]) -> Result<()> {
         ctx.deduct_gas(Self::calldata_gas_cost(calldata))
     }
@@ -642,11 +666,11 @@ where
     }
 }
 
-/// Helper methods for observer-only Beryl metric families.
+/// Helper methods for observer-only precompile metric families.
 #[derive(Debug, Clone, Copy)]
-pub struct BerylAuxiliaryMetrics;
+pub struct PrecompileAuxiliaryMetrics;
 
-impl BerylAuxiliaryMetrics {
+impl PrecompileAuxiliaryMetrics {
     /// Creates a singleton call descriptor for auxiliary metric recording.
     pub fn singleton(precompile: &'static str, method: &'static str) -> PrecompileCallMetric {
         PrecompileCallMetric::singleton(precompile, method, 0)
@@ -665,9 +689,9 @@ mod tests {
     use base_precompile_storage::{BasePrecompileError, PrecompileError, PrecompileOutput};
 
     use crate::{
-        BerylCallOutcome, BerylCallRecorder, BerylSelector, CALLDATA_WORD_GAS, IActivationRegistry,
-        IB20, IB20Asset, IB20Factory, IPolicyRegistry, NoopPrecompileCallObserver,
-        PrecompileErrorKind, PrecompileMetricLabels,
+        CALLDATA_WORD_GAS, IActivationRegistry, IB20, IB20Asset, IB20Factory, IPolicyRegistry,
+        NoopPrecompileCallObserver, PrecompileCallRecorder, PrecompileCallStatus,
+        PrecompileErrorKind, PrecompileMetricLabels, PrecompileSelector,
     };
 
     #[test]
@@ -739,7 +763,7 @@ mod tests {
     fn selector_extracts_revert_selector() {
         let bytes = IB20::Unauthorized {}.abi_encode();
         assert_eq!(
-            BerylSelector::selector(&bytes),
+            PrecompileSelector::selector(&bytes),
             Some(<IB20::Unauthorized as SolError>::SELECTOR)
         );
     }
@@ -750,14 +774,14 @@ mod tests {
         let revert = Ok(PrecompileOutput::revert(1, Default::default(), 0));
         let fatal = Err(PrecompileError::Fatal("boom".into()));
 
-        assert_eq!(BerylCallOutcome::from_result(&success), BerylCallOutcome::Success);
-        assert_eq!(BerylCallOutcome::from_result(&revert), BerylCallOutcome::Revert);
-        assert_eq!(BerylCallOutcome::from_result(&fatal), BerylCallOutcome::Fatal);
+        assert_eq!(PrecompileCallStatus::from_result(&success), PrecompileCallStatus::Success);
+        assert_eq!(PrecompileCallStatus::from_result(&revert), PrecompileCallStatus::Revert);
+        assert_eq!(PrecompileCallStatus::from_result(&fatal), PrecompileCallStatus::Fatal);
     }
 
     #[test]
     fn deduct_calldata_cost_gas_formula() {
-        type Recorder = BerylCallRecorder<NoopPrecompileCallObserver>;
+        type Recorder = PrecompileCallRecorder<NoopPrecompileCallObserver>;
 
         // 32 bytes = 1 word => CALLDATA_WORD_GAS
         assert_eq!(Recorder::calldata_gas_cost(&[0u8; 32]), CALLDATA_WORD_GAS);

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -313,10 +313,25 @@ impl BerylErrorKind {
                 selector,
             )
             || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::NoPendingAdmin>(selector)
+            || BerylErrorClassifier::is_error_selector::<
+                IPolicyRegistry::ChildPoliciesOutsideOfRange,
+            >(selector)
+            || BerylErrorClassifier::is_error_selector::<IPolicyRegistry::InvalidChildPolicy>(
+                selector,
+            )
             || BerylErrorClassifier::is_error_selector::<IB20Asset::AnnouncementIdAlreadyUsed>(
                 selector,
             )
             || BerylErrorClassifier::is_error_selector::<IB20Asset::InvalidMetadataKey>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::InvalidMultiplier>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::EffectiveAtInPast>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::EffectiveAtTooFar>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::UIMultiplierUpdateExists>(
+                selector,
+            )
+            || BerylErrorClassifier::is_error_selector::<IB20Asset::UIMultiplierUpdateDoesNotExist>(
+                selector,
+            )
             || BerylErrorClassifier::is_error_selector::<IB20Asset::LengthMismatch>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20Asset::EmptyBatch>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::InvalidSender>(selector)
@@ -330,6 +345,7 @@ impl BerylErrorKind {
             || BerylErrorClassifier::is_error_selector::<IB20::InsufficientAllowance>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::InsufficientBalance>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::AccountNotBlocked>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::AccountNotSeizable>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::ExpiredSignature>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::InvalidSigner>(selector)
             || BerylErrorClassifier::is_error_selector::<IB20::LastAdminCannotRenounce>(selector)
@@ -338,6 +354,13 @@ impl BerylErrorKind {
                 selector,
             )
             || BerylErrorClassifier::is_error_selector::<IB20::UnsupportedPolicyType>(selector)
+            || BerylErrorClassifier::is_error_selector::<IB20::NonPayable>(selector)
+            || BerylErrorClassifier::is_error_selector::<IActivationRegistry::AlreadyActivated>(
+                selector,
+            )
+            || BerylErrorClassifier::is_error_selector::<
+                IActivationRegistry::DelegateCallNotAllowed,
+            >(selector)
         {
             return Self::InvalidInput;
         }
@@ -442,32 +465,13 @@ impl BerylMetricLabels {
 
     /// Returns the metric method label for policy-registry calldata.
     pub fn policy_method(calldata: &[u8]) -> Cow<'static, str> {
-        match BerylSelector::selector(calldata) {
-            Some(IPolicyRegistry::createPolicyCall::SELECTOR) => Cow::Borrowed("createPolicy"),
-            Some(IPolicyRegistry::createPolicyWithAccountsCall::SELECTOR) => {
-                Cow::Borrowed("createPolicyWithAccounts")
-            }
-            Some(IPolicyRegistry::stageUpdateAdminCall::SELECTOR) => {
-                Cow::Borrowed("stageUpdateAdmin")
-            }
-            Some(IPolicyRegistry::finalizeUpdateAdminCall::SELECTOR) => {
-                Cow::Borrowed("finalizeUpdateAdmin")
-            }
-            Some(IPolicyRegistry::renounceAdminCall::SELECTOR) => Cow::Borrowed("renounceAdmin"),
-            Some(IPolicyRegistry::updateAllowlistCall::SELECTOR) => {
-                Cow::Borrowed("updateAllowlist")
-            }
-            Some(IPolicyRegistry::updateBlocklistCall::SELECTOR) => {
-                Cow::Borrowed("updateBlocklist")
-            }
-            Some(IPolicyRegistry::isAuthorizedCall::SELECTOR) => Cow::Borrowed("isAuthorized"),
-            Some(IPolicyRegistry::policyExistsCall::SELECTOR) => Cow::Borrowed("policyExists"),
-            Some(IPolicyRegistry::policyAdminCall::SELECTOR) => Cow::Borrowed("policyAdmin"),
-            Some(IPolicyRegistry::pendingPolicyAdminCall::SELECTOR) => {
-                Cow::Borrowed("pendingPolicyAdmin")
-            }
-            _ => Self::unknown(),
+        let Some(selector) = BerylSelector::selector(calldata) else {
+            return Self::unknown();
+        };
+        if let Some(method) = IPolicyRegistry::IPolicyRegistryCalls::name_by_selector(selector) {
+            return Cow::Borrowed(method);
         }
+        Self::unknown()
     }
 
     /// Returns call metadata for asset B-20 calldata.
@@ -656,13 +660,13 @@ impl BerylAuxiliaryMetrics {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, B256, U256};
-    use alloy_sol_types::{SolCall, SolError};
+    use alloy_primitives::{Address, B256, Bytes, U256};
+    use alloy_sol_types::{SolCall, SolError, SolInterface};
     use base_precompile_storage::{BasePrecompileError, PrecompileError, PrecompileOutput};
 
     use crate::{
         BerylCallOutcome, BerylCallRecorder, BerylErrorKind, BerylMetricLabels, BerylSelector,
-        CALLDATA_WORD_GAS, IActivationRegistry, IB20, IB20Factory, IPolicyRegistry,
+        CALLDATA_WORD_GAS, IActivationRegistry, IB20, IB20Asset, IB20Factory, IPolicyRegistry,
         NoopPrecompileCallObserver,
     };
 
@@ -749,5 +753,145 @@ mod tests {
 
         // 36 bytes (4-byte selector + 32-byte arg) = ceil(36/32) = 2 words => 2 * CALLDATA_WORD_GAS
         assert_eq!(Recorder::calldata_gas_cost(&[0u8; 36]), 2 * CALLDATA_WORD_GAS);
+    }
+
+    #[test]
+    fn policy_method_labels_every_canonical_selector() {
+        for selector in IPolicyRegistry::IPolicyRegistryCalls::selectors() {
+            let label = BerylMetricLabels::policy_method(&selector);
+            assert_ne!(
+                label,
+                BerylMetricLabels::unknown(),
+                "policy selector {selector:?} ({}) fell through to unknown",
+                IPolicyRegistry::IPolicyRegistryCalls::name_by_selector(selector)
+                    .unwrap_or("<unnamed>"),
+            );
+        }
+    }
+
+    #[test]
+    fn cobalt_policy_method_labels_are_stable() {
+        assert_eq!(
+            BerylMetricLabels::policy_method(
+                &IPolicyRegistry::createCompositePolicyCall::SELECTOR
+            ),
+            "createCompositePolicy"
+        );
+        assert_eq!(
+            BerylMetricLabels::policy_method(&IPolicyRegistry::updateCompositeCall::SELECTOR),
+            "updateComposite"
+        );
+        assert_eq!(
+            BerylMetricLabels::policy_method(
+                &IPolicyRegistry::compositePolicyChildIdsCall::SELECTOR
+            ),
+            "compositePolicyChildIds"
+        );
+        assert_eq!(
+            BerylMetricLabels::policy_method(
+                &IPolicyRegistry::MIN_COMPOSITE_CHILD_POLICIESCall::SELECTOR
+            ),
+            "MIN_COMPOSITE_CHILD_POLICIES"
+        );
+        assert_eq!(
+            BerylMetricLabels::policy_method(
+                &IPolicyRegistry::MAX_COMPOSITE_CHILD_POLICIESCall::SELECTOR
+            ),
+            "MAX_COMPOSITE_CHILD_POLICIES"
+        );
+    }
+
+    #[test]
+    fn cobalt_errors_classify_as_invalid_input() {
+        let child_range = IPolicyRegistry::ChildPoliciesOutsideOfRange {}.abi_encode().into();
+        assert_eq!(
+            BerylErrorKind::from_revert_bytes(&child_range),
+            BerylErrorKind::InvalidInput
+        );
+
+        let invalid_child = IPolicyRegistry::InvalidChildPolicy { childPolicyId: 0 }.abi_encode().into();
+        assert_eq!(
+            BerylErrorKind::from_revert_bytes(&invalid_child),
+            BerylErrorKind::InvalidInput
+        );
+
+        let effective_past =
+            IB20Asset::EffectiveAtInPast { effectiveAt: U256::ZERO }.abi_encode().into();
+        assert_eq!(
+            BerylErrorKind::from_revert_bytes(&effective_past),
+            BerylErrorKind::InvalidInput
+        );
+
+        let effective_far =
+            IB20Asset::EffectiveAtTooFar { effectiveAt: U256::ZERO }.abi_encode().into();
+        assert_eq!(
+            BerylErrorKind::from_revert_bytes(&effective_far),
+            BerylErrorKind::InvalidInput
+        );
+
+        let update_exists =
+            IB20Asset::UIMultiplierUpdateExists { effectiveAt: U256::ZERO }.abi_encode().into();
+        assert_eq!(
+            BerylErrorKind::from_revert_bytes(&update_exists),
+            BerylErrorKind::InvalidInput
+        );
+
+        let update_missing = IB20Asset::UIMultiplierUpdateDoesNotExist {}.abi_encode().into();
+        assert_eq!(
+            BerylErrorKind::from_revert_bytes(&update_missing),
+            BerylErrorKind::InvalidInput
+        );
+
+        let not_seizable =
+            IB20::AccountNotSeizable { account: Address::ZERO }.abi_encode().into();
+        assert_eq!(
+            BerylErrorKind::from_revert_bytes(&not_seizable),
+            BerylErrorKind::InvalidInput
+        );
+    }
+
+    #[test]
+    fn recorded_abi_errors_are_not_other_revert() {
+        fn assert_classified(name: &str, selector: [u8; 4]) {
+            let bytes = Bytes::from(selector.to_vec());
+            assert_ne!(
+                BerylErrorKind::from_revert_bytes(&bytes),
+                BerylErrorKind::OtherRevert,
+                "error selector {selector:?} ({name}) fell through to OtherRevert",
+            );
+        }
+
+        for selector in IPolicyRegistry::IPolicyRegistryErrors::selectors() {
+            assert_classified(
+                IPolicyRegistry::IPolicyRegistryErrors::name_by_selector(selector)
+                    .unwrap_or("<unnamed>"),
+                selector,
+            );
+        }
+        for selector in IB20::IB20Errors::selectors() {
+            assert_classified(
+                IB20::IB20Errors::name_by_selector(selector).unwrap_or("<unnamed>"),
+                selector,
+            );
+        }
+        for selector in IB20Asset::IB20AssetErrors::selectors() {
+            assert_classified(
+                IB20Asset::IB20AssetErrors::name_by_selector(selector).unwrap_or("<unnamed>"),
+                selector,
+            );
+        }
+        for selector in IB20Factory::IB20FactoryErrors::selectors() {
+            assert_classified(
+                IB20Factory::IB20FactoryErrors::name_by_selector(selector).unwrap_or("<unnamed>"),
+                selector,
+            );
+        }
+        for selector in IActivationRegistry::IActivationRegistryErrors::selectors() {
+            assert_classified(
+                IActivationRegistry::IActivationRegistryErrors::name_by_selector(selector)
+                    .unwrap_or("<unnamed>"),
+                selector,
+            );
+        }
     }
 }

--- a/crates/common/precompiles/src/observer.rs
+++ b/crates/common/precompiles/src/observer.rs
@@ -30,10 +30,10 @@ pub trait PrecompileCallObserver: Clone + Send + Sync + 'static {
     /// Records a B-20 token creation.
     fn record_b20_created(&self, _variant: &'static str) {}
 
-    /// Records the number of logical items in a Beryl batch call.
+    /// Records the number of logical items in a native precompile batch call.
     fn record_batch_items(&self, _call: &PrecompileCallMetric, _count: usize) {}
 
-    /// Records internal calls made by Beryl precompile logic.
+    /// Records internal calls made by native precompile logic.
     fn record_internal_calls(&self, _call: &PrecompileCallMetric, _calls: usize, _bytes: usize) {}
 }
 

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -5,10 +5,9 @@ use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx}
 
 use crate::{
     ActivationFeature, ActivationRegistryStorage, BerylAuxiliaryMetrics, BerylCallRecorder,
-    BerylMetricLabels,
     IPolicyRegistry::{self, IPolicyRegistryCalls as C},
     NoopPrecompileCallObserver, PolicyRegistryStorage, PolicyRegistryV2, PolicyVersion,
-    PolicyVersions, PrecompileCallObserver,
+    PolicyVersions, PrecompileCallObserver, PrecompileMetricLabels,
 };
 
 impl PolicyRegistryStorage<'_> {
@@ -36,8 +35,10 @@ impl PolicyRegistryStorage<'_> {
     where
         O: PrecompileCallObserver,
     {
-        let mut recorder =
-            BerylCallRecorder::start(observer.clone(), BerylMetricLabels::policy_call(calldata));
+        let mut recorder = BerylCallRecorder::start(
+            observer.clone(),
+            PrecompileMetricLabels::policy_call(calldata),
+        );
         if !ctx.call_value().is_zero() {
             return recorder.record_base_error_result(
                 ctx,
@@ -209,9 +210,9 @@ mod tests {
     use base_precompile_storage::{HashMapStorageProvider, PrecompileOutput, StorageCtx};
 
     use crate::{
-        ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, BerylErrorKind,
-        IPolicyRegistry, PolicyRegistryStorage, PolicyRegistryV1, PrecompileCallMetric,
-        PrecompileCallObserver, PrecompileCallOutcome, PrecompileCallStatus,
+        ActivationAdminConfig, ActivationFeature, ActivationRegistryStorage, IPolicyRegistry,
+        PolicyRegistryStorage, PolicyRegistryV1, PrecompileCallMetric, PrecompileCallObserver,
+        PrecompileCallOutcome, PrecompileCallStatus, PrecompileErrorKind,
     };
 
     const ACTIVATION_ADMIN: Address = address!("0xcb00000000000000000000000000000000000000");
@@ -341,7 +342,7 @@ mod tests {
         assert_eq!(calls[0].0.precompile, "policy");
         assert_eq!(calls[0].0.method, "createPolicy");
         assert_eq!(calls[0].1.status, PrecompileCallStatus::Revert);
-        assert_eq!(calls[0].1.error, Some(BerylErrorKind::FeatureInactive));
+        assert_eq!(calls[0].1.error, Some(PrecompileErrorKind::FeatureInactive));
     }
 
     #[test]

--- a/crates/common/precompiles/src/policy/dispatch.rs
+++ b/crates/common/precompiles/src/policy/dispatch.rs
@@ -4,10 +4,11 @@ use base_common_genesis::BaseUpgrade;
 use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
 
 use crate::{
-    ActivationFeature, ActivationRegistryStorage, BerylAuxiliaryMetrics, BerylCallRecorder,
+    ActivationFeature, ActivationRegistryStorage,
     IPolicyRegistry::{self, IPolicyRegistryCalls as C},
     NoopPrecompileCallObserver, PolicyRegistryStorage, PolicyRegistryV2, PolicyVersion,
-    PolicyVersions, PrecompileCallObserver, PrecompileMetricLabels,
+    PolicyVersions, PrecompileAuxiliaryMetrics, PrecompileCallObserver, PrecompileCallRecorder,
+    PrecompileMetricLabels,
 };
 
 impl PolicyRegistryStorage<'_> {
@@ -35,7 +36,7 @@ impl PolicyRegistryStorage<'_> {
     where
         O: PrecompileCallObserver,
     {
-        let mut recorder = BerylCallRecorder::start(
+        let mut recorder = PrecompileCallRecorder::start(
             observer.clone(),
             PrecompileMetricLabels::policy_call(calldata),
         );
@@ -106,7 +107,7 @@ impl PolicyRegistryStorage<'_> {
             }
             C::createPolicyWithAccounts(call) => {
                 observer.record_batch_items(
-                    &BerylAuxiliaryMetrics::singleton("policy", "createPolicyWithAccounts"),
+                    &PrecompileAuxiliaryMetrics::singleton("policy", "createPolicyWithAccounts"),
                     call.accounts.len(),
                 );
                 let id = logic.create_policy_with_accounts(
@@ -131,7 +132,7 @@ impl PolicyRegistryStorage<'_> {
             }
             C::updateAllowlist(call) => {
                 observer.record_batch_items(
-                    &BerylAuxiliaryMetrics::singleton("policy", "updateAllowlist"),
+                    &PrecompileAuxiliaryMetrics::singleton("policy", "updateAllowlist"),
                     call.accounts.len(),
                 );
                 logic.update_allowlist(self, call.policyId, call.allowed, call.accounts)?;
@@ -139,7 +140,7 @@ impl PolicyRegistryStorage<'_> {
             }
             C::updateBlocklist(call) => {
                 observer.record_batch_items(
-                    &BerylAuxiliaryMetrics::singleton("policy", "updateBlocklist"),
+                    &PrecompileAuxiliaryMetrics::singleton("policy", "updateBlocklist"),
                     call.accounts.len(),
                 );
                 logic.update_blocklist(self, call.policyId, call.blocked, call.accounts)?;


### PR DESCRIPTION
## Summary
- Teach `BerylMetricLabels::policy_method` about Cobalt composite policy selectors via `IPolicyRegistryCalls::name_by_selector`, so those calls no longer land on `unknown`.
- Classify Cobalt composite/asset/common custom errors (plus remaining recorded-surface ABI gaps such as `InvalidMultiplier`, `NonPayable`, `AlreadyActivated`, `DelegateCallNotAllowed`) as `InvalidInput` instead of `OtherRevert`.
- Add selector and error exhaustiveness tests so future ABI additions cannot silently fall through to generic labels.

Fixes [BOP-601](https://linear.app/coinbase/issue/BOP-601/cantina-14-cobalt-composite-policy-calls-and-errors-missing-from-beryl) / Cantina #14 (Informational). Transaction execution is unchanged; this restores operational classification only.

## Test plan
- [x] `cargo test -p base-common-precompiles metrics:: --lib`
- [ ] Confirm Cobalt policy method labels (`createCompositePolicy`, `updateComposite`, `compositePolicyChildIds`, `MIN_COMPOSITE_CHILD_POLICIES`, `MAX_COMPOSITE_CHILD_POLICIES`) are not `unknown`
- [ ] Confirm Cobalt errors classify as `invalid_input` rather than `other_revert`
- [ ] CI green on `base-common-precompiles`


Made with [Cursor](https://cursor.com)