### PR TITLE
refactor(b20): rename SEIZE_HOLDER_POLICY to SEIZE_EXEMPT_POLICY

### DIFF
--- a/.depot/workflows/base-std-fork-tests.yml
+++ b/.depot/workflows/base-std-fork-tests.yml
@@ -37,7 +37,7 @@ jobs:
           - fork: Cobalt
             key: cobalt
             base_anvil_ref: 3983d1f5c13592c5074bb47df67fa58f1295d758
-            base_std_ref: e30b34212689186b27acd3d340ba0d75d31495e9
+            base_std_ref: 607ef9a3da15b61d947af6301cbca83f8e5f9c7a
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}

--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -251,7 +251,7 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                         self.b20.transfer_executor_policy_id()
                     }
                     crate::B20PolicyType::MintReceiver => self.b20.mint_receiver_policy_id(),
-                    crate::B20PolicyType::SeizeHolder => self.b20.seize_holder_policy_id(),
+                    crate::B20PolicyType::SeizeExempt => self.b20.seize_exempt_policy_id(),
                     crate::B20PolicyType::SeizeReceiver => self.b20.seize_receiver_policy_id(),
                 }
             }
@@ -281,8 +281,8 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
                     crate::B20PolicyType::MintReceiver => {
                         self.b20.set_mint_receiver_policy_id(policy_id)
                     }
