### PR TITLE
chore(ci): bump Cobalt base-anvil pin

### DIFF
--- a/.depot/workflows/base-std-fork-tests.yml
+++ b/.depot/workflows/base-std-fork-tests.yml
@@ -36,7 +36,7 @@ jobs:
             base_std_ref: v1.0.0
           - fork: Cobalt
             key: cobalt
-            base_anvil_ref: fb00db40ee7e12ba271b5b0b546af7a669b7075e
+            base_anvil_ref: 3983d1f5c13592c5074bb47df67fa58f1295d758
             base_std_ref: e30b34212689186b27acd3d340ba0d75d31495e9
     env:
       FORK_NAME: ${{ matrix.fork }}


### PR DESCRIPTION
## Summary
- Point the Cobalt row in `base-std-fork-tests.yml` at `base-anvil@3983d1f5` (base-anvil#74, which bumps the `base/base` pin) instead of `fb00db40` (the Rust 1.96 bump).
- Beryl's pin and the Cobalt `base_std_ref` are unchanged.

## Test plan
- [ ] Confirm CI `Base Std Interface Tests (Cobalt)` checks out `3983d1f5c13592c5074bb47df67fa58f1295d758` and passes.
- [ ] Confirm Beryl fork tests still use the previous `base_anvil_ref`.


Made with [Cursor](https://cursor.com)