### PR TITLE
refactor(txpool): centralize lane-aware transaction identity

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -706,7 +706,7 @@ impl BasePayloadBuilderCtx {
 
     /// [`Self::skip_current`] using the pooled transaction's sender, nonce, and replay ID.
     fn skip_pooled_current<B: PayloadTxsBounds>(best_txs: &mut B, tx: &B::Transaction) {
-        Self::skip_current(best_txs, tx.sender(), tx.nonce(), tx.eip8130_replay_id().is_some());
+        Self::skip_current(best_txs, tx.sender(), tx.nonce(), tx.identity().is_replay());
     }
 
     fn emit_considered(&self, cx: &DecisionContext<'_>, tx_hash: TxHash, ordering_position: u64) {
@@ -868,7 +868,7 @@ impl BasePayloadBuilderCtx {
             num_txs_considered += 1;
             let ordering_position = num_txs_considered;
             let tx_hash = *tx.hash();
-            let replay_independent = tx.eip8130_replay_id().is_some();
+            let replay_independent = tx.identity().is_replay();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
             let has_coinbase_tip = tx
                 .as_eip8130()

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -29,7 +29,7 @@ use base_execution_payload_builder::{
     BaseBuiltPayload, BasePayloadBuilderAttributes, BuilderMetrics as SharedBuilderMetrics,
     ValidityMetrics,
 };
-use base_execution_txpool::AccountStateDiff;
+use base_execution_txpool::{AccountStateDiff, BaseTransactionIdentity};
 use base_observability_events::{GlobalTransactionEventWriter, TransactionEventType};
 use eyre::WrapErr as _;
 use reth_basic_payload_builder::BuildOutcome;
@@ -682,6 +682,9 @@ where
             .iter()
             .zip(info.executed_senders[info.extra.last_flashblock_index..].iter())
         {
+            if !BaseTransactionIdentity::new(*sender, tx.nonce(), tx.as_eip8130()).is_protocol() {
+                continue;
+            }
             executed_sender_nonces
                 .entry(*sender)
                 .and_modify(|n| *n = (*n).max(tx.nonce()))

--- a/crates/builder/core/src/flashblocks/payload.rs
+++ b/crates/builder/core/src/flashblocks/payload.rs
@@ -70,6 +70,22 @@ use crate::{
     },
 };
 
+fn record_executed_protocol_nonce(
+    executed_sender_nonces: &mut HashMap<Address, u64>,
+    sender: Address,
+    identity: BaseTransactionIdentity,
+    nonce: u64,
+) {
+    if !identity.is_protocol() {
+        return;
+    }
+
+    executed_sender_nonces
+        .entry(sender)
+        .and_modify(|current| *current = (*current).max(nonce))
+        .or_insert(nonce);
+}
+
 type NextBestFlashblocksTxs<Pool> = BestFlashblocksTxs<
     <Pool as TransactionPool>::Transaction,
     ParkableBestPayloadTransactions<<Pool as TransactionPool>::Transaction>,
@@ -682,13 +698,12 @@ where
             .iter()
             .zip(info.executed_senders[info.extra.last_flashblock_index..].iter())
         {
-            if !BaseTransactionIdentity::new(*sender, tx.nonce(), tx.as_eip8130()).is_protocol() {
-                continue;
-            }
-            executed_sender_nonces
-                .entry(*sender)
-                .and_modify(|n| *n = (*n).max(tx.nonce()))
-                .or_insert_with(|| tx.nonce());
+            record_executed_protocol_nonce(
+                executed_sender_nonces,
+                *sender,
+                BaseTransactionIdentity::new(*sender, tx.nonce(), tx.as_eip8130()),
+                tx.nonce(),
+            );
         }
 
         // We got block cancelled, we won't need anything from the block at this point
@@ -1387,13 +1402,14 @@ mod tests {
     use base_common_consensus::BaseReceipt;
     use base_common_flashblocks::{FlashblockId, Metadata};
     use base_execution_chainspec::BaseChainSpec;
+    use base_execution_txpool::{BaseTransactionIdentity, BaseTransactionLane};
     use reth_chainspec::ChainSpec;
     use reth_execution_cache::{CachedStateProvider, CachedStatus, ExecutionCache, SavedCache};
     use reth_primitives_traits::SealedHeader;
     use reth_provider::{StateProviderBox, noop::NoopProvider};
     use reth_revm::{State, database::StateProviderDatabase};
 
-    use super::{FlashblocksMetadata, build_block};
+    use super::{FlashblocksMetadata, build_block, record_executed_protocol_nonce};
     use crate::{ExecutionInfo, flashblocks::context::BasePayloadBuilderCtx};
 
     /// Creates a minimal [`BaseChainSpec`] with all L1 upgrades through Cancun
@@ -1420,6 +1436,33 @@ mod tests {
     fn genesis_header() -> Arc<SealedHeader> {
         let header = Header { gas_limit: 30_000_000, timestamp: 0, ..Default::default() };
         Arc::new(SealedHeader::seal_slow(header))
+    }
+
+    #[test]
+    fn channel_execution_does_not_advance_protocol_nonce_tracking() {
+        let sender = Address::random();
+        let mut executed_sender_nonces = HashMap::default();
+
+        record_executed_protocol_nonce(
+            &mut executed_sender_nonces,
+            sender,
+            BaseTransactionIdentity::Nonce {
+                lane: BaseTransactionLane::Protocol { sender },
+                nonce: 3,
+            },
+            3,
+        );
+        record_executed_protocol_nonce(
+            &mut executed_sender_nonces,
+            sender,
+            BaseTransactionIdentity::Nonce {
+                lane: BaseTransactionLane::Channel { sender, nonce_key: U256::from(1) },
+                nonce: 50,
+            },
+            50,
+        );
+
+        assert_eq!(executed_sender_nonces.get(&sender), Some(&3));
     }
 
     #[test]

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -1128,10 +1128,10 @@ where
                     tx_hash = ?tx.hash(),
                     "skipping transaction unable to pay gas plus declared coinbase tip"
                 );
-                if tx.eip8130_replay_id().is_none() {
-                    best_txs.mark_invalid(tx.sender(), tx.nonce());
-                } else {
+                if tx.identity().is_replay() {
                     best_txs.mark_current_committed();
+                } else {
+                    best_txs.mark_invalid(tx.sender(), tx.nonce());
                 }
                 continue;
             }

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -898,7 +898,7 @@ where
                     tx_hash = ?tx_hash,
                     "skipping transaction with unsupported flashblock-index predicate"
                 );
-                if tx.eip8130_replay_id().is_none() {
+                if !tx.identity().is_replay() {
                     best_txs.mark_invalid(tx.sender(), tx.nonce());
                 } else {
                     best_txs.mark_current_committed();
@@ -941,7 +941,7 @@ where
                             "permanent" => false,
                         }
                     );
-                    if tx.eip8130_replay_id().is_none() {
+                    if !tx.identity().is_replay() {
                         best_txs.mark_invalid(tx.sender(), tx.nonce());
                     } else {
                         best_txs.mark_current_committed();
@@ -988,7 +988,7 @@ where
                             tx_hash = ?tx_hash,
                             "skipping transaction with expired validity predicate"
                         );
-                        if tx.eip8130_replay_id().is_none() {
+                        if !tx.identity().is_replay() {
                             best_txs.mark_invalid(tx.sender(), tx.nonce());
                         } else {
                             best_txs.mark_current_committed();
@@ -1028,7 +1028,7 @@ where
                                     "permanent" => false,
                                 }
                             );
-                            if tx.eip8130_replay_id().is_none() {
+                            if !tx.identity().is_replay() {
                                 best_txs.mark_invalid(tx.sender(), tx.nonce());
                             } else {
                                 best_txs.mark_current_committed();
@@ -1056,7 +1056,7 @@ where
                             error = ?error,
                             "failed to read validity predicate state"
                         );
-                        if tx.eip8130_replay_id().is_none() {
+                        if !tx.identity().is_replay() {
                             best_txs.mark_invalid(tx.sender(), tx.nonce());
                         } else {
                             best_txs.mark_current_committed();
@@ -1081,7 +1081,7 @@ where
                 // payload adapter invalidates by sender (not by replay ID), so
                 // marking one would suppress unrelated entries from this sender.
                 // This transaction has already been consumed from the iterator.
-                if tx.eip8130_replay_id().is_none() {
+                if !tx.identity().is_replay() {
                     best_txs.mark_invalid(tx.sender(), tx.nonce());
                 } else {
                     best_txs.mark_current_committed();
@@ -1107,7 +1107,7 @@ where
                         );
                         // Mirror the manifest pre-check above: a nonce-free replay-ID entry is
                         // independent, so invalidating by sender would suppress unrelated entries.
-                        if tx.eip8130_replay_id().is_none() {
+                        if !tx.identity().is_replay() {
                             best_txs.mark_invalid(tx.sender(), tx.nonce());
                         } else {
                             best_txs.mark_current_committed();

--- a/crates/execution/txpool/src/best.rs
+++ b/crates/execution/txpool/src/best.rs
@@ -101,7 +101,7 @@ where
     O: TransactionOrdering<Transaction = T>,
 {
     fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
-        if transaction.transaction.is_eip8130_sidecar_transaction() {
+        if transaction.transaction.identity().is_sidecar() {
             self.next_sidecar = None;
             self.sidecar.mark_invalid(transaction, kind);
         } else {
@@ -113,6 +113,11 @@ where
     fn no_updates(&mut self) {
         self.protocol.no_updates();
         self.sidecar.no_updates();
+    }
+
+    fn allow_updates_out_of_order(&mut self) {
+        self.protocol.allow_updates_out_of_order();
+        self.sidecar.allow_updates_out_of_order();
     }
 
     fn set_skip_blobs(&mut self, skip_blobs: bool) {
@@ -137,7 +142,7 @@ mod tests {
     use reth_transaction_pool::{TransactionOrigin, identifier::TransactionId};
 
     use super::*;
-    use crate::{BaseOrdering, BasePooledTransaction, TimestampedTransaction};
+    use crate::{BaseOrdering, BasePooledTransaction, BaseTransactionLane, TimestampedTransaction};
 
     #[derive(Debug)]
     struct StaticBestTransactions<T: BasePooledTx> {
@@ -160,14 +165,12 @@ mod tests {
 
     impl<T: BasePooledTx> BestTransactions for StaticBestTransactions<T> {
         fn mark_invalid(&mut self, transaction: &Self::Item, _kind: InvalidPoolTransactionError) {
-            let nonce_key = transaction.transaction.eip8130_nonce_channel_key();
+            let identity = transaction.transaction.identity();
             self.transactions.retain(|candidate| {
-                if nonce_key.is_some() {
-                    candidate.sender() != transaction.sender()
-                        || candidate.transaction.eip8130_nonce_channel_key() != nonce_key
-                } else {
-                    candidate.sender() != transaction.sender()
-                }
+                identity.lane().map_or_else(
+                    || candidate.hash() != transaction.hash(),
+                    |lane| candidate.transaction.identity().lane() != Some(lane),
+                )
             });
         }
 
@@ -349,11 +352,17 @@ mod tests {
         );
 
         let first = merged.next().expect("expected protocol transaction");
-        assert_eq!(first.transaction.eip8130_nonce_channel_key(), None);
+        assert!(matches!(
+            first.transaction.identity().lane(),
+            Some(BaseTransactionLane::Protocol { .. })
+        ));
         assert_eq!(first.nonce(), 0);
 
         let second = merged.next().expect("expected sidecar transaction");
-        assert_eq!(second.transaction.eip8130_nonce_channel_key(), Some(U256::from(1)));
+        assert!(matches!(
+            second.transaction.identity().lane(),
+            Some(BaseTransactionLane::Channel { nonce_key, .. }) if nonce_key == U256::from(1)
+        ));
 
         merged.mark_invalid(&first, InvalidPoolTransactionError::Underpriced);
 

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -38,7 +38,8 @@ pub use block_expiry::BlockExpiryIndex;
 
 mod transaction;
 pub use transaction::{
-    BasePooledTransaction, BasePooledTx, TimestampedTransaction, unix_time_millis,
+    BasePooledTransaction, BasePooledTx, BaseTransactionIdentity, BaseTransactionLane,
+    TimestampedTransaction, unix_time_millis,
 };
 
 mod ordering;
@@ -49,8 +50,8 @@ pub use ordering::{
 
 mod parking;
 pub use parking::{
-    BestTransactionLane, BestTransactionLaneState, ParkableBestTransactions,
-    ParkableTransactionPool, ParkedBestTransactions,
+    BestTransactionLaneState, ParkableBestTransactions, ParkableTransactionPool,
+    ParkedBestTransactions,
 };
 
 mod pool;

--- a/crates/execution/txpool/src/parking.rs
+++ b/crates/execution/txpool/src/parking.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use alloy_primitives::{
-    Address, TxHash, U256,
+    TxHash,
     map::{HashMap, hash_map::Entry},
 };
 use reth_transaction_pool::{
@@ -14,16 +14,7 @@ use reth_transaction_pool::{
     TransactionPool, ValidPoolTransaction, error::InvalidPoolTransactionError,
 };
 
-use crate::{BasePooledTx, BestTransactionPriority};
-
-/// A sequential transaction lane whose members must execute in nonce order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct BestTransactionLane {
-    /// Transaction sender whose nonces define the lane.
-    pub sender: Address,
-    /// Nonce channel key, with zero representing the protocol nonce lane.
-    pub nonce_key: U256,
-}
+use crate::{BasePooledTx, BaseTransactionLane, BestTransactionPriority};
 
 /// Iteration-local state for a sequential transaction lane.
 #[derive(Debug)]
@@ -35,21 +26,6 @@ where
     Occupied(VecDeque<Arc<ValidPoolTransaction<T>>>),
     /// The lane was terminally invalidated and is excluded for the remainder of the iterator.
     Invalid,
-}
-
-impl BestTransactionLane {
-    /// Returns the sequential lane for a transaction, or `None` for an independent nonce-free
-    /// EIP-8130 transaction.
-    pub fn for_transaction<T>(transaction: &Arc<ValidPoolTransaction<T>>) -> Option<Self>
-    where
-        T: BasePooledTx,
-    {
-        let nonce_key = transaction.transaction.eip8130_nonce_channel_key();
-        if nonce_key.is_none() && transaction.transaction.eip8130_replay_id().is_some() {
-            return None;
-        }
-        Some(Self { sender: transaction.sender(), nonce_key: nonce_key.unwrap_or_default() })
-    }
 }
 
 /// Extra lifecycle operations required to temporarily park best transactions.
@@ -102,7 +78,7 @@ where
     ordering: O,
     base_fee: u64,
     source_head: Option<Arc<ValidPoolTransaction<T>>>,
-    lanes: HashMap<BestTransactionLane, BestTransactionLaneState<T>>,
+    lanes: HashMap<BaseTransactionLane, BestTransactionLaneState<T>>,
     parked: HashMap<TxHash, Arc<ValidPoolTransaction<T>>>,
     ready: HashMap<TxHash, Arc<ValidPoolTransaction<T>>>,
     ready_heap: BinaryHeap<(BestTransactionPriority<O::PriorityValue>, TxHash)>,
@@ -163,7 +139,7 @@ where
     }
 
     /// Releases the next buffered transaction in a committed lane.
-    pub fn release_lane(&mut self, lane: BestTransactionLane) {
+    pub fn release_lane(&mut self, lane: BaseTransactionLane) {
         let next = match self.lanes.entry(lane) {
             Entry::Occupied(mut entry) => match entry.get_mut() {
                 BestTransactionLaneState::Occupied(buffered) => {
@@ -186,22 +162,19 @@ where
     ///
     /// Buffered descendants have already been consumed from `inner`. Invalidating the yielded lane
     /// head notifies `inner`, whose lane bookkeeping excludes its remaining descendants.
-    pub fn invalidate_lane(&mut self, lane: BestTransactionLane) {
+    pub fn invalidate_lane(&mut self, lane: BaseTransactionLane) {
         self.lanes.insert(lane, BestTransactionLaneState::Invalid);
         if self
             .source_head
             .as_ref()
-            .and_then(BestTransactionLane::for_transaction)
+            .and_then(|transaction| transaction.transaction.identity().lane())
             .is_some_and(|head_lane| head_lane == lane)
         {
             self.source_head = None;
         }
-        self.parked.retain(|_, transaction| {
-            BestTransactionLane::for_transaction(transaction) != Some(lane)
-        });
-        self.ready.retain(|_, transaction| {
-            BestTransactionLane::for_transaction(transaction) != Some(lane)
-        });
+        self.parked
+            .retain(|_, transaction| transaction.transaction.identity().lane() != Some(lane));
+        self.ready.retain(|_, transaction| transaction.transaction.identity().lane() != Some(lane));
         self.ready_heap.retain(|(_, hash)| self.ready.contains_key(hash));
     }
 
@@ -216,7 +189,7 @@ where
             let Some(transaction) = self.inner.next() else {
                 return;
             };
-            let Some(lane) = BestTransactionLane::for_transaction(&transaction) else {
+            let Some(lane) = transaction.transaction.identity().lane() else {
                 self.source_head = Some(transaction);
                 return;
             };
@@ -255,7 +228,7 @@ where
         &mut self,
         transaction: Arc<ValidPoolTransaction<T>>,
     ) -> Arc<ValidPoolTransaction<T>> {
-        if let Some(lane) = BestTransactionLane::for_transaction(&transaction) {
+        if let Some(lane) = transaction.transaction.identity().lane() {
             self.lanes
                 .entry(lane)
                 .or_insert_with(|| BestTransactionLaneState::Occupied(VecDeque::new()));
@@ -300,7 +273,7 @@ where
     O: TransactionOrdering<Transaction = T>,
 {
     fn mark_invalid(&mut self, transaction: &Self::Item, kind: InvalidPoolTransactionError) {
-        if let Some(lane) = BestTransactionLane::for_transaction(transaction) {
+        if let Some(lane) = transaction.transaction.identity().lane() {
             self.invalidate_lane(lane);
         }
         self.inner.mark_invalid(transaction, kind);
@@ -308,6 +281,10 @@ where
 
     fn no_updates(&mut self) {
         self.inner.no_updates();
+    }
+
+    fn allow_updates_out_of_order(&mut self) {
+        self.inner.allow_updates_out_of_order();
     }
 
     fn set_skip_blobs(&mut self, skip_blobs: bool) {
@@ -342,7 +319,7 @@ where
         let Some(transaction) = self.parked.remove(&transaction_hash) else {
             return false;
         };
-        if let Some(lane) = BestTransactionLane::for_transaction(&transaction) {
+        if let Some(lane) = transaction.transaction.identity().lane() {
             self.invalidate_lane(lane);
         }
         self.inner.mark_invalid(&transaction, kind);
@@ -350,7 +327,7 @@ where
     }
 
     fn mark_committed(&mut self, transaction: &Arc<ValidPoolTransaction<T>>) {
-        if let Some(lane) = BestTransactionLane::for_transaction(transaction) {
+        if let Some(lane) = transaction.transaction.identity().lane() {
             self.release_lane(lane);
         }
     }
@@ -361,7 +338,7 @@ mod tests {
     use std::{collections::VecDeque, time::Instant};
 
     use alloy_eips::eip2718::Encodable2718;
-    use alloy_primitives::Bytes;
+    use alloy_primitives::{Bytes, U256};
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use base_common_chains::ChainConfig;
@@ -396,9 +373,9 @@ mod tests {
 
     impl BestTransactions for StaticBestTransactions {
         fn mark_invalid(&mut self, transaction: &Self::Item, _kind: InvalidPoolTransactionError) {
-            let lane = BestTransactionLane::for_transaction(transaction);
+            let lane = transaction.transaction.identity().lane();
             self.transactions.retain(|candidate| {
-                BestTransactionLane::for_transaction(candidate) != lane || lane.is_none()
+                candidate.transaction.identity().lane() != lane || lane.is_none()
             });
         }
 
@@ -531,7 +508,7 @@ mod tests {
     fn invalidating_lane_removes_its_ready_heap_entries() {
         let signer = PrivateKeySigner::random();
         let transaction = transaction(&signer, U256::from(1), 0, 100);
-        let lane = BestTransactionLane::for_transaction(&transaction).unwrap();
+        let lane = transaction.transaction.identity().lane().unwrap();
         let inner = StaticBestTransactions::new(Vec::new());
         let mut best = ParkedBestTransactions::new(inner, BaseOrdering::coinbase_tip(), 0);
 

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -220,7 +220,7 @@ where
     }
 
     fn is_sidecar_transaction(&self, transaction: &T) -> bool {
-        transaction.is_eip8130_sidecar_transaction()
+        transaction.identity().is_sidecar()
     }
 
     fn limit_rejection_error(

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -4,7 +4,9 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use alloy_consensus::{BlobTransactionValidationError, Typed2718, transaction::Recovered};
+use alloy_consensus::{
+    BlobTransactionValidationError, Transaction as _, Typed2718, transaction::Recovered,
+};
 use alloy_eips::{
     eip2718::{Encodable2718, WithEncoded},
     eip2930::AccessList,
@@ -20,6 +22,83 @@ use reth_transaction_pool::{
 };
 
 use crate::estimated_da_size::DataAvailabilitySized;
+
+/// A sequential nonce lane in the Base transaction pool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BaseTransactionLane {
+    /// The sender's protocol account-nonce lane.
+    Protocol {
+        /// Transaction sender.
+        sender: Address,
+    },
+    /// A finite non-zero EIP-8130 nonce-key lane.
+    Channel {
+        /// Transaction sender.
+        sender: Address,
+        /// EIP-8130 nonce key.
+        nonce_key: U256,
+    },
+}
+
+/// Canonical transaction identity used for lane-aware routing and sequencing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BaseTransactionIdentity {
+    /// A nonce-bearing transaction identified within a sequential lane.
+    Nonce {
+        /// Sequential lane containing the transaction.
+        lane: BaseTransactionLane,
+        /// Nonce or nonce sequence within the lane.
+        nonce: u64,
+    },
+    /// An independent nonce-free EIP-8130 transaction.
+    Replay {
+        /// Replay identifier committed to by the transaction.
+        replay_id: B256,
+    },
+}
+
+impl BaseTransactionIdentity {
+    /// Derives the canonical identity from consensus transaction properties.
+    pub fn new(sender: Address, nonce: u64, eip8130: Option<&Eip8130Signed>) -> Self {
+        let Some(signed) = eip8130 else {
+            return Self::Nonce { lane: BaseTransactionLane::Protocol { sender }, nonce };
+        };
+        let nonce_key = signed.tx().nonce_key;
+        if nonce_key.is_zero() {
+            Self::Nonce { lane: BaseTransactionLane::Protocol { sender }, nonce }
+        } else if nonce_key == Eip8130Constants::NONCE_KEY_MAX {
+            Self::Replay { replay_id: signed.tx().replay_id(sender) }
+        } else {
+            Self::Nonce { lane: BaseTransactionLane::Channel { sender, nonce_key }, nonce }
+        }
+    }
+
+    /// Returns the sequential lane, or `None` for an independent replay identity.
+    pub const fn lane(self) -> Option<BaseTransactionLane> {
+        match self {
+            Self::Nonce { lane, .. } => Some(lane),
+            Self::Replay { .. } => None,
+        }
+    }
+
+    /// Returns whether this identity is stored in the EIP-8130 sidecar.
+    pub const fn is_sidecar(self) -> bool {
+        matches!(
+            self,
+            Self::Nonce { lane: BaseTransactionLane::Channel { .. }, .. } | Self::Replay { .. }
+        )
+    }
+
+    /// Returns whether this is an independent nonce-free replay identity.
+    pub const fn is_replay(self) -> bool {
+        matches!(self, Self::Replay { .. })
+    }
+
+    /// Returns whether this identity advances a protocol account nonce.
+    pub const fn is_protocol(self) -> bool {
+        matches!(self, Self::Nonce { lane: BaseTransactionLane::Protocol { .. }, .. })
+    }
+}
 
 /// Returns current time as milliseconds since Unix epoch.
 pub fn unix_time_millis() -> u128 {
@@ -189,7 +268,7 @@ where
     }
 
     fn requires_nonce_check(&self) -> bool {
-        self.as_eip8130().is_none_or(|signed| signed.tx().nonce_key.is_zero())
+        BaseTransactionIdentity::new(self.sender(), self.nonce(), self.as_eip8130()).is_protocol()
     }
 }
 
@@ -350,15 +429,9 @@ pub trait BasePooledTx: PoolTransaction + DataAvailabilitySized {
         None
     }
 
-    /// Returns the EIP-8130 `nonce_key` when this transaction belongs to a
-    /// finite non-zero nonce channel handled by the 2D nonce pool.
-    fn eip8130_nonce_channel_key(&self) -> Option<U256> {
-        None
-    }
-
-    /// Returns the EIP-8130 replay identifier, if applicable.
-    fn eip8130_replay_id(&self) -> Option<B256> {
-        None
+    /// Returns the canonical lane-aware identity for this transaction.
+    fn identity(&self) -> BaseTransactionIdentity {
+        BaseTransactionIdentity::new(self.sender(), self.nonce(), self.as_eip8130())
     }
 
     /// Returns the invalidation watch set computed during validation, if set.
@@ -396,11 +469,6 @@ pub trait BasePooledTx: PoolTransaction + DataAvailabilitySized {
     ///
     /// Defaults to a no-op for transaction types that do not carry a manifest.
     fn set_watch_manifest(&self, _watch_manifest: crate::WatchManifest) {}
-
-    /// Returns whether this transaction belongs in the EIP-8130 sidecar.
-    fn is_eip8130_sidecar_transaction(&self) -> bool {
-        self.eip8130_nonce_channel_key().is_some() || self.eip8130_replay_id().is_some()
-    }
 }
 
 impl<Pooled> BasePooledTx for BasePooledTransaction<BaseTransactionSigned, Pooled>
@@ -419,26 +487,6 @@ where
 
     fn as_eip8130(&self) -> Option<&Eip8130Signed> {
         self.inner.transaction().inner().as_eip8130()
-    }
-
-    fn eip8130_nonce_channel_key(&self) -> Option<U256> {
-        let signed = self.as_eip8130()?;
-        let nonce_key = signed.tx().nonce_key;
-        (!nonce_key.is_zero() && nonce_key != Eip8130Constants::NONCE_KEY_MAX).then_some(nonce_key)
-    }
-
-    fn eip8130_replay_id(&self) -> Option<B256> {
-        let signed = self.as_eip8130()?;
-        // `replay_id` keys mempool dedup/replacement only for nonce-free
-        // (`nonce_key == NONCE_KEY_MAX`) transactions, which have no nonce slot.
-        // Standard and 2D transactions dedupe/replace on
-        // `(sender, nonce_key, nonce_sequence)` under the standard nonce rules,
-        // so they must not be tracked by `replay_id` (which excludes fees and
-        // would otherwise block legitimate replace-by-fee at the same sequence).
-        if signed.tx().nonce_key != Eip8130Constants::NONCE_KEY_MAX {
-            return None;
-        }
-        Some(signed.tx().replay_id(self.sender()))
     }
 
     fn watch_set(&self) -> Option<&crate::WatchSet> {
@@ -498,16 +546,19 @@ mod tests {
     };
     use base_execution_chainspec::BaseChainSpec;
     use base_execution_evm::BaseEvmConfig;
+    use base_test_utils::Account;
     use reth_primitives_traits::InMemorySize;
     use reth_provider::test_utils::MockEthProvider;
     use reth_transaction_pool::{
         PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
-        blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder,
+        blobstore::InMemoryBlobStore, test_utils::TransactionBuilder,
+        validate::EthTransactionValidatorBuilder,
     };
 
     use crate::{
-        BasePooledTransaction, BasePooledTx, BaseTransactionValidator, ConfigSlot, InvalidationKey,
-        ValidityOperator, ValidityPredicate, WatchManifest, WatchSet,
+        BasePooledTransaction, BasePooledTx, BaseTransactionIdentity, BaseTransactionLane,
+        BaseTransactionValidator, ConfigSlot, InvalidationKey, ValidityOperator, ValidityPredicate,
+        WatchManifest, WatchSet,
     };
 
     fn signer() -> PrivateKeySigner {
@@ -516,11 +567,19 @@ mod tests {
 
     fn eip8130_pooled(nonce_key: U256) -> BasePooledTransaction {
         let signer = signer();
+        eip8130_pooled_for(&signer, nonce_key, 0)
+    }
+
+    fn eip8130_pooled_for(
+        signer: &PrivateKeySigner,
+        nonce_key: U256,
+        nonce_sequence: u64,
+    ) -> BasePooledTransaction {
         let tx = TxEip8130 {
             chain_id: ChainConfig::mainnet().chain_id,
             sender: None,
             nonce_key,
-            nonce_sequence: 0,
+            nonce_sequence,
             valid_after: 0,
             valid_before: if nonce_key == Eip8130Constants::NONCE_KEY_MAX { 5 } else { 0 },
             max_priority_fee_per_gas: 0,
@@ -536,6 +595,26 @@ mod tests {
             Eip8130Signed::new(tx, Bytes::from(signature.as_bytes().to_vec()), Bytes::new());
         let pooled = ConsensusPooledTransaction::Eip8130(signed);
         BasePooledTransaction::from_pooled(Recovered::new_unchecked(pooled, signer.address()))
+    }
+
+    fn ordinary_pooled(nonce: u64) -> BasePooledTransaction {
+        let account = Account::Alice;
+        let signed = TransactionBuilder::default()
+            .signer(account.signer_b256())
+            .chain_id(ChainConfig::mainnet().chain_id)
+            .nonce(nonce)
+            .to(Account::Bob.address())
+            .value(1_000)
+            .gas_limit(21_000)
+            .max_fee_per_gas(10)
+            .max_priority_fee_per_gas(1)
+            .into_eip1559();
+        let transaction = BaseTransactionSigned::Eip1559(
+            signed.as_eip1559().expect("EIP-1559 transaction").clone(),
+        );
+        let recovered = Recovered::new_unchecked(transaction, account.address());
+        let encoded_length = recovered.encode_2718_len();
+        BasePooledTransaction::new(recovered, encoded_length)
     }
 
     #[tokio::test]
@@ -581,6 +660,35 @@ mod tests {
         assert!(eip8130_pooled(U256::ZERO).requires_nonce_check());
         assert!(!eip8130_pooled(U256::from(1)).requires_nonce_check());
         assert!(!eip8130_pooled(Eip8130Constants::NONCE_KEY_MAX).requires_nonce_check());
+    }
+
+    #[test]
+    fn identity_distinguishes_protocol_channels_and_replays() {
+        let signer = PrivateKeySigner::from_bytes(&Account::Alice.signer_b256()).unwrap();
+        let ordinary = ordinary_pooled(7).identity();
+        let key_zero = eip8130_pooled_for(&signer, U256::ZERO, 7).identity();
+        let channel_one = eip8130_pooled_for(&signer, U256::from(1), 7).identity();
+        let channel_two = eip8130_pooled_for(&signer, U256::from(2), 7).identity();
+        let replay = eip8130_pooled_for(&signer, Eip8130Constants::NONCE_KEY_MAX, 7).identity();
+
+        assert!(matches!(
+            ordinary,
+            BaseTransactionIdentity::Nonce { lane: BaseTransactionLane::Protocol { .. }, nonce: 7 }
+        ));
+        assert!(matches!(
+            key_zero,
+            BaseTransactionIdentity::Nonce { lane: BaseTransactionLane::Protocol { .. }, nonce: 7 }
+        ));
+        assert_eq!(ordinary, key_zero);
+        assert!(ordinary.is_protocol());
+        assert!(key_zero.is_protocol());
+        assert_ne!(channel_one, channel_two);
+        assert!(channel_one.is_sidecar());
+        assert!(!channel_one.is_protocol());
+        assert!(replay.is_sidecar());
+        assert!(replay.is_replay());
+        assert!(!replay.is_protocol());
+        assert_eq!(replay.lane(), None);
     }
 
     #[test]

--- a/crates/execution/txpool/src/two_d_nonce_pool.rs
+++ b/crates/execution/txpool/src/two_d_nonce_pool.rs
@@ -19,7 +19,7 @@ use reth_transaction_pool::{
     pool::{AddedTransactionState, QueuedReason},
 };
 
-use crate::{BasePooledTx, BestTransactionPriority};
+use crate::{BasePooledTx, BaseTransactionIdentity, BaseTransactionLane, BestTransactionPriority};
 
 type LaneId = (Address, U256);
 
@@ -249,7 +249,7 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
             return Err(PoolError::new(hash, PoolErrorKind::AlreadyImported));
         }
 
-        if let Some(replay_id) = transaction.transaction.eip8130_replay_id() {
+        if let BaseTransactionIdentity::Replay { replay_id } = transaction.transaction.identity() {
             let sender_id = self.senders.sender_id_or_create(transaction.sender());
             transaction.transaction_id = TransactionId::new(sender_id, transaction.nonce());
             let transaction = Arc::new(transaction);
@@ -273,14 +273,19 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
             });
         }
 
-        let sender = transaction.sender();
-        let nonce_key = transaction.transaction.eip8130_nonce_channel_key().ok_or_else(|| {
-            PoolError::other(hash, "2D nonce pool only accepts channelized EIP-8130 transactions")
-        })?;
+        let BaseTransactionIdentity::Nonce {
+            lane: BaseTransactionLane::Channel { sender, nonce_key },
+            nonce,
+        } = transaction.transaction.identity()
+        else {
+            return Err(PoolError::other(
+                hash,
+                "2D nonce pool only accepts sidecar EIP-8130 transactions",
+            ));
+        };
 
         let lane_id = (sender, nonce_key);
         let sender_id = self.senders.sender_id_or_create(sender);
-        let nonce = transaction.nonce();
         transaction.transaction_id = TransactionId::new(sender_id, nonce);
         let transaction = Arc::new(transaction);
         let lane = self.lanes.entry(lane_id).or_insert_with(|| NonceLane {
@@ -371,11 +376,9 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
     ) -> Vec<Arc<ValidPoolTransaction<T>>> {
         let mut removed = Vec::new();
         for hash in hashes {
-            if self
-                .hashes
-                .get(hash)
-                .is_some_and(|transaction| transaction.transaction.eip8130_replay_id().is_some())
-            {
+            if self.hashes.get(hash).is_some_and(|transaction| {
+                matches!(transaction.transaction.identity(), BaseTransactionIdentity::Replay { .. })
+            }) {
                 if let Some(transaction) = self.remove_hash(*hash, false) {
                     removed.push(transaction);
                 }
@@ -384,7 +387,11 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
             let Some(transaction) = self.hashes.get(hash) else {
                 continue;
             };
-            let Some(nonce_key) = transaction.transaction.eip8130_nonce_channel_key() else {
+            let BaseTransactionIdentity::Nonce {
+                lane: BaseTransactionLane::Channel { nonce_key, .. },
+                ..
+            } = transaction.transaction.identity()
+            else {
                 continue;
             };
             let lane_id = (transaction.sender(), nonce_key);
@@ -407,11 +414,9 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
     pub(crate) fn prune_mined(&mut self, hashes: &[TxHash]) -> PruneMinedOutcome<T> {
         let mut removed = Vec::new();
         for hash in hashes {
-            if self
-                .hashes
-                .get(hash)
-                .is_some_and(|transaction| transaction.transaction.eip8130_replay_id().is_some())
-                && let Some(transaction) = self.remove_hash(*hash, false)
+            if self.hashes.get(hash).is_some_and(|transaction| {
+                matches!(transaction.transaction.identity(), BaseTransactionIdentity::Replay { .. })
+            }) && let Some(transaction) = self.remove_hash(*hash, false)
             {
                 removed.push(transaction);
             }
@@ -420,8 +425,14 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
             .iter()
             .filter_map(|hash| {
                 let transaction = self.hashes.get(hash)?;
-                let nonce_key = transaction.transaction.eip8130_nonce_channel_key()?;
-                Some((transaction.sender(), nonce_key, transaction.nonce(), *hash))
+                let BaseTransactionIdentity::Nonce {
+                    lane: BaseTransactionLane::Channel { sender, nonce_key },
+                    nonce,
+                } = transaction.transaction.identity()
+                else {
+                    return None;
+                };
+                Some((sender, nonce_key, nonce, *hash))
             })
             .collect();
         ordered_hashes.sort_unstable();
@@ -485,16 +496,22 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
         advance_lane: bool,
     ) -> Option<Arc<ValidPoolTransaction<T>>> {
         if let Some(transaction) = self.hashes.get(&hash)
-            && let Some(replay_id) = transaction.transaction.eip8130_replay_id()
+            && let BaseTransactionIdentity::Replay { replay_id } =
+                transaction.transaction.identity()
         {
             let transaction = self.nonce_free.remove(&replay_id)?;
             self.hashes.remove(&hash);
             return Some(transaction);
         }
         let transaction = self.hashes.get(&hash)?;
-        let nonce_key = transaction.transaction.eip8130_nonce_channel_key()?;
-        let lane_id = (transaction.sender(), nonce_key);
-        let nonce = transaction.nonce();
+        let BaseTransactionIdentity::Nonce {
+            lane: BaseTransactionLane::Channel { sender, nonce_key },
+            nonce,
+        } = transaction.transaction.identity()
+        else {
+            return None;
+        };
+        let lane_id = (sender, nonce_key);
         let transaction = {
             let lane = self.lanes.get_mut(&lane_id)?;
             let transaction = lane.transactions.remove(&nonce)?;
@@ -645,10 +662,17 @@ where
     O: TransactionOrdering<Transaction = T>,
 {
     fn mark_invalid(&mut self, transaction: &Self::Item, _kind: InvalidPoolTransactionError) {
-        let index = if let Some(nonce_key) = transaction.transaction.eip8130_nonce_channel_key() {
-            self.lane_indexes.get(&(transaction.sender(), nonce_key)).copied()
-        } else {
-            self.nonce_free_indexes.get(transaction.hash()).copied()
+        let index = match transaction.transaction.identity() {
+            BaseTransactionIdentity::Nonce {
+                lane: BaseTransactionLane::Channel { sender, nonce_key },
+                ..
+            } => self.lane_indexes.get(&(sender, nonce_key)).copied(),
+            BaseTransactionIdentity::Replay { .. } => {
+                self.nonce_free_indexes.get(transaction.hash()).copied()
+            }
+            BaseTransactionIdentity::Nonce {
+                lane: BaseTransactionLane::Protocol { .. }, ..
+            } => None,
         };
         if let Some(index) = index {
             self.lanes[index].invalidated = true;


### PR DESCRIPTION
## Summary
- Introduce canonical protocol, EIP-8130 channel, and nonce-free replay transaction identities.
- Normalize ordinary transactions and EIP-8130 nonce key zero into the same protocol nonce lane.
- Reuse the identity boundary in routing, parking, payload selection, best-transaction wrappers, and flashblock nonce accounting.
- Fix flashblocks protocol nonce tracking so channel and replay sequences cannot advance a sender's account nonce view.

## Testing
- Identity mapping and lane-isolation unit tests.
- Targeted regression test where a channel transaction with a larger sequence executes after a protocol transaction without changing the tracked protocol nonce.
- Builder core, payload builder, txpool, and full workspace build validation.

Stack: base layer of #4837.