### PR TITLE
fix(precompiles): type-safe zero-address reject before transfer policy SLOAD (Cantina #13 / BOP-600)

### DIFF
--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -246,6 +246,12 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
+        if to == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        if caller == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: caller }));
+        }
         if privileged {
             return self.transfer_inner(token, caller, to, amount, None);
         }

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -20,8 +20,8 @@ use base_precompile_storage::{BasePrecompileError, Result};
 
 use crate::{
     Asset, AssetAccounting, B20_MAX_SUPPLY_CAP, B20AssetStorage, B20AssetToken, B20Guards,
-    B20PausableFeature, B20PolicyType, B20TokenRole, Eip712Domain, IB20, IB20Asset, PermitArgs,
-    PolicyAccounting, Token, TransferPolicyIds,
+    B20PausableFeature, B20PolicyType, B20TokenRole, Eip712Domain, IB20, IB20Asset, NonZeroAddress,
+    PermitArgs, PolicyAccounting, Token, TransferPolicyIds,
 };
 
 /// `keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")`
@@ -60,22 +60,20 @@ impl AssetV2 {
 
     /// Balance-moving core of `transfer`/`transferFrom`, without the pause check.
     ///
-    /// `policies` carries the sender/receiver ids pre-read from their shared slot by the caller;
-    /// `Some` enforces both (unprivileged path), `None` skips them (factory-privileged path).
+    /// `from` / `to` are [`NonZeroAddress`]: callers validate zero addresses (and choose the
+    /// typed revert) before any policy SLOAD. `policies` carries the sender/receiver ids
+    /// pre-read from their shared slot by the caller; `Some` enforces both (unprivileged
+    /// path), `None` skips them (factory-privileged path).
     fn transfer_inner<S: AssetAccounting, A: PolicyAccounting>(
         &self,
         token: &mut B20AssetToken<S, A>,
-        from: Address,
-        to: Address,
+        from: NonZeroAddress,
+        to: NonZeroAddress,
         amount: U256,
         policies: Option<&TransferPolicyIds>,
     ) -> Result<()> {
-        if to == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
-        }
-        if from == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
-        }
+        let from = from.get();
+        let to = to.get();
         if let Some(policies) = policies {
             B20Guards::ensure_authorized_by_id(
                 token,
@@ -246,17 +244,16 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        if to == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
-        }
-        if caller == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: caller }));
-        }
+        // Validate before any transfer-policy-id SLOAD (Cantina #13 / BOP-600).
+        let to = NonZeroAddress::new(to)
+            .map_err(|_| BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }))?;
+        let from = NonZeroAddress::new(caller)
+            .map_err(|_| BasePrecompileError::revert(IB20::InvalidSender { sender: caller }))?;
         if privileged {
-            return self.transfer_inner(token, caller, to, amount, None);
+            return self.transfer_inner(token, from, to, amount, None);
         }
         let policies = token.accounting().transfer_policy_ids()?;
