### PR TITLE
feat(txpool): enforce sidecar fee and capacity parity

### DIFF
--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -166,11 +166,12 @@ where
         >,
         ordering: O,
     ) -> Self {
-        let price_bump_config = protocol_pool.config().price_bumps;
+        let config = protocol_pool.config().clone();
+        let base_fee = protocol_pool.block_info().pending_basefee;
         Self {
             protocol_pool,
             ordering,
-            nonce_pool: Arc::new(RwLock::new(TwoDNoncePool::new(price_bump_config))),
+            nonce_pool: Arc::new(RwLock::new(TwoDNoncePool::new_with_config(config, base_fee))),
             listeners: Arc::new(RwLock::new(SidecarListeners::default())),
             guard: Arc::new(RwLock::new(MempoolGuard::unlimited())),
             block_expiry: Arc::new(RwLock::new(crate::BlockExpiryIndex::new())),
@@ -304,6 +305,7 @@ where
             }
             removed.extend(sidecar_removed);
         }
+        self.cleanup_removed_bookkeeping(&removed);
         removed
     }
 
@@ -314,6 +316,17 @@ where
         let mut guard = self.guard.write();
         for transaction in removed {
             guard.release(transaction.hash());
+        }
+    }
+
+    fn cleanup_removed_bookkeeping(&self, removed: &[Arc<ValidPoolTransaction<T>>]) {
+        if removed.is_empty() {
+            return;
+        }
+        self.release_from_guard(removed);
+        let mut block_expiry = self.block_expiry.write();
+        for transaction in removed {
+            block_expiry.remove(transaction.hash());
         }
     }
 
@@ -709,8 +722,11 @@ where
                     }
                     (None, None) => {}
                 }
-                drop(guard);
                 listeners.on_inserted(&nonce_pool, &outcome);
+                let discarded = nonce_pool.enforce_limits();
+                if !discarded.is_empty() {
+                    listeners.on_discarded(&discarded);
+                }
                 if is_validity {
                     ValidityPoolMetrics::record_admission(outcome.replaced.is_some());
                 }
@@ -720,9 +736,23 @@ where
                 // not acquired while holding the nonce pool.
                 let inserted_hash = outcome.outcome.hash;
                 let replaced_hash = outcome.replaced.as_ref().map(|replaced| *replaced.hash());
+                let discarded_on_insert =
+                    discarded.iter().any(|transaction| *transaction.hash() == inserted_hash);
+                drop(guard);
                 drop(listeners);
                 drop(nonce_pool);
-                self.register_block_expiry(inserted_hash, block_expiry_bound, replaced_hash);
+                self.cleanup_removed_bookkeeping(&discarded);
+                self.register_block_expiry(
+                    inserted_hash,
+                    (!discarded_on_insert).then_some(block_expiry_bound).flatten(),
+                    replaced_hash,
+                );
+                if discarded_on_insert {
+                    return Err(reth_transaction_pool::error::PoolError::new(
+                        inserted_hash,
+                        reth_transaction_pool::error::PoolErrorKind::DiscardedOnInsert,
+                    ));
+                }
                 Ok(outcome.outcome)
             }
             TransactionValidationOutcome::Invalid(transaction, error) => {
@@ -846,16 +876,15 @@ where
     fn pool_size(&self) -> PoolSize {
         let mut size = self.protocol_pool.pool_size();
         let nonce_pool = self.nonce_pool.read();
-        let (pending, queued) = nonce_pool.pending_and_queued_txn_count();
-        let pending_size: usize =
-            nonce_pool.pending_transactions().iter().map(|tx| tx.encoded_length()).sum();
-        let queued_size: usize =
-            nonce_pool.queued_transactions().iter().map(|tx| tx.encoded_length()).sum();
+        let [(pending, pending_size), (basefee, basefee_size), (queued, queued_size)] =
+            nonce_pool.subpool_size();
         size.pending += pending;
         size.pending_size += pending_size;
+        size.basefee += basefee;
+        size.basefee_size += basefee_size;
         size.queued += queued;
         size.queued_size += queued_size;
-        size.total += pending + queued;
+        size.total += pending + basefee + queued;
         size
     }
 
@@ -1150,7 +1179,9 @@ where
 
     fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut transactions = self.protocol_pool.queued_transactions();
-        transactions.extend(self.nonce_pool.read().queued_transactions());
+        let nonce_pool = self.nonce_pool.read();
+        transactions.extend(nonce_pool.basefee_transactions());
+        transactions.extend(nonce_pool.queued_transactions());
         transactions
     }
 
@@ -1165,6 +1196,7 @@ where
         let mut transactions = self.protocol_pool.all_transactions();
         let nonce_pool = self.nonce_pool.read();
         transactions.pending.extend(nonce_pool.pending_transactions());
+        transactions.queued.extend(nonce_pool.basefee_transactions());
         transactions.queued.extend(nonce_pool.queued_transactions());
         transactions
     }
@@ -1181,13 +1213,12 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(hashes);
         let mut removed = self.protocol_pool.remove_transactions(protocol_hashes);
-        self.release_from_guard(&removed);
         let sidecar_removed = self.nonce_pool.write().remove_transactions(&sidecar_hashes);
         if !sidecar_removed.is_empty() {
             self.listeners.write().on_discarded(&sidecar_removed);
         }
-        self.release_from_guard(&sidecar_removed);
         removed.extend(sidecar_removed);
+        self.cleanup_removed_bookkeeping(&removed);
         removed
     }
 
@@ -1197,14 +1228,13 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(hashes);
         let mut removed = self.protocol_pool.remove_transactions_and_descendants(protocol_hashes);
-        self.release_from_guard(&removed);
         let sidecar_removed =
             self.nonce_pool.write().remove_transactions_and_descendants(&sidecar_hashes);
         if !sidecar_removed.is_empty() {
             self.listeners.write().on_discarded(&sidecar_removed);
         }
-        self.release_from_guard(&sidecar_removed);
         removed.extend(sidecar_removed);
+        self.cleanup_removed_bookkeeping(&removed);
         removed
     }
 
