### PR TITLE
feat(payload): skip unaffordable declared coinbase tips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,6 +4631,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer 2.4.1",
  "alloy-signer-local 2.4.1",
+ "alloy-sol-types",
  "async-trait",
  "base-common-chains",
  "base-common-consensus",

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -21,8 +21,8 @@ use base_execution_chainspec::BaseChainSpec;
 use base_execution_eip8130::IntrinsicGas;
 use base_execution_evm::{BaseEvmConfig, BaseNextBlockEnvAttributes};
 use base_execution_payload_builder::{
-    BasePayloadBuilderAttributes, BuilderMetrics as SharedBuilderMetrics, ValidityMetrics,
-    error::BasePayloadBuilderError,
+    BasePayloadBuilderAttributes, BuilderMetrics as SharedBuilderMetrics, CoinbaseTipAffordability,
+    ValidityMetrics, error::BasePayloadBuilderError,
 };
 use base_execution_txpool::{
     BasePooledTx, GuardMetrics, PredicateContext, TimestampedTransaction,
@@ -1041,6 +1041,47 @@ impl BasePayloadBuilderCtx {
                 },
                 None => 0,
             };
+
+            if CoinbaseTipAffordability::unaffordable(&tx, tx_payer_auth, evm.db_mut()) {
+                let tx_hash = *tx.hash();
+                num_txs_considered += 1;
+                let ordering_position = num_txs_considered;
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx_hash,
+                    "skipping transaction unable to pay gas plus declared coinbase tip"
+                );
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderConsidered,
+                    tx_hash,
+                    Some(ordering_position),
+                    || BuilderConsideredEventData::new(info, limits, None),
+                );
+                self.emit_builder_decision_event(
+                    &payload_id,
+                    TransactionEventType::BuilderRejected,
+                    tx_hash,
+                    Some(ordering_position),
+                    || {
+                        BuilderRejectedEventData::new(
+                            "unaffordable_coinbase_tip",
+                            "sender and gas payer cannot cover worst-case gas plus the declared coinbase tip",
+                            false,
+                            info,
+                            limits,
+                            None,
+                        )
+                    },
+                );
+                diag.txs_rejected_other += 1;
+                // Nonce-free replay-ID entries are independent; leave them
+                // eligible for a later flashblock if state can fund the tip.
+                if tx.eip8130_replay_id().is_none() {
+                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                }
+                continue;
+            }
 
             let tx = tx.into_consensus();
             let tx_hash = tx.tx_hash();

--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -9,7 +9,7 @@ use alloy_eips::{Encodable2718, Typed2718};
 use alloy_evm::Database;
 #[cfg(any(test, feature = "test-utils"))]
 use alloy_primitives::B256;
-use alloy_primitives::{BlockHash, Bytes, TxHash, U256};
+use alloy_primitives::{Address, BlockHash, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::Withdrawals;
 use base_bundles::{MeterBundleResponse, RejectedTransaction, RejectionReason};
 use base_common_chains::Upgrades;
@@ -686,8 +686,91 @@ impl BasePayloadBuilderCtx {
         value
     }
 
+    /// Closes the iterator's current candidate.
+    ///
+    /// Nonce-free replay-ID entries are independent, so they are committed
+    /// rather than invalidating the sender's nonce lane. Either path is required
+    /// before the next `best_txs.next()` — leaving `current` set panics in debug.
+    fn skip_current<B: PayloadTxsBounds>(
+        best_txs: &mut B,
+        sender: Address,
+        nonce: u64,
+        replay_independent: bool,
+    ) {
+        if replay_independent {
+            best_txs.mark_current_committed();
+        } else {
+            best_txs.mark_invalid(sender, nonce);
+        }
+    }
+
+    /// [`Self::skip_current`] using the pooled transaction's sender, nonce, and replay ID.
+    fn skip_pooled_current<B: PayloadTxsBounds>(best_txs: &mut B, tx: &B::Transaction) {
+        Self::skip_current(best_txs, tx.sender(), tx.nonce(), tx.eip8130_replay_id().is_some());
+    }
+
+    fn emit_considered(&self, cx: &DecisionContext<'_>, tx_hash: TxHash, ordering_position: u64) {
+        self.emit_builder_decision_event(
+            cx.payload_id,
+            TransactionEventType::BuilderConsidered,
+            tx_hash,
+            Some(ordering_position),
+            || BuilderConsideredEventData::new(cx.info, cx.limits, None),
+        );
+    }
+
+    /// Emits considered + rejected, counts an "other" rejection, and closes the
+    /// current iterator candidate.
+    fn reject_current<B: PayloadTxsBounds>(
+        &self,
+        best_txs: &mut B,
+        diag: &mut FlashblockDiagnostics,
+        cx: &DecisionContext<'_>,
+        tx: &B::Transaction,
+        ordering_position: u64,
+    ) {
+        let tx_hash = *tx.hash();
+        self.emit_considered(cx, tx_hash, ordering_position);
+        self.emit_builder_decision_event(
+            cx.payload_id,
+            TransactionEventType::BuilderRejected,
+            tx_hash,
+            Some(ordering_position),
+            || BuilderRejectedEventData::new(cx.reason, cx.detail, false, cx.info, cx.limits, None),
+        );
+        diag.txs_rejected_other += 1;
+        Self::skip_pooled_current(best_txs, tx);
+    }
+
+    /// Emits considered + expired, records a permanent rejection, and closes the
+    /// current iterator candidate.
+    fn expire_current<B: PayloadTxsBounds>(
+        &self,
+        best_txs: &mut B,
+        diag: &mut FlashblockDiagnostics,
+        cx: &DecisionContext<'_>,
+        tx: &B::Transaction,
+        ordering_position: u64,
+    ) {
+        let tx_hash = *tx.hash();
+        self.emit_considered(cx, tx_hash, ordering_position);
+        self.emit_builder_decision_event(
+            cx.payload_id,
+            TransactionEventType::BuilderExpired,
+            tx_hash,
+            Some(ordering_position),
+            || BuilderExpiredEventData::new(cx.reason, cx.detail, cx.info, cx.limits, None),
+        );
+        diag.txs_rejected_other += 1;
+        diag.permanently_rejected_txs.push(tx_hash);
+        // Same series as the pool-side block eviction: the builder drops the tx
+        // before the pool sweep sees it.
+        GuardMetrics::record_block_expiry_invalidations(1);
+        Self::skip_pooled_current(best_txs, tx);
+    }
+
     /// Defers the current validity-gated candidate by parking it for a later flashblock, or, when
-    /// the iterator cannot park it, rejects it and marks it invalid. Emits the matching
+    /// the iterator cannot park it, rejects it and closes the candidate. Emits the matching
     /// builder-decision event and updates `diag`. Returns `true` when the transaction was parked.
     fn defer_or_reject_current<B: PayloadTxsBounds>(
         &self,
@@ -720,7 +803,7 @@ impl BasePayloadBuilderCtx {
                 },
             );
             diag.txs_rejected_other += 1;
-            best_txs.mark_invalid(tx.sender(), tx.nonce());
+            Self::skip_pooled_current(best_txs, tx);
             false
         }
     }
@@ -782,7 +865,10 @@ impl BasePayloadBuilderCtx {
                 return Ok(diag);
             }
 
+            num_txs_considered += 1;
+            let ordering_position = num_txs_considered;
             let tx_hash = *tx.hash();
