### PR TITLE
fix(grafana): Repair Devnet Dashboard Metrics

### DIFF
--- a/etc/scripts/devnet/grafana/dashboards/devnet.json
+++ b/etc/scripts/devnet/grafana/dashboards/devnet.json
@@ -299,7 +299,7 @@
             "type": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(reth_base_builder_block_built_success{job=\"l2_builder\"}[$__rate_interval])",
+          "expr": "rate(reth_base_builder_total_block_built_duration_count{job=\"l2_builder\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "Blocks Built",
           "range": true,
@@ -319,7 +319,7 @@
       },
       "id": 101,
       "panels": [],
-      "title": "OP Node (Consensus Layer)",
+      "title": "Base Consensus",
       "type": "row"
     },
     {
@@ -402,13 +402,13 @@
             "type": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(op_node_default_rpc_client_request_duration_seconds_bucket{method=\"engine_getPayloadV4\"}[$__rate_interval])) by (le))",
-          "legendFormat": "engine_payloadV4",
+          "expr": "reth_base_node_engine_method_request_duration{job=\"l2_builder\", method=\"engine_getPayload\", quantile=\"0.99\"}",
+          "legendFormat": "engine_getPayload",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "getPayload Duration P99 (op-node)",
+      "title": "getPayload Duration P99",
       "type": "barchart"
     },
     {
@@ -491,13 +491,13 @@
             "type": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(op_node_default_rpc_client_request_duration_seconds_bucket{method=\"engine_getPayloadV4\"}[$__rate_interval])) by (le))",
-          "legendFormat": "engine_payloadV4",
+          "expr": "reth_base_node_engine_method_request_duration{job=\"l2_builder\", method=\"engine_getPayload\", quantile=\"0.9\"}",
+          "legendFormat": "engine_getPayload",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "getPayload Duration P90 (op-node)",
+      "title": "getPayload Duration P90",
       "type": "barchart"
     },
     {
@@ -580,13 +580,13 @@
             "type": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(op_node_default_rpc_client_request_duration_seconds_bucket{method=\"engine_getPayloadV4\"}[$__rate_interval])) by (le))",
-          "legendFormat": "engine_payloadV4",
+          "expr": "reth_base_node_engine_method_request_duration{job=\"l2_builder\", method=\"engine_getPayload\", quantile=\"0.5\"}",
+          "legendFormat": "engine_getPayload",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "getPayload Duration P50 (op-node)",
+      "title": "getPayload Duration P50",
       "type": "barchart"
     },
     {
@@ -680,13 +680,13 @@
                 "type": "prometheus"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_flashblock_build_duration{quantile=\"0.99\"}",
-              "legendFormat": "Flashblocks Build Duration",
+              "expr": "reth_base_builder_total_block_built_duration{job=\"l2_builder\", quantile=\"0.99\"}",
+              "legendFormat": "Block Build Duration",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Flashblock Build Duration (P99)",
+          "title": "Block Build Duration (P99)",
           "type": "timeseries"
         },
         {
@@ -770,13 +770,13 @@
                 "type": "prometheus"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_flashblock_build_duration{quantile=\"0.9\"}",
-              "legendFormat": "Flashblocks Build Duration",
+              "expr": "reth_base_builder_total_block_built_duration{job=\"l2_builder\", quantile=\"0.9\"}",
+              "legendFormat": "Block Build Duration",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Flashblock Build Duration (P90)",
+          "title": "Block Build Duration (P90)",
           "type": "timeseries"
         },
         {
@@ -860,13 +860,13 @@
                 "type": "prometheus"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_flashblock_build_duration{quantile=\"0.5\"}",
-              "legendFormat": "Flashblocks Build Duration",
+              "expr": "reth_base_builder_total_block_built_duration{job=\"l2_builder\", quantile=\"0.5\"}",
+              "legendFormat": "Block Build Duration",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Flashblock Build Duration (P50)",
+          "title": "Block Build Duration (P50)",
           "type": "timeseries"
         },
         {


### PR DESCRIPTION
## Summary

Updates the local devnet Grafana dashboard to query the Base metrics that are actually exported by the builder and consensus services. It also renames the consensus section to Base Consensus and replaces stale flashblock panels with active block-build duration panels. All twelve dashboard queries were validated against a profiling-enabled local devnet.

<img width="2048" height="1137" alt="image" src="https://github.com/user-attachments/assets/efcd3248-fa0e-4e0b-a891-d36d614c2d91" />