@@ -1213,13 +1243,12 @@ where
         sender: Address,
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let mut removed = self.protocol_pool.remove_transactions_by_sender(sender);
-        self.release_from_guard(&removed);
         let sidecar_removed = self.nonce_pool.write().remove_transactions_by_sender(sender);
         if !sidecar_removed.is_empty() {
             self.listeners.write().on_discarded(&sidecar_removed);
         }
-        self.release_from_guard(&sidecar_removed);
         removed.extend(sidecar_removed);
+        self.cleanup_removed_bookkeeping(&removed);
         removed
     }
 
@@ -1229,10 +1258,9 @@ where
     ) -> Vec<Arc<ValidPoolTransaction<Self::Transaction>>> {
         let (protocol_hashes, sidecar_hashes) = self.partition_hashes_by_pool(hashes);
         let mut removed = self.protocol_pool.prune_transactions(protocol_hashes);
-        self.release_from_guard(&removed);
         let pruned = self.nonce_pool.write().prune_mined(&sidecar_hashes);
-        self.release_from_guard(&pruned.removed);
         removed.extend(pruned.removed);
+        self.cleanup_removed_bookkeeping(&removed);
         removed
     }
 
@@ -1481,7 +1509,18 @@ where
     type Block = <TransactionValidationTaskExecutor<BaseTransactionValidator<Client, T, Evm>> as TransactionValidator>::Block;
 
     fn set_block_info(&self, info: BlockInfo) {
-        self.protocol_pool.set_block_info(info)
+        self.protocol_pool.set_block_info(info);
+        let mut nonce_pool = self.nonce_pool.write();
+        let mut listeners = self.listeners.write();
+        let outcome = nonce_pool.set_base_fee(info.pending_basefee);
+        listeners.on_fee_update(&outcome.promoted, &outcome.demoted);
+        let discarded = nonce_pool.enforce_limits();
+        if !discarded.is_empty() {
+            listeners.on_discarded(&discarded);
+        }
+        drop(listeners);
+        drop(nonce_pool);
+        self.cleanup_removed_bookkeeping(&discarded);
     }
 
     fn on_canonical_state_change(
@@ -1507,7 +1546,7 @@ where
             }
         }
         self.protocol_pool.on_canonical_state_change(update);
-        {
+        let removed_sidecar = {
             let mut nonce_pool = self.nonce_pool.write();
             let pruned = nonce_pool.prune_mined(&mined_transactions);
             // The nonce-free validity window is in milliseconds, evaluated
@@ -1520,15 +1559,11 @@ where
             if !expired.is_empty() {
                 listeners.on_discarded(&expired);
             }
-            // Sidecar maintenance lock order is nonce_pool -> listeners -> guard.
-            let mut guard = self.guard.write();
-            for transaction in &pruned.removed {
-                guard.release(transaction.hash());
-            }
-            for transaction in &expired {
-                guard.release(transaction.hash());
-            }
-        }
+            let mut removed = pruned.removed;
+            removed.extend(expired);
+            removed
+        };
+        self.cleanup_removed_bookkeeping(&removed_sidecar);
         self.expire_due_buckets(now);
         self.expire_by_block(block_number);
         self.reconcile_guard();
@@ -1682,12 +1717,42 @@ impl<T: BasePooledTx> SidecarListeners<T> {
             AddedTransactionState::Queued(reason) => {
                 self.broadcast_hash_event(&hash, TransactionEvent::Queued);
                 self.broadcast_all(FullTransactionEvent::Queued(hash, Some(reason.clone())));
-                self.broadcast_new(NewTransactionEvent { subpool: SubPool::Queued, transaction });
+                let subpool =
+                    if *reason == reth_transaction_pool::pool::QueuedReason::InsufficientBaseFee {
+                        SubPool::BaseFee
+                    } else {
+                        SubPool::Queued
+                    };
+                self.broadcast_new(NewTransactionEvent { subpool, transaction });
             }
         }
 
         for promoted in &outcome.promoted {
             self.broadcast_pending_transaction(promoted);
+        }
+    }
+
+    fn on_fee_update(
+        &mut self,
+        promoted: &[Arc<ValidPoolTransaction<T>>],
+        demoted: &[(Arc<ValidPoolTransaction<T>>, SubPool)],
+    ) {
+        for transaction in promoted {
+            self.broadcast_pending_transaction(transaction);
+        }
+        for (transaction, subpool) in demoted {
+            let hash = *transaction.hash();
+            let reason = if *subpool == SubPool::BaseFee {
+                reth_transaction_pool::pool::QueuedReason::InsufficientBaseFee
+            } else {
+                reth_transaction_pool::pool::QueuedReason::ParkedAncestors
+            };
+            self.broadcast_hash_event(&hash, TransactionEvent::Queued);
+            self.broadcast_all(FullTransactionEvent::Queued(hash, Some(reason)));
+            self.broadcast_new(NewTransactionEvent {
+                subpool: *subpool,
+                transaction: Arc::clone(transaction),
+            });
         }
     }
 