+            let replay_independent = tx.eip8130_replay_id().is_some();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
             let has_coinbase_tip = tx
                 .as_eip8130()
@@ -796,35 +882,22 @@ impl BasePayloadBuilderCtx {
                 && predicate_eval_total
                     .is_some_and(|total| total >= self.builder_config.predicate_eval_hard_cutoff)
             {
-                num_txs_considered += 1;
-                let ordering_position = num_txs_considered;
+                let cx = DecisionContext {
+                    payload_id: &payload_id,
+                    info,
+                    limits,
+                    reason: "predicate_eval_budget_exhausted",
+                    detail: "validity-predicate evaluation time budget exhausted for this flashblock",
+                };
                 trace!(
                     target: "payload_builder",
                     tx_hash = ?tx_hash,
                     "deferring validity-gated transaction: predicate evaluation budget exhausted for this flashblock"
                 );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderConsidered,
-                    tx_hash,
-                    Some(ordering_position),
-                    || BuilderConsideredEventData::new(info, limits, None),
-                );
+                self.emit_considered(&cx, tx_hash, ordering_position);
                 ValidityMetrics::validity_predicate_evaluations_total("budget_exhausted")
                     .increment(1);
-                self.defer_or_reject_current(
-                    best_txs,
-                    &mut diag,
-                    &DecisionContext {
-                        payload_id: &payload_id,
-                        info,
-                        limits,
-                        reason: "predicate_eval_budget_exhausted",
-                        detail: "validity-predicate evaluation time budget exhausted for this flashblock",
-                    },
-                    &tx,
-                    ordering_position,
-                );
+                self.defer_or_reject_current(best_txs, &mut diag, &cx, &tx, ordering_position);
                 continue;
             }
 
@@ -870,9 +943,7 @@ impl BasePayloadBuilderCtx {
                 ValidityMetrics::validity_predicate_evaluations_total(outcome).increment(1);
             }
             if predicate_read_failed || blocking_predicate.is_some() {
-                num_txs_considered += 1;
-                let ordering_position = num_txs_considered;
-                let (decision_reason, decision_detail) = if predicate_read_failed {
+                let (reason, detail) = if predicate_read_failed {
                     (
                         "validity_predicate_read_failed",
                         "failed to read state required by a validity predicate",
@@ -888,18 +959,12 @@ impl BasePayloadBuilderCtx {
                         "a validity predicate is not satisfied by the current build state",
                     )
                 };
+                let cx = DecisionContext { payload_id: &payload_id, info, limits, reason, detail };
                 trace!(
                     target: "payload_builder",
                     tx_hash = ?tx_hash,
-                    decision_reason,
+                    decision_reason = reason,
                     "skipping transaction with unsatisfied validity predicate"
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderConsidered,
-                    tx_hash,
-                    Some(ordering_position),
-                    || BuilderConsideredEventData::new(info, limits, None),
                 );
                 // A read failure cannot be retried at a later ordering position: including the
                 // transaction there could place it behind a lower-priority transaction even though
@@ -908,65 +973,23 @@ impl BasePayloadBuilderCtx {
                 // are dropped rather than parked; only recoverable state mismatches are parked.
                 if predicate_read_failed {
                     // A read failure is only terminal for this scan, so it is not cached.
-                    self.emit_builder_decision_event(
-                        &payload_id,
-                        TransactionEventType::BuilderRejected,
-                        tx_hash,
-                        Some(ordering_position),
-                        || {
-                            BuilderRejectedEventData::new(
-                                decision_reason,
-                                decision_detail,
-                                false,
-                                info,
-                                limits,
-                                None,
-                            )
-                        },
-                    );
-                    diag.txs_rejected_other += 1;
-                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                    self.reject_current(best_txs, &mut diag, &cx, &tx, ordering_position);
                 } else if predicate_expired {
                     // A passed position bound can never be satisfied in any later
                     // block, so an expired predicate is permanently terminal:
                     // record it for the rejection cache and pool eviction so it is
                     // not re-evaluated on subsequent flashblock rebuilds.
-                    self.emit_builder_decision_event(
-                        &payload_id,
-                        TransactionEventType::BuilderExpired,
-                        tx_hash,
-                        Some(ordering_position),
-                        || {
-                            BuilderExpiredEventData::new(
-                                decision_reason,
-                                decision_detail,
-                                info,
-                                limits,
-                                None,
-                            )
-                        },
-                    );
-                    diag.txs_rejected_other += 1;
-                    diag.permanently_rejected_txs.push(tx_hash);
-                    // Same series as the pool-side block eviction: the builder
-                    // drops the tx before the pool sweep sees it.
-                    GuardMetrics::record_block_expiry_invalidations(1);
-                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                    self.expire_current(best_txs, &mut diag, &cx, &tx, ordering_position);
                 } else {
                     // Recoverable state mismatch: park under the current blocker to retry at a
                     // later position or flashblock, or reject if the iterator cannot park it.
+                    self.emit_considered(&cx, tx_hash, ordering_position);
                     let blocking_predicate = blocking_predicate
                         .expect("unsatisfied, non-terminal predicate implies a blocking key");
                     if self.defer_or_reject_current(
                         best_txs,
                         &mut diag,
-                        &DecisionContext {
-                            payload_id: &payload_id,
-                            info,
-                            limits,
-                            reason: decision_reason,
-                            detail: decision_detail,
-                        },
+                        &cx,
                         &tx,
                         ordering_position,
                     ) {
@@ -980,9 +1003,6 @@ impl BasePayloadBuilderCtx {
                 && let Some(manifest) = tx.watch_manifest()
                 && let Err(stale) = manifest.revalidate(evm.db_mut(), block_timestamp)
             {
-                let tx_hash = *tx.hash();
-                num_txs_considered += 1;
-                let ordering_position = num_txs_considered;
                 trace!(
                     target: "payload_builder",
                     tx_hash = ?tx_hash,
@@ -990,31 +1010,19 @@ impl BasePayloadBuilderCtx {
                     "skipping EIP-8130 transaction with stale authorization manifest"
                 );
                 GuardMetrics::record_builder_precheck_drop(&stale);
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderConsidered,
-                    tx_hash,
-                    Some(ordering_position),
-                    || BuilderConsideredEventData::new(info, limits, None),
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderRejected,
-                    tx_hash,
-                    Some(ordering_position),
-                    || {
-                        BuilderRejectedEventData::new(
-                            "manifest_precheck_stale",
-                            stale.cause(),
-                            false,
-                            info,
-                            limits,
-                            None,
-                        )
+                self.reject_current(
+                    best_txs,
+                    &mut diag,
+                    &DecisionContext {
+                        payload_id: &payload_id,
+                        info,
+                        limits,
+                        reason: "manifest_precheck_stale",
+                        detail: stale.cause(),
                     },
+                    &tx,
+                    ordering_position,
                 );
-                diag.txs_rejected_other += 1;
-                best_txs.mark_invalid(tx.sender(), tx.nonce());
                 continue;
             }
 
@@ -1032,10 +1040,22 @@ impl BasePayloadBuilderCtx {
                         trace!(
                             target: "payload_builder",
                             %err,
-                            tx_hash = ?tx.hash(),
+                            tx_hash = ?tx_hash,
                             "skipping EIP-8130 transaction with unschedulable payer authenticator"
                         );
-                        best_txs.mark_invalid(tx.sender(), tx.nonce());
+                        self.reject_current(
+                            best_txs,
+                            &mut diag,
+                            &DecisionContext {
+                                payload_id: &payload_id,
+                                info,
+                                limits,
+                                reason: "unschedulable_payer_authenticator",
+                                detail: "EIP-8130 payer authenticator cannot be scheduled against the gas budget",
+                            },
+                            &tx,
+                            ordering_position,
+                        );
                         continue;
                     }
                 },
@@ -1043,43 +1063,24 @@ impl BasePayloadBuilderCtx {
             };
 
             if CoinbaseTipAffordability::unaffordable(&tx, tx_payer_auth, evm.db_mut()) {
-                let tx_hash = *tx.hash();
-                num_txs_considered += 1;
-                let ordering_position = num_txs_considered;
                 trace!(
                     target: "payload_builder",
                     tx_hash = ?tx_hash,
                     "skipping transaction unable to pay gas plus declared coinbase tip"
                 );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderConsidered,
-                    tx_hash,
-                    Some(ordering_position),
-                    || BuilderConsideredEventData::new(info, limits, None),
-                );
-                self.emit_builder_decision_event(
-                    &payload_id,
-                    TransactionEventType::BuilderRejected,
-                    tx_hash,
-                    Some(ordering_position),
-                    || {
-                        BuilderRejectedEventData::new(
-                            "unaffordable_coinbase_tip",
-                            "sender and gas payer cannot cover worst-case gas plus the declared coinbase tip",
-                            false,
-                            info,
-                            limits,
-                            None,
-                        )
+                self.reject_current(
+                    best_txs,
+                    &mut diag,
+                    &DecisionContext {
+                        payload_id: &payload_id,
+                        info,
+                        limits,
+                        reason: "unaffordable_coinbase_tip",
+                        detail: "sender and gas payer cannot cover worst-case gas plus the declared coinbase tip",
                     },
+                    &tx,
+                    ordering_position,
                 );
-                diag.txs_rejected_other += 1;
-                // Nonce-free replay-ID entries are independent; leave them
-                // eligible for a later flashblock if state can fund the tip.
-                if tx.eip8130_replay_id().is_none() {
-                    best_txs.mark_invalid(tx.sender(), tx.nonce());
-                }
                 continue;
             }
 
@@ -1100,9 +1101,6 @@ impl BasePayloadBuilderCtx {
                     result = %result_str,
                 );
             };
-
-            num_txs_considered += 1;
-            let ordering_position = num_txs_considered;
 
             let resource_usage = self.builder_config.metering_provider.get(&tx_hash);
 
@@ -1153,7 +1151,7 @@ impl BasePayloadBuilderCtx {
                     log_txn(Err(err));
                     BuilderMetrics::metering_data_pending_skip().increment(1);
                     self.builder_config.metering_provider.skip(&tx_hash);
-                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    Self::skip_current(best_txs, tx.signer(), tx.nonce(), replay_independent);
                     continue;
                 }
             }
@@ -1240,7 +1238,7 @@ impl BasePayloadBuilderCtx {
                             },
                         );
                         log_txn(Err(err));
-                        best_txs.mark_invalid(tx.signer(), tx.nonce());
+                        Self::skip_current(best_txs, tx.signer(), tx.nonce(), replay_independent);
                         continue;
                     }
                 } else {
@@ -1269,7 +1267,7 @@ impl BasePayloadBuilderCtx {
                         },
                     );
                     log_txn(Err(err));
-                    best_txs.mark_invalid(tx.signer(), tx.nonce());
+                    Self::skip_current(best_txs, tx.signer(), tx.nonce(), replay_independent);
                     continue;
                 }
             }
@@ -1299,7 +1297,7 @@ impl BasePayloadBuilderCtx {
                     },
                 );
                 log_txn(Err(err));
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                Self::skip_current(best_txs, tx.signer(), tx.nonce(), replay_independent);
                 continue;
             }
 
