### PR TITLE
chore(reth): bump to v2.5.2 with parallel history reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6748,7 +6748,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -6768,7 +6768,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -9779,8 +9779,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -10672,7 +10672,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -10708,7 +10708,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -13201,7 +13201,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14891,7 +14891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -14924,7 +14924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14937,7 +14937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15050,7 +15050,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -15090,7 +15090,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -15682,8 +15682,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15709,8 +15709,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15740,8 +15740,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15760,8 +15760,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -15773,8 +15773,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15862,8 +15862,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -15872,8 +15872,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -15923,8 +15923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -15940,8 +15940,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -15954,8 +15954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15967,8 +15967,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15992,8 +15992,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16021,8 +16021,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16047,8 +16047,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16077,8 +16077,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16092,8 +16092,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16117,8 +16117,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16141,8 +16141,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16165,8 +16165,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16200,8 +16200,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16257,8 +16257,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16284,8 +16284,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16307,8 +16307,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16334,8 +16334,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16390,8 +16390,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16420,8 +16420,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16438,8 +16438,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16454,8 +16454,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16478,8 +16478,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16489,8 +16489,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16518,8 +16518,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16544,8 +16544,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16560,8 +16560,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16576,8 +16576,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -16590,8 +16590,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16620,8 +16620,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16634,8 +16634,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16644,8 +16644,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16670,8 +16670,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16690,8 +16690,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -16708,8 +16708,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -16721,8 +16721,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16740,8 +16740,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16778,8 +16778,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-test-utils"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -16810,8 +16810,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16824,8 +16824,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "serde",
  "serde_json",
@@ -16834,8 +16834,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16860,8 +16860,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "bytes",
  "futures",
@@ -16880,8 +16880,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -16897,8 +16897,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -16906,8 +16906,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "futures",
  "libc",
@@ -16920,8 +16920,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -16929,8 +16929,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -16943,8 +16943,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17002,8 +17002,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17027,8 +17027,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17051,8 +17051,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17066,8 +17066,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17080,8 +17080,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17097,8 +17097,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17121,8 +17121,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17189,8 +17189,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17244,8 +17244,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17293,8 +17293,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17317,8 +17317,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17341,8 +17341,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "bytes",
  "eyre",
@@ -17370,8 +17370,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17382,8 +17382,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17406,8 +17406,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17418,8 +17418,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17441,8 +17441,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17451,8 +17451,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17494,8 +17494,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17505,6 +17505,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
  "itertools 0.14.0",
+ "libc",
  "metrics",
  "notify",
  "parking_lot",
@@ -17543,8 +17544,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17570,8 +17571,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17586,8 +17587,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17601,8 +17602,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17677,8 +17678,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -17707,8 +17708,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -17750,8 +17751,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -17770,8 +17771,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17801,8 +17802,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17848,8 +17849,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -17899,8 +17900,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -17913,8 +17914,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17944,8 +17945,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17995,8 +17996,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18023,8 +18024,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18037,8 +18038,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18057,8 +18058,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18072,8 +18073,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18098,8 +18099,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18115,8 +18116,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18142,8 +18143,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18163,8 +18164,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18179,8 +18180,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18189,8 +18190,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "clap",
  "eyre",
@@ -18209,8 +18210,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18228,8 +18229,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18271,8 +18272,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18297,8 +18298,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18324,8 +18325,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18340,8 +18341,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18364,8 +18365,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.5.1"
-source = "git+https://github.com/niran/reth?rev=2fa11e6417e638207aefc11b33028b000a2b1f68#2fa11e6417e638207aefc11b33028b000a2b1f68"
+version = "2.5.2"
+source = "git+https://github.com/meyer9/reth?rev=966744f917711b2a4553653bd407653d7577e633#966744f917711b2a4553653bd407653d7577e633"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -22811,7 +22812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -23716,7 +23717,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,71 +309,71 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-cli = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-ipc = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-evm = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-rpc = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-revm = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-trie = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-exex = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-tasks = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-ecies = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-db-api = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-discv4 = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-discv5 = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-trie-db = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-rpc-api = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-network = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-net-nat = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-tracing = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-eth-wire = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-provider = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-cli-util = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-node-api = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-db-common = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-rpc-layer = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-node-core = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-consensus = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-chainspec = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-cli-runner = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-rpc-convert = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-network-p2p = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-storage-api = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-rpc-eth-api = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-chain-state = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-trie-common = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-payload-util = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-node-builder = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-node-metrics = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-cli-commands = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-evm-ethereum = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-tracing-otlp = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-testing-utils = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-rpc-eth-types = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-network-peers = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-node-ethereum = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-rpc-engine-api = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-e2e-test-utils = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-eth-wire-types = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-payload-builder = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-execution-types = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-execution-cache = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-exex-test-utils = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-rpc-server-types = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-transaction-pool = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-execution-errors = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-payload-validator = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-payload-primitives = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-ethereum-primitives = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-basic-payload-builder = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-payload-builder-primitives = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
-reth-prune-types = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68", default-features = false }
-reth-stages-types = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68", default-features = false }
-reth-storage-errors = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68", default-features = false }
-reth-consensus-common = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68", default-features = false }
-reth-trie-parallel = { git = "https://github.com/niran/reth", rev = "2fa11e6417e638207aefc11b33028b000a2b1f68" }
+reth-db = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-cli = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-ipc = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-evm = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-rpc = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-revm = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-trie = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-exex = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-tasks = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-ecies = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-db-api = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-discv4 = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-discv5 = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-trie-db = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-rpc-api = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-network = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-net-nat = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-tracing = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-eth-wire = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-provider = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-cli-util = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-node-api = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-db-common = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-rpc-layer = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-node-core = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-consensus = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-chainspec = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-cli-runner = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-rpc-convert = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-network-p2p = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-storage-api = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-rpc-eth-api = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-chain-state = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-trie-common = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-payload-util = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-node-builder = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-node-metrics = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-cli-commands = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-evm-ethereum = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-tracing-otlp = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-testing-utils = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-rpc-eth-types = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-network-peers = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-node-ethereum = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-rpc-engine-api = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-e2e-test-utils = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-eth-wire-types = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-payload-builder = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-execution-types = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-execution-cache = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-exex-test-utils = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-rpc-server-types = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-transaction-pool = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-execution-errors = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-payload-validator = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-payload-primitives = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-ethereum-primitives = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-basic-payload-builder = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-payload-builder-primitives = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
+reth-prune-types = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633", default-features = false }
+reth-stages-types = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633", default-features = false }
+reth-storage-errors = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633", default-features = false }
+reth-consensus-common = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633", default-features = false }
+reth-trie-parallel = { git = "https://github.com/meyer9/reth", rev = "966744f917711b2a4553653bd407653d7577e633" }
 
 # tokio
 tokio = "1.53.1"


### PR DESCRIPTION
Backports the Reth `v2.5.2` pin and parallel sharded-history-read change to the `v1.3.0` release line.

Pins `meyer9/reth` at `966744f917711b2a4553653bd407653d7577e633`.

Tests:
- `cargo +nightly check -p base --locked`