-        self.transfer_inner(token, caller, to, amount, Some(&policies))
+        self.transfer_inner(token, from, to, amount, Some(&policies))
     }
 
     fn transfer_from(
@@ -269,13 +266,12 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        if to == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
-        }
-        if from == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
-        }
-        let allowance = token.accounting().allowance(from, caller)?;
+        // Validate before allowance / transfer-policy-id SLOADs.
+        let to = NonZeroAddress::new(to)
+            .map_err(|_| BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }))?;
+        let from = NonZeroAddress::new(from)
+            .map_err(|_| BasePrecompileError::revert(IB20::InvalidSender { sender: from }))?;
+        let allowance = token.accounting().allowance(from.get(), caller)?;
         let is_infinite = allowance == U256::MAX;
         if !is_infinite && allowance < amount {
             return Err(BasePrecompileError::revert(IB20::InsufficientAllowance {
@@ -290,7 +286,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
             // One SLOAD fetches all transfer policy ids, reused for the executor and
             // sender/receiver checks.
             let policies = token.accounting().transfer_policy_ids()?;
-            if caller != from {
+            if caller != from.get() {
                 B20Guards::ensure_authorized_by_id(
                     token,
                     B20PolicyType::TransferExecutor.id(),
@@ -303,7 +299,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         if is_infinite {
             return Ok(());
         }
-        token.accounting_mut().set_allowance(from, caller, allowance - amount)
+        token.accounting_mut().set_allowance(from.get(), caller, allowance - amount)
     }
 
     fn approve(

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -244,7 +244,6 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        // Validate before any transfer-policy-id SLOAD (Cantina #13 / BOP-600).
         let to = NonZeroAddress::new(to)
             .map_err(|_| BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }))?;
         let from = NonZeroAddress::new(caller)

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -12,7 +12,7 @@ use base_precompile_storage::{BasePrecompileError, Result};
 
 use crate::{
     B20_MAX_SUPPLY_CAP, B20Guards, B20PausableFeature, B20PolicyType, B20StablecoinToken,
-    B20TokenRole, Eip712Domain, IB20, PermitArgs, PolicyAccounting, Stablecoin,
+    B20TokenRole, Eip712Domain, IB20, NonZeroAddress, PermitArgs, PolicyAccounting, Stablecoin,
     StablecoinAccounting, Token, TransferPolicyIds,
 };
 
@@ -38,22 +38,20 @@ impl StablecoinV2 {
 
     /// Balance-moving core of `transfer`/`transferFrom`, without the pause check.
     ///
-    /// `policies` carries the sender/receiver ids pre-read from their shared slot by the caller;
-    /// `Some` enforces both (unprivileged path), `None` skips them (factory-privileged path).
+    /// `from` / `to` are [`NonZeroAddress`]: callers validate zero addresses (and choose the
+    /// typed revert) before any policy SLOAD. `policies` carries the sender/receiver ids
+    /// pre-read from their shared slot by the caller; `Some` enforces both (unprivileged
+    /// path), `None` skips them (factory-privileged path).
     fn transfer_inner<S: StablecoinAccounting, A: PolicyAccounting>(
         &self,
         token: &mut B20StablecoinToken<S, A>,
-        from: Address,
-        to: Address,
+        from: NonZeroAddress,
+        to: NonZeroAddress,
         amount: U256,
         policies: Option<&TransferPolicyIds>,
     ) -> Result<()> {
-        if to == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
-        }
-        if from == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
-        }
+        let from = from.get();
+        let to = to.get();
         if let Some(policies) = policies {
             B20Guards::ensure_authorized_by_id(
                 token,
@@ -200,17 +198,16 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        if to == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
-        }
-        if caller == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: caller }));
-        }
+        // Validate before any transfer-policy-id SLOAD (Cantina #13 / BOP-600).
+        let to = NonZeroAddress::new(to)
+            .map_err(|_| BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }))?;
+        let from = NonZeroAddress::new(caller)
+            .map_err(|_| BasePrecompileError::revert(IB20::InvalidSender { sender: caller }))?;
         if privileged {
-            return self.transfer_inner(token, caller, to, amount, None);
+            return self.transfer_inner(token, from, to, amount, None);
         }
         let policies = token.accounting().transfer_policy_ids()?;
