### PR TITLE
feat(eip8130): reject seconds-denominated validity bounds at mempool ingress

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -278,6 +278,30 @@ impl Eip8130Constants {
     /// `MAX_CODE_SIZE` limit. EIP-8130 places runtime code directly, so the
     /// mempool rejects oversized code before execution.
     pub const MAX_CODE_SIZE: usize = 24_576;
+
+    /// Heuristic unit boundary distinguishing **seconds** from **milliseconds**
+    /// for the transaction validity-window bounds (`valid_after`/`valid_before`),
+    /// per EIP-8130 "Timestamp Normalization": a non-zero bound below this is a
+    /// seconds value, at or above it is milliseconds. A Unix timestamp in seconds
+    /// does not reach `10^11` until the year 5138, while a millisecond Unix
+    /// timestamp has exceeded `10^11` since 1973, so the split is unambiguous for
+    /// every realistic value.
+    ///
+    /// This node currently admits **millisecond**-denominated bounds only and
+    /// uses the threshold to reject seconds-denominated bounds at ingress with an
+    /// actionable error (see [`Self::timestamp_is_seconds`]) instead of silently
+    /// misreading them as long-expired. Full per-value seconds/ms normalization
+    /// (accepting both, per the spec) is a separate consensus-level change.
+    pub const TIMESTAMP_MS_THRESHOLD: u64 = 100_000_000_000;
+
+    /// Whether `value` is a non-zero validity-window bound that appears to be
+    /// denominated in **seconds** rather than milliseconds — i.e. below
+    /// [`Self::TIMESTAMP_MS_THRESHOLD`]. A `0` bound means "no bound" and returns
+    /// `false`.
+    #[must_use]
+    pub const fn timestamp_is_seconds(value: u64) -> bool {
+        value != 0 && value < Self::TIMESTAMP_MS_THRESHOLD
+    }
 }
 
 #[cfg(test)]
@@ -298,6 +322,21 @@ mod tests {
         assert_ne!(Eip8130Constants::EIP8130_TX_TYPE, EIP1559_TX_TYPE);
         assert_ne!(Eip8130Constants::EIP8130_TX_TYPE, EIP7702_TX_TYPE);
         assert_ne!(Eip8130Constants::EIP8130_TX_TYPE, DEPOSIT_TX_TYPE);
+    }
+
+    #[test]
+    fn timestamp_is_seconds_detects_sub_threshold_nonzero_bounds() {
+        // `0` means "no bound" and is never flagged.
+        assert!(!Eip8130Constants::timestamp_is_seconds(0));
+        // Anything non-zero below the threshold is treated as seconds.
+        assert!(Eip8130Constants::timestamp_is_seconds(1));
+        assert!(Eip8130Constants::timestamp_is_seconds(1_700_000_000)); // ~now, in seconds
+        assert!(Eip8130Constants::timestamp_is_seconds(
+            Eip8130Constants::TIMESTAMP_MS_THRESHOLD - 1
+        ));
+        // At and above the threshold is milliseconds.
+        assert!(!Eip8130Constants::timestamp_is_seconds(Eip8130Constants::TIMESTAMP_MS_THRESHOLD));
+        assert!(!Eip8130Constants::timestamp_is_seconds(1_700_000_000_000)); // ~now, in ms
     }
 
     #[test]

