### PR TITLE
fix(devnet): map fork activation blocks after Denim

### DIFF
--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -227,8 +227,8 @@ _up-devnet compose_profile mode:
     case "$devnet_mode" in
       default) ;;
       zenith)
-        export L2_BASE_DENIM_BLOCK="${L2_BASE_DENIM_BLOCK-23}"
-        export L2_BASE_ZENITH_BLOCK="${L2_BASE_ZENITH_BLOCK:-53}"
+        export L2_BASE_DENIM_BLOCK="${L2_BASE_DENIM_BLOCK-25}"
+        export L2_BASE_ZENITH_BLOCK="${L2_BASE_ZENITH_BLOCK:-100}"
         ;;
       *)
         echo "ERROR: mode must be 'default' or 'zenith' (got '${devnet_mode}')" >&2

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -228,7 +228,7 @@ _up-devnet compose_profile mode:
       default) ;;
       zenith)
         export L2_BASE_DENIM_BLOCK="${L2_BASE_DENIM_BLOCK-23}"
-        export L2_BASE_ZENITH_BLOCK="${L2_BASE_ZENITH_BLOCK:-28}"
+        export L2_BASE_ZENITH_BLOCK="${L2_BASE_ZENITH_BLOCK:-53}"
         ;;
       *)
         echo "ERROR: mode must be 'default' or 'zenith' (got '${devnet_mode}')" >&2

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -228,7 +228,7 @@ _up-devnet compose_profile mode:
       default) ;;
       zenith)
         export L2_BASE_DENIM_BLOCK="${L2_BASE_DENIM_BLOCK-23}"
-        export L2_BASE_ZENITH_BLOCK="${L2_BASE_ZENITH_BLOCK:-50}"
+        export L2_BASE_ZENITH_BLOCK="${L2_BASE_ZENITH_BLOCK:-28}"
         ;;
       *)
         echo "ERROR: mode must be 'default' or 'zenith' (got '${devnet_mode}')" >&2

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -101,7 +101,7 @@ storage, and block-number predicates; `flashblock_index` predicates remain
 specific to the Flashblocks builder and are rejected after the Denim cutover.
 
 Zenith is the permanently unscheduled, genesis-only gate for future hardfork feature testing.
-Zenith mode additionally activates Zenith at block 28:
+Zenith mode additionally activates Zenith at block 53:
 
 ```bash
 just devnet up zenith

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -75,7 +75,7 @@ Anvil mines one block every 12 seconds. Do not use timestamp-warp RPCs in
 this variant: Base derives Beacon slots from L1 timestamps, so arbitrary time
 jumps would break the one-slot-per-execution-block mapping used to fetch blobs.
 
-Denim activates at block 23 by default and switches the sequencer to its 200ms
+Denim activates at block 25 by default and switches the sequencer to its 200ms
 cadence. The local Nitro stack exercises proof generation across this boundary:
 
 ```bash
@@ -96,12 +96,12 @@ the forwarding path:
   `--builder-rpc-urls` endpoint targeting the builder
 
 The default devnet compose files include these flags and schedule Cobalt at
-block 22 followed by Denim at block 23. Native payload building supports balance,
+block 22 followed by Denim at block 25. Native payload building supports balance,
 storage, and block-number predicates; `flashblock_index` predicates remain
 specific to the Flashblocks builder and are rejected after the Denim cutover.
 
 Zenith is the permanently unscheduled, genesis-only gate for future hardfork feature testing.
-Zenith mode additionally activates Zenith at block 53:
+Zenith mode additionally activates Zenith at block 100:
 
 ```bash
 just devnet up zenith

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -101,7 +101,7 @@ storage, and block-number predicates; `flashblock_index` predicates remain
 specific to the Flashblocks builder and are rejected after the Denim cutover.
 
 Zenith is the permanently unscheduled, genesis-only gate for future hardfork feature testing.
-Zenith mode additionally activates Zenith at block 50:
+Zenith mode additionally activates Zenith at block 28:
 
 ```bash
 just devnet up zenith

--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -211,11 +211,11 @@ L2_BASE_BERYL_BLOCK=21
 # Optional: set to a non-negative block number to schedule Base Cobalt in devnet.
 # Leave unset to avoid setting base.cobalt during genesis generation.
 L2_BASE_COBALT_BLOCK=22