@@ -1364,7 +1362,12 @@ impl BasePayloadBuilderCtx {
                             );
                             log_txn(Err(diag_err));
                             trace!(target: "payload_builder", %err, ?tx, "skipping invalid transaction and its descendants");
-                            best_txs.mark_invalid(tx.signer(), tx.nonce());
+                            Self::skip_current(
+                                best_txs,
+                                tx.signer(),
+                                tx.nonce(),
+                                replay_independent,
+                            );
                         }
 
                         continue;
@@ -1442,7 +1445,7 @@ impl BasePayloadBuilderCtx {
                     },
                 );
                 log_txn(Err(err));
-                best_txs.mark_invalid(tx.signer(), tx.nonce());
+                Self::skip_current(best_txs, tx.signer(), tx.nonce(), replay_independent);
                 continue;
             }
 
@@ -1857,6 +1860,52 @@ mod tests {
         fn discard_parked(&mut self, _transaction_hash: TxHash) -> bool {
             false
         }
+    }
+
+    #[derive(Default)]
+    struct LifecycleRecorder {
+        invalid: usize,
+        committed: usize,
+    }
+
+    impl PayloadTransactions for LifecycleRecorder {
+        type Transaction = BasePooledTransaction;
+
+        fn next(&mut self, _ctx: ()) -> Option<Self::Transaction> {
+            None
+        }
+
+        fn mark_invalid(&mut self, _sender: Address, _nonce: u64) {
+            self.invalid += 1;
+        }
+    }
+
+    impl ParkablePayloadTransactions for LifecycleRecorder {
+        fn park_current(&mut self) -> bool {
+            false
+        }
+
+        fn mark_current_committed(&mut self) {
+            self.committed += 1;
+        }
+
+        fn promote(&mut self, _transaction_hash: TxHash) -> bool {
+            false
+        }
+
+        fn discard_parked(&mut self, _transaction_hash: TxHash) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn skip_current_commits_replay_independent_candidates() {
+        let mut txs = LifecycleRecorder::default();
+        BasePayloadBuilderCtx::skip_current(&mut txs, Address::ZERO, 0, true);
+        assert_eq!((txs.committed, txs.invalid), (1, 0));
+
+        BasePayloadBuilderCtx::skip_current(&mut txs, Address::ZERO, 0, false);
+        assert_eq!((txs.committed, txs.invalid), (1, 1));
     }
 
     #[test]

--- a/crates/execution/eip8130/README.md
+++ b/crates/execution/eip8130/README.md
@@ -110,7 +110,10 @@ caught here rather than silently diverging.
 the payer's worst-case ETH debit at `(gas_limit + payer_auth_cost) ·
 max_fee_per_gas` — `payer_auth_cost` is added because payer authentication is
 charged on top of `gas_limit`. For self-pay the payer is the sender and
-`payer_auth_cost` is `0`.
+`payer_auth_cost` is `0`. `validate_gas_and_tip` extends that check with a
+declared coinbase tip: self-pay must cover gas and tip from one balance, while
+sponsored payment requires the payer to cover gas and the sender to cover the
+tip.
 
 The gas and fee layer is pure accounting: it reads no state and runs no EVM. The
 state-derived inputs (whether the nonce channel is first-use, whether the sender

--- a/crates/execution/eip8130/src/fee.rs
+++ b/crates/execution/eip8130/src/fee.rs
@@ -109,6 +109,41 @@ impl FeeCheck {
         }
         Ok(())
     }
+
+    /// Validates that worst-case gas and a declared coinbase tip are payable.
+    ///
+    /// Self-pay (`payer_is_sender`) requires one balance to cover
+    /// `max_fee_charge + tip`. Sponsored payment requires the payer to cover
+    /// gas and the sender to cover the tip.
+    ///
+    /// # Errors
+    /// - [`FeeError::InsufficientBalance`] — a required balance is below its charge.
+    #[must_use = "discarding the result silently skips the gas-and-tip check"]
+    pub fn validate_gas_and_tip(
+        payer_balance: U256,
+        sender_balance: U256,
+        payer_is_sender: bool,
+        gas_limit: u64,
+        payer_auth_cost: u64,
+        max_fee: u128,
+        tip: U256,
+    ) -> Result<(), FeeError> {
+        let gas = Self::max_fee_charge(gas_limit, payer_auth_cost, max_fee);
+        if payer_is_sender {
+            let required = gas.saturating_add(tip);
+            if payer_balance < required {
+                return Err(FeeError::InsufficientBalance { balance: payer_balance, required });
+            }
+            return Ok(());
+        }
+        if payer_balance < gas {
+            return Err(FeeError::InsufficientBalance { balance: payer_balance, required: gas });
+        }
+        if sender_balance < tip {
+            return Err(FeeError::InsufficientBalance { balance: sender_balance, required: tip });
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -153,6 +188,86 @@ mod tests {
             Err(FeeError::InsufficientBalance {
                 balance: U256::from(41_999u64),
                 required: U256::from(42_000u64),
+            })
+        );
+    }
+
+    #[test]
+    fn self_pay_requires_gas_plus_tip_from_one_balance() {
+        // gas = 21_000 * 2 = 42_000; tip = 1_000; required = 43_000.
+        assert_eq!(
+            FeeCheck::validate_gas_and_tip(
+                U256::from(43_000u64),
+                U256::from(43_000u64),
+                true,
+                21_000,
+                0,
+                2,
+                U256::from(1_000u64),
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            FeeCheck::validate_gas_and_tip(
+                U256::from(42_999u64),
+                U256::from(42_999u64),
+                true,
+                21_000,
+                0,
+                2,
+                U256::from(1_000u64),
+            ),
+            Err(FeeError::InsufficientBalance {
+                balance: U256::from(42_999u64),
+                required: U256::from(43_000u64),
+            })
+        );
+    }
+
+    #[test]
+    fn sponsored_checks_payer_gas_and_sender_tip_separately() {
+        let payer = U256::from(42_000u64);
+        let sender = U256::from(1_000u64);
+        assert_eq!(
+            FeeCheck::validate_gas_and_tip(
+                payer,
+                sender,
+                false,
+                21_000,
+                0,
+                2,
+                U256::from(1_000u64)
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            FeeCheck::validate_gas_and_tip(
+                U256::from(41_999u64),
+                sender,
+                false,
+                21_000,
+                0,
+                2,
+                U256::from(1_000u64),
+            ),
+            Err(FeeError::InsufficientBalance {
+                balance: U256::from(41_999u64),
+                required: U256::from(42_000u64),
+            })
+        );
+        assert_eq!(
+            FeeCheck::validate_gas_and_tip(
+                payer,
+                U256::from(999u64),
+                false,
+                21_000,
+                0,
+                2,
+                U256::from(1_000u64),
+            ),
+            Err(FeeError::InsufficientBalance {
+                balance: U256::from(999u64),
+                required: U256::from(1_000u64),
             })
         );
     }

--- a/crates/execution/node/src/args.rs
+++ b/crates/execution/node/src/args.rs
@@ -38,10 +38,11 @@ const DEFAULT_ROCKSDB_WRITE_BUFFER_SIZE_MIB: u64 = 64;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum TxpoolOrdering {
-    /// Order by coinbase tip (fee-based, higher tip = higher priority).
+    /// Order by unified tip-per-gas (higher bid = higher priority).
     ///
-    /// This is the default ordering strategy that prioritizes transactions
-    /// based on the priority fee (tip) they offer to the block producer.
+    /// Standard transactions use `priorityFeePerGas`. EIP-8130 transactions
+    /// with a static coinbase tip use `tip / gasLimit`. Equal bids prefer
+    /// fewer validity predicates.
     #[default]
     CoinbaseTip,
     /// Order by receive timestamp (FIFO, earlier = higher priority).
@@ -360,7 +361,7 @@ pub struct RollupArgs {
     /// Transaction ordering strategy for the mempool.
     ///
     /// Determines how transactions are prioritized when building blocks.
-    /// - `coinbase-tip`: Order by priority fee (higher tip = higher priority). Default.
+    /// - `coinbase-tip`: Order by tip-per-gas (priority fee, or EIP-8130 coinbase tip / gas limit). Default.
     /// - `timestamp`: Order by receive time (FIFO, earlier = higher priority).
     #[arg(long = "rollup.txpool-ordering", default_value = "coinbase-tip")]
     pub txpool_ordering: TxpoolOrdering,

--- a/crates/execution/payload/src/affordability.rs
+++ b/crates/execution/payload/src/affordability.rs
@@ -1,0 +1,192 @@
+//! Build-time check that a declared EIP-8130 coinbase tip is payable.
+
+use alloy_primitives::{Address, U256};
+use base_common_consensus::CoinbaseTip;
+use base_execution_eip8130::FeeCheck;
+use base_execution_txpool::BasePooledTx;
+use revm::Database;
+
+/// Whether a statically decoded coinbase tip can be paid with worst-case gas.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CoinbaseTipAffordability;
+
+impl CoinbaseTipAffordability {
+    /// Returns `true` when `sender` and `payer` cannot cover worst-case gas plus
+    /// `tip` from the balances currently in `db`.
+    ///
+    /// A failed account read is treated as affordable so a transient DB error
+    /// does not drop an otherwise-valid candidate.
+    pub fn unaffordable_tip<DB: Database>(
+        sender: Address,
+        payer: Address,
+        gas_limit: u64,
+        payer_auth: u64,
+        max_fee: u128,
+        tip: U256,
+        db: &mut DB,
+    ) -> bool {
+        let Ok(payer_info) = db.basic(payer) else {
+            return false;
+        };
+        let payer_balance = payer_info.map_or(U256::ZERO, |info| info.balance);
+        let sender_balance = if payer == sender {
+            payer_balance
+        } else {
+            let Ok(sender_info) = db.basic(sender) else {
+                return false;
+            };
+            sender_info.map_or(U256::ZERO, |info| info.balance)
+        };
+        FeeCheck::validate_gas_and_tip(
+            payer_balance,
+            sender_balance,
+            payer == sender,
+            gas_limit,
+            payer_auth,
+            max_fee,
+            tip,
+        )
+        .is_err()
+    }
+
+    /// Returns `true` when the transaction declares a static coinbase tip that
+    /// the sender and gas payer cannot cover together with worst-case gas.
+    ///
+    /// Transactions without a statically decoded tip are treated as affordable.
+    pub fn unaffordable<T, DB>(tx: &T, payer_auth: u64, db: &mut DB) -> bool
+    where
+        T: BasePooledTx,
+        DB: Database,
+    {
+        let Some(signed) = tx.as_eip8130() else {
+            return false;
+        };
+        let Some(tip) = CoinbaseTip::decode(signed.tx(), tx.sender()) else {
+            return false;
+        };
+        let sender = tx.sender();
+        let payer = signed.tx().payer.unwrap_or(sender);
+        Self::unaffordable_tip(
+            sender,
+            payer,
+            tx.gas_limit(),
+            payer_auth,
+            tx.max_fee_per_gas(),
+            tip,
+            db,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, B256, U256};
+    use revm::{
+        Database,
+        database::InMemoryDB,
+        database_interface::DBErrorMarker,
+        state::{AccountInfo, Bytecode},
+    };
+
+    use super::CoinbaseTipAffordability;
+
+    const SENDER: Address = Address::repeat_byte(0x11);
+    const PAYER: Address = Address::repeat_byte(0x22);
+    const TIP: U256 = U256::from_limbs([1_000, 0, 0, 0]);
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test database read failed")]
+    struct ReadError;
+
+    impl DBErrorMarker for ReadError {}
+
+    #[derive(Debug, Default)]
+    struct FailingDatabase;
+
+    impl Database for FailingDatabase {
+        type Error = ReadError;
+
+        fn basic(&mut self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+            Err(ReadError)
+        }
+
+        fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+            Err(ReadError)
+        }
+
+        fn storage(&mut self, _address: Address, _index: U256) -> Result<U256, Self::Error> {
+            Err(ReadError)
+        }
+
+        fn block_hash(&mut self, _number: u64) -> Result<B256, Self::Error> {
+            Err(ReadError)
+        }
+    }
+
+    fn fund(db: &mut InMemoryDB, address: Address, balance: u64) {
+        db.insert_account_info(
+            address,
+            AccountInfo { balance: U256::from(balance), ..Default::default() },
+        );
+    }
+
+    #[test]
+    fn missing_account_cannot_cover_gas_plus_tip() {
+        let mut db = InMemoryDB::default();
+        assert!(CoinbaseTipAffordability::unaffordable_tip(
+            SENDER, SENDER, 21_000, 0, 2, TIP, &mut db
+        ));
+    }
+
+    #[test]
+    fn funded_self_pay_covers_gas_plus_tip() {
+        let mut db = InMemoryDB::default();
+        // gas = 21_000 * 2 = 42_000; tip = 1_000.
+        fund(&mut db, SENDER, 43_000);
+        assert!(!CoinbaseTipAffordability::unaffordable_tip(
+            SENDER, SENDER, 21_000, 0, 2, TIP, &mut db
+        ));
+    }
+
+    #[test]
+    fn self_pay_short_one_wei_is_unaffordable() {
+        let mut db = InMemoryDB::default();
+        fund(&mut db, SENDER, 42_999);
+        assert!(CoinbaseTipAffordability::unaffordable_tip(
+            SENDER, SENDER, 21_000, 0, 2, TIP, &mut db
+        ));
+    }
+
+    #[test]
+    fn sponsored_tip_needs_sender_balance() {
+        let mut db = InMemoryDB::default();
+        fund(&mut db, PAYER, 42_000);
+        fund(&mut db, SENDER, 999);
+        assert!(CoinbaseTipAffordability::unaffordable_tip(
+            SENDER, PAYER, 21_000, 0, 2, TIP, &mut db
+        ));
+    }
+
+    #[test]
+    fn sponsored_gas_and_tip_are_affordable_when_split() {
+        let mut db = InMemoryDB::default();
+        fund(&mut db, PAYER, 42_000);
+        fund(&mut db, SENDER, 1_000);
+        assert!(!CoinbaseTipAffordability::unaffordable_tip(
+            SENDER, PAYER, 21_000, 0, 2, TIP, &mut db
+        ));
+    }
+
+    #[test]
+    fn database_read_errors_fail_open() {
+        assert!(!CoinbaseTipAffordability::unaffordable_tip(
+            SENDER,
+            SENDER,
+            21_000,
+            0,
+            2,
+            TIP,
+            &mut FailingDatabase
+        ));
+    }
+}

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -52,10 +52,10 @@ use revm::context::{Block, BlockEnv};
 use tracing::{debug, debug_span, instrument, trace, warn};
 
 use crate::{
-    Attributes, BasePayloadBuilderAttributes, BuilderMetrics, InclusionTracker,
-    ParkableBestPayloadTransactions, ParkablePayloadTransactions, ParkedPredicateIndex,
-    PayloadPrimitives, PredicateLoadTracker, PredicateReadRecorder, StateChangeEffects,
-    ValidityMetrics, ValidityPredicateEvaluation, config::BaseBuilderConfig,
+    Attributes, BasePayloadBuilderAttributes, BuilderMetrics, CoinbaseTipAffordability,
+    InclusionTracker, ParkableBestPayloadTransactions, ParkablePayloadTransactions,
+    ParkedPredicateIndex, PayloadPrimitives, PredicateLoadTracker, PredicateReadRecorder,
+    StateChangeEffects, ValidityMetrics, ValidityPredicateEvaluation, config::BaseBuilderConfig,
     error::BasePayloadBuilderError, payload::BaseBuiltPayload,
 };
 
@@ -1117,6 +1117,24 @@ where
                 },
                 None => 0,
             };
+
+            if CoinbaseTipAffordability::unaffordable(
+                &tx,
+                tx_payer_auth,
+                builder.evm_mut().db_mut(),
+            ) {
+                trace!(
+                    target: "payload_builder",
+                    tx_hash = ?tx.hash(),
+                    "skipping transaction unable to pay gas plus declared coinbase tip"
+                );
+                if tx.eip8130_replay_id().is_none() {
+                    best_txs.mark_invalid(tx.sender(), tx.nonce());
+                } else {
+                    best_txs.mark_current_committed();
+                }
+                continue;
+            }
 
             let tx = tx.into_consensus();
 

--- a/crates/execution/payload/src/lib.rs
+++ b/crates/execution/payload/src/lib.rs
@@ -9,6 +9,8 @@
 
 extern crate alloc;
 
+mod affordability;
+pub use affordability::CoinbaseTipAffordability;
 pub mod builder;
 pub use builder::BasePayloadBuilder;
 pub mod config;

--- a/crates/execution/txpool/Cargo.toml
+++ b/crates/execution/txpool/Cargo.toml
@@ -61,6 +61,7 @@ jsonrpsee = { workspace = true, features = ["http-client", "server", "macros"] }
 
 [dev-dependencies]
 alloy-signer.workspace = true
+alloy-sol-types.workspace = true
 alloy-signer-local.workspace = true
 reth-tasks.workspace = true
 base-test-utils.workspace = true

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -42,7 +42,10 @@ pub use transaction::{
 };
 
 mod ordering;
-pub use ordering::{BaseOrdering, BestTransactionPriority, TimestampOrdering};
+pub use ordering::{
+    BaseOrdering, BasePriority, BestTransactionPriority, TimestampOrdering, UnifiedTipOrdering,
+    UnifiedTipPriority,
+};
 
 mod parking;
 pub use parking::{

--- a/crates/execution/txpool/src/ordering.rs
+++ b/crates/execution/txpool/src/ordering.rs
@@ -138,10 +138,10 @@ impl PartialOrd for UnifiedTipPriority {
 
 impl Ord for UnifiedTipPriority {
     fn cmp(&self, other: &Self) -> Ordering {
-        // `tip * gas` fits in U256: a larger product would already overflow the
-        // transaction's total fee spend.
-        let left = self.tip * U256::from(other.gas);
-        let right = other.tip * U256::from(self.gas);
+        // Saturate at U256::MAX so a pathological tip*gas product ranks as
+        // the highest bid instead of wrapping.
+        let left = self.tip.saturating_mul(U256::from(other.gas));
+        let right = other.tip.saturating_mul(U256::from(self.gas));
         left.cmp(&right).then_with(|| self.predicates.cmp(&other.predicates))
     }
 }
@@ -149,9 +149,10 @@ impl Ord for UnifiedTipPriority {
 /// Unified tip-per-gas ordering for standard and EIP-8130 transactions.
 ///
 /// Uses [`CoinbaseTip::decode`] when the transaction is a statically-analyzable
-/// EIP-8130 coinbase tip; otherwise ranks by `effective_tip_per_gas`. Same bid
-/// prefers fewer validity predicates, so standard transactions beat equally
-/// priced advanced transactions.
+/// EIP-8130 coinbase tip; otherwise ranks by `effective_tip_per_gas`. Returns
+/// [`Priority::None`] when `max_fee_per_gas < base_fee`, including for a
+/// decoded coinbase tip. Same bid prefers fewer validity predicates, so
+/// standard transactions beat equally priced advanced transactions.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct UnifiedTipOrdering<T = BasePooledTransaction>(PhantomData<T>);
@@ -180,6 +181,9 @@ where
         transaction: &Self::Transaction,
         base_fee: u64,
     ) -> Priority<Self::PriorityValue> {
+        let Some(effective_tip) = transaction.effective_tip_per_gas(base_fee) else {
+            return Priority::None;
+        };
         let predicates = transaction.validity_predicates().len();
         if let Some(signed) = transaction.as_eip8130()
             && let Some(tip) = CoinbaseTip::decode(signed.tx(), transaction.sender())
@@ -190,9 +194,7 @@ where
                 predicates,
             ));
         }
-        transaction.effective_tip_per_gas(base_fee).map_or(Priority::None, |tip| {
-            Priority::Value(UnifiedTipPriority::new(U256::from(tip), 1, predicates))
-        })
+        Priority::Value(UnifiedTipPriority::new(U256::from(effective_tip), 1, predicates))
     }
 }
 
@@ -641,6 +643,13 @@ mod tests {
     fn below_base_fee_standard_tx_has_no_priority() {
         let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
         let tx = eip1559_pooled(1, 10, 1, 21_000);
+        assert_eq!(ordering.priority(&tx, 20), Priority::None);
+    }
+
+    #[test]
+    fn below_base_fee_coinbase_tip_has_no_priority() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let tx = eip8130_pooled(10, 0, 21_000, Some(U256::from(42_000)));
         assert_eq!(ordering.priority(&tx, 20), Priority::None);
     }
 }

--- a/crates/execution/txpool/src/ordering.rs
+++ b/crates/execution/txpool/src/ordering.rs
@@ -11,7 +11,7 @@ use std::{
     time::Instant,
 };
 
-use alloy_primitives::{TxHash, U256, U512};
+use alloy_primitives::{TxHash, U256};
 use base_common_consensus::CoinbaseTip;
 use reth_transaction_pool::{PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction};
 
@@ -138,8 +138,10 @@ impl PartialOrd for UnifiedTipPriority {
 
 impl Ord for UnifiedTipPriority {
     fn cmp(&self, other: &Self) -> Ordering {
-        let left = U512::from(self.tip) * U512::from(other.gas);
-        let right = U512::from(other.tip) * U512::from(self.gas);
+        // `tip * gas` fits in U256: a larger product would already overflow the
+        // transaction's total fee spend.
+        let left = self.tip * U256::from(other.gas);
+        let right = other.tip * U256::from(self.gas);
         left.cmp(&right).then_with(|| self.predicates.cmp(&other.predicates))
     }
 }

--- a/crates/execution/txpool/src/ordering.rs
+++ b/crates/execution/txpool/src/ordering.rs
@@ -1,13 +1,21 @@
-//! Custom ordering for transactions based on timestamp.
+//! Transaction ordering strategies for the Base mempool.
+//!
+//! [`UnifiedTipOrdering`] ranks by tip-per-gas — an EIP-1559 priority fee, or a
+//! statically decoded EIP-8130 coinbase tip over `gas_limit` — and breaks ties
+//! in favor of fewer validity predicates. [`TimestampOrdering`] is FIFO.
 
-use std::{cmp::Reverse, marker::PhantomData, sync::Arc, time::Instant};
-
-use alloy_primitives::TxHash;
-use reth_transaction_pool::{
-    CoinbaseTipOrdering, PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction,
+use std::{
+    cmp::{Ordering, Reverse},
+    marker::PhantomData,
+    sync::Arc,
+    time::Instant,
 };
 
-use crate::{BasePooledTransaction, TimestampedTransaction};
+use alloy_primitives::{TxHash, U256, U512};
+use base_common_consensus::CoinbaseTip;
+use reth_transaction_pool::{PoolTransaction, Priority, TransactionOrdering, ValidPoolTransaction};
+
+use crate::{BasePooledTransaction, BasePooledTx, TimestampedTransaction};
 
 /// Complete priority key used when merging best-transaction sources.
 ///
@@ -44,16 +52,16 @@ impl<P: Ord + Clone> BestTransactionPriority<P> {
 /// Each variant holds only the ordering implementation it needs.
 #[derive(Debug)]
 pub enum BaseOrdering<T> {
-    /// Order by coinbase tip (fee-based, higher tip = higher priority).
-    CoinbaseTip(CoinbaseTipOrdering<T>),
+    /// Order by unified tip-per-gas, with fewer validity predicates winning ties.
+    CoinbaseTip(UnifiedTipOrdering<T>),
     /// Order by receive timestamp (FIFO, earlier = higher priority).
     Timestamp(TimestampOrdering<T>),
 }
 
 impl<T> BaseOrdering<T> {
-    /// Creates a new coinbase-tip ordering (fee-based).
+    /// Creates unified tip-per-gas ordering (default pool ranking).
     pub fn coinbase_tip() -> Self {
-        Self::CoinbaseTip(CoinbaseTipOrdering::default())
+        Self::CoinbaseTip(UnifiedTipOrdering::default())
     }
 
     /// Creates a new timestamp ordering (FIFO).
@@ -74,6 +82,147 @@ impl<T> Clone for BaseOrdering<T> {
 impl<T> Default for BaseOrdering<T> {
     fn default() -> Self {
         Self::coinbase_tip()
+    }
+}
+
+/// Tip-per-gas bid with a fewer-predicates tiebreak.
+///
+/// The bid is the rational `tip / gas`. Standard transactions and EIP-8130
+/// transactions without a static coinbase tip use `effective_tip_per_gas` as
+/// `tip` and `gas = 1`. A statically decoded coinbase tip uses that amount as
+/// `tip` and the transaction `gas_limit` as `gas`.
+///
+/// Equality and ordering compare the bid by cross-multiplication, then fewer
+/// predicates. Distinct `(tip, gas)` pairs that represent the same ratio compare
+/// equal.
+#[derive(Debug, Clone, Copy)]
+pub struct UnifiedTipPriority {
+    /// Numerator of the tip-per-gas bid.
+    pub tip: U256,
+    /// Denominator of the tip-per-gas bid (`gas_limit`, or `1` for a priority-fee bid).
+    pub gas: u64,
+    /// Fewer predicates rank higher (`Reverse` so `0` beats `1`).
+    pub predicates: Reverse<u32>,
+}
+
+impl UnifiedTipPriority {
+    /// Builds a priority from a tip amount, gas denominator, and predicate count.
+    pub fn new(tip: U256, gas: u64, predicate_count: usize) -> Self {
+        Self {
+            tip,
+            gas: gas.max(1),
+            predicates: Reverse(u32::try_from(predicate_count).unwrap_or(u32::MAX)),
+        }
+    }
+}
+
+impl Default for UnifiedTipPriority {
+    fn default() -> Self {
+        Self::new(U256::ZERO, 1, 0)
+    }
+}
+
+impl PartialEq for UnifiedTipPriority {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for UnifiedTipPriority {}
+
+impl PartialOrd for UnifiedTipPriority {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for UnifiedTipPriority {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let left = U512::from(self.tip) * U512::from(other.gas);
+        let right = U512::from(other.tip) * U512::from(self.gas);
+        left.cmp(&right).then_with(|| self.predicates.cmp(&other.predicates))
+    }
+}
+
+/// Unified tip-per-gas ordering for standard and EIP-8130 transactions.
+///
+/// Uses [`CoinbaseTip::decode`] when the transaction is a statically-analyzable
+/// EIP-8130 coinbase tip; otherwise ranks by `effective_tip_per_gas`. Same bid
+/// prefers fewer validity predicates, so standard transactions beat equally
+/// priced advanced transactions.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct UnifiedTipOrdering<T = BasePooledTransaction>(PhantomData<T>);
+
+impl<T> Default for UnifiedTipOrdering<T> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<T> Clone for UnifiedTipOrdering<T> {
+    fn clone(&self) -> Self {
+        Self::default()
+    }
+}
+
+impl<T> TransactionOrdering for UnifiedTipOrdering<T>
+where
+    T: BasePooledTx + 'static,
+{
+    type PriorityValue = UnifiedTipPriority;
+    type Transaction = T;
+
+    fn priority(
+        &self,
+        transaction: &Self::Transaction,
+        base_fee: u64,
+    ) -> Priority<Self::PriorityValue> {
+        let predicates = transaction.validity_predicates().len();
+        if let Some(signed) = transaction.as_eip8130()
+            && let Some(tip) = CoinbaseTip::decode(signed.tx(), transaction.sender())
+        {
+            return Priority::Value(UnifiedTipPriority::new(
+                tip,
+                transaction.gas_limit(),
+                predicates,
+            ));
+        }
+        transaction.effective_tip_per_gas(base_fee).map_or(Priority::None, |tip| {
+            Priority::Value(UnifiedTipPriority::new(U256::from(tip), 1, predicates))
+        })
+    }
+}
+
+/// Pool priority value for [`BaseOrdering`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BasePriority {
+    /// Unified tip-per-gas bid plus predicate-count tiebreak.
+    Unified(UnifiedTipPriority),
+    /// Inverted receive timestamp (`u128::MAX - received_at`).
+    Timestamp(u128),
+}
+
+impl Default for BasePriority {
+    fn default() -> Self {
+        Self::Unified(UnifiedTipPriority::default())
+    }
+}
+
+impl PartialOrd for BasePriority {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BasePriority {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::Unified(left), Self::Unified(right)) => left.cmp(right),
+            (Self::Timestamp(left), Self::Timestamp(right)) => left.cmp(right),
+            (Self::Unified(_), Self::Timestamp(_)) => Ordering::Less,
+            (Self::Timestamp(_), Self::Unified(_)) => Ordering::Greater,
+        }
     }
 }
 
@@ -118,9 +267,9 @@ where
 
 impl<T> TransactionOrdering for BaseOrdering<T>
 where
-    T: PoolTransaction + TimestampedTransaction + 'static,
+    T: BasePooledTx + TimestampedTransaction + 'static,
 {
-    type PriorityValue = u128;
+    type PriorityValue = BasePriority;
     type Transaction = T;
 
     fn priority(
@@ -129,8 +278,14 @@ where
         base_fee: u64,
     ) -> Priority<Self::PriorityValue> {
         match self {
-            Self::CoinbaseTip(ordering) => ordering.priority(transaction, base_fee),
-            Self::Timestamp(ordering) => ordering.priority(transaction, base_fee),
+            Self::CoinbaseTip(ordering) => match ordering.priority(transaction, base_fee) {
+                Priority::Value(priority) => Priority::Value(BasePriority::Unified(priority)),
+                Priority::None => Priority::None,
+            },
+            Self::Timestamp(ordering) => match ordering.priority(transaction, base_fee) {
+                Priority::Value(priority) => Priority::Value(BasePriority::Timestamp(priority)),
+                Priority::None => Priority::None,
+            },
         }
     }
 }
@@ -138,13 +293,23 @@ where
 #[cfg(test)]
 mod tests {
     use alloy_eips::eip2718::Encodable2718;
-    use base_common_consensus::BaseTransactionSigned;
+    use alloy_primitives::{Address, Bytes, U256};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use alloy_sol_types::SolCall;
+    use base_common_chains::ChainConfig;
+    use base_common_consensus::{
+        BasePooledTransaction as ConsensusPooledTransaction, BaseTransactionSigned, Call,
+        Eip8130Signed, IDefaultAccount, Predeploys, TxEip8130,
+    };
     use base_test_utils::Account;
     use reth_primitives_traits::Recovered;
-    use reth_transaction_pool::{TransactionOrdering, test_utils::TransactionBuilder};
+    use reth_transaction_pool::{
+        CoinbaseTipOrdering, PoolTransaction, TransactionOrdering, test_utils::TransactionBuilder,
+    };
 
     use super::*;
-    use crate::BasePooledTransaction;
+    use crate::{BasePooledTransaction, ValidityOperator, ValidityPredicate};
 
     fn create_test_tx(nonce: u64) -> BasePooledTransaction {
         let alice = Account::Alice;
@@ -217,6 +382,80 @@ mod tests {
         let recovered = Recovered::new_unchecked(tx, account.address());
         let len = recovered.encode_2718_len();
         BasePooledTransaction::new_with_received_at(recovered, len, received_at)
+    }
+
+    fn eip1559_pooled(
+        nonce: u64,
+        max_fee_per_gas: u128,
+        max_priority_fee_per_gas: u128,
+        gas_limit: u64,
+    ) -> BasePooledTransaction {
+        let alice = Account::Alice;
+        let bob = Account::Bob;
+        let signed_tx = TransactionBuilder::default()
+            .signer(alice.signer_b256())
+            .chain_id(1)
+            .nonce(nonce)
+            .to(bob.address())
+            .value(1_000)
+            .gas_limit(gas_limit)
+            .max_fee_per_gas(max_fee_per_gas)
+            .max_priority_fee_per_gas(max_priority_fee_per_gas)
+            .into_eip1559();
+        let tx = BaseTransactionSigned::Eip1559(
+            signed_tx.as_eip1559().expect("eip1559 transaction").clone(),
+        );
+        let recovered = Recovered::new_unchecked(tx, alice.address());
+        let len = recovered.encode_2718_len();
+        BasePooledTransaction::new(recovered, len)
+    }
+
+    fn encode_execute(target: Address, value: U256) -> Bytes {
+        Bytes::from(
+            IDefaultAccount::executeCall { target, value, data: Default::default() }.abi_encode(),
+        )
+    }
+
+    fn eip8130_pooled(
+        max_fee_per_gas: u128,
+        max_priority_fee_per_gas: u128,
+        gas_limit: u64,
+        coinbase_tip: Option<U256>,
+    ) -> BasePooledTransaction {
+        let signer = PrivateKeySigner::random();
+        let calls = coinbase_tip.map_or_else(Vec::new, |amount| {
+            vec![vec![Call {
+                to: signer.address(),
+                data: encode_execute(Predeploys::SEQUENCER_FEE_VAULT, amount),
+            }]]
+        });
+        let tx = TxEip8130 {
+            chain_id: ChainConfig::mainnet().chain_id,
+            sender: None,
+            nonce_key: U256::ZERO,
+            nonce_sequence: 0,
+            valid_after: 0,
+            valid_before: 0,
+            max_priority_fee_per_gas,
+            max_fee_per_gas,
+            gas_limit,
+            account_changes: Vec::new(),
+            calls,
+            metadata: Bytes::new(),
+            payer: None,
+        };
+        let signature = signer.sign_hash_sync(&tx.sender_signature_hash()).unwrap();
+        let signed =
+            Eip8130Signed::new(tx, Bytes::from(signature.as_bytes().to_vec()), Bytes::new());
+        let pooled = ConsensusPooledTransaction::Eip8130(signed);
+        BasePooledTransaction::from_pooled(Recovered::new_unchecked(pooled, signer.address()))
+    }
+
+    fn block_number_predicate() -> ValidityPredicate {
+        ValidityPredicate::BlockNumber {
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: U256::from(1),
+        }
     }
 
     #[test]
@@ -293,13 +532,16 @@ mod tests {
     }
 
     #[test]
-    fn test_base_ordering_default_is_coinbase_tip() {
+    fn test_base_ordering_default_is_unified_tip() {
         let ordering = BaseOrdering::<BasePooledTransaction>::default();
+        let unified = UnifiedTipOrdering::<BasePooledTransaction>::default();
         let tx = create_test_tx(1);
-        let priority = ordering.priority(&tx, 0);
-        let coinbase = CoinbaseTipOrdering::<BasePooledTransaction>::default();
-        let coinbase_priority = coinbase.priority(&tx, 0);
-        assert_eq!(priority, coinbase_priority);
+        match (ordering.priority(&tx, 0), unified.priority(&tx, 0)) {
+            (Priority::Value(BasePriority::Unified(base)), Priority::Value(inner)) => {
+                assert_eq!(base, inner);
+            }
+            other => panic!("expected matching unified priorities, got {other:?}"),
+        }
     }
 
     // NOTE: Same-sender nonce ordering is enforced by the txpool layer, not the
@@ -328,5 +570,75 @@ mod tests {
             priority_0 > priority_1,
             "earlier tx should have higher priority regardless of nonce",
         );
+    }
+
+    #[test]
+    fn standard_tx_ranking_matches_reth_coinbase_tip_order() {
+        let unified = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let reth = CoinbaseTipOrdering::<BasePooledTransaction>::default();
+        let higher = eip1559_pooled(1, 10, 2, 21_000);
+        let lower = eip1559_pooled(2, 10, 1, 21_000);
+
+        assert_eq!(
+            unified.priority(&higher, 0).cmp(&unified.priority(&lower, 0)),
+            reth.priority(&higher, 0).cmp(&reth.priority(&lower, 0)),
+        );
+        assert!(unified.priority(&higher, 0) > unified.priority(&lower, 0));
+    }
+
+    #[test]
+    fn coinbase_tip_per_gas_competes_with_priority_fee() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let standard = eip1559_pooled(1, 10, 2, 21_000);
+        let cheaper_at = eip8130_pooled(10, 0, 21_000, Some(U256::from(21_000)));
+        let richer_at = eip8130_pooled(10, 0, 21_000, Some(U256::from(63_000)));
+
+        assert!(ordering.priority(&standard, 0) > ordering.priority(&cheaper_at, 0));
+        assert!(ordering.priority(&richer_at, 0) > ordering.priority(&standard, 0));
+    }
+
+    #[test]
+    fn fewer_predicates_win_equal_bid() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let standard = eip1559_pooled(1, 10, 2, 21_000);
+        let one_predicate = eip8130_pooled(10, 0, 21_000, Some(U256::from(42_000)))
+            .with_validity_predicates(vec![block_number_predicate()]);
+        let two_predicates = eip8130_pooled(10, 0, 21_000, Some(U256::from(42_000)))
+            .with_validity_predicates(vec![block_number_predicate(), block_number_predicate()]);
+
+        assert!(ordering.priority(&standard, 0) > ordering.priority(&one_predicate, 0));
+        assert!(ordering.priority(&one_predicate, 0) > ordering.priority(&two_predicates, 0));
+    }
+
+    #[test]
+    fn eip8130_without_static_tip_uses_priority_fee() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let standard = eip1559_pooled(1, 10, 3, 21_000);
+        let aa = eip8130_pooled(10, 3, 50_000, None);
+
+        assert_eq!(ordering.priority(&standard, 0), ordering.priority(&aa, 0));
+    }
+
+    #[test]
+    fn equivalent_ratios_compare_equal_before_predicate_tiebreak() {
+        assert_eq!(
+            UnifiedTipPriority::new(U256::from(3u64), 2, 0),
+            UnifiedTipPriority::new(U256::from(6u64), 4, 0),
+        );
+        assert!(
+            UnifiedTipPriority::new(U256::from(3u64), 2, 0)
+                > UnifiedTipPriority::new(U256::from(1u64), 1, 0)
+        );
+        assert!(
+            UnifiedTipPriority::new(U256::from(3u64), 2, 0)
+                > UnifiedTipPriority::new(U256::from(3u64), 2, 1)
+        );
+    }
+
+    #[test]
+    fn below_base_fee_standard_tx_has_no_priority() {
+        let ordering = UnifiedTipOrdering::<BasePooledTransaction>::default();
+        let tx = eip1559_pooled(1, 10, 1, 21_000);
+        assert_eq!(ordering.priority(&tx, 20), Priority::None);
     }
 }


### PR DESCRIPTION
## Summary
- Skip EIP-8130 transactions in the native payload builder and flashblocks loops when a statically decoded coinbase tip cannot be paid together with worst-case gas (`(gas_limit + payer_auth) * max_fee`).
- Self-pay requires one balance to cover gas plus tip; sponsored payment requires the payer to cover gas and the sender to cover the tip. Transient account reads fail open so a DB error does not drop the candidate.
- Stacked on #4818 so an unbounded declared tip cannot win unified pool ranking and then revert at execution. Follow-up to [BASE-145](https://linear.app/coinbase/issue/BASE-145/implement-unified-priority-scoring-for-sts-priorityfeepergas-and-ats).

## Test plan
- [ ] `cargo test -p base-execution-eip8130 --lib fee`
- [ ] `cargo test -p base-execution-payload-builder --lib affordability`
- [ ] Confirm an 8130 with a static tip and `sender_balance < gas + tip` is skipped before execute
- [ ] Confirm a sponsored 8130 with a funded payer and underfunded sender is skipped
- [ ] Confirm STs and 8130s without a static tip are unchanged
- [ ] Confirm a transient `db.basic` failure does not skip the transaction