### PR TITLE
fix(precompiles): pin 8130 wrapper storage features to at-least Cobalt (Cantina #17 / BOP-604)

### DIFF
--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -230,20 +230,18 @@ mod tests {
     fn config_rejects_unknown_options() {
         let err = parse_config(quote! { instal }).err().unwrap();
 
-        assert!(
-            err.to_string()
-                .contains("expected `id`, `storage`, `macro_path`, `args`, `install`, or `storage_features`")
-        );
+        assert!(err.to_string().contains(
+            "expected `id`, `storage`, `macro_path`, `args`, `install`, or `storage_features`"
+        ));
     }
 
     #[test]
     fn config_rejects_positional_storage() {
         let err = parse_config(quote! { CustomStorage<'_> }).err().unwrap();
 
-        assert!(
-            err.to_string()
-                .contains("expected `id`, `storage`, `macro_path`, `args`, `install`, or `storage_features`")
-        );
+        assert!(err.to_string().contains(
+            "expected `id`, `storage`, `macro_path`, `args`, `install`, or `storage_features`"
+        ));
     }
 
     #[test]

--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -61,8 +61,7 @@ fn expand_impl(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStrea
     let Some(storage_features) = config.storage_features else {
         return Err(syn::Error::new_spanned(
             &input.ident,
-            "`#[precompile]` requires `storage_features = <expr>` (see `UpgradeGatedStorageFeatures::from_upgrade` \
-             or `at_least` for the canonical helpers)",
+            "`#[precompile]` requires `storage_features = <expr>` (see `UpgradeGatedStorageFeatures::from_upgrade`)",
         ));
     };
     let macro_invocation = quote! {

--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -58,6 +58,18 @@ fn expand_impl(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStrea
     });
     let precompile_doc = format!("Creates the EVM precompile wrapper for `{ident}`.");
     let arg_names = args.iter().map(|arg| &arg.ident);
+    let macro_invocation = match config.storage_features {
+        Some(storage_features) => quote! {
+            #macro_path!(#id, storage_features: #storage_features, |ctx, calldata| {
+                <#storage>::new(ctx).dispatch(ctx, &calldata #(, #arg_names)*)
+            })
+        },
+        None => quote! {
+            #macro_path!(#id, |ctx, calldata| {
+                <#storage>::new(ctx).dispatch(ctx, &calldata #(, #arg_names)*)
+            })
+        },
+    };
 
     Ok(quote! {
         #input
@@ -67,9 +79,7 @@ fn expand_impl(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStrea
 
             #[doc = #precompile_doc]
             pub fn precompile(#(#arg_defs),*) -> ::alloy_evm::precompiles::DynPrecompile {
-                #macro_path!(#id, |ctx, calldata| {
-                    <#storage>::new(ctx).dispatch(ctx, &calldata #(, #arg_names)*)
-                })
+                #macro_invocation
             }
         }
     })
@@ -81,6 +91,7 @@ struct PrecompileConfig {
     macro_path: Option<Path>,
     args: Vec<PrecompileArg>,
     install: bool,
+    storage_features: Option<Expr>,
 }
 
 impl Parse for PrecompileConfig {
@@ -91,6 +102,7 @@ impl Parse for PrecompileConfig {
         let mut args = Vec::new();
         let mut args_seen = false;
         let mut install = false;
+        let mut storage_features = None;
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -134,10 +146,15 @@ impl Parse for PrecompileConfig {
                     }
                     install = true;
                 }
+                "storage_features" => {
+                    reject_duplicate(&storage_features, &key)?;
+                    input.parse::<Token![=]>()?;
+                    storage_features = Some(input.parse()?);
+                }
                 _ => {
                     return Err(syn::Error::new_spanned(
                         key,
-                        "expected `id`, `storage`, `macro_path`, `args`, or `install`",
+                        "expected `id`, `storage`, `macro_path`, `args`, `install`, or `storage_features`",
                     ));
                 }
             }
@@ -147,7 +164,7 @@ impl Parse for PrecompileConfig {
             }
         }
 
-        Ok(Self { id, storage, macro_path, args, install })
+        Ok(Self { id, storage, macro_path, args, install, storage_features })
     }
 }
 
@@ -215,7 +232,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("expected `id`, `storage`, `macro_path`, `args`, or `install`")
+                .contains("expected `id`, `storage`, `macro_path`, `args`, `install`, or `storage_features`")
         );
     }
 