-        self.transfer_inner(token, caller, to, amount, Some(&policies))
+        self.transfer_inner(token, from, to, amount, Some(&policies))
     }
 
     fn transfer_from(
@@ -223,13 +220,12 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        if to == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
-        }
-        if from == Address::ZERO {
-            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: from }));
-        }
-        let allowance = token.accounting().allowance(from, caller)?;
+        // Validate before allowance / transfer-policy-id SLOADs.
+        let to = NonZeroAddress::new(to)
+            .map_err(|_| BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }))?;
+        let from = NonZeroAddress::new(from)
+            .map_err(|_| BasePrecompileError::revert(IB20::InvalidSender { sender: from }))?;
+        let allowance = token.accounting().allowance(from.get(), caller)?;
         let is_infinite = allowance == U256::MAX;
         if !is_infinite && allowance < amount {
             return Err(BasePrecompileError::revert(IB20::InsufficientAllowance {
@@ -244,7 +240,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
             // One SLOAD fetches all transfer policy ids, reused for the executor and
             // sender/receiver checks.
             let policies = token.accounting().transfer_policy_ids()?;
-            if caller != from {
+            if caller != from.get() {
                 B20Guards::ensure_authorized_by_id(
                     token,
                     B20PolicyType::TransferExecutor.id(),
@@ -257,7 +253,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         if is_infinite {
             return Ok(());
         }
-        token.accounting_mut().set_allowance(from, caller, allowance - amount)
+        token.accounting_mut().set_allowance(from.get(), caller, allowance - amount)
     }
 
     fn approve(

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -200,6 +200,12 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
+        if to == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }));
+        }
+        if caller == Address::ZERO {
+            return Err(BasePrecompileError::revert(IB20::InvalidSender { sender: caller }));
+        }
         if privileged {
             return self.transfer_inner(token, caller, to, amount, None);
         }

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -198,7 +198,6 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         privileged: bool,
     ) -> Result<()> {
         B20Guards::ensure_not_paused(token, IB20::PausableFeature::TRANSFER)?;
-        // Validate before any transfer-policy-id SLOAD (Cantina #13 / BOP-600).
         let to = NonZeroAddress::new(to)
             .map_err(|_| BasePrecompileError::revert(IB20::InvalidReceiver { receiver: to }))?;
         let from = NonZeroAddress::new(caller)

--- a/crates/common/precompiles/src/common/mod.rs
+++ b/crates/common/precompiles/src/common/mod.rs
@@ -12,7 +12,9 @@ mod core_storage;
 pub use core_storage::B20CoreStorage;
 
 mod ops;
-pub use ops::{B20Guards, B20TokenRole, Eip712Domain, PermitArgs};
+pub use ops::{
+    B20Guards, B20TokenRole, Eip712Domain, NonZeroAddress, PermitArgs, ZeroAddressError,
+};
 
 mod pausable_feature;
 pub use pausable_feature::B20PausableFeature;

--- a/crates/common/precompiles/src/common/ops/mod.rs
+++ b/crates/common/precompiles/src/common/ops/mod.rs
@@ -2,10 +2,13 @@
 //!
 //! Token behavior itself lives in each variant's versioned `logic/vN` implementation. What stays
 //! here is the part every version must agree on: the authorization guards, the built-in role
-//! identifiers, and the EIP-2612 permit argument hashing.
+//! identifiers, the non-zero address wrapper, and the EIP-2612 permit argument hashing.
 
 mod guards;
 pub use guards::B20Guards;
+
+mod non_zero_address;
+pub use non_zero_address::{NonZeroAddress, ZeroAddressError};
 
 mod permit;
 pub use permit::{Eip712Domain, PermitArgs};

--- a/crates/common/precompiles/src/common/ops/non_zero_address.rs
+++ b/crates/common/precompiles/src/common/ops/non_zero_address.rs
@@ -17,11 +17,7 @@ pub struct NonZeroAddress(Address);
 impl NonZeroAddress {
     /// Returns a non-zero address, or [`ZeroAddressError`] if `address` is zero.
     pub fn new(address: Address) -> Result<Self, ZeroAddressError> {
-        if address == Address::ZERO {
-            Err(ZeroAddressError)
-        } else {
-            Ok(Self(address))
-        }
+        if address == Address::ZERO { Err(ZeroAddressError) } else { Ok(Self(address)) }
     }
 
     /// Returns the wrapped address.

--- a/crates/common/precompiles/src/common/ops/non_zero_address.rs
+++ b/crates/common/precompiles/src/common/ops/non_zero_address.rs
@@ -1,0 +1,47 @@
+//! Non-zero address wrapper for B-20 transfer parties.
+
+use alloy_primitives::Address;
+
+/// Error returned when constructing a [`NonZeroAddress`] from [`Address::ZERO`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ZeroAddressError;
+
+/// An [`Address`] proven not to be the zero address.
+///
+/// Construction fails with [`ZeroAddressError`] for the zero address. Callers map that into the
+/// appropriate typed revert (`InvalidReceiver`, `InvalidSender`, …). The private field preserves
+/// the invariant: there is no public way to wrap [`Address::ZERO`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct NonZeroAddress(Address);
+
+impl NonZeroAddress {
+    /// Returns a non-zero address, or [`ZeroAddressError`] if `address` is zero.
+    pub fn new(address: Address) -> Result<Self, ZeroAddressError> {
+        if address == Address::ZERO {
+            Err(ZeroAddressError)
+        } else {
+            Ok(Self(address))
+        }
+    }
+
+    /// Returns the wrapped address.
+    pub const fn get(self) -> Address {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_accepts_non_zero() {
+        let addr = Address::with_last_byte(1);
+        assert_eq!(NonZeroAddress::new(addr).unwrap().get(), addr);
+    }
+
+    #[test]
+    fn new_rejects_zero() {
+        assert_eq!(NonZeroAddress::new(Address::ZERO), Err(ZeroAddressError));
+    }
+}

--- a/crates/common/precompiles/src/lib.rs
+++ b/crates/common/precompiles/src/lib.rs
@@ -44,8 +44,8 @@ pub use common::{
 };
 pub use common::{
     B20_MAX_SUPPLY_CAP, B20Abi, B20CoreStorage, B20Guards, B20PausableFeature, B20PolicyType,
-    B20TokenRole, Eip712Domain, IB20, IB20V1, IB20V2, PermitArgs, Token, TokenAccounting,
-    TransferPolicyIds,
+    B20TokenRole, Eip712Domain, IB20, IB20V1, IB20V2, NonZeroAddress, PermitArgs, Token,
+    TokenAccounting, TransferPolicyIds, ZeroAddressError,
 };
 
 mod observer;

--- a/crates/common/precompiles/tests/b20_asset_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v2_golden.rs
@@ -3168,10 +3168,7 @@ fn gas_unprivileged_revert(
         .route(ctx, &calldata, version, false, NoopPrecompileCallObserver)
     })
     .expect_err("reject-path gas golden must revert");
-    assert_eq!(
-        err,
-        BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
-    );
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO }));
     (s.counter_sload(), s.counter_sstore(), s.counter_keccak256())
 }
 