-# Base Denim activates at block 23 by default. Override with another non-negative block number.
-L2_BASE_DENIM_BLOCK=23
+# Base Denim activates at block 25 by default. Override with another non-negative block number.
+L2_BASE_DENIM_BLOCK=25
 # Optional: set to a non-negative block number to schedule the genesis-only Base Zenith gate
-# used for future hardfork feature testing. `just devnet up zenith` defaults this to 53.
+# used for future hardfork feature testing. `just devnet up zenith` defaults this to 100.
 # Leave unset to avoid setting base.zenith during genesis generation.
-# L2_BASE_ZENITH_BLOCK=53
+# L2_BASE_ZENITH_BLOCK=100
 
 BUILDER_MAX_REJECTED_TXS_PER_BLOCK=20000

--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -214,8 +214,8 @@ L2_BASE_COBALT_BLOCK=22
 # Base Denim activates at block 23 by default. Override with another non-negative block number.
 L2_BASE_DENIM_BLOCK=23
 # Optional: set to a non-negative block number to schedule the genesis-only Base Zenith gate
-# used for future hardfork feature testing. `just devnet up zenith` defaults this to 28.
+# used for future hardfork feature testing. `just devnet up zenith` defaults this to 53.
 # Leave unset to avoid setting base.zenith during genesis generation.
-# L2_BASE_ZENITH_BLOCK=28
+# L2_BASE_ZENITH_BLOCK=53
 
 BUILDER_MAX_REJECTED_TXS_PER_BLOCK=20000

--- a/etc/docker/devnet-env
+++ b/etc/docker/devnet-env
@@ -214,8 +214,8 @@ L2_BASE_COBALT_BLOCK=22
 # Base Denim activates at block 23 by default. Override with another non-negative block number.
 L2_BASE_DENIM_BLOCK=23
 # Optional: set to a non-negative block number to schedule the genesis-only Base Zenith gate
-# used for future hardfork feature testing. `just devnet up zenith` defaults this to 50.
+# used for future hardfork feature testing. `just devnet up zenith` defaults this to 28.
 # Leave unset to avoid setting base.zenith during genesis generation.
-# L2_BASE_ZENITH_BLOCK=50
+# L2_BASE_ZENITH_BLOCK=28
 
 BUILDER_MAX_REJECTED_TXS_PER_BLOCK=20000

--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -19,6 +19,7 @@ L2_EL_BOOTNODE_ENODE_ID="${L2_EL_BOOTNODE_ENODE_ID:-4f355bdcb7cc0af728ef3cceb961
 L2_EL_BOOTNODE_ENODE="${L2_EL_BOOTNODE_ENODE:-enode://4f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa385b6b1b8ead809ca67454d9683fcf2ba03456d6fe2c4abe2b07f0fbdbb2f1c1@172.30.0.10:9303}"
 L2_CL_BOOTNODE_P2P_KEY="${L2_CL_BOOTNODE_P2P_KEY:-2222222222222222222222222222222222222222222222222222222222222222}"
 L2_CL_BOOTNODE_ENR_PATH="${L2_CL_BOOTNODE_ENR_PATH:-/bootnodes/cl-bootnode.enr}"
+NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS=200
 
 if [ "${SETUP_L2_SKIP_IF_CONFIGURED:-}" = "true" ] && [ -f "$OUTPUT_DIR/.setup-complete" ]; then
   echo "L2 configuration already generated; reusing $OUTPUT_DIR"
