### PR TITLE
docs(tests): clarify batch parent validation comments

### DIFF
--- a/actions/harness/tests/batcher/gap_filling.rs
+++ b/actions/harness/tests/batcher/gap_filling.rs
@@ -25,7 +25,8 @@ use base_batcher_encoder::{DaType, EncoderConfig};
 /// 2. **Phase 2** — [`signal_reorg`] clears the encoder, then the batcher posts
 ///    blocks 8-10.
 ///    These land on L1 but the verifier **cannot** derive them because
-///    blocks 6-7 are missing (parent-hash mismatch against safe head 5).
+///    blocks 6-7 are missing. Block 8's timestamp is ahead of the next expected
+///    slot (block 6), so it is classified as future.
 ///
 /// 3. **Phase 3** — [`signal_reorg`] clears the encoder again, then the batcher
 ///    posts blocks 6-10. The verifier derives all remaining blocks and reaches
@@ -87,8 +88,8 @@ async fn batcher_gap_fill_single_instance_reorg_signal() {
     batcher.advance(&mut h.l1).await;
     chain.push(h.l1.tip().clone());
 
-    // The verifier should NOT advance past 5: batches for 8-10 have
-    // parent_hash = hash(block 7) which doesn't match safe_head hash(block 5).
+    // The verifier should NOT advance past 5: block 8's timestamp is ahead of the next expected
+    // slot (block 6), so it is classified as future.
     let derived = node.run_until_idle().await;
     assert_eq!(
         node.l2_safe_number(),

--- a/actions/harness/tests/batcher/upgrade_transitions.rs
+++ b/actions/harness/tests/batcher/upgrade_transitions.rs
@@ -112,10 +112,9 @@ async fn span_batch_with_non_empty_transition_block_rejected() {
     // starting from genesis, advance it to block 2's state, then build the
     // correct recovery blocks 3 (empty, ts=6) and 4 (user tx, ts=8).
     //
-    // The Holocene BatchValidator overwrites each singular batch's parent_hash
-    // with the current chain head before validating, so the recovery blocks
-    // only need the correct timestamps and user-tx content — not the exact
-    // parent hashes from the primary sequencer's chain.
+    // Rebuilding blocks 1–2 deterministically makes the recovery span's parent check match
+    // canonical block 2. `BatchStream` then assigns each span-derived singular the current
+    // safe-head hash when emitting it.
     {
         let l1_chain2 = SharedL1Chain::from_blocks(h.l1.chain().to_vec());
         let mut builder2 = h.create_l2_sequencer(l1_chain2);


### PR DESCRIPTION
## Summary
Updates some comments as a follow-up to [#4812](https://github.com/base/base/pull/4812), which changed `BatchValidator` to preserve the encoded parent hash of direct singular batches instead of overwriting it with the current safe-head hash.