--- a/crates/common/consensus/src/transaction/eip8130/signed.rs
+++ b/crates/common/consensus/src/transaction/eip8130/signed.rs
@@ -135,6 +135,18 @@ pub enum Eip8130StaticError {
 /// same pass keeps the nonce-free rules in one place.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum Eip8130TimestampError {
+    /// A non-zero `valid_after`/`valid_before` bound appears to be denominated in
+    /// **seconds** rather than milliseconds (below
+    /// [`Eip8130Constants::TIMESTAMP_MS_THRESHOLD`]).
+    ///
+    /// Like [`Self::NonceFreeMalformed`] this is a `now`-independent structural
+    /// check on the transaction's fields, not a timing relationship. This node
+    /// admits millisecond-denominated bounds only; a seconds value compared
+    /// against `block.timestamp * 1000` would otherwise be misread as
+    /// long-expired, so it is rejected up front with an actionable reason
+    /// instead of a misleading [`Self::Expired`]/[`Self::NotYetValid`].
+    #[error("valid_after/valid_before must be Unix milliseconds, not seconds")]
+    TimestampNotMilliseconds,
     /// Nonce-free mode (`nonce_key == NONCE_KEY_MAX`) requires `nonce_sequence
     /// == 0` and a non-zero `valid_before`; one of those invariants is violated.
     ///
@@ -244,6 +256,18 @@ impl Eip8130Signed {
     /// concurrently.
     pub fn validate_timestamp(&self, now: u64) -> Result<(), Eip8130TimestampError> {
         let tx = self.tx();
+        // Unit guard first (field-format, `now`-independent): this node admits
+        // millisecond-denominated bounds only. A non-zero bound below
+        // `TIMESTAMP_MS_THRESHOLD` is almost certainly a seconds value, which —
+        // compared against `block.timestamp * 1000` below — would be misread as
+        // long-expired. Reject it with an actionable reason rather than a
+        // misleading `Expired`/`NotYetValid`. (Full per-value seconds/ms
+        // normalization, accepting both, is a separate consensus-level change.)
+        if Eip8130Constants::timestamp_is_seconds(tx.valid_after)
+            || Eip8130Constants::timestamp_is_seconds(tx.valid_before)
+        {
+            return Err(Eip8130TimestampError::TimestampNotMilliseconds);
+        }
         if tx.nonce_key == Eip8130Constants::NONCE_KEY_MAX {
             // Structural precondition first (independent of `now`).
             if tx.nonce_sequence != 0 || tx.valid_before == 0 {
@@ -783,7 +807,9 @@ mod tests {
 
     #[test]
     fn timestamp_validation_covers_channel_and_nonce_free_rules() {
-        let now = 1_000;
+        // Millisecond-scale reference so the window arithmetic stays above the
+        // seconds/ms unit guard (`TIMESTAMP_MS_THRESHOLD`).
+        let now = 1_700_000_000_000;
         let mut tx = sample_signed(false).into_tx();
         // Nonce-bearing upper bound is inclusive: valid at `now == valid_before`,
         // expired only once `now` is strictly past it.
@@ -823,6 +849,57 @@ mod tests {
         tx.valid_before = now + 1;
         assert_eq!(
             Eip8130Signed::new(tx, Bytes::new(), Bytes::new()).validate_timestamp(now),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn seconds_denominated_bounds_are_rejected_before_window_checks() {
+        // This node admits millisecond bounds only: a non-zero bound below
+        // `TIMESTAMP_MS_THRESHOLD` is treated as seconds and rejected up front
+        // with `TimestampNotMilliseconds`, not the misleading `Expired` /
+        // `NotYetValid` a raw comparison against `block.timestamp * 1000` would
+        // otherwise produce.
+        let now = 1_700_000_000_000;
+        let secs = Eip8130Constants::TIMESTAMP_MS_THRESHOLD - 1; // largest seconds value
+        let base = sample_signed(false).into_tx();
+
+        // `valid_before` in seconds.
+        let mut tx = base.clone();
+        tx.valid_before = secs;
+        assert_eq!(
+            Eip8130Signed::new(tx, Bytes::new(), Bytes::new()).validate_timestamp(now),
+            Err(Eip8130TimestampError::TimestampNotMilliseconds)
+        );
+
+        // `valid_after` in seconds (independent of `valid_before`).
+        let mut tx = base.clone();
+        tx.valid_after = secs;
+        tx.valid_before = 0;
+        assert_eq!(
+            Eip8130Signed::new(tx, Bytes::new(), Bytes::new()).validate_timestamp(now),
+            Err(Eip8130TimestampError::TimestampNotMilliseconds)
+        );
+
+        // The unit guard precedes the nonce-free structural/window checks: a
+        // seconds `valid_before` reports the unit error, not `NonceFreeExpired`.
+        let mut tx = base.clone();
+        tx.nonce_key = Eip8130Constants::NONCE_KEY_MAX;
+        tx.nonce_sequence = 0;
+        tx.valid_before = secs;
+        assert_eq!(
+            Eip8130Signed::new(tx, Bytes::new(), Bytes::new()).validate_timestamp(now),
+            Err(Eip8130TimestampError::TimestampNotMilliseconds)
+        );
+
+        // Boundary: exactly `TIMESTAMP_MS_THRESHOLD` is milliseconds (not
+        // seconds), so it clears the unit guard. Evaluated at `now == valid_before`
+        // it is inclusively valid — proving the threshold value is admitted.
+        let mut tx = base;
+        tx.valid_before = Eip8130Constants::TIMESTAMP_MS_THRESHOLD;
+        assert_eq!(
+            Eip8130Signed::new(tx, Bytes::new(), Bytes::new())
+                .validate_timestamp(Eip8130Constants::TIMESTAMP_MS_THRESHOLD),
             Ok(())
         );
     }

--- a/crates/execution/txpool/src/pool.rs
+++ b/crates/execution/txpool/src/pool.rs
@@ -2029,6 +2029,14 @@ mod tests {
         BaseEvmConfig,
     >;
 
+    /// Realistic head-block timestamp (Unix **seconds**, ~Nov 2023) seeded into
+    /// the integration harness. `NOW_MS = NOW_SECS * 1000` is the millisecond
+    /// reference the pool derives from `block.timestamp`; nonce-free validity
+    /// bounds are expressed relative to it so they clear the seconds/ms unit
+    /// guard (`Eip8130Constants::TIMESTAMP_MS_THRESHOLD`).
+    const NOW_SECS: u64 = 1_700_000_000;
+    const NOW_MS: u64 = NOW_SECS * 1_000;
+
     fn build_integration_pool()
     -> (IntegrationPool, MockEthProvider<BasePrimitives, Arc<BaseChainSpec>>) {
         let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().cobalt_activated().build());
@@ -2042,7 +2050,13 @@ mod tests {
             .no_cancun()
             .build_with_tasks(Runtime::test(), blob_store.clone())
             .map(|inner| {
-                BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default())
+                // Seed a realistic head-block timestamp (Unix seconds) so
+                // nonce-free millisecond validity bounds (`block.timestamp *
+                // 1000 = NOW_MS`) clear the seconds/ms unit guard
+                // (`Eip8130Constants::TIMESTAMP_MS_THRESHOLD`).
+                let block_info = BaseL1BlockInfo::default();
+                block_info.set_timestamp(NOW_SECS);
+                BaseTransactionValidator::with_block_info(inner, block_info)
                     .require_l1_data_gas_fee(false)
             });
         let ordering = BaseOrdering::default();
@@ -2157,22 +2171,40 @@ mod tests {
 
         let mut admitted = Vec::new();
         for offset in 0..cap {
-            let transaction =
-                self_paid_eoa_8130(&signer, Eip8130Constants::NONCE_KEY_MAX, 0, offset + 1, 1_000);
+            // Distinct millisecond `valid_before` per member, each inside the
+            // nonce-free window `(NOW_MS, NOW_MS + NONCE_FREE_MAX_EXPIRY_WINDOW]`.
+            let transaction = self_paid_eoa_8130(
+                &signer,
+                Eip8130Constants::NONCE_KEY_MAX,
+                0,
+                NOW_MS + offset + 1,
+                1_000,
+            );
             admitted.push(*transaction.hash());
             assert!(pool.add_transaction(TransactionOrigin::Local, transaction).await.is_ok());
         }
         assert!(admitted.iter().all(|hash| pool.nonce_pool.read().contains(hash)));
 
-        let over = self_paid_eoa_8130(&signer, Eip8130Constants::NONCE_KEY_MAX, 0, cap + 1, 1_000);
+        let over = self_paid_eoa_8130(
+            &signer,
+            Eip8130Constants::NONCE_KEY_MAX,
+            0,
+            NOW_MS + cap + 1,
+            1_000,
+        );
         let over_hash = *over.hash();
         assert!(pool.add_transaction(TransactionOrigin::Local, over).await.is_err());
         assert!(pool.get(&over_hash).is_none());
 
         let removed = pool.remove_transactions(vec![admitted[0]]);
         assert_eq!(removed.len(), 1);
-        let replacement =
-            self_paid_eoa_8130(&signer, Eip8130Constants::NONCE_KEY_MAX, 0, cap + 2, 1_000);
+        let replacement = self_paid_eoa_8130(
+            &signer,
+            Eip8130Constants::NONCE_KEY_MAX,
+            0,
+            NOW_MS + cap + 2,
+            1_000,
+        );
         assert!(pool.add_transaction(TransactionOrigin::Local, replacement).await.is_ok());
     }
 
@@ -2306,7 +2338,7 @@ mod tests {
             &signer,
             Eip8130Constants::NONCE_KEY_MAX,
             0,
-            Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW,
+            NOW_MS + Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW,
             1_000,
         );
         let nonce_free_hash = *nonce_free.hash();
@@ -2353,7 +2385,7 @@ mod tests {
             &signer,
             Eip8130Constants::NONCE_KEY_MAX,
             0,
-            Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW,
+            NOW_MS + Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW,
             1_000,
         );
         let hash = *transaction.hash();

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -661,6 +661,14 @@ impl BaseL1BlockInfo {
     pub fn timestamp(&self) -> u64 {
         self.timestamp.load(Ordering::Relaxed)
     }
+
+    /// Overwrites the tracked block timestamp (Unix seconds). Symmetric with
+    /// [`Self::timestamp`]; used to seed or advance the validator clock in dev
+    /// and test setups without threading a full header through
+    /// [`BaseTransactionValidator::update_l1_block_info`].
+    pub fn set_timestamp(&self, timestamp: u64) {
+        self.timestamp.store(timestamp, Ordering::Relaxed);
+    }
 }
 
 /// Validator for Base transactions.
@@ -1608,6 +1616,9 @@ where
         now: u64,
     ) -> InvalidPoolTransactionError {
         let reason = match error {
+            Eip8130TimestampError::TimestampNotMilliseconds => {
+                "valid_after/valid_before must be Unix milliseconds, not seconds"
+            }
             Eip8130TimestampError::NonceFreeMalformed => {
                 "nonce-free transaction must set a non-zero valid_before and a zero nonce sequence"
             }
@@ -2199,6 +2210,20 @@ mod tests {
         build_test_validator_with_spec(chain_spec)
     }
 
+    /// Realistic head-block timestamp (Unix **seconds**, ~Nov 2023) for
+    /// timestamp-window tests. `NOW_MS = NOW_SECS * 1000` is the millisecond
+    /// reference the pool derives from `block.timestamp`; both millisecond
+    /// validity bounds stay well above the seconds/ms unit guard
+    /// (`Eip8130Constants::TIMESTAMP_MS_THRESHOLD`).
+    const NOW_SECS: u64 = 1_700_000_000;
+    const NOW_MS: u64 = NOW_SECS * 1_000;
+
+    /// Advances a test validator's tracked head-block timestamp to `secs`.
+    fn set_block_timestamp(validator: &TestValidator, secs: u64) {
+        let header = alloy_consensus::Header { timestamp: secs, ..Default::default() };
+        validator.update_l1_block_info::<_, TxEip1559>(&header, None);
+    }
+
     /// Builds a Cobalt-activated validator with one canonical account seeded.
     fn build_test_validator_with_account(
         address: Address,
@@ -2593,7 +2618,9 @@ mod tests {
         let tx = TxEip8130 {
             nonce_key: Eip8130Constants::NONCE_KEY_MAX,
             nonce_sequence: 1,
-            valid_before: 5,
+            // Millisecond-scale bound so the unit guard passes and the nonzero
+            // sequence is what trips the structural check.
+            valid_before: NOW_MS + 10_000,
             ..minimal_valid_eoa_tx()
         };
         let signed = sign_eoa_eip8130(tx);
@@ -2605,17 +2632,15 @@ mod tests {
 
     #[test]
     fn rejects_eip8130_nonce_free_already_expired() {
-        // Advance the validator's tracked block timestamp to 100s (now_ms =
-        // 100_000) so that valid_before=50_000 is strictly in the past; the
-        // default fixture sits at timestamp 0 where there is no way to express
-        // "already expired".
+        // Advance the block timestamp to a realistic `now_ms` so a millisecond
+        // `valid_before` strictly in the past expresses "already expired" while
+        // clearing the seconds/ms unit guard.
         let validator = build_test_validator();
-        let header = alloy_consensus::Header { timestamp: 100, ..Default::default() };
-        validator.update_l1_block_info::<_, TxEip1559>(&header, None);
+        set_block_timestamp(&validator, NOW_SECS);
         let tx = TxEip8130 {
             nonce_key: Eip8130Constants::NONCE_KEY_MAX,
             nonce_sequence: 0,
-            valid_before: 50_000,
+            valid_before: NOW_MS - 1_000,
             ..minimal_valid_eoa_tx()
         };
         let signed = sign_eoa_eip8130(tx);
@@ -2627,15 +2652,15 @@ mod tests {
 
     #[test]
     fn rejects_eip8130_nonce_free_not_yet_valid() {
-        // Default fixture sits at block timestamp 0 (now_ms = 0). A future
-        // `valid_after` opens the window later, so the nonce-free branch must
-        // reject with `NotYetValid` before the (satisfiable) expiry checks.
+        // A future `valid_after` opens the window later, so the nonce-free branch
+        // must reject with `NotYetValid` before the (satisfiable) expiry checks.
         let validator = build_test_validator();
+        set_block_timestamp(&validator, NOW_SECS);
         let tx = TxEip8130 {
             nonce_key: Eip8130Constants::NONCE_KEY_MAX,
             nonce_sequence: 0,
-            valid_after: 50_000,
-            valid_before: 60_000,
+            valid_after: NOW_MS + 5_000,
+            valid_before: NOW_MS + 10_000,
             ..minimal_valid_eoa_tx()
         };
         let signed = sign_eoa_eip8130(tx);
@@ -2647,11 +2672,11 @@ mod tests {
 
     #[test]
     fn rejects_eip8130_nonce_bearing_not_yet_valid() {
-        // Sequenced (nonce-bearing) transaction with a future `valid_after` and
-        // now_ms = 0: the else-branch of `validate_timestamp` must reject with
-        // `NotYetValid`.
+        // Sequenced (nonce-bearing) transaction with a future `valid_after`: the
+        // else-branch of `validate_timestamp` must reject with `NotYetValid`.
         let validator = build_test_validator();
-        let tx = TxEip8130 { valid_after: 50_000, ..minimal_valid_eoa_tx() };
+        set_block_timestamp(&validator, NOW_SECS);
+        let tx = TxEip8130 { valid_after: NOW_MS + 50_000, ..minimal_valid_eoa_tx() };
         let signed = sign_eoa_eip8130(tx);
         assert_structural_reason(
             validator.validate_eip8130_structural(&signed),
@@ -2660,13 +2685,39 @@ mod tests {
     }
 
     #[test]
+    fn rejects_eip8130_seconds_denominated_bounds_with_unit_reason() {
+        // A validity bound passed in Unix *seconds* (below TIMESTAMP_MS_THRESHOLD)
+        // is rejected at ingress with an actionable unit error, not a misleading
+        // "not yet valid" / "already elapsed" it would produce when compared
+        // against `block.timestamp * 1000`.
+        let validator = build_test_validator();
+        set_block_timestamp(&validator, NOW_SECS);
+
+        // `valid_before` in seconds (nonce-bearing path).
+        let tx = TxEip8130 { valid_before: NOW_SECS, ..minimal_valid_eoa_tx() };
+        assert_structural_reason(
+            validator.validate_eip8130_structural(&sign_eoa_eip8130(tx)),
+            "valid_after/valid_before must be Unix milliseconds, not seconds",
+        );
+
+        // `valid_after` in seconds.
+        let tx = TxEip8130 { valid_after: NOW_SECS, ..minimal_valid_eoa_tx() };
+        assert_structural_reason(
+            validator.validate_eip8130_structural(&sign_eoa_eip8130(tx)),
+            "valid_after/valid_before must be Unix milliseconds, not seconds",
+        );
+    }
+
+    #[test]
     fn rejects_eip8130_nonce_free_expiry_too_far_in_future() {
         let validator = build_test_validator();
-        // block_timestamp returns 0 by default; cap is NONCE_FREE_MAX_EXPIRY_WINDOW.
+        // Window cap is NONCE_FREE_MAX_EXPIRY_WINDOW past `now_ms`; one past it is
+        // "too far". Realistic `now_ms` keeps the bound above the unit guard.
+        set_block_timestamp(&validator, NOW_SECS);
         let tx = TxEip8130 {
             nonce_key: Eip8130Constants::NONCE_KEY_MAX,
             nonce_sequence: 0,
-            valid_before: Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW + 1,
+            valid_before: NOW_MS + Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW + 1,
             ..minimal_valid_eoa_tx()
         };
         let signed = sign_eoa_eip8130(tx);
@@ -2679,10 +2730,11 @@ mod tests {
     #[test]
     fn accepts_eip8130_nonce_free_at_expiry_window_edge() {
         let validator = build_test_validator();
+        set_block_timestamp(&validator, NOW_SECS);
         let tx = TxEip8130 {
             nonce_key: Eip8130Constants::NONCE_KEY_MAX,
             nonce_sequence: 0,
-            valid_before: Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW,
+            valid_before: NOW_MS + Eip8130Constants::NONCE_FREE_MAX_EXPIRY_WINDOW,
             ..minimal_valid_eoa_tx()
         };
         let signed = sign_eoa_eip8130(tx);


### PR DESCRIPTION
## Summary

EIP-8130 `valid_after`/`valid_before` are Unix **milliseconds**, evaluated on-chain against `block.timestamp * 1000`. A bound accidentally supplied in **seconds** (e.g. `1_700_000_000` instead of `1_700_000_000_000`) is ~1000× too small. Today the mempool would reject it with a misleading reason — `"transaction is not yet valid"` / `"transaction validity window has elapsed"` — and worse, a seconds-valued `valid_after` would be treated as *already active* at execution rather than delaying activation.

This adds a **unit guard at mempool ingress**: a non-zero bound below `TIMESTAMP_MS_THRESHOLD` (`10^11`, the seconds/ms split from the EIP's Timestamp Normalization section) is rejected up front with an actionable reason:

> `valid_after/valid_before must be Unix milliseconds, not seconds`

## Scope: pool-only, non-consensus

Block validity is **unchanged** — the execution path in `common/evm/src/eip8130.rs` is untouched, so no fork coordination is required. A seconds-valued tx that bypassed the pool would still fail its window check at execution (it is long-"expired" against `block.timestamp * 1000`), so no honest block producer could include it. This guard purely upgrades the *mempool rejection reason* from confusing to actionable, and closes the `valid_after`-in-seconds footgun.

This is **deliberately stricter than the EIP**, which normalizes seconds vs. milliseconds *per value* (accepting both). Full acceptance of both denominations is a separate, **consensus-level** change (it must also normalize in the execution/block-validity path); this PR is the safe interim step.

## Changes

- **`constants.rs`** — `Eip8130Constants::TIMESTAMP_MS_THRESHOLD` (`100_000_000_000`) and a `timestamp_is_seconds(value)` helper.
- **`signed.rs`** — new `Eip8130TimestampError::TimestampNotMilliseconds`, checked first (field-format, `now`-independent) in `validate_timestamp`.
- **`validator.rs`** — maps the new error to its ingress rejection reason; adds a `BaseL1BlockInfo::set_timestamp` seam so the integration harness can seed a realistic clock.
- **Tests** — new unit + ingress coverage (seconds `valid_before`/`valid_after`, threshold boundary, ordering vs. nonce-free structural checks). Existing timestamp/nonce-free fixtures migrated from toy values (`now_ms = 0`) to realistic millisecond-scale timestamps, since sub-`10^11` bounds are now (correctly) treated as seconds.

## Follow-up (not in this PR)

Full spec-conformant seconds↔ms normalization across the consensus/execution path, if we decide to accept both denominations rather than require milliseconds.