-                    crate::B20PolicyType::SeizeHolder => {
-                        self.b20.set_seize_holder_policy_id(policy_id)
+                    crate::B20PolicyType::SeizeExempt => {
+                        self.b20.set_seize_exempt_policy_id(policy_id)
                     }
                     crate::B20PolicyType::SeizeReceiver => {
                         self.b20.set_seize_receiver_policy_id(policy_id)

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -175,7 +175,7 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
                 B20PolicyType::TransferExecutor.id().abi_encode().into()
             }
             C::MINT_RECEIVER_POLICY(_) => B20PolicyType::MintReceiver.id().abi_encode().into(),
-            C::SEIZE_HOLDER_POLICY(_) => B20PolicyType::SeizeHolder.id().abi_encode().into(),
+            C::SEIZE_EXEMPT_POLICY(_) => B20PolicyType::SeizeExempt.id().abi_encode().into(),
             C::SEIZE_RECEIVER_POLICY(_) => B20PolicyType::SeizeReceiver.id().abi_encode().into(),
 
             // --- Role reads ---

--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -145,7 +145,7 @@ impl AssetV1 {
     /// Ensures `policy_scope` names a built-in B-20 policy slot available on the frozen V1 (Beryl)
     /// common surface.
     ///
-    /// The seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) were introduced at Cobalt
+    /// The seize scopes (`SEIZE_EXEMPT_POLICY` / `SEIZE_RECEIVER_POLICY`) were introduced at Cobalt
     /// (V2), so they are rejected here — matching the base-std `v1.0.0` reference. This is what keeps
     /// the common `updatePolicy` / `policyId` selectors (dialable on V1) from reaching a V2-only
     /// scope.
@@ -163,7 +163,7 @@ impl AssetV1 {
                 | B20PolicyType::MintReceiver,
             ) => Ok(()),
             // Cobalt (V2)-only scopes, and any unrecognized id, are not part of the frozen V1 surface.
-            Some(B20PolicyType::SeizeHolder | B20PolicyType::SeizeReceiver) | None => {
+            Some(B20PolicyType::SeizeExempt | B20PolicyType::SeizeReceiver) | None => {
                 Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
                     policyScope: policy_scope,
                 }))

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -187,7 +187,7 @@ impl AssetV2 {
     }
 
     /// Ensures `policy_scope` names a built-in B-20 policy slot available on the V2 (Cobalt) common
-    /// surface, which adds the seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) on top
+    /// surface, which adds the seize scopes (`SEIZE_EXEMPT_POLICY` / `SEIZE_RECEIVER_POLICY`) on top
     /// of V1.
     ///
     /// The match is exhaustive on purpose: a policy scope added to `B20PolicyType` for a future fork
@@ -200,7 +200,7 @@ impl AssetV2 {
                 | B20PolicyType::TransferReceiver
                 | B20PolicyType::TransferExecutor
                 | B20PolicyType::MintReceiver
-                | B20PolicyType::SeizeHolder
+                | B20PolicyType::SeizeExempt
                 | B20PolicyType::SeizeReceiver,
             ) => Ok(()),
             None => Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
@@ -1621,10 +1621,10 @@ mod tests {
 
     // --- seize ---
 
-    /// Points `SEIZE_HOLDER_POLICY` at the always-block policy, making every account seizable.
+    /// Points `SEIZE_EXEMPT_POLICY` at the always-block policy, making every account seizable.
     fn make_seizable(tok: &mut Tok) {
         tok.accounting_mut()
-            .set_policy_id(B20PolicyType::SeizeHolder.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+            .set_policy_id(B20PolicyType::SeizeExempt.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID)
             .unwrap();
     }
 
@@ -1660,7 +1660,7 @@ mod tests {
         let mut tok = token();
         fund(&mut tok, ALICE, U256::from(100u64));
         grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
-        // SEIZE_HOLDER_POLICY unset => ALWAYS_ALLOW => ALICE authorized => not seizable.
+        // SEIZE_EXEMPT_POLICY unset => ALWAYS_ALLOW => ALICE authorized (exempt) => not seizable.
         let err =
             LOGIC.seize_with_memo(&mut tok, ADMIN, ALICE, BOB, U256::from(1u64), MEMO).unwrap_err();
         assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotSeizable { account: ALICE }));
@@ -1683,7 +1683,7 @@ mod tests {
     #[test]
     fn seize_reverts_on_zero_from() {
         let mut tok = token();
-        // A non-default `SeizeHolder` (here ALWAYS_BLOCK via `make_seizable`) treats the zero
+        // A non-default `SeizeExempt` (here ALWAYS_BLOCK via `make_seizable`) treats the zero
         // address as seizable, so without the `from != 0` guard a zero-amount seize from the zero
         // address would emit a misleading `Transfer(0x0, to, 0)` that indexers read as a mint.
         make_seizable(&mut tok);
@@ -1791,10 +1791,10 @@ mod tests {
     }
 
     #[test]
-    fn seize_holder_policy_beats_receiver_policy() {
+    fn seize_exempt_policy_beats_receiver_policy() {
         let mut tok = token();
         grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
-        // SEIZE_HOLDER unset => ALICE not seizable; SEIZE_RECEIVER blocks BOB. Holder check fires first.
+        // SEIZE_EXEMPT unset => ALICE not seizable; SEIZE_RECEIVER blocks BOB. Exempt check fires first.
         tok.accounting_mut()
             .set_policy_id(
                 B20PolicyType::SeizeReceiver.id(),

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -165,7 +165,7 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                     B20PolicyType::TransferExecutor.id().abi_encode().into()
                 }
                 C::MINT_RECEIVER_POLICY(_) => B20PolicyType::MintReceiver.id().abi_encode().into(),
-                C::SEIZE_HOLDER_POLICY(_) => B20PolicyType::SeizeHolder.id().abi_encode().into(),
+                C::SEIZE_EXEMPT_POLICY(_) => B20PolicyType::SeizeExempt.id().abi_encode().into(),
                 C::SEIZE_RECEIVER_POLICY(_) => {
                     B20PolicyType::SeizeReceiver.id().abi_encode().into()
                 }

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -138,7 +138,7 @@ impl StablecoinV1 {
     /// Ensures `policy_scope` names a built-in B-20 policy slot available on the frozen V1 (Beryl)
     /// common surface.
     ///
-    /// The seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) were introduced at Cobalt
+    /// The seize scopes (`SEIZE_EXEMPT_POLICY` / `SEIZE_RECEIVER_POLICY`) were introduced at Cobalt
     /// (V2), so they are rejected here — matching the base-std `v1.0.0` reference. This is what keeps
     /// the common `updatePolicy` / `policyId` selectors (dialable on V1) from reaching a V2-only
     /// scope.
@@ -156,7 +156,7 @@ impl StablecoinV1 {
                 | B20PolicyType::MintReceiver,
             ) => Ok(()),
             // Cobalt (V2)-only scopes, and any unrecognized id, are not part of the frozen V1 surface.
-            Some(B20PolicyType::SeizeHolder | B20PolicyType::SeizeReceiver) | None => {
+            Some(B20PolicyType::SeizeExempt | B20PolicyType::SeizeReceiver) | None => {
                 Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
                     policyScope: policy_scope,
                 }))

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -165,7 +165,7 @@ impl StablecoinV2 {
     }
 
     /// Ensures `policy_scope` names a built-in B-20 policy slot available on the V2 (Cobalt) common
-    /// surface, which adds the seize scopes (`SEIZE_HOLDER_POLICY` / `SEIZE_RECEIVER_POLICY`) on top
+    /// surface, which adds the seize scopes (`SEIZE_EXEMPT_POLICY` / `SEIZE_RECEIVER_POLICY`) on top
     /// of V1.
     ///
     /// The match is exhaustive on purpose: a policy scope added to `B20PolicyType` for a future fork
@@ -178,7 +178,7 @@ impl StablecoinV2 {
                 | B20PolicyType::TransferReceiver
                 | B20PolicyType::TransferExecutor
                 | B20PolicyType::MintReceiver
-                | B20PolicyType::SeizeHolder
+                | B20PolicyType::SeizeExempt
                 | B20PolicyType::SeizeReceiver,
             ) => Ok(()),
             None => Err(BasePrecompileError::revert(IB20::UnsupportedPolicyType {
@@ -1315,10 +1315,10 @@ mod tests {
 
     // --- seize ---
 
-    /// Points `SEIZE_HOLDER_POLICY` at the always-block policy, making every account seizable.
+    /// Points `SEIZE_EXEMPT_POLICY` at the always-block policy, making every account seizable.
     fn make_seizable(tok: &mut Tok) {
         tok.accounting_mut()
-            .set_policy_id(B20PolicyType::SeizeHolder.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID)
+            .set_policy_id(B20PolicyType::SeizeExempt.id(), PolicyRegistryStorage::ALWAYS_BLOCK_ID)
             .unwrap();
     }
 
@@ -1376,7 +1376,7 @@ mod tests {
     #[test]
     fn seize_reverts_on_zero_from() {
         let mut tok = token();
-        // A non-default `SeizeHolder` (here ALWAYS_BLOCK via `make_seizable`) treats the zero
+        // A non-default `SeizeExempt` (here ALWAYS_BLOCK via `make_seizable`) treats the zero
         // address as seizable, so without the `from != 0` guard a zero-amount seize from the zero
         // address would emit a misleading `Transfer(0x0, to, 0)` that indexers read as a mint.
         make_seizable(&mut tok);
@@ -1483,10 +1483,10 @@ mod tests {
     }
 
     #[test]
-    fn seize_holder_policy_beats_receiver_policy() {
+    fn seize_exempt_policy_beats_receiver_policy() {
         let mut tok = token();
         grant(&mut tok, B20TokenRole::Seize.id(), ADMIN);
-        // SEIZE_HOLDER unset => ALICE not seizable; SEIZE_RECEIVER blocks BOB. Holder check fires first.
+        // SEIZE_EXEMPT unset => ALICE not seizable; SEIZE_RECEIVER blocks BOB. Exempt check fires first.
         tok.accounting_mut()
             .set_policy_id(
                 B20PolicyType::SeizeReceiver.id(),

--- a/crates/common/precompiles/src/common/abi/v2.rs
+++ b/crates/common/precompiles/src/common/abi/v2.rs
@@ -89,7 +89,7 @@ sol! {
         function TRANSFER_RECEIVER_POLICY() external view returns (bytes32);
         function TRANSFER_EXECUTOR_POLICY() external view returns (bytes32);
         function MINT_RECEIVER_POLICY() external view returns (bytes32);
-        function SEIZE_HOLDER_POLICY() external view returns (bytes32);
+        function SEIZE_EXEMPT_POLICY() external view returns (bytes32);
         function SEIZE_RECEIVER_POLICY() external view returns (bytes32);
 
         // ERC-20
@@ -181,7 +181,7 @@ impl IB20::IB20Calls {
             Self::TRANSFER_RECEIVER_POLICY(_) => "precompile-b20-TRANSFER_RECEIVER_POLICY",
             Self::TRANSFER_EXECUTOR_POLICY(_) => "precompile-b20-TRANSFER_EXECUTOR_POLICY",
             Self::MINT_RECEIVER_POLICY(_) => "precompile-b20-MINT_RECEIVER_POLICY",
-            Self::SEIZE_HOLDER_POLICY(_) => "precompile-b20-SEIZE_HOLDER_POLICY",
+            Self::SEIZE_EXEMPT_POLICY(_) => "precompile-b20-SEIZE_EXEMPT_POLICY",
             Self::SEIZE_RECEIVER_POLICY(_) => "precompile-b20-SEIZE_RECEIVER_POLICY",
             Self::hasRole(_) => "precompile-b20-hasRole",
             Self::getRoleAdmin(_) => "precompile-b20-getRoleAdmin",
@@ -238,10 +238,10 @@ mod tests {
         b256!("bcece6954307d847db07d6f723438cd1fa93ae40fe0c4c7ee5578779cb502661");
 
     /// Absolute wire fingerprint for Cobalt's (canonical) surface. Diverges from V1: Cobalt adds
-    /// the seize surface (`seizeWithMemo`, the `SEIZE_ROLE`/`SEIZE_HOLDER_POLICY`/`SEIZE_RECEIVER_POLICY`
+    /// the seize surface (`seizeWithMemo`, the `SEIZE_ROLE`/`SEIZE_EXEMPT_POLICY`/`SEIZE_RECEIVER_POLICY`
     /// getters, the `Seized` event, the `AccountNotSeizable` error, and the `SEIZE` pause feature).
     const V2_ABI_FINGERPRINT: B256 =
-        b256!("ad267d8b4250d41910b7f6cbcea4dcb1ba9273cf75cd27ae97a3e4ba9d9aded8");
+        b256!("040ce4a6601295ef3caa0a4095a60295cf95726b6e783dcc40eb2dc42d5716eb");
 
     fn v1_abi_fingerprint() -> B256 {
         AbiFingerprint::compute(

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -82,12 +82,13 @@ pub struct B20CoreStorage {
     pub nonces: Mapping<Address, U256>, // offset 13
     // The base-std mock keeps an `initialized` bootstrap flag as its last field; this impl checks
     // factory-init via deployed marker bytecode instead, so it stores no such field.
-    /// Seize-holder policy ID, consulted against `from` by the seize operations. `from` is
-    /// seizable only when NOT authorized by this policy; the unset always-allow default keeps
-    /// seizure closed until an issuer configures it.
+    /// Seize-exempt policy ID, consulted against `from` by the seize operations. Accounts
+    /// authorized by this policy are exempt from seizure; `from` is seizable only when it is NOT
+    /// in the scope. The unset always-allow default keeps seizure closed until an issuer
+    /// configures it.
     #[accessor]
     #[mutator]
-    pub seize_holder_policy_id: u64, // slot 14, offset 0
+    pub seize_exempt_policy_id: u64, // slot 14, offset 0
     /// Seize-receiver policy ID, consulted against `to` by the seize operations.
     #[accessor]
     #[mutator]
@@ -167,8 +168,8 @@ mod tests {
         assert_eq!(__packing_b20_core_storage::PAUSED_LOC.offset_slots, 11);
         assert_eq!(__packing_b20_core_storage::SUPPLY_CAP_LOC.offset_slots, 12);
         assert_eq!(__packing_b20_core_storage::NONCES_LOC.offset_slots, 13);
-        assert_eq!(__packing_b20_core_storage::SEIZE_HOLDER_POLICY_ID_LOC.offset_slots, 14);
-        assert_eq!(__packing_b20_core_storage::SEIZE_HOLDER_POLICY_ID_LOC.offset_bytes, 0);
+        assert_eq!(__packing_b20_core_storage::SEIZE_EXEMPT_POLICY_ID_LOC.offset_slots, 14);
+        assert_eq!(__packing_b20_core_storage::SEIZE_EXEMPT_POLICY_ID_LOC.offset_bytes, 0);
         assert_eq!(__packing_b20_core_storage::SEIZE_RECEIVER_POLICY_ID_LOC.offset_slots, 14);
         assert_eq!(__packing_b20_core_storage::SEIZE_RECEIVER_POLICY_ID_LOC.offset_bytes, 8);
         assert_eq!(__packing_b20_core_storage::SEIZE_RESERVED_LOC.offset_slots, 14);

--- a/crates/common/precompiles/src/common/ops/guards.rs
+++ b/crates/common/precompiles/src/common/ops/guards.rs
@@ -106,16 +106,17 @@ impl B20Guards {
         }
     }
 
-    /// Ensures `account` is seizable, i.e. NOT authorized by the current seize-holder policy.
+    /// Ensures `account` is seizable, i.e. NOT authorized by the current seize-exempt policy.
     ///
-    /// Mirrors [`Self::ensure_blocked`] but consults `SEIZE_HOLDER_POLICY` instead of the
-    /// transfer-sender policy: an account is seizable only when the configured registry policy does
-    /// not authorize it, so the unset always-allow default keeps seizure closed until an issuer
-    /// configures the slot. Used by `seizeWithMemo`. Enforced unconditionally, including in the
-    /// factory bootstrap window. Reverts `AccountNotSeizable` (distinct from `ensure_blocked`'s
-    /// `AccountNotBlocked`) so the seize path and the deprecated `burnBlocked` report separately.
+    /// Mirrors [`Self::ensure_blocked`] but consults `SEIZE_EXEMPT_POLICY` instead of the
+    /// transfer-sender policy: accounts authorized by that scope are exempt from seizure, so an
+    /// account is seizable only when the configured registry policy does not authorize it, and
+    /// the unset always-allow default keeps seizure closed until an issuer configures the slot.
+    /// Used by `seizeWithMemo`. Enforced unconditionally, including in the factory bootstrap
+    /// window. Reverts `AccountNotSeizable` (distinct from `ensure_blocked`'s `AccountNotBlocked`)
+    /// so the seize path and the deprecated `burnBlocked` report separately.
     pub fn ensure_seizable<T: Token + ?Sized>(token: &T, account: Address) -> Result<()> {
-        let policy_scope = B20PolicyType::SeizeHolder.id();
+        let policy_scope = B20PolicyType::SeizeExempt.id();
         let policy_id = token.accounting().policy_id(policy_scope)?;
         if token.policy().is_authorized(token.policy_storage(), policy_id, account)? {
             Err(BasePrecompileError::revert(IB20::AccountNotSeizable { account }))
@@ -149,7 +150,7 @@ mod tests {
 
     fn token_with_seizable_policy(account: Address) -> TestStablecoinToken {
         let mut accounting = InMemoryTokenAccounting::new(Address::repeat_byte(0x20));
-        accounting.policy_ids.insert(B20PolicyType::SeizeHolder.id(), EXTERNAL_POLICY_ID);
+        accounting.policy_ids.insert(B20PolicyType::SeizeExempt.id(), EXTERNAL_POLICY_ID);
 
         let mut policy = FakePolicyAccounting::new();
         policy.allow(EXTERNAL_POLICY_ID, account);

--- a/crates/common/precompiles/src/common/ops/roles.rs
+++ b/crates/common/precompiles/src/common/ops/roles.rs
@@ -26,7 +26,7 @@ pub enum B20TokenRole {
     BurnBlocked,
     /// Role required for `seizeWithMemo`; permits reassigning a seizable account's balance
     /// without going through the normal transfer policy checks. An account is seizable when it
-    /// is NOT authorized by `SEIZE_HOLDER_POLICY`; the unset always-allow default keeps seizure
+    /// is NOT authorized by `SEIZE_EXEMPT_POLICY`; the unset always-allow default keeps seizure
     /// closed until an issuer configures the policy.
     Seize,
     /// Role required for `pause`.

--- a/crates/common/precompiles/src/common/policy_type.rs
+++ b/crates/common/precompiles/src/common/policy_type.rs
@@ -10,8 +10,8 @@ const TRANSFER_EXECUTOR_POLICY: B256 =
     b256!("10be5173aff2a44e748bd9acd8b19fe34689581398a9db7ba2fb671e786ff7d8");
 const MINT_RECEIVER_POLICY: B256 =
     b256!("a0d5ae037e66a09119acf080a1d807abb9b6d03b6b9130eb19f7c1e6bdb8ffc8");
-const SEIZE_HOLDER_POLICY: B256 =
-    b256!("1497ab2b67ebb0a75dd9cdd6aec9f0e64620e6b87e911af7a088ac12e58d9ef2");
+const SEIZE_EXEMPT_POLICY: B256 =
+    b256!("edb5da348cfb67af08746d3afd1be81034b50d5c8576f31aff688f39dfd540ed");
 const SEIZE_RECEIVER_POLICY: B256 =
     b256!("bf15b19caf5c77422c038bc25f26b8b815c3a14f6d04c6616076b81bcfe07b3d");
 
@@ -26,9 +26,10 @@ pub enum B20PolicyType {
     TransferExecutor,
     /// Policy slot checked against mint receivers.
     MintReceiver,
-    /// Policy slot consulted against `from` by the seize operations. A `from` is seizable only when
-    /// it is NOT authorized by this policy (mirroring the `burnBlocked` "blocked" semantics).
-    SeizeHolder,
+    /// Policy slot consulted against `from` by the seize operations. Accounts authorized by this
+    /// policy are exempt from seizure; a `from` is seizable only when it is NOT in this scope
+    /// (mirroring the `burnBlocked` "blocked" semantics).
+    SeizeExempt,
     /// Policy slot consulted against `to` by the seize operations. Mirrors [`Self::MintReceiver`]:
     /// the destination must be authorized by this policy. An unset scope reads as always-allow, so
     /// seize may send anywhere until an issuer configures it.
@@ -46,8 +47,8 @@ impl B20PolicyType {
             Some(Self::TransferExecutor)
         } else if id == MINT_RECEIVER_POLICY {
             Some(Self::MintReceiver)
-        } else if id == SEIZE_HOLDER_POLICY {
-            Some(Self::SeizeHolder)
+        } else if id == SEIZE_EXEMPT_POLICY {
+            Some(Self::SeizeExempt)
         } else if id == SEIZE_RECEIVER_POLICY {
             Some(Self::SeizeReceiver)
         } else {
@@ -62,7 +63,7 @@ impl B20PolicyType {
             Self::TransferReceiver => TRANSFER_RECEIVER_POLICY,
             Self::TransferExecutor => TRANSFER_EXECUTOR_POLICY,
             Self::MintReceiver => MINT_RECEIVER_POLICY,
-            Self::SeizeHolder => SEIZE_HOLDER_POLICY,
+            Self::SeizeExempt => SEIZE_EXEMPT_POLICY,
             Self::SeizeReceiver => SEIZE_RECEIVER_POLICY,
         }
     }
@@ -82,16 +83,28 @@ mod tests {
         assert_eq!(B20PolicyType::TransferReceiver.id(), keccak256("TRANSFER_RECEIVER_POLICY"));
         assert_eq!(B20PolicyType::TransferExecutor.id(), keccak256("TRANSFER_EXECUTOR_POLICY"));
         assert_eq!(B20PolicyType::MintReceiver.id(), keccak256("MINT_RECEIVER_POLICY"));
-        assert_eq!(B20PolicyType::SeizeHolder.id(), keccak256("SEIZE_HOLDER_POLICY"));
+        assert_eq!(B20PolicyType::SeizeExempt.id(), keccak256("SEIZE_EXEMPT_POLICY"));
         assert_eq!(B20PolicyType::SeizeReceiver.id(), keccak256("SEIZE_RECEIVER_POLICY"));
+    }
+
+    /// The seize-from scope id must derive from the new `SEIZE_EXEMPT_POLICY` preimage, not the
+    /// legacy `SEIZE_HOLDER_POLICY` preimage the scope was originally shipped under.
+    #[test]
+    fn seize_exempt_scope_uses_renamed_preimage() {
+        assert_ne!(B20PolicyType::SeizeExempt.id(), keccak256("SEIZE_HOLDER_POLICY"));
+        assert_eq!(
+            B20PolicyType::from_id(keccak256("SEIZE_HOLDER_POLICY")),
+            None,
+            "the legacy SEIZE_HOLDER_POLICY id must no longer resolve to any built-in scope"
+        );
     }
 
     /// `from_id` is the inverse of `id`, including for the seize scopes.
     #[test]
     fn seizable_scope_round_trips() {
         assert_eq!(
-            B20PolicyType::from_id(B20PolicyType::SeizeHolder.id()),
-            Some(B20PolicyType::SeizeHolder)
+            B20PolicyType::from_id(B20PolicyType::SeizeExempt.id()),
+            Some(B20PolicyType::SeizeExempt)
         );
         assert_eq!(
             B20PolicyType::from_id(B20PolicyType::SeizeReceiver.id()),

--- a/crates/common/precompiles/src/common/policy_type.rs
+++ b/crates/common/precompiles/src/common/policy_type.rs
@@ -87,18 +87,6 @@ mod tests {
         assert_eq!(B20PolicyType::SeizeReceiver.id(), keccak256("SEIZE_RECEIVER_POLICY"));
     }
 
-    /// The seize-from scope id must derive from the new `SEIZE_EXEMPT_POLICY` preimage, not the
-    /// legacy `SEIZE_HOLDER_POLICY` preimage the scope was originally shipped under.
-    #[test]
-    fn seize_exempt_scope_uses_renamed_preimage() {
-        assert_ne!(B20PolicyType::SeizeExempt.id(), keccak256("SEIZE_HOLDER_POLICY"));
-        assert_eq!(
-            B20PolicyType::from_id(keccak256("SEIZE_HOLDER_POLICY")),
-            None,
-            "the legacy SEIZE_HOLDER_POLICY id must no longer resolve to any built-in scope"
-        );
-    }
-
     /// `from_id` is the inverse of `id`, including for the seize scopes.
     #[test]
     fn seizable_scope_round_trips() {

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -283,7 +283,7 @@ fn golden_v2_selectors_unknown_at_v1() {
     }
 }
 
-/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_HOLDER_POLICY` /
+/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_EXEMPT_POLICY` /
 /// `SEIZE_RECEIVER_POLICY` getters) were introduced at Cobalt (`AssetV2`). At V1 (Beryl) they are
 /// absent from the frozen common `IB20` surface, so `route` rejects them as `UnknownFunctionSelector`.
 #[test]
@@ -292,7 +292,7 @@ fn golden_seize_selectors_unknown_at_v1() {
     let calls: Vec<Vec<u8>> = vec![
         IB20::seizeWithMemoCall { from: ALICE, to: BOB, amount: u(1), memo: MEMO }.abi_encode(),
         IB20::SEIZE_ROLECall {}.abi_encode(),
-        IB20::SEIZE_HOLDER_POLICYCall {}.abi_encode(),
+        IB20::SEIZE_EXEMPT_POLICYCall {}.abi_encode(),
         IB20::SEIZE_RECEIVER_POLICYCall {}.abi_encode(),
     ];
     for calldata in calls {
@@ -302,13 +302,13 @@ fn golden_seize_selectors_unknown_at_v1() {
     }
 }
 
-/// The seize policy scopes were introduced at Cobalt (`AssetV2`). Although the `SEIZE_HOLDER_POLICY()`
+/// The seize policy scopes were introduced at Cobalt (`AssetV2`). Although the `SEIZE_EXEMPT_POLICY()`
 /// / `SEIZE_RECEIVER_POLICY()` getter selectors are absent from V1, the scope *values* must also not
 /// leak through the common `updatePolicy` selector, which is dialable on V1: V1 rejects them with
 /// `UnsupportedPolicyType`, matching the base-std `v1.0.0` reference.
 #[test]
 fn golden_update_policy_rejects_seize_scopes_at_v1() {
-    for scope in [B20PolicyType::SeizeHolder.id(), B20PolicyType::SeizeReceiver.id()] {
+    for scope in [B20PolicyType::SeizeExempt.id(), B20PolicyType::SeizeReceiver.id()] {
         let mut s = fresh();
         let mut policy = FakePolicyAccounting::new();
         policy.create_existing_policy(7);
@@ -330,7 +330,7 @@ fn golden_update_policy_rejects_seize_scopes_at_v1() {
 /// `policyId` selector is dialable on V1 but must reject the V2-only seize scopes.
 #[test]
 fn golden_policy_id_rejects_seize_scopes_at_v1() {
-    for scope in [B20PolicyType::SeizeHolder.id(), B20PolicyType::SeizeReceiver.id()] {
+    for scope in [B20PolicyType::SeizeExempt.id(), B20PolicyType::SeizeReceiver.id()] {
         let mut s = fresh();
         let err = op(
             &mut s,
@@ -2778,7 +2778,7 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
         ]),
         C::seizeWithMemo(_)
         | C::SEIZE_ROLE(_)
-        | C::SEIZE_HOLDER_POLICY(_)
+        | C::SEIZE_EXEMPT_POLICY(_)
         | C::SEIZE_RECEIVER_POLICY(_) => covered(&[golden_seize_selectors_unknown_at_v1]),
 
         // pause / config / roles / policy / permit

--- a/crates/common/precompiles/tests/b20_asset_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v2_golden.rs
@@ -274,10 +274,10 @@ fn domain_separator(storage: &mut HashMapStorageProvider) -> B256 {
     })
 }
 
-/// Configures `from` as seizable (not authorized by `SeizeHolder`) and `to` as an authorized
+/// Configures `from` as seizable (not authorized by `SeizeExempt`) and `to` as an authorized
 /// `SeizeReceiver`, using two distinct policy ids so the two scopes are independently exercised.
 fn make_seizable(token: &mut B20AssetStorage<'_>) {
-    token.set_policy_id(B20PolicyType::SeizeHolder.id(), POLICY_ID).unwrap();
+    token.set_policy_id(B20PolicyType::SeizeExempt.id(), POLICY_ID).unwrap();
     token.set_policy_id(B20PolicyType::SeizeReceiver.id(), POLICY_ID_2).unwrap();
 }
 
@@ -1079,7 +1079,7 @@ fn golden_seize_reverts_zero_from() {
     let mut s = fresh();
     seed(&mut s, |t| {
         give_role(t, B20TokenRole::Seize.id(), ADMIN);
-        // A non-default `SeizeHolder` treats the zero address as seizable; the `from != 0` guard
+        // A non-default `SeizeExempt` treats the zero address as seizable; the `from != 0` guard
         // still rejects a zero-amount seize that would otherwise emit a mint-like Transfer(0x0,..).
         make_seizable(t);
     });
@@ -1100,8 +1100,8 @@ fn golden_seize_reverts_account_not_seizable() {
     seed(&mut s, |t| {
         fund(t, ALICE, u(100));
         give_role(t, B20TokenRole::Seize.id(), ADMIN);
-        // ALICE authorized under SeizeHolder => not seizable.
-        t.set_policy_id(B20PolicyType::SeizeHolder.id(), POLICY_ID).unwrap();
+        // ALICE authorized under SeizeExempt => not seizable.
+        t.set_policy_id(B20PolicyType::SeizeExempt.id(), POLICY_ID).unwrap();
     });
     let mut policy = FakePolicyAccounting::new();
     policy.allow(POLICY_ID, ALICE);
@@ -1220,7 +1220,7 @@ fn golden_read_seize_role_and_policy_constants() {
     let mut s = fresh();
     let cases: Vec<(Vec<u8>, B256)> = vec![
         (IB20::SEIZE_ROLECall {}.abi_encode(), B20TokenRole::Seize.id()),
-        (IB20::SEIZE_HOLDER_POLICYCall {}.abi_encode(), B20PolicyType::SeizeHolder.id()),
+        (IB20::SEIZE_EXEMPT_POLICYCall {}.abi_encode(), B20PolicyType::SeizeExempt.id()),
         (IB20::SEIZE_RECEIVER_POLICYCall {}.abi_encode(), B20PolicyType::SeizeReceiver.id()),
     ];
     for (calldata, expected) in cases {
@@ -3566,7 +3566,7 @@ fn v2_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Asset::IB20AssetCall
             golden_seize_enforces_receiver_policy,
             golden_seize_privileged_still_enforces_role_and_seizable,
         ]),
-        C::SEIZE_ROLE(_) | C::SEIZE_HOLDER_POLICY(_) | C::SEIZE_RECEIVER_POLICY(_) => {
+        C::SEIZE_ROLE(_) | C::SEIZE_EXEMPT_POLICY(_) | C::SEIZE_RECEIVER_POLICY(_) => {
             covered(&[golden_read_seize_role_and_policy_constants])
         }
 

--- a/crates/common/precompiles/tests/b20_factory_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_factory_v1_golden.rs
@@ -739,13 +739,13 @@ fn seed_union_composite(s: &mut HashMapStorageProvider) -> u64 {
 }
 
 #[test]
-fn golden_cobalt_bootstrap_routes_asset_seize_holder_policy_init_call() {
+fn golden_cobalt_bootstrap_routes_asset_seize_exempt_policy_init_call() {
     let mut s = fresh();
     let composite = seed_union_composite(&mut s);
     let token = asset_addr(CREATOR, SALT);
 
     let update = IB20::updatePolicyCall {
-        policyScope: B20PolicyType::SeizeHolder.id(),
+        policyScope: B20PolicyType::SeizeExempt.id(),
         newPolicyId: composite,
     }
     .abi_encode();
@@ -764,18 +764,18 @@ fn golden_cobalt_bootstrap_routes_asset_seize_holder_policy_init_call() {
     assert!(!rev, "Cobalt bootstrap must not revert; got {bytes:?}");
     assert_eq!(bytes, Bytes::from(IB20Factory::createB20Call::abi_encode_returns(&token)));
     read_asset(&mut s, token, |t| {
-        assert_eq!(t.policy_id(B20PolicyType::SeizeHolder.id()).unwrap(), composite);
+        assert_eq!(t.policy_id(B20PolicyType::SeizeExempt.id()).unwrap(), composite);
     });
 }
 
 #[test]
-fn golden_cobalt_bootstrap_routes_stablecoin_seize_holder_policy_init_call() {
+fn golden_cobalt_bootstrap_routes_stablecoin_seize_exempt_policy_init_call() {
     let mut s = fresh();
     let composite = seed_union_composite(&mut s);
     let token = stablecoin_addr(CREATOR, SALT);
 
     let update = IB20::updatePolicyCall {
-        policyScope: B20PolicyType::SeizeHolder.id(),
+        policyScope: B20PolicyType::SeizeExempt.id(),
         newPolicyId: composite,
     }
     .abi_encode();
@@ -794,16 +794,16 @@ fn golden_cobalt_bootstrap_routes_stablecoin_seize_holder_policy_init_call() {
     assert!(!rev, "Cobalt bootstrap must not revert; got {bytes:?}");
     assert_eq!(bytes, Bytes::from(IB20Factory::createB20Call::abi_encode_returns(&token)));
     read_stablecoin(&mut s, token, |t| {
-        assert_eq!(t.policy_id(B20PolicyType::SeizeHolder.id()).unwrap(), composite);
+        assert_eq!(t.policy_id(B20PolicyType::SeizeExempt.id()).unwrap(), composite);
     });
 }
 
 #[test]
-fn golden_beryl_bootstrap_rejects_asset_seize_holder_policy_init_call() {
+fn golden_beryl_bootstrap_rejects_asset_seize_exempt_policy_init_call() {
     let mut s = fresh();
     let composite = seed_union_composite(&mut s);
     let update = IB20::updatePolicyCall {
-        policyScope: B20PolicyType::SeizeHolder.id(),
+        policyScope: B20PolicyType::SeizeExempt.id(),
         newPolicyId: composite,
     }
     .abi_encode();
@@ -823,18 +823,18 @@ fn golden_beryl_bootstrap_rejects_asset_seize_holder_policy_init_call() {
     assert_eq!(
         bytes,
         Bytes::from(
-            IB20::UnsupportedPolicyType { policyScope: B20PolicyType::SeizeHolder.id() }
+            IB20::UnsupportedPolicyType { policyScope: B20PolicyType::SeizeExempt.id() }
                 .abi_encode()
         )
     );
 }
 
 #[test]
-fn golden_beryl_bootstrap_rejects_stablecoin_seize_holder_policy_init_call() {
+fn golden_beryl_bootstrap_rejects_stablecoin_seize_exempt_policy_init_call() {
     let mut s = fresh();
     let composite = seed_union_composite(&mut s);
     let update = IB20::updatePolicyCall {
-        policyScope: B20PolicyType::SeizeHolder.id(),
+        policyScope: B20PolicyType::SeizeExempt.id(),
         newPolicyId: composite,
     }
     .abi_encode();
@@ -854,7 +854,7 @@ fn golden_beryl_bootstrap_rejects_stablecoin_seize_holder_policy_init_call() {
     assert_eq!(
         bytes,
         Bytes::from(
-            IB20::UnsupportedPolicyType { policyScope: B20PolicyType::SeizeHolder.id() }
+            IB20::UnsupportedPolicyType { policyScope: B20PolicyType::SeizeExempt.id() }
                 .abi_encode()
         )
     );
@@ -969,10 +969,10 @@ fn v1_op_coverage_checklist(call: IB20Factory::IB20FactoryCalls) {
             golden_create_reverts_when_not_activated,
             golden_create_propagates_typed_init_call_revert,
             golden_create_reverts_malformed_params,
-            golden_cobalt_bootstrap_routes_asset_seize_holder_policy_init_call,
-            golden_cobalt_bootstrap_routes_stablecoin_seize_holder_policy_init_call,
-            golden_beryl_bootstrap_rejects_asset_seize_holder_policy_init_call,
-            golden_beryl_bootstrap_rejects_stablecoin_seize_holder_policy_init_call,
+            golden_cobalt_bootstrap_routes_asset_seize_exempt_policy_init_call,
+            golden_cobalt_bootstrap_routes_stablecoin_seize_exempt_policy_init_call,
+            golden_beryl_bootstrap_rejects_asset_seize_exempt_policy_init_call,
+            golden_beryl_bootstrap_rejects_stablecoin_seize_exempt_policy_init_call,
         ]),
         C::getB20Address(_) => covered(&[golden_get_b20_address]),
         C::isB20(_) => covered(&[golden_is_b20]),

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -733,7 +733,7 @@ fn golden_burn_blocked_reverts_when_not_blocked() {
     assert_eq!(err, BasePrecompileError::revert(IB20::AccountNotBlocked { account: ALICE }));
 }
 
-/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_HOLDER_POLICY` /
+/// The seize common selectors (`seizeWithMemo` and the `SEIZE_ROLE` / `SEIZE_EXEMPT_POLICY` /
 /// `SEIZE_RECEIVER_POLICY` getters) were introduced at Cobalt (`StablecoinV2`). At V1 (Beryl) they
 /// are absent from the frozen common `IB20` surface, so `route` rejects them as `UnknownFunctionSelector`.
 #[test]
@@ -742,7 +742,7 @@ fn golden_seize_selectors_unknown_at_v1() {
     let calls: Vec<Vec<u8>> = vec![
         IB20::seizeWithMemoCall { from: ALICE, to: BOB, amount: u(1), memo: MEMO }.abi_encode(),
         IB20::SEIZE_ROLECall {}.abi_encode(),
-        IB20::SEIZE_HOLDER_POLICYCall {}.abi_encode(),
+        IB20::SEIZE_EXEMPT_POLICYCall {}.abi_encode(),
         IB20::SEIZE_RECEIVER_POLICYCall {}.abi_encode(),
     ];
     for calldata in calls {
@@ -753,12 +753,12 @@ fn golden_seize_selectors_unknown_at_v1() {
 }
 
 /// The seize policy scopes were introduced at Cobalt (`StablecoinV2`). Although the
-/// `SEIZE_HOLDER_POLICY()` / `SEIZE_RECEIVER_POLICY()` getter selectors are absent from V1, the scope
+/// `SEIZE_EXEMPT_POLICY()` / `SEIZE_RECEIVER_POLICY()` getter selectors are absent from V1, the scope
 /// *values* must also not leak through the common `updatePolicy` selector, which is dialable on V1:
 /// V1 rejects them with `UnsupportedPolicyType`, matching the base-std `v1.0.0` reference.
 #[test]
 fn golden_update_policy_rejects_seize_scopes_at_v1() {
-    for scope in [B20PolicyType::SeizeHolder.id(), B20PolicyType::SeizeReceiver.id()] {
+    for scope in [B20PolicyType::SeizeExempt.id(), B20PolicyType::SeizeReceiver.id()] {
         let mut s = fresh();
         let mut policy = FakePolicyAccounting::new();
         policy.create_existing_policy(7);
@@ -780,7 +780,7 @@ fn golden_update_policy_rejects_seize_scopes_at_v1() {
 /// `policyId` selector is dialable on V1 but must reject the V2-only seize scopes.
 #[test]
 fn golden_policy_id_rejects_seize_scopes_at_v1() {
-    for scope in [B20PolicyType::SeizeHolder.id(), B20PolicyType::SeizeReceiver.id()] {
+    for scope in [B20PolicyType::SeizeExempt.id(), B20PolicyType::SeizeReceiver.id()] {
         let mut s = fresh();
         let err = op(
             &mut s,
@@ -2203,7 +2203,7 @@ fn v1_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
         ]),
         C::seizeWithMemo(_)
         | C::SEIZE_ROLE(_)
-        | C::SEIZE_HOLDER_POLICY(_)
+        | C::SEIZE_EXEMPT_POLICY(_)
         | C::SEIZE_RECEIVER_POLICY(_) => covered(&[golden_seize_selectors_unknown_at_v1]),
 
         // pause / config / roles / policy / permit

--- a/crates/common/precompiles/tests/b20_stablecoin_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v2_golden.rs
@@ -239,10 +239,10 @@ fn domain_separator(storage: &mut HashMapStorageProvider) -> B256 {
     })
 }
 
-/// Configures `from` as seizable (not authorized by `SeizeHolder`) and `to` as an authorized
+/// Configures `from` as seizable (not authorized by `SeizeExempt`) and `to` as an authorized
 /// `SeizeReceiver`, using two distinct policy ids so the two scopes are independently exercised.
 fn make_seizable(token: &mut B20StablecoinStorage<'_>) {
-    token.set_policy_id(B20PolicyType::SeizeHolder.id(), POLICY_ID).unwrap();
+    token.set_policy_id(B20PolicyType::SeizeExempt.id(), POLICY_ID).unwrap();
     token.set_policy_id(B20PolicyType::SeizeReceiver.id(), POLICY_ID_2).unwrap();
 }
 
@@ -1049,8 +1049,8 @@ fn golden_seize_reverts_account_not_seizable() {
     seed(&mut s, |t| {
         fund(t, ALICE, u(100));
         give_role(t, B20TokenRole::Seize.id(), ADMIN);
-        // ALICE authorized under SeizeHolder => not seizable.
-        t.set_policy_id(B20PolicyType::SeizeHolder.id(), POLICY_ID).unwrap();
+        // ALICE authorized under SeizeExempt => not seizable.
+        t.set_policy_id(B20PolicyType::SeizeExempt.id(), POLICY_ID).unwrap();
     });
     let mut policy = FakePolicyAccounting::new();
     policy.allow(POLICY_ID, ALICE);
@@ -1169,7 +1169,7 @@ fn golden_read_seize_role_and_policy_constants() {
     let mut s = fresh();
     let cases: Vec<(Vec<u8>, B256)> = vec![
         (IB20::SEIZE_ROLECall {}.abi_encode(), B20TokenRole::Seize.id()),
-        (IB20::SEIZE_HOLDER_POLICYCall {}.abi_encode(), B20PolicyType::SeizeHolder.id()),
+        (IB20::SEIZE_EXEMPT_POLICYCall {}.abi_encode(), B20PolicyType::SeizeExempt.id()),
         (IB20::SEIZE_RECEIVER_POLICYCall {}.abi_encode(), B20PolicyType::SeizeReceiver.id()),
     ];
     for (calldata, expected) in cases {
@@ -2475,7 +2475,7 @@ fn v2_op_coverage_checklist(call: IB20::IB20Calls, ext: IB20Stablecoin::IB20Stab
             golden_seize_enforces_receiver_policy,
             golden_seize_privileged_still_enforces_role_and_seizable,
         ]),
-        C::SEIZE_ROLE(_) | C::SEIZE_HOLDER_POLICY(_) | C::SEIZE_RECEIVER_POLICY(_) => {
+        C::SEIZE_ROLE(_) | C::SEIZE_EXEMPT_POLICY(_) | C::SEIZE_RECEIVER_POLICY(_) => {
             covered(&[golden_read_seize_role_and_policy_constants])
         }
 


### PR DESCRIPTION
## Summary

Mirrors [base-std #214](https://github.com/base/base-std/pull/214): the seize-from policy scope is inverted (accounts *in* the scope are exempt from seizure), so the new name states that polarity directly instead of reading like a seizable-holders list.

This is a **Cobalt wire change** — must land in the same window as base-std #214, otherwise `base-forge test` / `make fork-tests` will diverge.

## Wire deltas

- Preimage flips:
  - `keccak256("SEIZE_HOLDER_POLICY")` = `0x1497ab2b67ebb0a75dd9cdd6aec9f0e64620e6b87e911af7a088ac12e58d9ef2`
  - `keccak256("SEIZE_EXEMPT_POLICY")` = `0xedb5da348cfb67af08746d3afd1be81034b50d5c8576f31aff688f39dfd540ed`
- `IB20` getter selector: `0xfeb346ec` (regenerated by `sol!`; not hard-coded anywhere in this repo).
- V2 ABI fingerprint re-pinned: `0x040ce4a6601295ef3caa0a4095a60295cf95726b6e783dcc40eb2dc42d5716eb`.
- `SEIZE_RECEIVER_POLICY`, `SEIZE_ROLE`, `seizeWithMemo` — all unchanged.

## What changed

- Enum variant `B20PolicyType::SeizeHolder` → `SeizeExempt`.
- Preimage constant + hash in `common/policy_type.rs`.
- `sol!` function + tracing label in `common/abi/v2.rs`; recomputed V2 fingerprint.
- Storage field `seize_holder_policy_id` → `seize_exempt_policy_id` (slot 14 / offset 0 unchanged — position pins layout, not the identifier).
- Dispatcher arms in `b20_asset/dispatch.rs`, `b20_stablecoin/dispatch.rs`.
- Accounting macro dispatch in `precompile-macros/src/accounting.rs`.
- `ensure_seizable` guard + doc comments across `common/ops/{guards,roles}.rs` and `b20_*/logic/{v1,v2}.rs`.
- Golden tests: renamed `IB20::SEIZE_HOLDER_POLICYCall` → `SEIZE_EXEMPT_POLICYCall`, enum arms, and the four `..._seize_holder_policy_init_call` factory test names.
- New regression test in `common::policy_type::tests` (mirror of base-std's `B20Renames.t.sol`): asserts `SeizeExempt.id() != keccak256("SEIZE_HOLDER_POLICY")` and `from_id(keccak256("SEIZE_HOLDER_POLICY")) == None`.

## Test plan

- [x] `cargo check --workspace` — clean.
- [x] `cargo test -p base-common-precompiles --lib` — 680 passed.
- [x] `cargo test -p base-common-precompiles --features test-utils --tests` — 508 passed across the six golden binaries (b20_asset v1/v2, b20_stablecoin v1/v2, b20_policy v1, b20_factory v1).
- [x] `common::policy_type::tests::policy_ids_match_base_std_keccak` reflects the new preimage.
- [x] `common::policy_type::tests::seize_exempt_scope_uses_renamed_preimage` (new) pins the old preimage no longer resolves.
- [x] `common::abi::v2::tests::v2_abi_fingerprint_is_pinned` — re-pinned and green.
- [x] `common::core_storage::tests::b20_core_offsets_match_mock_b20_storage` — slot 14 / offset 0 unchanged.
- [ ] After base-std #214 merges + the consumer bumps land: run `make fork-tests` locally to confirm end-to-end wire parity.

## Out of scope

- The untracked `base-bop599/` scratch tree in the working copy (stacked-branch snapshot; not tracked).
- Docs sweep — no top-level `CHANGELOG.md` / `docs/` mentions this scope in the primary tree.