--- a/crates/common/precompiles/tests/b20_asset_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v2_golden.rs
@@ -3142,6 +3142,54 @@ fn gas(
     (s.counter_sload(), s.counter_sstore(), s.counter_keccak256())
 }
 
+/// Unprivileged reject-path footprint: `(sload, sstore, keccak256)` after `calldata` reverts.
+///
+/// Locks that a zero-address `transfer` rejects before the transfer-policy-id SLOAD
+/// (Cantina #13 / BOP-600). Privileged success-path `gas()` cannot catch that.
+fn gas_unprivileged_revert(
+    setup: impl FnOnce(&mut B20AssetStorage<'_>),
+    caller: Address,
+    policy: FakePolicyAccounting,
+    calldata: Vec<u8>,
+) -> (u64, u64, u64) {
+    let mut s = fresh();
+    seed(&mut s, setup);
+    s.set_caller(caller);
+    warp(&mut s, U256::ZERO);
+    s.reset_counters();
+    let err = StorageCtx::enter(&mut s, |ctx| {
+        let version =
+            AssetVersions::from_base_upgrade(BaseUpgrade::Cobalt).expect("Cobalt activates V2");
+        B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            policy,
+            PolicyVersion::V2,
+        )
+        .route(ctx, &calldata, version, false, NoopPrecompileCallObserver)
+    })
+    .expect_err("reject-path gas golden must revert");
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+    );
+    (s.counter_sload(), s.counter_sstore(), s.counter_keccak256())
+}
+
+#[test]
+fn golden_transfer_unprivileged_zero_receiver_storage_access() {
+    let actual = gas_unprivileged_revert(
+        |t| fund(t, ALICE, u(10)),
+        ALICE,
+        FakePolicyAccounting::new(),
+        IB20::transferCall { to: Address::ZERO, amount: u(1) }.abi_encode(),
+    );
+    // Pause SLOAD only — no transfer_policy_ids SLOAD before InvalidReceiver.
+    bless_or_assert_gas(
+        &[("transfer_unprivileged_zero_receiver", actual)],
+        &[("transfer_unprivileged_zero_receiver", (1, 0, 0))],
+    );
+}
+
 #[test]
 fn golden_gas_footprints() {
     let actual: Vec<(&str, (u64, u64, u64))> = vec![
@@ -3470,6 +3518,7 @@ fn v2_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_transfer_unprivileged_allowed,
             golden_transfer_unprivileged_blocked_sender_reverts,
             golden_transfer_reverts_zero_receiver,
+            golden_transfer_unprivileged_zero_receiver_storage_access,
             golden_transfer_reverts_insufficient_balance,
             golden_transfer_reverts_when_paused,
             golden_transfer_reverts_zero_sender,

--- a/crates/common/precompiles/tests/b20_stablecoin_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v2_golden.rs
@@ -1998,10 +1998,7 @@ fn gas_unprivileged_revert(
         .route(ctx, &calldata, version, false, NoopPrecompileCallObserver)
     })
     .expect_err("reject-path gas golden must revert");
-    assert_eq!(
-        err,
-        BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
-    );
+    assert_eq!(err, BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO }));
     (s.counter_sload(), s.counter_sstore(), s.counter_keccak256())
 }
 

