### PR TITLE
chore(reth): bump to v2.5.2 with parallel history reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16013,8 +16013,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16040,8 +16040,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16071,8 +16071,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16091,8 +16091,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -16104,8 +16104,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16193,8 +16193,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -16203,8 +16203,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16254,8 +16254,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -16271,8 +16271,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16285,8 +16285,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16298,8 +16298,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16323,8 +16323,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16352,8 +16352,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16378,8 +16378,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16408,8 +16408,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16423,8 +16423,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16448,8 +16448,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16472,8 +16472,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16496,8 +16496,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16531,8 +16531,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16588,8 +16588,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16615,8 +16615,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16638,8 +16638,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16665,8 +16665,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16721,8 +16721,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16751,8 +16751,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16769,8 +16769,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16785,8 +16785,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16809,8 +16809,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16820,8 +16820,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16849,8 +16849,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16875,8 +16875,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16891,8 +16891,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16907,8 +16907,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -16921,8 +16921,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16951,8 +16951,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16965,8 +16965,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16975,8 +16975,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17001,8 +17001,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17021,8 +17021,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -17039,8 +17039,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -17052,8 +17052,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17071,8 +17071,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17109,8 +17109,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -17141,8 +17141,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17155,8 +17155,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "serde",
  "serde_json",
@@ -17165,8 +17165,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17191,8 +17191,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "bytes",
  "futures",
@@ -17211,8 +17211,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -17228,8 +17228,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -17237,8 +17237,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "futures",
  "libc",
@@ -17251,8 +17251,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -17260,8 +17260,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -17274,8 +17274,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17333,8 +17333,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17358,8 +17358,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17382,8 +17382,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17397,8 +17397,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17411,8 +17411,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17428,8 +17428,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17452,8 +17452,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17520,8 +17520,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17575,8 +17575,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17624,8 +17624,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17648,8 +17648,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17672,8 +17672,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "bytes",
  "eyre",
@@ -17701,8 +17701,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17713,8 +17713,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17737,8 +17737,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17749,8 +17749,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17772,8 +17772,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17782,8 +17782,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17825,8 +17825,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17836,6 +17836,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "itertools 0.14.0",
+ "libc",
  "metrics",
  "notify",
  "parking_lot",
@@ -17874,8 +17875,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17901,8 +17902,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17917,8 +17918,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17932,8 +17933,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -18008,8 +18009,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -18038,8 +18039,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -18081,8 +18082,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -18101,8 +18102,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18132,8 +18133,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -18179,8 +18180,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -18230,8 +18231,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -18244,8 +18245,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18275,8 +18276,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18326,8 +18327,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18354,8 +18355,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18368,8 +18369,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18388,8 +18389,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18403,8 +18404,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18429,8 +18430,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18446,8 +18447,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18473,8 +18474,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18494,8 +18495,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18510,8 +18511,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18520,8 +18521,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "clap",
  "eyre",
@@ -18540,8 +18541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18559,8 +18560,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18602,8 +18603,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18628,8 +18629,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18655,8 +18656,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18671,8 +18672,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18695,8 +18696,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.5.1"
-source = "git+https://github.com/base/reth?tag=base-v2.5.1.2#78658a84600d7d0567f6626f39a76bc7d8e8290c"
+version = "2.5.2"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -331,72 +331,72 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-network-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
-reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
-reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
-reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
-reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2", default-features = false }
-reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.1.2" }
+reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-network-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
+reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
+reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
+reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
+reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
 
 # tokio
 tokio = "1.53.1"

--- a/etc/upstream-pins/reth.toml
+++ b/etc/upstream-pins/reth.toml
@@ -7,21 +7,9 @@
 # To return to an official Reth tag, edit this file and run `just pin-reth`.
 
 repository = "https://github.com/base/reth"
-reference = "base-v2.5.1.2"
-rev = "78658a84600d7d0567f6626f39a76bc7d8e8290c"
+reference = "base-v2.5.2.2"
+rev = "966744f917711b2a4553653bd407653d7577e633"
 
 [upstream_base]
-tag = "v2.5.1"
-rev = "6dec1b96b625584956883c34ad0eafbe550480ac"
-
-[[patches]]
-pr = "https://github.com/paradigmxyz/reth/pull/26708"
-head = "f213ff930925e0912a2f6907cec0c62d473bc330"
-
-[[patches]]
-pr = "https://github.com/paradigmxyz/reth/pull/26766"
-head = "f47fd63a3762d8add2e07f1d4afa9363e60d0853"
-
-[[patches]]
-pr = "https://github.com/paradigmxyz/reth/pull/26794"
-head = "70f22cbb8a0a385135c58a57648f1bbf7bd55bee"
+tag = "v2.5.2"
+rev = "5a6940e351fed80458fe6c9da8581cbe4b8bd036"


### PR DESCRIPTION
Pins Reth to `base/reth` tag `base-v2.5.2.2` (`966744f917711b2a4553653bd407653d7577e633`), built from upstream `v2.5.2` plus the parallel sharded-history-read change.

The carried change parallelizes last-shard history reads and bounds collection/preparation batches.

Tests:
- `just check-reth-pin`
- `cargo +nightly check -p base --locked`