### PR TITLE
ci: remove duplicate action test lint

### DIFF
--- a/.depot/workflows/action-tests.yml
+++ b/.depot/workflows/action-tests.yml
@@ -33,11 +33,8 @@ jobs:
         with:
           native-deps: "true"
           foundry: "true"
-          components: clippy
           tools: cargo-nextest
       - name: Build test contracts
         run: just build::contracts
-      - name: Lint action tests
-        run: just actions::lint-ci
       - name: Run action tests
         run: just actions::test-ci

--- a/actions/Justfile
+++ b/actions/Justfile
@@ -25,7 +25,3 @@ check:
 # Clippy the action harness crate
 lint:
     cargo clippy -p base-action-harness --all-targets -- -D warnings
-
-# Clippy the action harness crate with the CI profile
-lint-ci:
-    cargo clippy --locked -p base-action-harness --all-targets --profile ci -- -D warnings

--- a/docs/guides/TESTING.md
+++ b/docs/guides/TESTING.md
@@ -165,9 +165,8 @@ merge queue (not pull requests) so PR feedback stays fast; they are a required s
 the queue will not merge if they fail.
 
 `action-tests.yml`, despite the name, is unrelated to testing GitHub Actions workflows — it runs
-the [action tests](#action-tests) described above (`just actions::lint-ci` and
-`just actions::test-ci`) on every PR and merge-queue run. Action tests are also a required
-status check.
+the [action tests](#action-tests) described above (`just actions::test-ci`) on every PR and
+merge-queue run. Action tests are also a required status check.
 
 
 ## Guidelines


### PR DESCRIPTION
## Summary
- remove the redundant Clippy step from the Action Tests workflow
- keep the developer-facing `actions::lint` recipe while removing `actions::lint-ci`
- update the testing guide to reflect the workflow command

The centralized PR and merge-queue Clippy jobs already cover `base-action-harness`; the centralized full-workspace CI command was also verified to catch an injected harness Clippy error.

## Testing
- `just check::clippy-ci` (expected failure with a temporary `clippy::needless_bool` probe in `base-action-harness`; probe subsequently removed)
- `just actions`
- `git diff --check`