### PR TITLE
feat(txpool): retain validated payer funding metadata

### DIFF
--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -39,7 +39,7 @@ pub use block_expiry::BlockExpiryIndex;
 mod transaction;
 pub use transaction::{
     BasePooledTransaction, BasePooledTx, BaseTransactionIdentity, BaseTransactionLane,
-    TimestampedTransaction, unix_time_millis,
+    TimestampedTransaction, ValidatedFunding, unix_time_millis,
 };
 
 mod ordering;

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -1807,6 +1807,7 @@ mod tests {
         BaseTxEnvelope, Eip8130Constants, Eip8130Signed, TxEip8130,
     };
     use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
+    use base_execution_eip8130::{AccountConfigurationStorage, AccountState};
     use base_execution_evm::BaseEvmConfig;
     use futures::{StreamExt, future::join_all};
     use reth_primitives_traits::SealedBlock;
@@ -1814,7 +1815,7 @@ mod tests {
     use reth_tasks::Runtime;
     use reth_transaction_pool::{
         CanonicalStateUpdate, PoolConfig, PoolUpdateKind, PriceBumpConfig, TransactionOrigin,
-        blobstore::InMemoryBlobStore, identifier::TransactionId,
+        blobstore::InMemoryBlobStore, error::PoolErrorKind, identifier::TransactionId,
         validate::EthTransactionValidatorBuilder,
     };
 
@@ -2058,11 +2059,19 @@ mod tests {
     }
 
     fn signed_1559(signer: &PrivateKeySigner, nonce: u64) -> BasePooledTransaction {
+        signed_1559_with_fee(signer, nonce, 1_000)
+    }
+
+    fn signed_1559_with_fee(
+        signer: &PrivateKeySigner,
+        nonce: u64,
+        max_fee_per_gas: u128,
+    ) -> BasePooledTransaction {
         let tx = TxEip1559 {
             chain_id: test_chain_id(),
             nonce,
             gas_limit: 50_000,
-            max_fee_per_gas: 1_000,
+            max_fee_per_gas,
             max_priority_fee_per_gas: 0,
             to: TxKind::Call(Address::repeat_byte(0xEE)),
             value: U256::ZERO,
@@ -2085,6 +2094,58 @@ mod tests {
         signed_8130(signer, nonce_key, nonce_sequence, expiry, max_fee_per_gas, 1_000_000)
     }
 
+    fn sponsored_eoa_8130(
+        sender: &PrivateKeySigner,
+        payer: &PrivateKeySigner,
+        nonce_sequence: u64,
+        max_fee_per_gas: u128,
+    ) -> BasePooledTransaction {
+        let tx = TxEip8130 {
+            chain_id: test_chain_id(),
+            sender: None,
+            nonce_key: U256::ZERO,
+            nonce_sequence,
+            valid_after: 0,
+            valid_before: 0,
+            max_priority_fee_per_gas: 0,
+            max_fee_per_gas,
+            gas_limit: 1_000_000,
+            account_changes: Vec::new(),
+            calls: Vec::new(),
+            metadata: Bytes::new(),
+            payer: Some(payer.address()),
+        };
+        let sender_signature = sender.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
+        let payer_signature =
+            payer.sign_hash_sync(&tx.payer_signature_hash(sender.address())).unwrap();
+        let mut payer_auth = Vec::with_capacity(85);
+        payer_auth.extend_from_slice(Eip8130Constants::K1_AUTHENTICATOR.as_slice());
+        payer_auth.extend_from_slice(&payer_signature.r().to_be_bytes::<32>());
+        payer_auth.extend_from_slice(&payer_signature.s().to_be_bytes::<32>());
+        payer_auth.push(27 + u8::from(payer_signature.v()));
+        let signed = Eip8130Signed::new(
+            tx,
+            Bytes::from(sender_signature.as_bytes().to_vec()),
+            Bytes::from(payer_auth),
+        );
+        let pooled = ConsensusPooledTransaction::Eip8130(signed);
+        BasePooledTransaction::from_pooled(Recovered::new_unchecked(pooled, sender.address()))
+    }
+
+    fn configure_sponsors(
+        client: &MockEthProvider<BasePrimitives, Arc<BaseChainSpec>>,
+        payers: impl IntoIterator<Item = Address>,
+    ) {
+        let state =
+            AccountState::from_word(U256::from(Eip8130Constants::SCOPE_SPONSOR_PAYER) << 232);
+        client.add_account(
+            AccountConfigurationStorage::ADDRESS,
+            ExtendedAccount::new(0, U256::ZERO).extend_storage(payers.into_iter().map(|payer| {
+                (AccountConfigurationStorage::account_state_slot(payer), state.to_word())
+            })),
+        );
+    }
+
     #[tokio::test]
     async fn standard_transactions_are_not_eip8130_gated() {
         let (pool, client) = build_integration_pool();
@@ -2098,6 +2159,96 @@ mod tests {
             assert!(result.is_ok(), "standard transaction {nonce} was guard-rejected: {result:?}");
         }
         assert!(pool.guard.read().is_empty());
+    }
+
+    #[tokio::test]
+    async fn key_zero_eip8130_replaces_ordinary_transaction() {
+        let (pool, client) = build_integration_pool();
+        let signer = signer();
+        fund(&client, signer.address());
+        let ordinary = signed_1559_with_fee(&signer, 0, 1_000);
+        let ordinary_hash = *ordinary.hash();
+        pool.add_transaction(TransactionOrigin::Local, ordinary).await.unwrap();
+
+        let replacement = self_paid_eoa_8130(&signer, U256::ZERO, 0, 0, 1_250);
+        let replacement_hash = *replacement.hash();
+        pool.add_transaction(TransactionOrigin::Local, replacement)
+            .await
+            .expect("key-zero EIP-8130 fee bump must replace ordinary transaction");
+
+        assert!(pool.get(&ordinary_hash).is_none());
+        assert!(pool.get(&replacement_hash).is_some());
+    }
+
+    #[tokio::test]
+    async fn ordinary_transaction_replaces_key_zero_eip8130() {
+        let (pool, client) = build_integration_pool();
+        let signer = signer();
+        fund(&client, signer.address());
+        let eip8130 = self_paid_eoa_8130(&signer, U256::ZERO, 0, 0, 1_000);
+        let eip8130_hash = *eip8130.hash();
+        pool.add_transaction(TransactionOrigin::Local, eip8130).await.unwrap();
+
+        let replacement = signed_1559_with_fee(&signer, 0, 1_250);
+        let replacement_hash = *replacement.hash();
+        pool.add_transaction(TransactionOrigin::Local, replacement)
+            .await
+            .expect("ordinary fee bump must replace key-zero EIP-8130 transaction");
+
+        assert!(pool.get(&eip8130_hash).is_none());
+        assert!(pool.get(&replacement_hash).is_some());
+        assert!(!pool.guard.read().contains(&eip8130_hash));
+    }
+
+    #[tokio::test]
+    async fn underpriced_cross_type_key_zero_replacement_is_rejected() {
+        let (pool, client) = build_integration_pool();
+        let signer = signer();
+        fund(&client, signer.address());
+        let ordinary = signed_1559_with_fee(&signer, 0, 1_000);
+        let ordinary_hash = *ordinary.hash();
+        pool.add_transaction(TransactionOrigin::Local, ordinary).await.unwrap();
+
+        let replacement = self_paid_eoa_8130(&signer, U256::ZERO, 0, 0, 1_050);
+        let replacement_hash = *replacement.hash();
+        let error = pool
+            .add_transaction(TransactionOrigin::Local, replacement)
+            .await
+            .expect_err("replacement below the configured bump must be rejected");
+
+        assert!(matches!(error.kind, PoolErrorKind::ReplacementUnderpriced));
+        assert!(pool.get(&ordinary_hash).is_some());
+        assert!(pool.get(&replacement_hash).is_none());
+    }
+
+    #[tokio::test]
+    async fn key_zero_replacement_reaccounts_changed_payer() {
+        let (pool, client) = build_integration_pool();
+        let sender = signer();
+        let first_payer = signer();
+        let second_payer = signer();
+        fund(&client, sender.address());
+        fund(&client, first_payer.address());
+        fund(&client, second_payer.address());
+        configure_sponsors(&client, [first_payer.address(), second_payer.address()]);
+
+        let original = sponsored_eoa_8130(&sender, &first_payer, 0, 1_000);
+        let original_hash = *original.hash();
+        pool.add_transaction(TransactionOrigin::Local, original).await.unwrap();
+        let replacement = sponsored_eoa_8130(&sender, &second_payer, 0, 1_250);
+        let replacement_hash = *replacement.hash();
+        pool.add_transaction(TransactionOrigin::Local, replacement)
+            .await
+            .expect("fee bump with a different payer must replace the key-zero transaction");
+
+        assert!(pool.get(&original_hash).is_none());
+        let replacement = pool.get(&replacement_hash).expect("replacement transaction");
+        assert_eq!(
+            replacement.transaction.validated_funding().expect("funding metadata").payer(),
+            second_payer.address()
+        );
+        assert!(!pool.guard.read().contains(&original_hash));
+        assert!(pool.guard.read().contains(&replacement_hash));
     }
 
     #[tokio::test]

--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -23,6 +23,34 @@ use reth_transaction_pool::{
 
 use crate::estimated_da_size::DataAvailabilitySized;
 
+/// Funding actors and cost established by successful transaction validation.
+///
+/// This is independent of transaction identity and nonce sequencing: the payer
+/// may differ from the sender, and `max_cost` includes every fee component used
+/// by Base admission checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ValidatedFunding {
+    payer: Address,
+    max_cost: U256,
+}
+
+impl ValidatedFunding {
+    /// Creates validated funding metadata.
+    pub const fn new(payer: Address, max_cost: U256) -> Self {
+        Self { payer, max_cost }
+    }
+
+    /// Returns the account responsible for the complete maximum cost.
+    pub const fn payer(&self) -> Address {
+        self.payer
+    }
+
+    /// Returns the complete maximum cost checked during admission.
+    pub const fn max_cost(&self) -> U256 {
+        self.max_cost
+    }
+}
+
 /// A sequential nonce lane in the Base transaction pool.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BaseTransactionLane {
@@ -147,6 +175,8 @@ pub struct BasePooledTransaction<
     /// EIP-8130 validation. Unset for other transaction types; see
     /// [`crate::WatchManifest`].
     watch_manifest: OnceLock<crate::WatchManifest>,
+    /// Payer and complete maximum cost established once during validation.
+    validated_funding: OnceLock<ValidatedFunding>,
 }
 
 impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
@@ -173,6 +203,7 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
             watch_set: OnceLock::new(),
             limit_class: OnceLock::new(),
             watch_manifest: OnceLock::new(),
+            validated_funding: OnceLock::new(),
         }
     }
 