@@ -31,6 +32,26 @@ replace_output_file() {
 
   chmod 0644 "$source_file"
   mv "$source_file" "$destination_file"
+}
+
+block_to_timestamp() {
+  local target_block="$1"
+
+  if [ -z "$L2_BASE_DENIM_BLOCK" ] || [ "$target_block" -le "$L2_BASE_DENIM_BLOCK" ]; then
+    echo $((L2_GENESIS_TIME + L2_BLOCK_TIME * target_block))
+  else
+    echo $((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_BASE_DENIM_BLOCK + (target_block - L2_BASE_DENIM_BLOCK) * NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS / 1000))
+  fi
+}
+
+validate_activation_block_alignment() {
+  local variable_name="$1"
+  local target_block="$2"
+
+  if [ -n "$L2_BASE_DENIM_BLOCK" ] && [ -n "$target_block" ] && [ "$target_block" -gt "$L2_BASE_DENIM_BLOCK" ] && [ $(((target_block - L2_BASE_DENIM_BLOCK) * NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS % 1000)) -ne 0 ]; then
+    echo "ERROR: $variable_name must align to a whole-second timestamp after L2_BASE_DENIM_BLOCK (post-Denim block offset must be divisible by 5), got: $target_block"
+    exit 1
+  fi
 }
 
 if [ -n "$L2_BASE_AZUL_BLOCK" ] && ! [[ "$L2_BASE_AZUL_BLOCK" =~ ^[0-9]+$ ]]; then
@@ -57,6 +78,13 @@ if [ -n "$L2_ISTHMUS_BLOCK" ] && ! [[ "$L2_ISTHMUS_BLOCK" =~ ^[0-9]+$ ]]; then
   echo "ERROR: L2_ISTHMUS_BLOCK must be a non-negative integer when set, got: $L2_ISTHMUS_BLOCK"
   exit 1
 fi
+
+validate_activation_block_alignment "L2_BASE_AZUL_BLOCK" "$L2_BASE_AZUL_BLOCK"
+validate_activation_block_alignment "L2_BASE_BERYL_BLOCK" "$L2_BASE_BERYL_BLOCK"
+validate_activation_block_alignment "L2_BASE_COBALT_BLOCK" "$L2_BASE_COBALT_BLOCK"
+validate_activation_block_alignment "L2_BASE_DENIM_BLOCK" "$L2_BASE_DENIM_BLOCK"
+validate_activation_block_alignment "L2_BASE_ZENITH_BLOCK" "$L2_BASE_ZENITH_BLOCK"
+validate_activation_block_alignment "L2_ISTHMUS_BLOCK" "$L2_ISTHMUS_BLOCK"
 
 echo "=== L2 Genesis Generator (Live Deployment) ==="
 echo "L1 RPC URL: $L1_RPC_URL"
@@ -211,7 +239,7 @@ echo "Patched activation admin into genesis config"
 L2_BLOCK_TIME=$(jq -re '.block_time' "$OUTPUT_DIR/rollup.json")
 L2_GENESIS_TIME=$(jq -re '.genesis.l2_time' "$OUTPUT_DIR/rollup.json")
 if [ -n "$L2_ISTHMUS_BLOCK" ]; then
-  L2_ISTHMUS_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_ISTHMUS_BLOCK))
+  L2_ISTHMUS_TIME=$(block_to_timestamp "$L2_ISTHMUS_BLOCK")
 
   echo ""
   echo "=== Configuring Isthmus Activation ==="
@@ -246,7 +274,7 @@ else
 fi
 
 if [ -n "$L2_BASE_AZUL_BLOCK" ]; then
-  L2_BASE_AZUL_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_BASE_AZUL_BLOCK))
+  L2_BASE_AZUL_TIME=$(block_to_timestamp "$L2_BASE_AZUL_BLOCK")
 
   echo ""
   echo "=== Configuring Base Azul Activation ==="
@@ -282,7 +310,7 @@ else
 fi
 
 if [ -n "$L2_BASE_BERYL_BLOCK" ]; then
-  L2_BASE_BERYL_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_BASE_BERYL_BLOCK))
+  L2_BASE_BERYL_TIME=$(block_to_timestamp "$L2_BASE_BERYL_BLOCK")
 
   echo ""
   echo "=== Configuring Base Beryl Activation ==="
@@ -317,7 +345,7 @@ else
 fi
 
 if [ -n "$L2_BASE_COBALT_BLOCK" ]; then
-  L2_BASE_COBALT_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_BASE_COBALT_BLOCK))
+  L2_BASE_COBALT_TIME=$(block_to_timestamp "$L2_BASE_COBALT_BLOCK")
 
   echo ""
   echo "=== Configuring Base Cobalt Activation ==="
@@ -352,7 +380,7 @@ else
 fi
 
 if [ -n "$L2_BASE_DENIM_BLOCK" ]; then