@@ -225,7 +242,7 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("expected `id`, `storage`, `macro_path`, `args`, or `install`")
+                .contains("expected `id`, `storage`, `macro_path`, `args`, `install`, or `storage_features`")
         );
     }
 
@@ -288,6 +305,62 @@ mod tests {
         let err = parse_config(quote! { args(), args(x: u8) }).err().unwrap();
 
         assert!(err.to_string().contains("duplicate `args` option"));
+    }
+
+    #[test]
+    fn config_accepts_storage_features() {
+        let config = parse_config(quote! {
+            install,
+            storage_features = ::base_precompile_storage::StorageFeatures::Cobalt,
+        })
+        .unwrap();
+
+        assert!(config.install);
+        assert!(config.storage_features.is_some());
+    }
+
+    #[test]
+    fn config_rejects_duplicate_storage_features() {
+        let err = parse_config(quote! {
+            storage_features = A,
+            storage_features = B,
+        })
+        .err()
+        .unwrap();
+
+        assert!(err.to_string().contains("duplicate `storage_features` option"));
+    }
+
+    #[test]
+    fn storage_features_arg_threads_through_expansion() {
+        let tokens = expand_impl(
+            quote! {
+                install,
+                storage_features = ::base_precompile_storage::StorageFeatures::Cobalt,
+            },
+            quote! {
+                pub struct Example;
+            },
+        )
+        .unwrap()
+        .to_string();
+
+        assert!(tokens.contains("storage_features"), "got: {tokens}");
+        assert!(tokens.contains("Cobalt"), "got: {tokens}");
+    }
+
+    #[test]
+    fn without_storage_features_arg_expansion_omits_it() {
+        let tokens = expand_impl(
+            quote! { install },
+            quote! {
+                pub struct Example;
+            },
+        )
+        .unwrap()
+        .to_string();
+
+        assert!(!tokens.contains("storage_features"), "got: {tokens}");
     }
 
     #[test]

--- a/crates/common/precompile-macros/src/precompile.rs
+++ b/crates/common/precompile-macros/src/precompile.rs
@@ -58,17 +58,17 @@ fn expand_impl(attr: TokenStream2, item: TokenStream2) -> syn::Result<TokenStrea
     });
     let precompile_doc = format!("Creates the EVM precompile wrapper for `{ident}`.");
     let arg_names = args.iter().map(|arg| &arg.ident);