--- a/crates/common/precompiles/tests/b20_stablecoin_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v2_golden.rs
@@ -1973,6 +1973,53 @@ fn gas(
     (s.counter_sload(), s.counter_sstore(), s.counter_keccak256())
 }
 
+/// Unprivileged reject-path footprint: `(sload, sstore, keccak256)` after `calldata` reverts.
+///
+/// Locks that a zero-address `transfer` rejects before the transfer-policy-id SLOAD
+/// (Cantina #13 / BOP-600). Privileged success-path `gas()` cannot catch that.
+fn gas_unprivileged_revert(
+    setup: impl FnOnce(&mut B20StablecoinStorage<'_>),
+    caller: Address,
+    policy: FakePolicyAccounting,
+    calldata: Vec<u8>,
+) -> (u64, u64, u64) {
+    let mut s = fresh();
+    seed(&mut s, setup);
+    s.set_caller(caller);
+    s.reset_counters();
+    let err = StorageCtx::enter(&mut s, |ctx| {
+        let version = StablecoinVersions::from_base_upgrade(BaseUpgrade::Cobalt)
+            .expect("Cobalt activates V2");
+        B20StablecoinToken::with_storage_and_policy(
+            B20StablecoinStorage::from_address(TOKEN, ctx),
+            policy,
+            PolicyVersion::V2,
+        )
+        .route(ctx, &calldata, version, false, NoopPrecompileCallObserver)
+    })
+    .expect_err("reject-path gas golden must revert");
+    assert_eq!(
+        err,
+        BasePrecompileError::revert(IB20::InvalidReceiver { receiver: Address::ZERO })
+    );
+    (s.counter_sload(), s.counter_sstore(), s.counter_keccak256())
+}
+
+#[test]
+fn golden_transfer_unprivileged_zero_receiver_storage_access() {
+    let actual = gas_unprivileged_revert(
+        |t| fund(t, ALICE, u(10)),
+        ALICE,
+        FakePolicyAccounting::new(),
+        IB20::transferCall { to: Address::ZERO, amount: u(1) }.abi_encode(),
+    );
+    // Pause SLOAD only — no transfer_policy_ids SLOAD before InvalidReceiver.
+    bless_or_assert_gas(
+        &[("transfer_unprivileged_zero_receiver", actual)],
+        &[("transfer_unprivileged_zero_receiver", (1, 0, 0))],
+    );
+}
+
 #[test]
 fn golden_gas_footprints() {
     let actual: Vec<(&str, (u64, u64, u64))> = vec![
@@ -2380,6 +2427,7 @@ fn v2_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
             golden_transfer_unprivileged_allowed,
             golden_transfer_unprivileged_blocked_sender_reverts,
             golden_transfer_reverts_zero_receiver,
+            golden_transfer_unprivileged_zero_receiver_storage_access,
             golden_transfer_reverts_insufficient_balance,
             golden_transfer_reverts_when_paused,
             golden_transfer_reverts_zero_sender,


### PR DESCRIPTION
## Summary
- Introduce `NonZeroAddress` so V2 `transfer` / `transfer_from` prove non-zero `from`/`to` at the ABI edge, then map `ZeroAddressError` to `InvalidReceiver` / `InvalidSender`.
- `transfer_inner` takes `NonZeroAddress`, so the redundant zero checks can be dropped; the type system enforces the invariant.
- Validation runs before `transfer_policy_ids` (and before allowance SLOADs on `transfer_from`), fixing Cantina #13 / BOP-600 without duplicate manual checks.
- `transferWithMemo` routes through `transfer`, so it is covered.
- Unprivileged zero-receiver storage-access goldens lock the reject path at `(1, 0, 0)` (pause SLOAD only; no policy-id SLOAD).

## Test plan
- [x] `cargo test -p base-common-precompiles --features test-utils --lib common::ops::non_zero_address`
- [x] `cargo test -p base-common-precompiles --features test-utils --test b20_asset_v2_golden -- golden_transfer_unprivileged_zero_receiver_storage_access`
- [x] `cargo test -p base-common-precompiles --features test-utils --test b20_stablecoin_v2_golden -- golden_transfer_unprivileged_zero_receiver_storage_access`
- [x] `cargo test -p base-common-precompiles --features test-utils --test b20_asset_v2_golden --test b20_stablecoin_v2_golden -- golden_gas_footprints`
- [ ] CI green on this PR

Fixes BOP-600