@@ -1814,9 +1879,9 @@ mod tests {
     use reth_provider::test_utils::{ExtendedAccount, MockEthProvider};
     use reth_tasks::Runtime;
     use reth_transaction_pool::{
-        CanonicalStateUpdate, PoolConfig, PoolUpdateKind, PriceBumpConfig, TransactionOrigin,
-        blobstore::InMemoryBlobStore, error::PoolErrorKind, identifier::TransactionId,
-        validate::EthTransactionValidatorBuilder,
+        CanonicalStateUpdate, PoolConfig, PoolUpdateKind, PriceBumpConfig, SubPoolLimit,
+        TransactionOrigin, blobstore::InMemoryBlobStore, error::PoolErrorKind,
+        identifier::TransactionId, validate::EthTransactionValidatorBuilder,
     };
 
     use super::*;
@@ -1979,6 +2044,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn base_fee_updates_emit_sidecar_demotions_and_promotions() {
+        let mut nonce_pool = TwoDNoncePool::new_with_config(PoolConfig::default(), 50);
+        let mut listeners = SidecarListeners::default();
+        let signer = signer();
+        let transaction = valid_pool_transaction(signed_channel_tx(&signer, U256::from(2), 0, 100));
+        let hash = *transaction.hash();
+        let mut hash_events = listeners.subscribe_hash(hash).0;
+        let mut new_events = listeners.subscribe_new_transactions(TransactionListenerKind::All);
+
+        let inserted = nonce_pool.insert_validated(transaction, 0).unwrap();
+        listeners.on_inserted(&nonce_pool, &inserted);
+        assert!(matches!(hash_events.next().await, Some(TransactionEvent::Pending)));
+        assert!(
+            matches!(new_events.recv().await, Some(event) if event.subpool == SubPool::Pending)
+        );
+
+        let raised = nonce_pool.set_base_fee(101);
+        listeners.on_fee_update(&raised.promoted, &raised.demoted);
+        assert!(matches!(hash_events.next().await, Some(TransactionEvent::Queued)));
+        assert!(
+            matches!(new_events.recv().await, Some(event) if event.subpool == SubPool::BaseFee)
+        );
+
+        let lowered = nonce_pool.set_base_fee(100);
+        listeners.on_fee_update(&lowered.promoted, &lowered.demoted);
+        assert!(matches!(hash_events.next().await, Some(TransactionEvent::Pending)));
+        assert!(
+            matches!(new_events.recv().await, Some(event) if event.subpool == SubPool::Pending)
+        );
+    }
+
+    #[tokio::test]
     async fn discarded_sidecar_transaction_broadcasts_terminal_events() {
         let mut listeners = SidecarListeners::default();
         let signer = signer();
@@ -2032,6 +2129,12 @@ mod tests {
 
     fn build_integration_pool()
     -> (IntegrationPool, MockEthProvider<BasePrimitives, Arc<BaseChainSpec>>) {
+        build_integration_pool_with_config(PoolConfig::default())
+    }
+
+    fn build_integration_pool_with_config(
+        config: PoolConfig,
+    ) -> (IntegrationPool, MockEthProvider<BasePrimitives, Arc<BaseChainSpec>>) {
         let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().cobalt_activated().build());
         let client = MockEthProvider::<BasePrimitives>::new()
             .with_chain_spec(Arc::clone(&chain_spec))
@@ -2047,7 +2150,7 @@ mod tests {
                     .require_l1_data_gas_fee(false)
             });
         let ordering = BaseOrdering::default();
-        let pool = Pool::new(validator, ordering.clone(), blob_store, PoolConfig::default());
+        let pool = Pool::new(validator, ordering.clone(), blob_store, config);
         (BaseTransactionPool::new(pool, ordering).with_guard_limits(GuardLimits::default()), client)
     }
 
@@ -2325,6 +2428,33 @@ mod tests {
         let replacement =
             self_paid_eoa_8130(&signer, Eip8130Constants::NONCE_KEY_MAX, 0, cap + 2, 1_000);
         assert!(pool.add_transaction(TransactionOrigin::Local, replacement).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn sidecar_limit_eviction_releases_guard_and_block_expiry_bookkeeping() {
+        let config =
+            PoolConfig { pending_limit: SubPoolLimit::new(1, usize::MAX), ..PoolConfig::default() };
+        let (pool, client) = build_integration_pool_with_config(config);
+        let low_signer = signer();
+        let high_signer = signer();
+        fund(&client, low_signer.address());
+        fund(&client, high_signer.address());
+        let low = self_paid_eoa_8130(&low_signer, U256::from(1), 0, 0, 1_000);
+        let low_hash = *low.hash();
+        pool.add_transaction(TransactionOrigin::External, low).await.unwrap();
+        pool.block_expiry.write().insert(low_hash, 100);
+        assert!(pool.guard.read().contains(&low_hash));
+        assert_eq!(pool.block_expiry.read().len(), 1);
+
+        let high = self_paid_eoa_8130(&high_signer, U256::from(1), 0, 0, 2_000);
+        let high_hash = *high.hash();
+        pool.add_transaction(TransactionOrigin::External, high).await.unwrap();
+
+        assert!(pool.get(&low_hash).is_none());
+        assert!(pool.get(&high_hash).is_some());
+        assert!(!pool.guard.read().contains(&low_hash));
+        assert!(pool.guard.read().contains(&high_hash));
+        assert!(pool.block_expiry.read().is_empty());
     }
 
     #[tokio::test]

--- a/crates/execution/txpool/src/two_d_nonce_pool.rs
+++ b/crates/execution/txpool/src/two_d_nonce_pool.rs
@@ -11,9 +11,11 @@ use alloy_primitives::{
 };
 use base_common_consensus::Eip8130Constants;
 use reth_primitives_traits::transaction::error::InvalidTransactionError;
+#[cfg(test)]
+use reth_transaction_pool::PriceBumpConfig;
 use reth_transaction_pool::{
-    AddedTransactionOutcome, BestTransactions, PoolResult, PriceBumpConfig, TransactionOrdering,
-    ValidPoolTransaction,
+    AddedTransactionOutcome, BestTransactions, PoolConfig, PoolResult, SubPool,
+    TransactionOrdering, ValidPoolTransaction,
     error::{InvalidPoolTransactionError, PoolError, PoolErrorKind},
     identifier::{SenderIdentifiers, TransactionId},
     pool::{AddedTransactionState, QueuedReason},
@@ -29,6 +31,13 @@ struct NonceLane<T: BasePooledTx> {
     transactions: BTreeMap<u64, Arc<ValidPoolTransaction<T>>>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SidecarSubPool {
+    Pending,
+    BaseFee,
+    Queued,
+}
+
 impl<T: BasePooledTx> Default for NonceLane<T> {
     fn default() -> Self {
         Self { next_nonce: 0, transactions: BTreeMap::new() }
@@ -40,25 +49,49 @@ impl<T: BasePooledTx> NonceLane<T> {
         self.transactions.range(self.next_nonce..).map(|(_, transaction)| transaction)
     }
 
+    fn classified_transactions(
+        &self,
+        base_fee: u64,
+    ) -> Vec<(SidecarSubPool, &Arc<ValidPoolTransaction<T>>)> {
+        let mut expected_nonce = self.next_nonce;
+        let mut blocked = false;
+        self.live_transactions()
+            .map(|transaction| {
+                let subpool = if blocked || transaction.nonce() != expected_nonce {
+                    blocked = true;
+                    SidecarSubPool::Queued
+                } else if transaction.transaction.max_fee_per_gas() < u128::from(base_fee) {
+                    blocked = true;
+                    SidecarSubPool::BaseFee
+                } else {
+                    SidecarSubPool::Pending
+                };
+                expected_nonce = expected_nonce.saturating_add(1);
+                (subpool, transaction)
+            })
+            .collect()
+    }
+
+    fn transactions_in(
+        &self,
+        subpool: SidecarSubPool,
+        base_fee: u64,
+    ) -> impl Iterator<Item = &Arc<ValidPoolTransaction<T>>> {
+        self.classified_transactions(base_fee).into_iter().filter_map(
+            move |(candidate, transaction)| (candidate == subpool).then_some(transaction),
+        )
+    }
+
+    #[cfg(test)]
     fn consecutive_pending_transactions(
         &self,
     ) -> impl Iterator<Item = &Arc<ValidPoolTransaction<T>>> {
-        self.live_transactions()
-            .enumerate()
-            .take_while(|(offset, transaction)| {
-                self.next_nonce
-                    .checked_add(*offset as u64)
-                    .is_some_and(|expected| transaction.nonce() == expected)
-            })
-            .map(|(_, transaction)| transaction)
+        self.transactions_in(SidecarSubPool::Pending, 0)
     }
 
-    fn consecutive_pending_len(&self) -> usize {
-        self.consecutive_pending_transactions().count()
-    }
-
+    #[cfg(test)]
     fn queued_transactions(&self) -> impl Iterator<Item = &Arc<ValidPoolTransaction<T>>> {
-        self.live_transactions().skip(self.consecutive_pending_len())
+        self.transactions_in(SidecarSubPool::Queued, 0)
     }
 }
 
@@ -68,6 +101,13 @@ pub(crate) struct InsertOutcome<T: BasePooledTx> {
     pub outcome: AddedTransactionOutcome,
     pub replaced: Option<Arc<ValidPoolTransaction<T>>>,
     pub promoted: Vec<Arc<ValidPoolTransaction<T>>>,
+}
+
+/// Sidecar transactions whose pending status changed after a base-fee update.
+#[derive(Debug)]
+pub(crate) struct FeeUpdateOutcome<T: BasePooledTx> {
+    pub promoted: Vec<Arc<ValidPoolTransaction<T>>>,
+    pub demoted: Vec<(Arc<ValidPoolTransaction<T>>, SubPool)>,
 }
 
 /// Outcome returned after pruning mined transactions from the 2D nonce sidecar.
@@ -87,18 +127,28 @@ pub(crate) struct TwoDNoncePool<T: BasePooledTx> {
     nonce_free: B256Map<Arc<ValidPoolTransaction<T>>>,
     hashes: B256Map<Arc<ValidPoolTransaction<T>>>,
     senders: SenderIdentifiers,
-    price_bump_config: PriceBumpConfig,
+    config: PoolConfig,
+    base_fee: u64,
 }
 
 impl<T: BasePooledTx> TwoDNoncePool<T> {
-    /// Creates a new 2D nonce sidecar pool.
-    pub(crate) fn new(price_bump_config: PriceBumpConfig) -> Self {
+    #[cfg(test)]
+    pub(crate) fn new(price_bumps: PriceBumpConfig) -> Self {
+        Self::new_with_config(
+            PoolConfig { price_bumps, max_account_slots: usize::MAX, ..PoolConfig::default() },
+            0,
+        )
+    }
+
+    /// Creates a new 2D nonce sidecar pool using the protocol pool configuration.
+    pub(crate) fn new_with_config(config: PoolConfig, base_fee: u64) -> Self {
         Self {
             lanes: HashMap::default(),
             nonce_free: B256Map::default(),
             hashes: B256Map::default(),
             senders: SenderIdentifiers::default(),
-            price_bump_config,
+            config,
+            base_fee,
         }
     }
 
@@ -109,35 +159,54 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
 
     /// Returns the number of pending and queued transactions.
     pub(crate) fn pending_and_queued_txn_count(&self) -> (usize, usize) {
-        let mut pending = 0;
-        let mut queued = 0;
-        for lane in self.lanes.values() {
-            let pending_in_lane = lane.consecutive_pending_len();
-            let live_in_lane = lane.live_transactions().count();
-            pending += pending_in_lane;
-            queued += live_in_lane.saturating_sub(pending_in_lane);
+        let (pending, basefee, queued) = self.subpool_counts();
+        (pending, basefee + queued)
+    }
+
+    /// Returns pending, base-fee, and queued transaction counts and sizes.
+    pub(crate) fn subpool_size(&self) -> [(usize, usize); 3] {
+        let mut sizes = [(0, 0); 3];
+        for (subpool, transaction) in self.classified_transactions() {
+            let index = match subpool {
+                SidecarSubPool::Pending => 0,
+                SidecarSubPool::BaseFee => 1,
+                SidecarSubPool::Queued => 2,
+            };
+            sizes[index].0 += 1;
+            sizes[index].1 += transaction.encoded_length();
         }
-        pending += self.nonce_free.len();
-        (pending, queued)
+        sizes
     }
 
     /// Returns all pending transactions.
     pub(crate) fn pending_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>> {
         let mut transactions = Vec::new();
         for lane in self.lanes.values() {
-            for transaction in lane.consecutive_pending_transactions() {
+            for transaction in lane.transactions_in(SidecarSubPool::Pending, self.base_fee) {
                 transactions.push(Arc::clone(transaction));
             }
         }
-        transactions.extend(self.nonce_free.values().cloned());
+        transactions.extend(
+            self.nonce_free
+                .values()
+                .filter(|transaction| {
+                    transaction.transaction.max_fee_per_gas() >= u128::from(self.base_fee)
+                })
+                .cloned(),
+        );
         transactions
+    }
+
+    /// Returns transactions parked because their fee cap is below the current base fee.
+    pub(crate) fn basefee_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        self.transactions_in(SidecarSubPool::BaseFee)
     }
 
     /// Returns all queued transactions.
     pub(crate) fn queued_transactions(&self) -> Vec<Arc<ValidPoolTransaction<T>>> {
         let mut transactions = Vec::new();
         for lane in self.lanes.values() {
-            for transaction in lane.queued_transactions() {
+            for transaction in lane.transactions_in(SidecarSubPool::Queued, self.base_fee) {
                 transactions.push(Arc::clone(transaction));
             }
         }
@@ -195,11 +264,17 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
             .lanes
             .iter()
             .filter(|((lane_sender, _), _)| *lane_sender == sender)
-            .flat_map(|(_, lane)| lane.consecutive_pending_transactions())
+            .flat_map(|(_, lane)| lane.transactions_in(SidecarSubPool::Pending, self.base_fee))
             .cloned()
             .collect();
         transactions.extend(
-            self.nonce_free.values().filter(|transaction| transaction.sender() == sender).cloned(),
+            self.nonce_free
+                .values()
+                .filter(|transaction| {
+                    transaction.sender() == sender
+                        && transaction.transaction.max_fee_per_gas() >= u128::from(self.base_fee)
+                })
+                .cloned(),
         );
         transactions
     }
@@ -212,7 +287,13 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
         self.lanes
             .iter()
             .filter(|((lane_sender, _), _)| *lane_sender == sender)
-            .flat_map(|(_, lane)| lane.queued_transactions())
+            .flat_map(|(_, lane)| {
+                lane.classified_transactions(self.base_fee).into_iter().filter_map(
+                    |(subpool, transaction)| {
+                        (subpool != SidecarSubPool::Pending).then_some(transaction)
+                    },
+                )
+            })
             .cloned()
             .collect()
     }
@@ -254,20 +335,24 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
             transaction.transaction_id = TransactionId::new(sender_id, transaction.nonce());
             let transaction = Arc::new(transaction);
             let replaced = if let Some(existing) = self.nonce_free.get(&replay_id) {
-                if existing.is_underpriced(&transaction, &self.price_bump_config) {
+                if existing.is_underpriced(&transaction, &self.config.price_bumps) {
                     return Err(PoolError::new(hash, PoolErrorKind::ReplacementUnderpriced));
                 }
                 Some(Arc::clone(existing))
             } else {
                 None
             };
+            self.ensure_sender_capacity(&transaction, replaced.is_some())?;
             if let Some(existing) = &replaced {
                 self.hashes.remove(existing.hash());
             }
             self.nonce_free.insert(replay_id, Arc::clone(&transaction));
-            self.hashes.insert(hash, transaction);
+            self.hashes.insert(hash, Arc::clone(&transaction));
             return Ok(InsertOutcome {
-                outcome: AddedTransactionOutcome { hash, state: AddedTransactionState::Pending },
+                outcome: AddedTransactionOutcome {
+                    hash,
+                    state: self.added_state(&transaction, SidecarSubPool::Pending),
+                },
                 replaced,
                 promoted: Vec::new(),
             });
@@ -288,40 +373,44 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
         let sender_id = self.senders.sender_id_or_create(sender);
         transaction.transaction_id = TransactionId::new(sender_id, nonce);
         let transaction = Arc::new(transaction);
-        let lane = self.lanes.entry(lane_id).or_insert_with(|| NonceLane {
-            next_nonce: state_nonce,
-            transactions: BTreeMap::new(),
-        });
-        // Keep the lane anchored to the state view used by validation. This may
-        // move backward after a reorg lowers the on-chain channel nonce, allowing
-        // now-valid transactions to be accepted instead of treating them as
-        // already executed under the pre-reorg lane cursor.
-        if state_nonce != lane.next_nonce {
+        let replaced = {
+            let lane = self.lanes.entry(lane_id).or_insert_with(|| NonceLane {
+                next_nonce: state_nonce,
+                transactions: BTreeMap::new(),
+            });
+            // Keep the lane anchored to the state view used by validation. This may
+            // move backward after a reorg lowers the on-chain channel nonce.
             lane.next_nonce = state_nonce;
-        }
-        let pending_len_before = lane.consecutive_pending_len();
-
-        if nonce < lane.next_nonce {
-            return Err(PoolError::new(
-                hash,
-                PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Consensus(
-                    InvalidTransactionError::NonceNotConsistent {
-                        tx: nonce,
-                        state: lane.next_nonce,
-                    },
-                )),
-            ));
-        }
-
-        let replaced: Option<Arc<ValidPoolTransaction<T>>> =
+            if nonce < lane.next_nonce {
+                return Err(PoolError::new(
+                    hash,
+                    PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Consensus(
+                        InvalidTransactionError::NonceNotConsistent {
+                            tx: nonce,
+                            state: lane.next_nonce,
+                        },
+                    )),
+                ));
+            }
             if let Some(existing) = lane.transactions.get(&nonce) {
-                if existing.is_underpriced(&transaction, &self.price_bump_config) {
+                if existing.is_underpriced(&transaction, &self.config.price_bumps) {
                     return Err(PoolError::new(hash, PoolErrorKind::ReplacementUnderpriced));
                 }
                 Some(Arc::clone(existing))
             } else {
                 None
-            };
+            }
+        };
+        self.ensure_sender_capacity(&transaction, replaced.is_some())?;
+
+        let pending_before: HashSet<_> = self
+            .lanes
+            .get(&lane_id)
+            .into_iter()
+            .flat_map(|lane| lane.transactions_in(SidecarSubPool::Pending, self.base_fee))
+            .map(|transaction| *transaction.hash())
+            .collect();
+        let lane = self.lanes.get_mut(&lane_id).expect("lane was initialized");
 
         lane.transactions.insert(nonce, Arc::clone(&transaction));
         self.hashes.insert(hash, Arc::clone(&transaction));
@@ -331,26 +420,19 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
             self.hashes.remove(&replaced_hash);
         }
 
-        let pending_len_after = lane.consecutive_pending_len();
-        let state = if lane
-            .next_nonce
-            .checked_add(pending_len_after as u64)
-            .is_none_or(|boundary| nonce < boundary)
-        {
-            AddedTransactionState::Pending
-        } else {
-            AddedTransactionState::Queued(QueuedReason::NonceGap)
-        };
-
-        let promoted = if matches!(state, AddedTransactionState::Pending) {
-            lane.consecutive_pending_transactions()
-                .skip(pending_len_before)
-                .filter(|candidate| *candidate.hash() != hash)
-                .cloned()
-                .collect()
-        } else {
-            Vec::new()
-        };
+        let subpool = lane
+            .classified_transactions(self.base_fee)
+            .into_iter()
+            .find_map(|(subpool, candidate)| (*candidate.hash() == hash).then_some(subpool))
+            .expect("inserted transaction is classified");
+        let state = Self::state_for(subpool);
+        let promoted = lane
+            .transactions_in(SidecarSubPool::Pending, self.base_fee)
+            .filter(|candidate| {
+                *candidate.hash() != hash && !pending_before.contains(candidate.hash())
+            })
+            .cloned()
+            .collect();
 
         Ok(InsertOutcome { outcome: AddedTransactionOutcome { hash, state }, replaced, promoted })
     }
@@ -478,6 +560,74 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
         self.remove_transactions(&hashes)
     }
 
+    /// Applies a new base fee and reports transactions entering or leaving pending.
+    pub(crate) fn set_base_fee(&mut self, base_fee: u64) -> FeeUpdateOutcome<T> {
+        if self.base_fee == base_fee {
+            return FeeUpdateOutcome { promoted: Vec::new(), demoted: Vec::new() };
+        }
+        let before: B256Map<_> = self
+            .classified_transactions()
+            .map(|(subpool, transaction)| (*transaction.hash(), subpool))
+            .collect();
+        self.base_fee = base_fee;
+        let mut promoted = Vec::new();
+        let mut demoted = Vec::new();
+        for (subpool, transaction) in self.classified_transactions() {
+            match (before.get(transaction.hash()), subpool) {
+                (Some(SidecarSubPool::Pending), SidecarSubPool::BaseFee) => {
+                    demoted.push((Arc::clone(transaction), SubPool::BaseFee));
+                }
+                (Some(SidecarSubPool::Pending), SidecarSubPool::Queued) => {
+                    demoted.push((Arc::clone(transaction), SubPool::Queued));
+                }
+                (Some(previous), SidecarSubPool::Pending)
+                    if *previous != SidecarSubPool::Pending =>
+                {
+                    promoted.push(Arc::clone(transaction));
+                }
+                _ => {}
+            }
+        }
+        FeeUpdateOutcome { promoted, demoted }
+    }
+
+    /// Evicts non-local transactions until all configured sidecar subpool limits hold.
+    pub(crate) fn enforce_limits(&mut self) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        let mut discarded = Vec::new();
+        loop {
+            let sizes = self.subpool_size();
+            let exceeded = [
+                (SidecarSubPool::Pending, self.config.pending_limit, sizes[0]),
+                (SidecarSubPool::BaseFee, self.config.basefee_limit, sizes[1]),
+                (SidecarSubPool::Queued, self.config.queued_limit, sizes[2]),
+            ]
+            .into_iter()
+            .find_map(|(subpool, limit, (count, size))| {
+                limit.is_exceeded(count, size).then_some(subpool)
+            });
+            let Some(exceeded) = exceeded else { break };
+            let victim = self
+                .transactions_in(exceeded)
+                .into_iter()
+                .filter(|transaction| {
+                    !self
+                        .config
+                        .local_transactions_config
+                        .is_local(transaction.origin, transaction.sender_ref())
+                })
+                .min_by_key(|transaction| {
+                    (
+                        transaction.transaction.max_fee_per_gas(),
+                        transaction.transaction.priority_fee_or_price(),
+                        *transaction.hash(),
+                    )
+                });
+            let Some(victim) = victim else { break };
+            discarded.extend(self.remove_transactions_and_descendants(&[*victim.hash()]));
+        }
+        discarded
+    }
+
     /// Returns a best-transactions iterator snapshot.
     pub(crate) fn best_transactions<O>(
         &self,
@@ -488,6 +638,79 @@ impl<T: BasePooledTx> TwoDNoncePool<T> {
         O: TransactionOrdering<Transaction = T>,
     {
         BestTwoDTransactions::new(&self.lanes, &self.nonce_free, ordering, base_fee)
+    }
+
+    fn ensure_sender_capacity(
+        &self,
+        transaction: &ValidPoolTransaction<T>,
+        replacing: bool,
+    ) -> PoolResult<()> {
+        if replacing
+            || self
+                .config
+                .local_transactions_config
+                .is_local(transaction.origin, transaction.sender_ref())
+        {
+            return Ok(());
+        }
+        let sender = transaction.sender();
+        if self.transactions_by_sender(sender).len() >= self.config.max_account_slots {
+            return Err(PoolError::new(
+                *transaction.hash(),
+                PoolErrorKind::SpammerExceededCapacity(sender),
+            ));
+        }
+        Ok(())
+    }
+
+    fn added_state(
+        &self,
+        transaction: &Arc<ValidPoolTransaction<T>>,
+        otherwise: SidecarSubPool,
+    ) -> AddedTransactionState {
+        if transaction.transaction.max_fee_per_gas() < u128::from(self.base_fee) {
+            Self::state_for(SidecarSubPool::BaseFee)
+        } else {
+            Self::state_for(otherwise)
+        }
+    }
+
+    const fn state_for(subpool: SidecarSubPool) -> AddedTransactionState {
+        match subpool {
+            SidecarSubPool::Pending => AddedTransactionState::Pending,
+            SidecarSubPool::BaseFee => {
+                AddedTransactionState::Queued(QueuedReason::InsufficientBaseFee)
+            }
+            SidecarSubPool::Queued => AddedTransactionState::Queued(QueuedReason::NonceGap),
+        }
+    }
+
+    fn subpool_counts(&self) -> (usize, usize, usize) {
+        let sizes = self.subpool_size();
+        (sizes[0].0, sizes[1].0, sizes[2].0)
+    }
+
+    fn classified_transactions(
+        &self,
+    ) -> impl Iterator<Item = (SidecarSubPool, &Arc<ValidPoolTransaction<T>>)> {
+        self.lanes.values().flat_map(|lane| lane.classified_transactions(self.base_fee)).chain(
+            self.nonce_free.values().map(|transaction| {
+                let subpool =
+                    if transaction.transaction.max_fee_per_gas() < u128::from(self.base_fee) {
+                        SidecarSubPool::BaseFee
+                    } else {
+                        SidecarSubPool::Pending
+                    };
+                (subpool, transaction)
+            }),
+        )
+    }
+
+    fn transactions_in(&self, subpool: SidecarSubPool) -> Vec<Arc<ValidPoolTransaction<T>>> {
+        self.classified_transactions()
+            .filter(|(candidate, _)| *candidate == subpool)
+            .map(|(_, transaction)| Arc::clone(transaction))
+            .collect()
     }
 
     fn remove_hash(
@@ -573,6 +796,9 @@ where
                 let mut next_nonce = lane.next_nonce;
                 let mut transactions = Vec::new();
                 while let Some(transaction) = lane.transactions.get(&next_nonce) {
+                    if transaction.transaction.max_fee_per_gas() < u128::from(base_fee) {
+                        break;
+                    }
                     transactions.push(Arc::clone(transaction));
                     let Some(incremented_nonce) = next_nonce.checked_add(1) else {
                         break;
@@ -588,12 +814,19 @@ where
             })
             .collect();
         let finite_lane_count = lanes.len();
-        lanes.extend(nonce_free.values().map(|transaction| LaneIterator {
-            id: (transaction.sender(), Eip8130Constants::NONCE_KEY_MAX),
-            transactions: vec![Arc::clone(transaction)],
-            index: 0,
-            invalidated: false,
-        }));
+        lanes.extend(
+            nonce_free
+                .values()
+                .filter(|transaction| {
+                    transaction.transaction.max_fee_per_gas() >= u128::from(base_fee)
+                })
+                .map(|transaction| LaneIterator {
+                    id: (transaction.sender(), Eip8130Constants::NONCE_KEY_MAX),
+                    transactions: vec![Arc::clone(transaction)],
+                    index: 0,
+                    invalidated: false,
+                }),
+        );
         let lane_indexes = lanes[..finite_lane_count]
             .iter()
             .enumerate()
@@ -699,7 +932,9 @@ mod tests {
     use base_common_consensus::{
         BasePooledTransaction as ConsensusPooledTransaction, Eip8130Signed, TxEip8130,
     };
-    use reth_transaction_pool::{PoolTransaction, PriceBumpConfig, Priority, TransactionOrigin};
+    use reth_transaction_pool::{
+        PoolTransaction, PriceBumpConfig, Priority, SubPoolLimit, TransactionOrigin,
+    };
 
     use super::*;
     use crate::{BaseOrdering, BasePooledTransaction};
@@ -814,6 +1049,10 @@ mod tests {
             origin: TransactionOrigin::External,
             authority_ids: None,
         }
+    }
+
+    fn pool_with_config(config: PoolConfig, base_fee: u64) -> TwoDNoncePool<BasePooledTransaction> {
+        TwoDNoncePool::new_with_config(config, base_fee)
     }
 
     fn best_transaction_priority_evaluations(lane_count: usize) -> usize {
@@ -1381,5 +1620,199 @@ mod tests {
 
         let mut best = pool.best_transactions(BaseOrdering::coinbase_tip(), 10);
         assert_eq!(best.next().map(|transaction| *transaction.hash()), Some(older_hash));
+    }
+
+    #[test]
+    fn under_base_fee_transactions_are_parked_outside_pending() {
+        let mut pool = pool_with_config(PoolConfig::default(), 100);
+        let signer = signer();
+        let channel = valid_pool_transaction(signed_channel_tx(&signer, U256::from(51), 0, 99));
+        let nonce_free = valid_pool_transaction(signed_nonce_free_tx(&signer, 1, 0, 98));
+
+        let channel_outcome = pool.insert_validated(channel, 0).unwrap();
+        let nonce_free_outcome = pool.insert_validated(nonce_free, 0).unwrap();
+
+        assert_eq!(
+            channel_outcome.outcome.state,
+            AddedTransactionState::Queued(QueuedReason::InsufficientBaseFee)
+        );
+        assert_eq!(
+            nonce_free_outcome.outcome.state,
+            AddedTransactionState::Queued(QueuedReason::InsufficientBaseFee)
+        );
+        assert!(pool.pending_transactions().is_empty());
+        assert_eq!(pool.basefee_transactions().len(), 2);
+        assert_eq!(pool.pending_and_queued_txn_count(), (0, 2));
+        assert!(pool.best_transactions(BaseOrdering::coinbase_tip(), 100).next().is_none());
+    }
+
+    #[test]
+    fn base_fee_updates_demote_and_promote_entire_channel_run() {
+        let mut pool = pool_with_config(PoolConfig::default(), 50);
+        let signer = signer();
+        let head = valid_pool_transaction(signed_channel_tx(&signer, U256::from(52), 0, 100));
+        let next = valid_pool_transaction(signed_channel_tx(&signer, U256::from(52), 1, 200));
+        let head_hash = *head.hash();
+        let next_hash = *next.hash();
+        pool.insert_validated(head, 0).unwrap();
+        pool.insert_validated(next, 0).unwrap();
+
+        let raised = pool.set_base_fee(150);
+        assert_eq!(
+            raised.demoted.iter().map(|(tx, pool)| (*tx.hash(), *pool)).collect::<Vec<_>>(),
+            vec![(head_hash, SubPool::BaseFee), (next_hash, SubPool::Queued)]
+        );
+        assert!(raised.promoted.is_empty());
+        assert_eq!(pool.subpool_counts(), (0, 1, 1));
+
+        let lowered = pool.set_base_fee(50);
+        assert_eq!(
+            lowered.promoted.iter().map(|tx| *tx.hash()).collect::<Vec<_>>(),
+            vec![head_hash, next_hash]
+        );
+        assert!(lowered.demoted.is_empty());
+        assert_eq!(pool.subpool_counts(), (2, 0, 0));
+    }
+
+    #[test]
+    fn pending_count_limit_evicts_the_lowest_fee_lane() {
+        let config = PoolConfig {
+            pending_limit: SubPoolLimit::new(1, usize::MAX),
+            max_account_slots: usize::MAX,
+            ..PoolConfig::default()
+        };
+        let mut pool = pool_with_config(config, 0);
+        let signer = signer();
+        let low = valid_pool_transaction(signed_channel_tx(&signer, U256::from(53), 0, 100));
+        let high = valid_pool_transaction(signed_channel_tx(&signer, U256::from(54), 0, 200));
+        let low_hash = *low.hash();
+        let high_hash = *high.hash();
+        pool.insert_validated(low, 0).unwrap();
+        pool.insert_validated(high, 0).unwrap();
+
+        let discarded = pool.enforce_limits();
+
+        assert_eq!(discarded.iter().map(|tx| *tx.hash()).collect::<Vec<_>>(), vec![low_hash]);
+        assert!(pool.get(&low_hash).is_none());
+        assert!(pool.get(&high_hash).is_some());
+        assert_eq!(pool.subpool_counts(), (1, 0, 0));
+    }
+
+    #[test]
+    fn pending_byte_limit_evicts_the_lowest_fee_lane() {
+        let signer = signer();
+        let low = valid_pool_transaction(signed_channel_tx(&signer, U256::from(60), 0, 100));
+        let high = valid_pool_transaction(signed_channel_tx(&signer, U256::from(61), 0, 200));
+        let config = PoolConfig {
+            pending_limit: SubPoolLimit::new(
+                usize::MAX,
+                low.encoded_length() + high.encoded_length() - 1,
+            ),
+            max_account_slots: usize::MAX,
+            ..PoolConfig::default()
+        };
+        let mut pool = pool_with_config(config, 0);
+        let low_hash = *low.hash();
+        pool.insert_validated(low, 0).unwrap();
+        pool.insert_validated(high, 0).unwrap();
+
+        let discarded = pool.enforce_limits();
+
+        assert_eq!(discarded.iter().map(|tx| *tx.hash()).collect::<Vec<_>>(), vec![low_hash]);
+        assert_eq!(pool.subpool_counts(), (1, 0, 0));
+    }
+
+    #[test]
+    fn queued_count_limit_evicts_the_lowest_fee_lane() {
+        let config = PoolConfig {
+            queued_limit: SubPoolLimit::new(1, usize::MAX),
+            max_account_slots: usize::MAX,
+            ..PoolConfig::default()
+        };
+        let mut pool = pool_with_config(config, 0);
+        let signer = signer();
+        let low = valid_pool_transaction(signed_channel_tx(&signer, U256::from(62), 2, 100));
+        let high = valid_pool_transaction(signed_channel_tx(&signer, U256::from(63), 2, 200));
+        let low_hash = *low.hash();
+        pool.insert_validated(low, 0).unwrap();
+        pool.insert_validated(high, 0).unwrap();
+
+        let discarded = pool.enforce_limits();
+
+        assert_eq!(discarded.iter().map(|tx| *tx.hash()).collect::<Vec<_>>(), vec![low_hash]);
+        assert_eq!(pool.subpool_counts(), (0, 0, 1));
+    }
+
+    #[test]
+    fn basefee_limit_is_enforced_independently() {
+        let config = PoolConfig {
+            basefee_limit: SubPoolLimit::new(1, usize::MAX),
+            max_account_slots: usize::MAX,
+            ..PoolConfig::default()
+        };
+        let mut pool = pool_with_config(config, 300);
+        let signer = signer();
+        let low = valid_pool_transaction(signed_nonce_free_tx(&signer, 1, 0, 100));
+        let high = valid_pool_transaction(signed_nonce_free_tx(&signer, 2, 0, 200));
+        let low_hash = *low.hash();
+        pool.insert_validated(low, 0).unwrap();
+        pool.insert_validated(high, 0).unwrap();
+
+        let discarded = pool.enforce_limits();
+
+        assert_eq!(discarded.iter().map(|tx| *tx.hash()).collect::<Vec<_>>(), vec![low_hash]);
+        assert_eq!(pool.subpool_counts(), (0, 1, 0));
+    }
+
+    #[test]
+    fn queued_byte_limit_removes_a_lane_and_its_descendants() {
+        let signer = signer();
+        let first = valid_pool_transaction(signed_channel_tx(&signer, U256::from(55), 2, 100));
+        let second = valid_pool_transaction(signed_channel_tx(&signer, U256::from(55), 3, 200));
+        let max_size = first.encoded_length() + second.encoded_length() - 1;
+        let config = PoolConfig {
+            queued_limit: SubPoolLimit::new(usize::MAX, max_size),
+            max_account_slots: usize::MAX,
+            ..PoolConfig::default()
+        };
+        let mut pool = pool_with_config(config, 0);
+        let first_hash = *first.hash();
+        let second_hash = *second.hash();
+        pool.insert_validated(first, 0).unwrap();
+        pool.insert_validated(second, 0).unwrap();
+
+        let discarded = pool.enforce_limits();
+
+        assert_eq!(discarded.len(), 2);
+        assert!(discarded.iter().any(|tx| *tx.hash() == first_hash));
+        assert!(discarded.iter().any(|tx| *tx.hash() == second_hash));
+        assert!(pool.all_transactions().is_empty());
+    }
+
+    #[test]
+    fn physical_sender_slots_apply_to_external_but_not_local_transactions() {
+        let config = PoolConfig { max_account_slots: 1, ..PoolConfig::default() };
+        let signer = signer();
+        let mut external_pool = pool_with_config(config.clone(), 0);
+        external_pool
+            .insert_validated(
+                valid_pool_transaction(signed_channel_tx(&signer, U256::from(56), 0, 100)),
+                0,
+            )
+            .unwrap();
+        let over = valid_pool_transaction(signed_channel_tx(&signer, U256::from(57), 0, 100));
+        assert!(matches!(
+            external_pool.insert_validated(over, 0).unwrap_err().kind,
+            PoolErrorKind::SpammerExceededCapacity(address) if address == signer.address()
+        ));
+
+        let mut local_pool = pool_with_config(config, 0);
+        for nonce_key in [U256::from(58), U256::from(59)] {
+            let mut transaction =
+                valid_pool_transaction(signed_channel_tx(&signer, nonce_key, 0, 100));
+            transaction.origin = TransactionOrigin::Local;
+            local_pool.insert_validated(transaction, 0).unwrap();
+        }
+        assert_eq!(local_pool.all_transactions().len(), 2);
     }
 }


### PR DESCRIPTION
## Summary
- Bring the transitional EIP-8130 sidecar under configured count, byte, and sender limits.
- Add real base-fee pending/queued classification and fee-driven promotions and demotions.
- Keep admission-guard and expiry bookkeeping coherent when sidecar transactions are evicted.

## Testing
- Count, byte, sender-capacity, base-fee, and bookkeeping unit tests.

Stack: layer 3 of #4832; based on #4825.