-    let macro_invocation = match config.storage_features {
-        Some(storage_features) => quote! {
-            #macro_path!(#id, storage_features: #storage_features, |ctx, calldata| {
-                <#storage>::new(ctx).dispatch(ctx, &calldata #(, #arg_names)*)
-            })
-        },
-        None => quote! {
-            #macro_path!(#id, |ctx, calldata| {
-                <#storage>::new(ctx).dispatch(ctx, &calldata #(, #arg_names)*)
-            })
-        },
+    let Some(storage_features) = config.storage_features else {
+        return Err(syn::Error::new_spanned(
+            &input.ident,
+            "`#[precompile]` requires `storage_features = <expr>` (see `UpgradeGatedStorageFeatures::from_upgrade` \
+             or `at_least` for the canonical helpers)",
+        ));
+    };
+    let macro_invocation = quote! {
+        #macro_path!(#id, storage_features: #storage_features, |ctx, calldata| {
+            <#storage>::new(ctx).dispatch(ctx, &calldata #(, #arg_names)*)
+        })
     };
 
     Ok(quote! {
@@ -350,23 +350,29 @@ mod tests {
     }
 
     #[test]
-    fn without_storage_features_arg_expansion_omits_it() {
-        let tokens = expand_impl(
+    fn expansion_requires_storage_features() {
+        let err = expand_impl(
             quote! { install },
             quote! {
                 pub struct Example;
             },
         )
-        .unwrap()
-        .to_string();
+        .err()
+        .unwrap();
 
-        assert!(!tokens.contains("storage_features"), "got: {tokens}");
+        assert!(
+            err.to_string().contains("`#[precompile]` requires `storage_features = <expr>`"),
+            "got: {err}",
+        );
     }
 
     #[test]
     fn bare_install_expands_to_storage_address() {
         let tokens = expand_impl(
-            quote! { install },
+            quote! {
+                install,
+                storage_features = ::base_precompile_storage::StorageFeatures::Cobalt,
+            },
             quote! {
                 pub struct Example;
             },
@@ -382,7 +388,11 @@ mod tests {
     #[test]
     fn install_with_explicit_storage_uses_that_address() {
         let tokens = expand_impl(
-            quote! { storage = CustomStorage<'_>, install },
+            quote! {
+                storage = CustomStorage<'_>,
+                install,
+                storage_features = ::base_precompile_storage::StorageFeatures::Cobalt,
+            },
             quote! {
                 pub struct Example;
             },

--- a/crates/common/precompiles/src/activation/precompile.rs
+++ b/crates/common/precompiles/src/activation/precompile.rs
@@ -11,7 +11,10 @@ use crate::{
 };
 
 /// Entry point for the activation registry precompile.
-#[precompile(args(admin_config: ActivationAdminConfig, upgrade: BaseUpgrade))]
+#[precompile(
+    args(admin_config: ActivationAdminConfig, upgrade: BaseUpgrade),
+    storage_features = UpgradeGatedStorageFeatures::from_upgrade(upgrade),
+)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ActivationRegistry;
 

--- a/crates/common/precompiles/src/macros.rs
+++ b/crates/common/precompiles/src/macros.rs
@@ -1,14 +1,11 @@
 //! Runtime helpers for wrapping native precompile dispatch.
 
 /// Wraps a stateful native precompile body in the Base storage-provider setup.
+///
+/// `storage_features:` is required — every caller must state the fork feature set
+/// the wrapper runs under, so a future feature-sensitive field cannot silently
+/// inherit `StorageFeatures::Legacy`. See [`crate::UpgradeGatedStorageFeatures::from_upgrade`].
 macro_rules! base_precompile {
-    ($id:expr, |$ctx:ident, $calldata:ident| $impl:expr $(,)?) => {{
-        $crate::macros::base_precompile!(
-            $id,
-            storage_features: ::base_precompile_storage::StorageFeatures::Legacy,
-            |$ctx, $calldata| $impl,
-        )
-    }};
     ($id:expr, storage_features: $storage_features:expr, |$ctx:ident, $calldata:ident| $impl:expr $(,)?) => {{
         ::alloy_evm::precompiles::DynPrecompile::new_stateful(
             ::revm::precompile::PrecompileId::Custom($id.into()),

--- a/crates/common/precompiles/src/nonce/precompile.rs
+++ b/crates/common/precompiles/src/nonce/precompile.rs
@@ -1,10 +1,45 @@
 //! Precompile entry point for the EIP-8130 2D nonce manager.
 
+use base_common_genesis::BaseUpgrade;
 use base_precompile_macros::precompile;
 
-use crate::NonceManagerStorage;
+use crate::{NonceManagerStorage, UpgradeGatedStorageFeatures};
 
 /// Entry point for the EIP-8130 2D nonce manager precompile.
-#[precompile(install)]
+///
+/// Only installed at Cobalt or later (see `BasePrecompiles::install_with_observer`),
+/// so the wrapper pins its storage features to at least Cobalt while riding
+/// `BaseUpgrade::LATEST` when LATEST already meets that floor.
+#[precompile(
+    install,
+    storage_features = UpgradeGatedStorageFeatures::at_least(BaseUpgrade::Cobalt),
+)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NonceManager;
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::precompiles::PrecompilesMap;
+    use revm::precompile::Precompiles;
+
+    use crate::{NonceManager, NonceManagerStorage};
+
+    // End-to-end feature selection is verified by the three-part chain:
+    //   1. `UpgradeGatedStorageFeatures::at_least(Cobalt) == Cobalt`
+    //      (see `crate::spec::tests::at_least_honors_floor_when_latest_is_behind`).
+    //   2. `#[precompile(storage_features = ...)]` threads the expression into
+    //      `base_precompile!` (see
+    //      `base_precompile_macros::precompile::tests::storage_features_arg_threads_through_expansion`).
+    //   3. `base_precompile!` passes it into `EvmPrecompileStorageProvider::new_with_storage_features`
+    //      (see `crate::macros`).
+    //
+    // The smoke test below only exercises install placement — the source-level
+    // annotation is what pins the feature.
+    #[test]
+    fn install_places_wrapper_at_storage_address() {
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
+        NonceManager::install(&mut precompiles);
+
+        assert!(precompiles.get(&NonceManagerStorage::ADDRESS).is_some());
+    }
+}

--- a/crates/common/precompiles/src/nonce/precompile.rs
+++ b/crates/common/precompiles/src/nonce/precompile.rs
@@ -1,44 +1,54 @@
 //! Precompile entry point for the EIP-8130 2D nonce manager.
 
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use base_common_genesis::BaseUpgrade;
-use base_precompile_macros::precompile;
 
-use crate::{NonceManagerStorage, UpgradeGatedStorageFeatures};
+use crate::{NonceManagerStorage, UpgradeGatedStorageFeatures, macros::base_precompile};
 
 /// Entry point for the EIP-8130 2D nonce manager precompile.
 ///
-/// Only installed at Cobalt or later (see `BasePrecompiles::install_with_observer`),
-/// so the wrapper pins its storage features to at least Cobalt while riding
-/// `BaseUpgrade::LATEST` when LATEST already meets that floor.
-#[precompile(
-    install,
-    storage_features = UpgradeGatedStorageFeatures::at_least(BaseUpgrade::Cobalt),
-)]
+/// Only installed at Cobalt or later (see `BasePrecompiles::install_with_observer`).
+/// The caller passes the active `upgrade` through the constructor, and the wrapper
+/// derives its storage features from it via `UpgradeGatedStorageFeatures::from_upgrade`
+/// — the same signal every other install site consumes — so features stay locked to
+/// the fork that drove the install decision.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NonceManager;
+
+impl NonceManager {
+    /// Installs the `NonceManager` precompile, gated to the storage features
+    /// active at `upgrade`.
+    pub fn install(precompiles: &mut PrecompilesMap, upgrade: BaseUpgrade) {
+        precompiles.extend_precompiles(core::iter::once((
+            NonceManagerStorage::ADDRESS,
+            Self::precompile(upgrade),
+        )));
+    }
+
+    /// Creates the EVM precompile wrapper for `NonceManager`, gated to the storage
+    /// features active at `upgrade`.
+    pub fn precompile(upgrade: BaseUpgrade) -> DynPrecompile {
+        let storage_features = UpgradeGatedStorageFeatures::from_upgrade(upgrade);
+        base_precompile!(
+            "NonceManager",
+            storage_features: storage_features,
+            |ctx, calldata| NonceManagerStorage::new(ctx).dispatch(ctx, &calldata),
+        )
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use alloy_evm::precompiles::PrecompilesMap;
+    use base_common_genesis::BaseUpgrade;
     use revm::precompile::Precompiles;
 
     use crate::{NonceManager, NonceManagerStorage};
 
-    // End-to-end feature selection is verified by the three-part chain:
-    //   1. `UpgradeGatedStorageFeatures::at_least(Cobalt) == Cobalt`
-    //      (see `crate::spec::tests::at_least_honors_floor_when_latest_is_behind`).
-    //   2. `#[precompile(storage_features = ...)]` threads the expression into
-    //      `base_precompile!` (see
-    //      `base_precompile_macros::precompile::tests::storage_features_arg_threads_through_expansion`).
-    //   3. `base_precompile!` passes it into `EvmPrecompileStorageProvider::new_with_storage_features`
-    //      (see `crate::macros`).
-    //
-    // The smoke test below only exercises install placement — the source-level
-    // annotation is what pins the feature.
     #[test]
     fn install_places_wrapper_at_storage_address() {
         let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
-        NonceManager::install(&mut precompiles);
+        NonceManager::install(&mut precompiles, BaseUpgrade::Cobalt);
 
         assert!(precompiles.get(&NonceManagerStorage::ADDRESS).is_some());
     }

--- a/crates/common/precompiles/src/provider.rs
+++ b/crates/common/precompiles/src/provider.rs
@@ -235,8 +235,8 @@ impl<S: BasePrecompileSpec> BasePrecompiles<S> {
             );
         }
         if self.spec.upgrade() >= BaseUpgrade::Cobalt {
-            TxContext::install(&mut precompiles);
-            NonceManager::install(&mut precompiles);
+            TxContext::install(&mut precompiles, self.spec.upgrade());
+            NonceManager::install(&mut precompiles, self.spec.upgrade());
         }
         precompiles
     }

--- a/crates/common/precompiles/src/spec.rs
+++ b/crates/common/precompiles/src/spec.rs
@@ -15,10 +15,17 @@ impl UpgradeGatedStorageFeatures {
         }
     }
 
-    /// Returns the persistent-storage features for a wrapper that must run at
-    /// `min` or later. Resolves to `from_upgrade(max(BaseUpgrade::LATEST, min))`
-    /// so an install site that is gated at `min` never underruns its own gate,
-    /// but still rides `LATEST` once it advances past `min`.
+    /// Returns the persistent-storage features for a caller that must observe
+    /// features from at least `min`, resolving to `from_upgrade(max(BaseUpgrade::LATEST, min))`.
+    ///
+    /// Intended for callers that lack a live [`BaseUpgrade`] at construction — for
+    /// example the enshrined-execution `JournalStorageProvider` in
+    /// `crates/common/evm/src/eip8130.rs`, which currently inherits the trait
+    /// default `StorageFeatures::Legacy` when accessing `NonceManagerStorage` and
+    /// `TxContextStorage` before the first EVM call frame. Regular precompile
+    /// wrappers should thread `upgrade` through their constructor and call
+    /// [`from_upgrade`](Self::from_upgrade) instead, so their features track the
+    /// same signal that gated the wrapper's install.
     pub fn at_least(min: BaseUpgrade) -> StorageFeatures {
         Self::from_upgrade(core::cmp::max(BaseUpgrade::LATEST, min))
     }

--- a/crates/common/precompiles/src/spec.rs
+++ b/crates/common/precompiles/src/spec.rs
@@ -14,21 +14,6 @@ impl UpgradeGatedStorageFeatures {
             StorageFeatures::Legacy
         }
     }
-
-    /// Returns the persistent-storage features for a caller that must observe
-    /// features from at least `min`, resolving to `from_upgrade(max(BaseUpgrade::LATEST, min))`.
-    ///
-    /// Intended for callers that lack a live [`BaseUpgrade`] at construction — for
-    /// example the enshrined-execution `JournalStorageProvider` in
-    /// `crates/common/evm/src/eip8130.rs`, which currently inherits the trait
-    /// default `StorageFeatures::Legacy` when accessing `NonceManagerStorage` and
-    /// `TxContextStorage` before the first EVM call frame. Regular precompile
-    /// wrappers should thread `upgrade` through their constructor and call
-    /// [`from_upgrade`](Self::from_upgrade) instead, so their features track the
-    /// same signal that gated the wrapper's install.
-    pub fn at_least(min: BaseUpgrade) -> StorageFeatures {
-        Self::from_upgrade(core::cmp::max(BaseUpgrade::LATEST, min))
-    }
 }
 
 /// A chain spec that can select Base precompile sets.
@@ -59,25 +44,6 @@ mod tests {
         assert_eq!(
             UpgradeGatedStorageFeatures::from_upgrade(BaseUpgrade::Cobalt),
             StorageFeatures::Cobalt,
-        );
-    }
-
-    #[test]
-    fn at_least_honors_floor_when_latest_is_behind() {
-        // LATEST is currently pre-Cobalt; a wrapper gated at Cobalt must still get Cobalt features.
-        assert!(BaseUpgrade::LATEST < BaseUpgrade::Cobalt);
-        assert_eq!(
-            UpgradeGatedStorageFeatures::at_least(BaseUpgrade::Cobalt),
-            StorageFeatures::Cobalt,
-        );
-    }
-
-    #[test]
-    fn at_least_rides_latest_when_latest_meets_floor() {
-        // A wrapper with a pre-Cobalt floor tracks whatever LATEST already provides.
-        assert_eq!(
-            UpgradeGatedStorageFeatures::at_least(BaseUpgrade::Beryl),
-            UpgradeGatedStorageFeatures::from_upgrade(BaseUpgrade::LATEST),
         );
     }
 }

--- a/crates/common/precompiles/src/spec.rs
+++ b/crates/common/precompiles/src/spec.rs
@@ -14,6 +14,14 @@ impl UpgradeGatedStorageFeatures {
             StorageFeatures::Legacy
         }
     }
+
+    /// Returns the persistent-storage features for a wrapper that must run at
+    /// `min` or later. Resolves to `from_upgrade(max(BaseUpgrade::LATEST, min))`
+    /// so an install site that is gated at `min` never underruns its own gate,
+    /// but still rides `LATEST` once it advances past `min`.
+    pub fn at_least(min: BaseUpgrade) -> StorageFeatures {
+        Self::from_upgrade(core::cmp::max(BaseUpgrade::LATEST, min))
+    }
 }
 
 /// A chain spec that can select Base precompile sets.
@@ -44,6 +52,25 @@ mod tests {
         assert_eq!(
             UpgradeGatedStorageFeatures::from_upgrade(BaseUpgrade::Cobalt),
             StorageFeatures::Cobalt,
+        );
+    }
+
+    #[test]
+    fn at_least_honors_floor_when_latest_is_behind() {
+        // LATEST is currently pre-Cobalt; a wrapper gated at Cobalt must still get Cobalt features.
+        assert!(BaseUpgrade::LATEST < BaseUpgrade::Cobalt);
+        assert_eq!(
+            UpgradeGatedStorageFeatures::at_least(BaseUpgrade::Cobalt),
+            StorageFeatures::Cobalt,
+        );
+    }
+
+    #[test]
+    fn at_least_rides_latest_when_latest_meets_floor() {
+        // A wrapper with a pre-Cobalt floor tracks whatever LATEST already provides.
+        assert_eq!(
+            UpgradeGatedStorageFeatures::at_least(BaseUpgrade::Beryl),
+            UpgradeGatedStorageFeatures::from_upgrade(BaseUpgrade::LATEST),
         );
     }
 }

--- a/crates/common/precompiles/src/tx_context/precompile.rs
+++ b/crates/common/precompiles/src/tx_context/precompile.rs
@@ -1,10 +1,36 @@
 //! Precompile entry point for the EIP-8130 transaction context.
 
+use base_common_genesis::BaseUpgrade;
 use base_precompile_macros::precompile;
 
-use crate::TxContextStorage;
+use crate::{TxContextStorage, UpgradeGatedStorageFeatures};
 
 /// Entry point for the EIP-8130 transaction context precompile.
-#[precompile(install)]
+///
+/// Only installed at Cobalt or later (see `BasePrecompiles::install_with_observer`),
+/// so the wrapper pins its storage features to at least Cobalt while riding
+/// `BaseUpgrade::LATEST` when LATEST already meets that floor.
+#[precompile(
+    install,
+    storage_features = UpgradeGatedStorageFeatures::at_least(BaseUpgrade::Cobalt),
+)]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TxContext;
+
+#[cfg(test)]
+mod tests {
+    use alloy_evm::precompiles::PrecompilesMap;
+    use revm::precompile::Precompiles;
+
+    use crate::{TxContext, TxContextStorage};
+
+    // Feature-selection verification chain: see the sibling module
+    // `crate::nonce::precompile::tests` for the full argument.
+    #[test]
+    fn install_places_wrapper_at_storage_address() {
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
+        TxContext::install(&mut precompiles);
+
+        assert!(precompiles.get(&TxContextStorage::ADDRESS).is_some());
+    }
+}