-  L2_BASE_DENIM_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_BASE_DENIM_BLOCK))
+  L2_BASE_DENIM_TIME=$(block_to_timestamp "$L2_BASE_DENIM_BLOCK")
 
   echo ""
   echo "=== Configuring Base Denim Activation ==="
@@ -389,7 +417,7 @@ fi
 # Zenith is the permanently-off gate used for future hardfork feature testing. It is not
 # contract-backed, so genesis config is the only way to schedule it.
 if [ -n "$L2_BASE_ZENITH_BLOCK" ]; then
-  L2_BASE_ZENITH_TIME=$((L2_GENESIS_TIME + L2_BLOCK_TIME * L2_BASE_ZENITH_BLOCK))
+  L2_BASE_ZENITH_TIME=$(block_to_timestamp "$L2_BASE_ZENITH_BLOCK")
 
   echo ""
   echo "=== Configuring Base Zenith Activation ==="

--- a/etc/scripts/devnet/setup-l2.sh
+++ b/etc/scripts/devnet/setup-l2.sh
@@ -82,7 +82,6 @@ fi
 validate_activation_block_alignment "L2_BASE_AZUL_BLOCK" "$L2_BASE_AZUL_BLOCK"
 validate_activation_block_alignment "L2_BASE_BERYL_BLOCK" "$L2_BASE_BERYL_BLOCK"
 validate_activation_block_alignment "L2_BASE_COBALT_BLOCK" "$L2_BASE_COBALT_BLOCK"
-validate_activation_block_alignment "L2_BASE_DENIM_BLOCK" "$L2_BASE_DENIM_BLOCK"
 validate_activation_block_alignment "L2_BASE_ZENITH_BLOCK" "$L2_BASE_ZENITH_BLOCK"
 validate_activation_block_alignment "L2_ISTHMUS_BLOCK" "$L2_ISTHMUS_BLOCK"
 

