### PR TITLE
ci: test sccache client-side mode

### DIFF
--- a/.depot/workflows/action-tests.yml
+++ b/.depot/workflows/action-tests.yml
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: true
 env:
   CARGO_TERM_COLOR: always
+  SCCACHE_CLIENT_SIDE: "1"
   RUSTC_WRAPPER: "sccache"
 permissions:
   contents: read
@@ -35,6 +36,14 @@ jobs:
           foundry: "true"
           components: clippy
           tools: cargo-nextest
+      - name: Check sccache error logging
+        shell: bash
+        run: |
+          if [[ -v SCCACHE_ERROR_LOG ]]; then
+            echo "SCCACHE_ERROR_LOG is set"
+          else
+            echo "SCCACHE_ERROR_LOG is not set"
+          fi
       - name: Build test contracts
         run: just build::contracts
       - name: Lint action tests

--- a/.depot/workflows/action-tests.yml
+++ b/.depot/workflows/action-tests.yml
@@ -14,6 +14,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   SCCACHE_CLIENT_SIDE: "1"
+  SCCACHE_MAX_FRAME_LENGTH: "536870912"
   RUSTC_WRAPPER: "sccache"
 permissions:
   contents: read
@@ -36,9 +37,14 @@ jobs:
           foundry: "true"
           components: clippy
           tools: cargo-nextest
-      - name: Check sccache error logging
+      - name: Check sccache logging
         shell: bash
         run: |
+          if [[ -v SCCACHE_LOG ]]; then
+            echo "SCCACHE_LOG is set"
+          else
+            echo "SCCACHE_LOG is not set"
+          fi
           if [[ -v SCCACHE_ERROR_LOG ]]; then
             echo "SCCACHE_ERROR_LOG is set"
           else


### PR DESCRIPTION
## Summary

- enables `SCCACHE_CLIENT_SIDE=1` for the Action Tests workflow
- reports whether `SCCACHE_ERROR_LOG` is set in the CI environment

## Test plan

- [x] Parse the modified workflow YAML
- [x] Run `git diff --check`
- [ ] Observe Action Tests and sccache statistics in CI