@@ -294,6 +325,7 @@ impl<Cons: InMemorySize, Pooled> InMemorySize for BasePooledTransaction<Cons, Po
             + watch_keys_size
             + core::mem::size_of::<OnceLock<crate::LimitClass>>()
             + core::mem::size_of::<OnceLock<crate::WatchManifest>>()
+            + core::mem::size_of::<OnceLock<ValidatedFunding>>()
             + manifest_slots_size
             + validity_predicates_size
     }
@@ -469,6 +501,20 @@ pub trait BasePooledTx: PoolTransaction + DataAvailabilitySized {
     ///
     /// Defaults to a no-op for transaction types that do not carry a manifest.
     fn set_watch_manifest(&self, _watch_manifest: crate::WatchManifest) {}
+
+    /// Returns the payer and complete maximum cost established during validation.
+    ///
+    /// Defaults to `None` for transaction types that do not retain validation
+    /// metadata.
+    fn validated_funding(&self) -> Option<&ValidatedFunding> {
+        None
+    }
+
+    /// Records the payer and complete maximum cost established during validation.
+    ///
+    /// Defaults to a no-op for transaction types that do not retain validation
+    /// metadata.
+    fn set_validated_funding(&self, _funding: ValidatedFunding) {}
 }
 
 impl<Pooled> BasePooledTx for BasePooledTransaction<BaseTransactionSigned, Pooled>