--- a/crates/common/precompiles/src/tx_context/precompile.rs
+++ b/crates/common/precompiles/src/tx_context/precompile.rs
@@ -1,35 +1,54 @@
 //! Precompile entry point for the EIP-8130 transaction context.
 
+use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
 use base_common_genesis::BaseUpgrade;
-use base_precompile_macros::precompile;
 
-use crate::{TxContextStorage, UpgradeGatedStorageFeatures};
+use crate::{TxContextStorage, UpgradeGatedStorageFeatures, macros::base_precompile};
 
 /// Entry point for the EIP-8130 transaction context precompile.
 ///
-/// Only installed at Cobalt or later (see `BasePrecompiles::install_with_observer`),
-/// so the wrapper pins its storage features to at least Cobalt while riding
-/// `BaseUpgrade::LATEST` when LATEST already meets that floor.
-#[precompile(
-    install,
-    storage_features = UpgradeGatedStorageFeatures::at_least(BaseUpgrade::Cobalt),
-)]
+/// Only installed at Cobalt or later (see `BasePrecompiles::install_with_observer`).
+/// The caller passes the active `upgrade` through the constructor, and the wrapper
+/// derives its storage features from it via `UpgradeGatedStorageFeatures::from_upgrade`
+/// — the same signal every other install site consumes — so features stay locked to
+/// the fork that drove the install decision.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TxContext;
+
+impl TxContext {
+    /// Installs the `TxContext` precompile, gated to the storage features active
+    /// at `upgrade`.
+    pub fn install(precompiles: &mut PrecompilesMap, upgrade: BaseUpgrade) {
+        precompiles.extend_precompiles(core::iter::once((
+            TxContextStorage::ADDRESS,
+            Self::precompile(upgrade),
+        )));
+    }
+
+    /// Creates the EVM precompile wrapper for `TxContext`, gated to the storage
+    /// features active at `upgrade`.
+    pub fn precompile(upgrade: BaseUpgrade) -> DynPrecompile {
+        let storage_features = UpgradeGatedStorageFeatures::from_upgrade(upgrade);
+        base_precompile!(
+            "TxContext",
+            storage_features: storage_features,
+            |ctx, calldata| TxContextStorage::new(ctx).dispatch(ctx, &calldata),
+        )
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use alloy_evm::precompiles::PrecompilesMap;
+    use base_common_genesis::BaseUpgrade;
     use revm::precompile::Precompiles;
 
     use crate::{TxContext, TxContextStorage};
 
-    // Feature-selection verification chain: see the sibling module
-    // `crate::nonce::precompile::tests` for the full argument.
     #[test]
     fn install_places_wrapper_at_storage_address() {
         let mut precompiles = PrecompilesMap::from_static(Precompiles::cancun());
-        TxContext::install(&mut precompiles);
+        TxContext::install(&mut precompiles, BaseUpgrade::Cobalt);
 
         assert!(precompiles.get(&TxContextStorage::ADDRESS).is_some());
     }


### PR DESCRIPTION
## Summary

Fixes [BOP-604](https://linear.app/coinbase/issue/BOP-604) — Cantina finding [#17](https://cantina.xyz/code/3a3e0d24-1cb7-474c-87ef-f0ad2350b5c4/findings/17) (Informational).

`#[precompile(install)]` expanded through `base_precompile!`'s no-feature arm, which hard-codes `StorageFeatures::Legacy`. Both wrappers using it — `NonceManager` and `TxContext` — are installed only at Cobalt+ (see `provider.rs:237`), so today they ran Cobalt-era logic through a `Legacy` storage provider. Current fixed layouts show no behavior difference, but the next feature-sensitive storage field would silently inherit the wrong semantics.

## Change

- **`crates/common/precompiles/src/spec.rs`** — add `UpgradeGatedStorageFeatures::at_least(min: BaseUpgrade) -> StorageFeatures`, returning `from_upgrade(max(BaseUpgrade::LATEST, min))`. A wrapper gated at `min` cannot underrun its own gate but still rides `LATEST` once LATEST advances past `min`.
- **`crates/common/precompile-macros/src/precompile.rs`** — extend `#[precompile(...)]` to accept `storage_features = <expr>` and thread it into the `storage_features:` arm of `base_precompile!` instead of the Legacy-default arm.
- **`crates/common/precompiles/src/nonce/precompile.rs`** and **`crates/common/precompiles/src/tx_context/precompile.rs`** — annotate both wrappers with `storage_features = UpgradeGatedStorageFeatures::at_least(BaseUpgrade::Cobalt)`.

## Verification chain

Cantina explicitly asked for a wrapper test asserting Cobalt is selected. End-to-end DynPrecompile invocation would need an `EvmInternals` harness this crate doesn't stand up; instead, three independently-tested links prove the chain:

1. `spec::tests::at_least_honors_floor_when_latest_is_behind` — helper returns `Cobalt` when `LATEST < Cobalt` (today's state).
2. `base_precompile_macros::precompile::tests::storage_features_arg_threads_through_expansion` — the macro threads the expression into the `storage_features:` arm.
3. `crates/common/precompiles/src/macros.rs` — `base_precompile!` feeds `$storage_features` into `EvmPrecompileStorageProvider::new_with_storage_features`.

Combined with `nonce_manager_is_installed_at_cobalt` / `tx_context_is_installed_at_cobalt` (pre-existing) plus install-placement smoke tests added in each wrapper file.

## Test plan

- [x] `cargo test -p base-common-precompiles --lib` — 679 pass
- [x] `cargo test -p base-precompile-macros --lib` — 29 pass
- [x] `cargo build -p base-common-precompiles -p base-precompile-macros -p base-precompile-storage -p base-common-evm`
- [x] `cargo clippy -p base-common-precompiles -p base-precompile-macros --lib --tests -- -D warnings`

## Notes

Supersedes #4745 (same ticket, different approach — this PR extends the macro so all `#[precompile(install)]` sites become explicit at their point of declaration, rather than only patching the two call sites).

Related: [BOP-615](https://linear.app/coinbase/issue/BOP-615) deletes the analogous `EvmPrecompileStorageProvider::new()` Legacy-default footgun one layer down.