--- a/etc/systems/tests/smoke.rs
+++ b/etc/systems/tests/smoke.rs
@@ -28,7 +28,7 @@ static SMOKE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new((
 async fn denim_and_zenith_activation_matches_el_and_cl_configs() -> Result<()> {
     const AZUL_ACTIVATION_BLOCK: u64 = 20;
     const DENIM_ACTIVATION_BLOCK: u64 = 23;
-    const ZENITH_ACTIVATION_BLOCK: u64 = 28;
+    const ZENITH_ACTIVATION_BLOCK: u64 = 53;
 
     let _guard = SMOKE_TEST_LOCK.lock().await;
     let system = SystemTestStackBuilder::new()

--- a/etc/systems/tests/smoke.rs
+++ b/etc/systems/tests/smoke.rs
@@ -27,8 +27,8 @@ static SMOKE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new((
 #[tokio::test]
 async fn denim_and_zenith_activation_matches_el_and_cl_configs() -> Result<()> {
     const AZUL_ACTIVATION_BLOCK: u64 = 20;
-    const DENIM_ACTIVATION_BLOCK: u64 = 23;
-    const ZENITH_ACTIVATION_BLOCK: u64 = 53;
+    const DENIM_ACTIVATION_BLOCK: u64 = 25;
+    const ZENITH_ACTIVATION_BLOCK: u64 = 100;
 
     let _guard = SMOKE_TEST_LOCK.lock().await;
     let system = SystemTestStackBuilder::new()
@@ -67,8 +67,8 @@ async fn denim_and_zenith_activation_matches_el_and_cl_configs() -> Result<()> {
 fn rejects_post_denim_block_without_whole_second_timestamp() {
     let output = Command::new("bash")
         .arg(concat!(env!("CARGO_MANIFEST_DIR"), "/../scripts/devnet/setup-l2.sh"))
-        .env("L2_BASE_DENIM_BLOCK", "23")
-        .env("L2_BASE_ZENITH_BLOCK", "24")
+        .env("L2_BASE_DENIM_BLOCK", "25")
+        .env("L2_BASE_ZENITH_BLOCK", "26")
         .output()
         .unwrap();
 

--- a/etc/systems/tests/smoke.rs
+++ b/etc/systems/tests/smoke.rs
@@ -1,6 +1,6 @@
 //! Smoke tests for the full `SystemTestStack` stack.
 
-use std::time::Duration;
+use std::{process::Command, time::Duration};
 
 use alloy_consensus::SignableTransaction;
 use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
@@ -9,6 +9,7 @@ use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, RootProvider};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
+use base_common_genesis::RollupConfig;
 use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_system_tests::{ANVIL_ACCOUNT_1, SystemTestStackBuilder};
@@ -25,26 +26,32 @@ static SMOKE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new((
 
 #[tokio::test]
 async fn denim_and_zenith_activation_matches_el_and_cl_configs() -> Result<()> {
+    const AZUL_ACTIVATION_BLOCK: u64 = 20;
     const DENIM_ACTIVATION_BLOCK: u64 = 23;
-    const ZENITH_ACTIVATION_BLOCK: u64 = 25;
+    const ZENITH_ACTIVATION_BLOCK: u64 = 28;
 
     let _guard = SMOKE_TEST_LOCK.lock().await;
     let system = SystemTestStackBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
+        .with_base_azul_activation_block(AZUL_ACTIVATION_BLOCK)
         .with_base_denim_activation_block(DENIM_ACTIVATION_BLOCK)
         .with_base_zenith_activation_block(ZENITH_ACTIVATION_BLOCK)
         .build()
         .await?;
 
     let genesis: serde_json::Value = serde_json::from_str(&system.l2_deployment().read_genesis()?)?;
-    let rollup: serde_json::Value =
-        serde_json::from_str(&system.l2_deployment().read_rollup_config()?)?;
-    let l2_time = rollup["genesis"]["l2_time"].as_u64().unwrap();
-    let block_time = rollup["block_time"].as_u64().unwrap();
-    let expected_denim = l2_time + block_time * DENIM_ACTIVATION_BLOCK;
-    let expected_zenith = l2_time + block_time * ZENITH_ACTIVATION_BLOCK;
+    let rollup_json = system.l2_deployment().read_rollup_config()?;
+    let rollup: serde_json::Value = serde_json::from_str(&rollup_json)?;
+    let rollup_config: RollupConfig = serde_json::from_str(&rollup_json)?;
+    let expected_azul =
+        rollup_config.genesis.l2_time + rollup_config.block_time * AZUL_ACTIVATION_BLOCK;
+    let expected_denim = rollup_config.l2_block_timestamp(DENIM_ACTIVATION_BLOCK);
+    let expected_zenith = rollup_config.l2_block_timestamp(ZENITH_ACTIVATION_BLOCK);
+    assert_eq!(rollup_config.l2_block_timestamp_parts(ZENITH_ACTIVATION_BLOCK).1, 0);
 
+    assert_eq!(rollup["base"]["azul"].as_u64(), Some(expected_azul));
+    assert_eq!(genesis["config"]["base"]["azul"].as_u64(), Some(expected_azul));
     assert_eq!(rollup["base"]["denim"].as_u64(), Some(expected_denim));
     assert_eq!(genesis["config"]["base"]["denim"].as_u64(), Some(expected_denim));
 
@@ -54,6 +61,21 @@ async fn denim_and_zenith_activation_matches_el_and_cl_configs() -> Result<()> {
     assert_eq!(genesis["config"]["base"]["zenith"].as_u64(), Some(expected_zenith));
 
     Ok(())
+}
+
+#[test]
+fn rejects_post_denim_block_without_whole_second_timestamp() {
+    let output = Command::new("bash")
+        .arg(concat!(env!("CARGO_MANIFEST_DIR"), "/../scripts/devnet/setup-l2.sh"))
+        .env("L2_BASE_DENIM_BLOCK", "23")
+        .env("L2_BASE_ZENITH_BLOCK", "24")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stdout).contains(
+        "L2_BASE_ZENITH_BLOCK must align to a whole-second timestamp after L2_BASE_DENIM_BLOCK"
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
- Convert post-Denim fork block settings using the canonical 200 ms cadence while preserving legacy pre-Denim timestamps.
- Reject subsecond activation boundaries, align Denim at block 25, and leave room for intervening forks before Zenith at block 100.