@@ -511,6 +557,14 @@ where
 
     fn set_limit_class(&self, limit_class: crate::LimitClass) {
         let _ = self.limit_class.set(limit_class);
+    }
+
+    fn validated_funding(&self) -> Option<&ValidatedFunding> {
+        self.validated_funding.get()
+    }
+
+    fn set_validated_funding(&self, funding: ValidatedFunding) {
+        let _ = self.validated_funding.set(funding);
     }
 }
 
@@ -557,8 +611,8 @@ mod tests {
 
     use crate::{
         BasePooledTransaction, BasePooledTx, BaseTransactionIdentity, BaseTransactionLane,
-        BaseTransactionValidator, ConfigSlot, InvalidationKey, ValidityOperator, ValidityPredicate,
-        WatchManifest, WatchSet,
+        BaseTransactionValidator, ConfigSlot, InvalidationKey, ValidatedFunding, ValidityOperator,
+        ValidityPredicate, WatchManifest, WatchSet,
     };
 
     fn signer() -> PrivateKeySigner {
@@ -727,6 +781,17 @@ mod tests {
         transaction.set_watch_manifest(manifest);
 
         assert_eq!(transaction.size(), size_without_slots + slots_size);
+    }
+
+    #[test]
+    fn validated_funding_is_recorded_once() {
+        let transaction = ordinary_pooled(0);
+        let initial = ValidatedFunding::new(Address::repeat_byte(1), U256::from(2));
+        transaction.set_validated_funding(initial);
+        transaction
+            .set_validated_funding(ValidatedFunding::new(Address::repeat_byte(3), U256::from(4)));
+
+        assert_eq!(transaction.validated_funding(), Some(&initial));
     }
 
     #[test]

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -929,6 +929,10 @@ where
                 matches!(origin, TransactionOrigin::External | TransactionOrigin::Local);
             transaction.set_watch_set(state.watch_set.clone());
             transaction.set_watch_manifest(state.manifest.clone());
+            transaction.set_validated_funding(crate::ValidatedFunding::new(
+                state.payer,
+                state.payer_max_cost,
+            ));
             transaction.set_limit_class(LimitClass {
                 sender: state.sender,
                 payer: state.payer,
@@ -2043,11 +2047,6 @@ where
         outcome: TransactionValidationOutcome<Tx>,
         operator_fee_gas_addition: u64,
     ) -> TransactionValidationOutcome<Tx> {
-        if !self.requires_l1_data_gas_fee() {
-            // no need to check L1 gas fee
-            return outcome;
-        }
-        // ensure that the account has enough balance to cover the L1 gas cost
         if let TransactionValidationOutcome::Valid {
             balance,
             state_nonce,
@@ -2057,6 +2056,23 @@ where
             authorities,
         } = outcome
         {
+            if !self.requires_l1_data_gas_fee() {
+                if valid_tx.transaction().validated_funding().is_none() {
+                    valid_tx.transaction().set_validated_funding(crate::ValidatedFunding::new(
+                        valid_tx.transaction().sender(),
+                        *valid_tx.transaction().cost(),
+                    ));
+                }
+                return TransactionValidationOutcome::Valid {
+                    balance,
+                    state_nonce,
+                    transaction: valid_tx,
+                    propagate,
+                    bytecode_hash,
+                    authorities,
+                };
+            }
+
             let mut l1_block_info = self.block_info.l1_block_info.read().clone();
 
             // Check to ensure tx doesn't exceed the DA footprint limit
@@ -2106,6 +2122,13 @@ where
                 );
             }
 
+            if valid_tx.transaction().validated_funding().is_none() {
+                valid_tx.transaction().set_validated_funding(crate::ValidatedFunding::new(
+                    valid_tx.transaction().sender(),
+                    cost,
+                ));
+            }
+
             return TransactionValidationOutcome::Valid {
                 balance,
                 state_nonce,
@@ -2147,7 +2170,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloy_consensus::{SignableTransaction, TxEip1559, transaction::SignerRecoverable};
+    use alloy_consensus::{
+        SignableTransaction, TxEip1559,
+        transaction::{Recovered, SignerRecoverable},
+    };
     use alloy_eips::eip2718::Encodable2718;
     use alloy_primitives::{Address, B256, Bytes, TxKind, U256, bytes, hex::decode};
     use alloy_signer::SignerSync;
@@ -2164,8 +2190,8 @@ mod tests {
     use base_test_utils::Account;
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_transaction_pool::{
-        TransactionOrigin, TransactionValidationOutcome, blobstore::InMemoryBlobStore,
-        validate::EthTransactionValidatorBuilder,
+        PoolTransaction, TransactionOrigin, TransactionValidationOutcome,
+        blobstore::InMemoryBlobStore, validate::EthTransactionValidatorBuilder,
     };
 
     use super::*;
@@ -3449,6 +3475,168 @@ mod tests {
                 "expected operator-fee-underfunded tx to be rejected at admission, got {other:?}"
             ),
         }
+    }
+
+    #[tokio::test]
+    async fn ordinary_transaction_records_complete_base_funding_cost() {
+        let chain_config = ChainConfig::mainnet();
+        let chain_spec = Arc::new(BaseChainSpec::mainnet());
+        let signer = Account::Alice.signer();
+        let sender = signer.address();
+        let tx = TxEip1559 {
+            chain_id: chain_config.chain_id,
+            nonce: 0,
+            gas_limit: 50_000,
+            max_fee_per_gas: 1_000,
+            max_priority_fee_per_gas: 0,
+            to: TxKind::Call(Address::random()),
+            value: U256::from(17),
+            access_list: Default::default(),
+            input: bytes!("FACADE"),
+        };
+        let signature = signer.sign_hash_sync(&tx.signature_hash()).unwrap();
+        let envelope = BaseTxEnvelope::Eip1559(tx.into_signed(signature));
+        let recovered = envelope.clone().try_into_recovered().unwrap();
+        let encoded = recovered.encoded_2718();
+        let isthmus_data = decode(ISTHMUS_L1_INFO_DATA_HEX).expect("valid hex fixture");
+        let mut l1_block_info = base_execution_evm::parse_l1_info(&isthmus_data).unwrap();
+        let additional_cost = l1_block_info.tx_cost(
+            &encoded,
+            U256::from(envelope.gas_limit()),
+            BaseSpecId::from_timestamp(Arc::clone(&chain_spec), chain_config.isthmus_timestamp),
+        );
+        let expected_max_cost = U256::from(envelope.value())
+            .saturating_add(U256::from(
+                envelope.max_fee_per_gas().saturating_mul(envelope.gas_limit() as u128),
+            ))
+            .saturating_add(additional_cost);
+
+        let client = MockEthProvider::<BasePrimitives>::new()
+            .with_chain_spec(Arc::clone(&chain_spec))
+            .with_genesis_block();
+        client.add_account(sender, ExtendedAccount::new(0, expected_max_cost));
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
+        let inner = EthTransactionValidatorBuilder::new(client, evm_config)
+            .no_shanghai()
+            .no_cancun()
+            .build(InMemoryBlobStore::default());
+        let validator: TestValidator =
+            BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default());
+        let header = alloy_consensus::Header {
+            timestamp: chain_config.isthmus_timestamp,
+            ..Default::default()
+        };
+        let l1_info_tx: BaseTransactionSigned = TxDeposit {
+            source_hash: Default::default(),
+            from: Address::ZERO,
+            to: TxKind::Create,
+            mint: 0,
+            value: U256::ZERO,
+            gas_limit: 0,
+            is_system_transaction: false,
+            input: isthmus_data.into(),
+        }
+        .into();
+        validator.update_l1_block_info(&header, Some(&l1_info_tx));
+
+        let transaction: BasePooledTransaction =
+            BasePooledTransaction::new(recovered, envelope.encode_2718_len());
+        let outcome = validator.validate_one(TransactionOrigin::External, transaction).await;
+        let valid = outcome.as_valid_transaction().expect("fully funded ordinary transaction");
+        let funding = valid.transaction().validated_funding().expect("validated funding metadata");
+
+        assert_eq!(funding.payer(), sender);
+        assert_eq!(funding.max_cost(), expected_max_cost);
+    }
+
+    #[tokio::test]
+    async fn eip8130_records_self_paid_and_sponsored_funding() {
+        let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().cobalt_activated().build());
+        let sender_signer = PrivateKeySigner::random();
+        let sender = sender_signer.address();
+        let payer_signer = PrivateKeySigner::random();
+        let payer = payer_signer.address();
+        let balance = U256::from(1_000_000_000_000_000_000u64);
+
+        let client = MockEthProvider::<BasePrimitives>::new()
+            .with_chain_spec(Arc::clone(&chain_spec))
+            .with_genesis_block();
+        client.add_account(sender, ExtendedAccount::new(0, balance));
+        client.add_account(payer, ExtendedAccount::new(0, balance));
+        let payer_state =
+            AccountState::from_word(U256::from(Eip8130Constants::SCOPE_SPONSOR_PAYER) << 232);
+        let payer_state_slot = AccountConfigurationStorage::account_state_slot(payer);
+        client.add_account(
+            AccountConfigurationStorage::ADDRESS,
+            ExtendedAccount::new(0, U256::ZERO)
+                .extend_storage([(payer_state_slot, payer_state.to_word())]),
+        );
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
+        let inner = EthTransactionValidatorBuilder::new(client, evm_config)
+            .no_shanghai()
+            .no_cancun()
+            .build(InMemoryBlobStore::default());
+        let validator: TestValidator =
+            BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default())
+                .require_l1_data_gas_fee(false);
+
+        let self_paid_tx =
+            TxEip8130 { nonce_sequence: 0, gas_limit: 100_000, ..minimal_valid_eoa_tx() };
+        let self_paid_signature =
+            sender_signer.sign_hash_sync(&self_paid_tx.sender_signature_hash()).unwrap();
+        let self_paid_signed = Eip8130Signed::new(
+            self_paid_tx,
+            Bytes::from(self_paid_signature.as_bytes().to_vec()),
+            Bytes::new(),
+        );
+        let expected_self = validator
+            .validate_eip8130_full(&self_paid_signed)
+            .expect("valid self-paid transaction");
+        let self_paid = BasePooledTransaction::from_pooled(Recovered::new_unchecked(
+            base_common_consensus::BasePooledTransaction::Eip8130(self_paid_signed),
+            sender,
+        ));
+        let self_outcome = validator.validate_one(TransactionOrigin::External, self_paid).await;
+        let self_funding = self_outcome
+            .as_valid_transaction()
+            .expect("valid self-paid outcome")
+            .transaction()
+            .validated_funding()
+            .expect("self-paid funding metadata");
+        assert_eq!(self_funding.payer(), sender);
+        assert_eq!(self_funding.max_cost(), expected_self.payer_max_cost);
+
+        let sponsored_tx = TxEip8130 {
+            nonce_sequence: 0,
+            gas_limit: 100_000,
+            payer: Some(payer),
+            ..minimal_valid_eoa_tx()
+        };
+        let sender_auth =
+            sender_signer.sign_hash_sync(&sponsored_tx.sender_signature_hash()).unwrap();
+        let payer_auth = k1_auth_blob(&payer_signer, sponsored_tx.payer_signature_hash(sender));
+        let sponsored_signed = Eip8130Signed::new(
+            sponsored_tx,
+            Bytes::from(sender_auth.as_bytes().to_vec()),
+            payer_auth,
+        );
+        let expected_sponsored = validator
+            .validate_eip8130_full(&sponsored_signed)
+            .expect("valid sponsored transaction");
+        let sponsored = BasePooledTransaction::from_pooled(Recovered::new_unchecked(
+            base_common_consensus::BasePooledTransaction::Eip8130(sponsored_signed),
+            sender,
+        ));
+        let sponsored_outcome =
+            validator.validate_one(TransactionOrigin::External, sponsored).await;
+        let sponsored_funding = sponsored_outcome
+            .as_valid_transaction()
+            .expect("valid sponsored outcome")
+            .transaction()
+            .validated_funding()
+            .expect("sponsored funding metadata");
+        assert_eq!(sponsored_funding.payer(), payer);
+        assert_eq!(sponsored_funding.max_cost(), expected_sponsored.payer_max_cost);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add validated funding metadata that separates the payer from the nonce-owning sender.
- Retain the complete Base maximum cost established during validation.
- Cover ordinary, sponsored, self-paid, and cross-envelope key-zero replacement behavior.

## Testing
- Funding metadata validator tests.
- Cross-type EIP-1559/EIP-8130 replacement tests.

Stack: layer 2 of #4832; based on #4824.