### PR TITLE
feat(devnet): Add Base MEV Dashboard

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -855,6 +855,9 @@ impl BasePayloadBuilderCtx {
         // evaluation, so it both accumulates and records whether any validity
         // transaction was seen; emitted once when the loop finishes.
         let mut predicate_eval_total: Option<Duration> = None;
+        let mut validity_candidates_evaluated = 0_u64;
+        let mut validity_candidates_deferred = 0_u64;
+        let mut predicate_eval_cutoff_hit = false;
 
         while let Some(tx) = best_txs.next(()) {
             if self.cancel.is_cancelled() {
@@ -897,6 +900,8 @@ impl BasePayloadBuilderCtx {
                 self.emit_considered(&cx, tx_hash, ordering_position);
                 ValidityMetrics::validity_predicate_evaluations_total("budget_exhausted")
                     .increment(1);
+                validity_candidates_deferred += 1;
+                predicate_eval_cutoff_hit = true;
                 self.defer_or_reject_current(best_txs, &mut diag, &cx, &tx, ordering_position);
                 continue;
             }
@@ -904,6 +909,7 @@ impl BasePayloadBuilderCtx {
             let mut predicate_read_failed = false;
             let mut predicate_expired = false;
             let blocking_predicate = if has_validity_predicates {
+                validity_candidates_evaluated += 1;
                 match Self::accumulate_elapsed(&mut predicate_eval_total, || {
                     let mut recorder =
                         PredicateReadRecorder::new(&mut **evm.db_mut(), &mut info.predicate_loads);
@@ -1509,6 +1515,7 @@ impl BasePayloadBuilderCtx {
                         "rescan_budget_exhausted",
                     )
                     .increment(remaining);
+                    predicate_eval_cutoff_hit = true;
                     break;
                 }
                 let mut predicate_read_failed = false;
@@ -1612,6 +1619,11 @@ impl BasePayloadBuilderCtx {
         if let Some(predicate_eval_total) = predicate_eval_total {
             ValidityMetrics::record_predicate_eval_duration(predicate_eval_total);
         }
+        ValidityMetrics::record_predicate_evaluation_coverage(
+            validity_candidates_evaluated,
+            validity_candidates_deferred,
+            predicate_eval_cutoff_hit,
+        );
 
         let payload_transaction_simulation_time = execute_txs_start_time.elapsed();
         BuilderMetrics::set_payload_builder_metrics(

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -847,6 +847,9 @@ where
         let mut predicate_eval_duration = None;
         let mut predicate_bucket_wakeups = 0;
         let mut validity_consideration_index = 0_u64;
+        let mut validity_candidates_evaluated = 0_u64;
+        let mut validity_candidates_deferred = 0_u64;
+        let mut predicate_eval_cutoff_hit = false;
 
         let block_timestamp = self.attributes().timestamp();
         let can_finalize_early = self.is_denim_active();
@@ -913,6 +916,8 @@ where
             {
                 ValidityMetrics::validity_predicate_evaluations_total("budget_exhausted")
                     .increment(1);
+                validity_candidates_deferred += 1;
+                predicate_eval_cutoff_hit = true;
                 trace!(
                     target: "payload_builder",
                     tx_hash = ?tx_hash,
@@ -951,6 +956,7 @@ where
             }
 
             if has_validity_predicates {
+                validity_candidates_evaluated += 1;
                 let evaluation_start = Instant::now();
                 let evaluation = {
                     let mut recorder = PredicateReadRecorder::new(
@@ -1215,6 +1221,7 @@ where
                         "rescan_budget_exhausted",
                     )
                     .increment(remaining as u64);
+                    predicate_eval_cutoff_hit = true;
                     break;
                 }
                 let Some(parked_transaction) = predicate_index.transaction(parked_hash) else {
@@ -1294,6 +1301,11 @@ where
         if let Some(predicate_eval_duration) = predicate_eval_duration {
             ValidityMetrics::record_predicate_eval_duration(predicate_eval_duration);
         }
+        ValidityMetrics::record_predicate_evaluation_coverage(
+            validity_candidates_evaluated,
+            validity_candidates_deferred,
+            predicate_eval_cutoff_hit,
+        );
         ValidityMetrics::record_predicate_loads(&predicate_loads);
         ValidityMetrics::record_predicate_index_diagnostics(
             predicate_bucket_wakeups,

--- a/crates/execution/payload/src/metrics.rs
+++ b/crates/execution/payload/src/metrics.rs
@@ -16,6 +16,22 @@ base_metrics::define_metrics! {
     )]
     validity_predicate_eval_duration_per_block: histogram,
     #[describe(
+        "Supported validity transaction candidates evaluated during the primary scan per build"
+    )]
+    validity_predicate_candidates_evaluated_per_build: histogram,
+    #[describe(
+        "Validity transaction candidates deferred without evaluation after the predicate budget was exhausted per build"
+    )]
+    validity_predicate_candidates_deferred_per_build: histogram,
+    #[describe(
+        "Fraction of supported primary-scan validity transaction candidates evaluated per build"
+    )]
+    validity_predicate_evaluation_coverage_per_build: histogram,
+    #[describe(
+        "Builds that deferred at least one primary or rescan validity transaction after exhausting the predicate evaluation budget"
+    )]
+    validity_predicate_eval_cutoff_builds_total: counter,
+    #[describe(
         "Number of validity-predicate index buckets woken per build"
     )]
     predicate_bucket_wakeups: histogram,
@@ -74,6 +90,25 @@ impl ValidityMetrics {
     /// Records the total validity predicate evaluation time accumulated across one build.
     pub fn record_predicate_eval_duration(duration: Duration) {
         Self::validity_predicate_eval_duration_per_block().record(duration.as_secs_f64());
+    }
+
+    /// Records primary-scan predicate evaluation coverage and whether the build exhausted its
+    /// evaluation budget.
+    ///
+    /// Counts are emitted for every completed build, including builds with no validity candidates.
+    /// Coverage is emitted only when at least one supported candidate was evaluated or deferred.
+    pub fn record_predicate_evaluation_coverage(evaluated: u64, deferred: u64, cutoff_hit: bool) {
+        Self::validity_predicate_candidates_evaluated_per_build().record(evaluated as f64);
+        Self::validity_predicate_candidates_deferred_per_build().record(deferred as f64);
+
+        let candidates = evaluated + deferred;
+        if candidates > 0 {
+            Self::validity_predicate_evaluation_coverage_per_build()
+                .record(evaluated as f64 / candidates as f64);
+        }
+        if cutoff_hit {
+            Self::validity_predicate_eval_cutoff_builds_total().increment(1);
+        }
     }
 
     /// Records the block's accumulated validity-predicate state loads.
@@ -153,6 +188,7 @@ mod tests {
 
         metrics::with_local_recorder(&recorder, || {
             ValidityMetrics::record_predicate_eval_duration(Duration::from_millis(500));
+            ValidityMetrics::record_predicate_evaluation_coverage(4, 1, true);
             ValidityMetrics::record_predicate_loads(&tracker);
             ValidityMetrics::record_predicate_index_diagnostics(3, &index);
         });
@@ -161,6 +197,19 @@ mod tests {
         assert!(
             rendered.contains("base_builder_validity_predicate_eval_duration_per_block_sum 0.5")
         );
+        assert!(
+            rendered
+                .contains("base_builder_validity_predicate_candidates_evaluated_per_build_sum 4")
+        );
+        assert!(
+            rendered
+                .contains("base_builder_validity_predicate_candidates_deferred_per_build_sum 1")
+        );
+        assert!(
+            rendered
+                .contains("base_builder_validity_predicate_evaluation_coverage_per_build_sum 0.8")
+        );
+        assert!(rendered.contains("base_builder_validity_predicate_eval_cutoff_builds_total 1"));
         assert!(rendered.contains("base_builder_predicate_accounts_loaded_total_sum 2"));
         assert!(rendered.contains("base_builder_predicate_accounts_loaded_unique_sum 1"));
         assert!(rendered.contains("base_builder_predicate_slots_loaded_total_sum 1"));

--- a/etc/scripts/devnet/grafana/dashboards/base-mev.json
+++ b/etc/scripts/devnet/grafana/dashboards/base-mev.json
@@ -1,0 +1,3319 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Devnet Overview",
+      "tooltip": "Open the general devnet dashboard",
+      "type": "link",
+      "url": "/d/devnet-overview"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Prometheus",
+      "tooltip": "Inspect raw local metrics",
+      "type": "link",
+      "url": "http://localhost:9090"
+    }
+  ],
+  "liveNow": false,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 200,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "# 🔵 Base MEV · Validity Transaction Control Room\nFollow the local path from **RPC/client admission → builder predicates → Flashblock selection → inclusion and fee value**. Blue is validity traffic, cyan is standard traffic, green is healthy, amber needs attention, and red is actionable. Rates use **$window**; summary charts use **p$quantile**.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "10.4.1",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Triage · Is validity traffic flowing safely?",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Fraction of builder, client, and Base RPC Prometheus targets currently reachable. Check this before interpreting zeros or missing series.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "color": "#8A95A5",
+                  "text": "NO TELEMETRY"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#F2495C",
+                "value": null
+              },
+              {
+                "color": "#F2B84B",
+                "value": 0.67
+              },
+              {
+                "color": "#3BD671",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "avg(up{job=~\"l2_builder|l2_client|l2_base_rpc\"})",
+          "legendFormat": "targets online",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Core Targets",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Successfully completed L2 block builds per second. A gap with the builder target up indicates stalled construction.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#0052FF",
+            "mode": "fixed"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 4
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate((reth_base_builder_block_built_success{job=\"l2_builder\"} * 1)[$window:]))",
+          "legendFormat": "blocks / s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Build Throughput",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Share of included user transactions carrying validity predicates. The value is intentionally absent when no transactions were included; use throughput beside it to distinguish idle traffic.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#0052FF",
+            "mode": "fixed"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 4
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "((sum(rate(reth_base_builder_txs_included_per_block_sum{job=\"l2_builder\",flow=\"validity\"}[$window])) / sum(rate(reth_base_builder_txs_included_per_block_sum{job=\"l2_builder\"}[$window]))) and on() (sum(rate(reth_base_builder_txs_included_per_block_sum{job=\"l2_builder\"}[$window])) > 0))",
+          "legendFormat": "validity share",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Validity Share",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Direct validity-transaction inclusion throughput from per-block observations. This is an endpoint signal, not a subtraction-based funnel estimate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "#0052FF",
+            "mode": "fixed"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 4
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(reth_base_builder_txs_included_per_block_sum{job=\"l2_builder\",flow=\"validity\"}[$window]))",
+          "legendFormat": "validity tx / s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Validity Included",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Invalid blocks built during the selected rate window. Any non-zero result requires immediate builder log and trace inspection.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#3BD671",
+                "value": null
+              },
+              {
+                "color": "#F2495C",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(reth_base_builder_invalid_built_blocks_count{job=\"l2_builder\"}[$window])) or vector(0)",
+          "legendFormat": "invalid blocks",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Invalid Blocks",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Status of the Tips ingress metrics endpoint. OFFLINE is expected for the standard devnet; ONLINE appears when the ingress overlay is running.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "#8A95A5",
+                  "text": "OFFLINE"
+                },
+                "1": {
+                  "color": "#3BD671",
+                  "text": "ONLINE"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#8A95A5",
+                "value": null
+              },
+              {
+                "color": "#3BD671",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "max(up{job=\"tips_ingress\"}) or vector(0)",
+          "legendFormat": "Tips ingress",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Optional Ingress",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 101,
+      "panels": [],
+      "title": "Validity lifecycle · Where are transactions admitted, parked, rejected, and included?",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Successful validity admissions by node and outcome. Added and replaced measure pool activity, not unique end-to-end transactions; the same transaction may appear at several nodes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 45,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/added/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3BD671",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/replaced/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2B84B",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job, outcome) (rate(reth_txpool_validity_admitted{job=~\"l2_builder|l2_client|l2_base_rpc\"}[$window]))",
+          "legendFormat": "{{job}} · {{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Validity Admissions by Node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Direct included transaction throughput segmented by standard and validity flow. Both flow series emit zero observations for empty blocks.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 45,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "validity"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0052FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "standard"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#00A3FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (flow) (rate(reth_base_builder_txs_included_per_block_sum{job=\"l2_builder\"}[$window]))",
+          "legendFormat": "{{flow}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Included Transactions by Flow",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Builder predicate evaluations by outcome. Investigate read errors immediately; budget exhaustion means candidates were deferred to a later Flashblock rather than rejected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 45,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/matched/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3BD671",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/not_satisfied|budget/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2B84B",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/expired|error/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2495C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (outcome) (rate(reth_base_builder_validity_predicate_evaluations_total{job=\"l2_builder\"}[$window]))",
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Predicate Outcomes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Independent stage rates. Admission limits reject before pooling, invalidations evict tracked transactions, and prechecks drop stale manifests. Do not subtract these asynchronous counters as a transaction-exact funnel.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 38,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 3,
+          "mappings": [],
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job, reason) (rate(reth_txpool_guard_admission_rejected{job=~\"l2_builder|l2_client|l2_base_rpc\"}[$window]))",
+          "legendFormat": "{{job}} · admission · {{reason}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (job, cause) (rate(reth_txpool_guard_invalidated{job=~\"l2_builder|l2_client|l2_base_rpc\"}[$window]))",
+          "legendFormat": "{{job}} · invalidated · {{cause}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cause) (rate(reth_txpool_guard_builder_precheck_dropped{job=\"l2_builder\"}[$window]))",
+          "legendFormat": "builder · precheck · {{cause}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Admission, Invalidation & Precheck Pressure",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 102,
+      "panels": [],
+      "title": "Flow economics · Which cohort earns inclusion and fee value?",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Priority-fee value directed to the builder and base-fee value represented by included gas, converted to ETH per second. Base fee is shown as burn/value and is not builder profit.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 8,
+          "mappings": [],
+          "unit": "ETH/s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/validity/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0052FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/standard/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#00A3FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/base-fee/i"
+            },
+            "properties": [
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    8,
+                    8
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (flow) (rate(reth_base_builder_priority_fee_revenue_wei_sum{job=\"l2_builder\"}[$window])) / 1e18",
+          "legendFormat": "{{flow}} · priority fee",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (flow) (rate(reth_base_builder_base_fee_revenue_wei_sum{job=\"l2_builder\"}[$window])) / 1e18",
+          "legendFormat": "{{flow}} · base-fee value",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Fee Value by Flow",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Transaction-weighted mean builder ordering score for included transactions, split by flow and bid mechanism. Empty cohorts remain absent rather than appearing as zero bids.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "unit": "wei/gas"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/validity/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0052FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/standard/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#00A3FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (flow, bid) (rate(reth_base_builder_tip_per_gas_sum{job=\"l2_builder\"}[$window])) / sum by (flow, bid) (rate(reth_base_builder_tip_per_gas_count{job=\"l2_builder\"}[$window]))",
+          "legendFormat": "{{flow}} · {{bid}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Mean Tip per Gas",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Observation-weighted mean included user transactions per block. These summary sums and counts include zero observations for empty flow cohorts.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "validity"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0052FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "standard"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#00A3FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (flow) (rate(reth_base_builder_txs_included_per_block_sum{job=\"l2_builder\"}[$window])) / sum by (flow) (rate(reth_base_builder_txs_included_per_block_count{job=\"l2_builder\"}[$window]))",
+          "legendFormat": "{{flow}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transactions per Block",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Observation-weighted mean included gas per block, segmented by flow. Use the Flashblock headroom row to diagnose saturation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "validity"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#0052FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "standard"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#00A3FF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum by (flow) (rate(reth_base_builder_tx_gas_used_per_block_sum{job=\"l2_builder\"}[$window])) / sum by (flow) (rate(reth_base_builder_tx_gas_used_per_block_count{job=\"l2_builder\"}[$window]))",
+          "legendFormat": "{{flow}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Gas per Block by Flow",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 103,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Selected local summary quantile for initial predicate evaluation and rescans. These quantiles come from the single devnet builder and are not aggregated across instances.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "decimals": 4,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#3BD671",
+                    "value": null
+                  },
+                  {
+                    "color": "#F2B84B",
+                    "value": 0.05
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 0.15
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_validity_predicate_eval_duration_per_block{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "initial · p$quantile",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_validity_predicate_rescan_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "rescan · p$quantile",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Predicate Latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Mean account and storage reads for builds with predicate activity. These summaries intentionally omit builds with no predicate reads; widening total-versus-unique lines expose repeated state access.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 16,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(reth_base_builder_predicate_accounts_loaded_total_sum{job=\"l2_builder\"}[$window])) / sum(rate(reth_base_builder_predicate_accounts_loaded_total_count{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "accounts · total",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(reth_base_builder_predicate_accounts_loaded_unique_sum{job=\"l2_builder\"}[$window])) / sum(rate(reth_base_builder_predicate_accounts_loaded_unique_count{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "accounts · unique",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(reth_base_builder_predicate_slots_loaded_total_sum{job=\"l2_builder\"}[$window])) / sum(rate(reth_base_builder_predicate_slots_loaded_total_count{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "slots · total",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(reth_base_builder_predicate_slots_loaded_unique_sum{job=\"l2_builder\"}[$window])) / sum(rate(reth_base_builder_predicate_slots_loaded_unique_count{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "slots · unique",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Predicate State Reads per Active Build",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Predicate detail · Are validity conditions cheap, readable, and becoming satisfiable?",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 104,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Direct reader and forwarder stage rates by node. These are not a lossless funnel because batching, retries, deduplication, and multiple nodes can repeat a transaction.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 17,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_txpool_reader_txs_read{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · read",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_txpool_reader_txs_sent{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · queued",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_txpool_forwarder_txs_forwarded{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · forwarded",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_txpool_forwarder_num_tx_rejected_in_batch{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · builder rejected",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Node Intake → Builder",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Current transactions waiting in the destination channel or buffered for a batch. Sustained growth with flat forwarded throughput indicates backpressure.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 18,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "max by (job, builder_url) (reth_txpool_forwarder_queue_size{job=~\"l2_client|l2_base_rpc\"})",
+              "legendFormat": "{{job}} · queue",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "max by (job, builder_url) (reth_txpool_forwarder_buffer_size{job=~\"l2_client|l2_base_rpc\"})",
+              "legendFormat": "{{job}} · buffer",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Forwarding Queue & Buffer",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Forwarding failures after retries plus successful calls with per-item builder rejection. Any sustained rate is actionable; the two families count different failure stages.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#F2495C",
+                "mode": "fixed"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 45,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 19,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job, reason) (rate(reth_txpool_forwarder_rpc_errors{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · {{reason}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_txpool_forwarder_num_tx_rejected_in_batch{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · builder item rejection",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Forwarding Faults",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Selected local summary quantiles for forwarding round trips and txpool validation. Keep each node and kind separate because exporter summary quantiles cannot be aggregated.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 4,
+              "mappings": [],
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 20,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_txpool_forwarder_rpc_latency{job=~\"l2_client|l2_base_rpc\",quantile=\"$quantile\"}",
+              "legendFormat": "{{job}} · forward · p$quantile",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_txpool_validator_validate_seconds{job=~\"l2_builder|l2_client|l2_base_rpc\",quantile=\"$quantile\"}",
+              "legendFormat": "{{job}} · {{kind}} validate · p$quantile",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Forwarding & Validation Latency",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Forwarding detail · Does node demand reach the builder without pressure or retry loss?",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 105,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Observation-weighted mean cumulative gas headroom by Flashblock index. Headroom should decline as a block fills; early exhaustion indicates capacity pressure.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "decimals": 1,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#F2495C",
+                    "value": null
+                  },
+                  {
+                    "color": "#F2B84B",
+                    "value": 5
+                  },
+                  {
+                    "color": "#3BD671",
+                    "value": 15
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 21,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (flashblock_index) (rate(reth_base_builder_flashblock_gas_headroom_pct_sum{job=\"l2_builder\"}[$window])) / sum by (flashblock_index) (rate(reth_base_builder_flashblock_gas_headroom_pct_count{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "FB {{flashblock_index}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Mean Gas Headroom by Flashblock",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Direct selection rejection rates by Flashblock index and reason. Deferred candidates are separate; do not derive rejection by subtracting considered and included transactions.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 45,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 22,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (flashblock_index, reason) (rate(reth_base_builder_flashblock_rejections_total{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "FB {{flashblock_index}} · {{reason}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Rejections by Flashblock & Reason",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Selected local summary quantile for builder stages that consume the 200 ms local Flashblock budget. The red threshold marks the configured interval, not a universal production limit.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "decimals": 4,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#3BD671",
+                    "value": null
+                  },
+                  {
+                    "color": "#F2B84B",
+                    "value": 0.15
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 0.2
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 23,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_flashblock_build_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "build · p$quantile",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_transaction_pool_fetch_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "pool fetch · p$quantile",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_payload_transaction_simulation_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "payload simulation · p$quantile",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Flashblock Critical Path · p$quantile",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Selected summary quantile of Flashblocks omitted because construction started late or missed its schedule. Zero is healthy; sustained non-zero values indicate deadline pressure.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 45,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 1,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/missing/i"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/reduced/i"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2B84B",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 24,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_missing_flashblocks_count{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "missing · p$quantile",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_reduced_flashblocks_number{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "reduced · p$quantile",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Missing or Reduced Flashblocks",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Flashblock capacity · Are selection passes on time and using gas efficiently?",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 106,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Share of observed included transactions with metering information. The value is absent when no metering decisions occurred; pending skips and late arrivals expose delivery races.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#F2495C",
+                    "value": null
+                  },
+                  {
+                    "color": "#F2B84B",
+                    "value": 0.95
+                  },
+                  {
+                    "color": "#3BD671",
+                    "value": 0.99
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 0,
+            "y": 45
+          },
+          "id": 25,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "value_and_name",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "((sum(rate(reth_base_builder_metering_known_transaction{job=\"l2_builder\"}[$window])) / (sum(rate(reth_base_builder_metering_known_transaction{job=\"l2_builder\"}[$window])) + sum(rate(reth_base_builder_metering_unknown_transaction{job=\"l2_builder\"}[$window])))) and on() ((sum(rate(reth_base_builder_metering_known_transaction{job=\"l2_builder\"}[$window])) + sum(rate(reth_base_builder_metering_unknown_transaction{job=\"l2_builder\"}[$window]))) > 0))",
+              "legendFormat": "known share",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Metering Coverage",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Rates of known/unknown metering decisions, pending skips, and late arrivals. Unknown, pending, or late events are degradation signals.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 45,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 18,
+            "x": 6,
+            "y": 45
+          },
+          "id": 26,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(reth_base_builder_metering_known_transaction{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "known",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(reth_base_builder_metering_unknown_transaction{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "unknown",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(reth_base_builder_metering_data_pending_skip{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "pending skip",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(reth_base_builder_metering_late_arrival_total{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "late arrival",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Metering Activity",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Potential and enforced resource-budget violations by dimension and transaction/block scope. Limit-exceeded includes enforced throttles, so the series overlap and are not stacked.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 45,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 52
+          },
+          "id": 27,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (dimension, scope) (rate(reth_base_payload_resource_metering_limit_exceeded_total{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "would exceed · {{scope}} · {{dimension}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (dimension, scope) (rate(reth_base_payload_resource_metering_throttled_total{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "throttled · {{scope}} · {{dimension}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Resource Metering Decisions",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Selected local summary quantile for predicted execution time, signed prediction error, and actual execution time of unmetered transactions. All values are microseconds.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 1,
+              "mappings": [],
+              "unit": "µs"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 52
+          },
+          "id": 28,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_tx_predicted_execution_time_us{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "predicted · p$quantile",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_execution_time_prediction_error_us{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "prediction error · p$quantile",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_unmetered_tx_actual_execution_time_us{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "unmetered actual · p$quantile",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Execution Metering Prediction · p$quantile",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Metering & execution · Is the builder informed, accurate, and resource-safe?",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 107,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Messages received from the builder Flashblock stream by consumer node. A drop to zero with targets up suggests a disconnected or stalled stream.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 46
+          },
+          "id": 29,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_reth_flashblocks_upstream_messages{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Flashblock Receive Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Upstream errors, processing failures, unexpected order, reconnects, and stale drops. These should remain zero outside deliberate fault testing.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "#F2495C",
+                "mode": "fixed"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 45,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 46
+          },
+          "id": 30,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_reth_flashblocks_upstream_errors{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · upstream error",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_reth_flashblocks_block_processing_error{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · processing error",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_reth_flashblocks_unexpected_block_order{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · unexpected order",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_reth_flashblocks_reconnect_attempts{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · reconnect",
+              "range": true,
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum by (job) (rate(reth_reth_flashblocks_pending_drop_stale{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "legendFormat": "{{job}} · stale drop",
+              "range": true,
+              "refId": "E"
+            }
+          ],
+          "title": "Stream Integrity Events",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Selected local summary quantile for Flashblock processing by consumer. Keep each node separate because exporter summary quantiles are not aggregatable.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 4,
+              "mappings": [],
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 46
+          },
+          "id": 31,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_reth_flashblocks_block_processing_duration{job=~\"l2_client|l2_base_rpc\",quantile=\"$quantile\"}",
+              "legendFormat": "{{job}} · p$quantile",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Processing Latency · p$quantile",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Consumer integrity · Do clients receive and process Flashblocks cleanly?",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 108,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Independent optional ingress transaction, bundle, and simulation rates. No data is expected when the ingress Compose overlay is not selected.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 45,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 47
+          },
+          "id": 32,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tips_ingress_rpc_transactions_received{job=\"tips_ingress\"}[$window]))",
+              "legendFormat": "transactions received",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tips_ingress_rpc_bundles_parsed{job=\"tips_ingress\"}[$window]))",
+              "legendFormat": "bundles parsed",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tips_ingress_rpc_successful_simulations{job=\"tips_ingress\"}[$window]))",
+              "legendFormat": "simulation success",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tips_ingress_rpc_failed_simulations{job=\"tips_ingress\"}[$window]))",
+              "legendFormat": "simulation failed",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Ingress Lifecycle Activity",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Selected ingress summary quantiles for simulation-side RPC methods and successful sendRawTransaction calls. Send latency is recorded only on the successful return path.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 4,
+              "mappings": [],
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 47
+          },
+          "id": 33,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "tips_ingress_rpc_rpc_latency{job=\"tips_ingress\",quantile=\"$quantile\"}",
+              "legendFormat": "{{rpc}} · p$quantile",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "tips_ingress_rpc_send_raw_transaction_duration{job=\"tips_ingress\",quantile=\"$quantile\"}",
+              "legendFormat": "sendRawTransaction · p$quantile",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Ingress RPC Latency · p$quantile",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Buffered metering responses plus failed simulations, metering deadline exceedances, and full audit channels. Correlated growth indicates delayed or failing ingress fan-out.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 15,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 3,
+              "mappings": [],
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 55
+          },
+          "id": 34,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "tips_ingress_rpc_buffered_meter_bundle_responses_size{job=\"tips_ingress\"}",
+              "legendFormat": "buffered responses",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tips_ingress_rpc_failed_simulations{job=\"tips_ingress\"}[$window]))",
+              "legendFormat": "failed simulations / s",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tips_ingress_rpc_bundles_exceeded_metering_time{job=\"tips_ingress\"}[$window]))",
+              "legendFormat": "metering deadline / s",
+              "range": true,
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(tips_ingress_rpc_audit_channel_full{job=\"tips_ingress\"}[$window]))",
+              "legendFormat": "audit channel full / s",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Ingress Backpressure & Faults",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Optional Tips ingress · Are bundles simulated, metered, and delivered on time?",
+      "type": "row"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "devnet",
+    "mev",
+    "validity",
+    "builder",
+    "flashblocks"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "1m",
+          "value": "1m"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Rate window",
+        "multi": false,
+        "name": "window",
+        "options": [
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": true,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "15m",
+            "value": "15m"
+          }
+        ],
+        "query": "30s,1m,5m,15m",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "0.99",
+          "value": "0.99"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Summary quantile",
+        "multi": false,
+        "name": "quantile",
+        "options": [
+          {
+            "selected": false,
+            "text": "0.5",
+            "value": "0.5"
+          },
+          {
+            "selected": false,
+            "text": "0.9",
+            "value": "0.9"
+          },
+          {
+            "selected": true,
+            "text": "0.99",
+            "value": "0.99"
+          }
+        ],
+        "query": "0.5,0.9,0.99",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "6h",
+      "12h",
+      "24h"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Base MEV",
+  "uid": "base-mev",
+  "version": 1,
+  "weekStart": ""
+}

--- a/etc/scripts/devnet/grafana/dashboards/base-mev.json
+++ b/etc/scripts/devnet/grafana/dashboards/base-mev.json
@@ -217,7 +217,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum(rate((reth_base_builder_block_built_success{job=\"l2_builder\"} * 1)[$window:]))",
+          "expr": "sum(rate(reth_base_builder_total_block_built_duration_count{job=\"l2_builder\"}[$window]))",
           "legendFormat": "blocks / s",
           "range": true,
           "refId": "A"
@@ -506,7 +506,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 26
       },
       "id": 101,
       "panels": [],
@@ -576,7 +576,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 10
+        "y": 27
       },
       "id": 7,
       "options": {
@@ -602,7 +602,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "sum by (job, outcome) (rate(reth_txpool_validity_admitted{job=~\"l2_builder|l2_client|l2_base_rpc\"}[$window]))",
+          "expr": "sum by (job, outcome) (rate((reth_txpool_validity_admitted{job=~\"l2_builder|l2_client|l2_base_rpc\"} * 1)[$window:]))",
           "legendFormat": "{{job}} · {{outcome}}",
           "range": true,
           "refId": "A"
@@ -674,7 +674,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 10
+        "y": 27
       },
       "id": 8,
       "options": {
@@ -788,7 +788,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 10
+        "y": 27
       },
       "id": 9,
       "options": {
@@ -824,101 +824,12 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "description": "Independent stage rates. Admission limits reject before pooling, invalidations evict tracked transactions, and prechecks drop stale manifests. Do not subtract these asynchronous counters as a transaction-exact funnel.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "drawStyle": "bars",
-            "fillOpacity": 38,
-            "lineWidth": 1,
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "decimals": 3,
-          "mappings": [],
-          "unit": "cps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 18
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "10.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "sum by (job, reason) (rate(reth_txpool_guard_admission_rejected{job=~\"l2_builder|l2_client|l2_base_rpc\"}[$window]))",
-          "legendFormat": "{{job}} · admission · {{reason}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "sum by (job, cause) (rate(reth_txpool_guard_invalidated{job=~\"l2_builder|l2_client|l2_base_rpc\"}[$window]))",
-          "legendFormat": "{{job}} · invalidated · {{cause}}",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "code",
-          "expr": "sum by (cause) (rate(reth_txpool_guard_builder_precheck_dropped{job=\"l2_builder\"}[$window]))",
-          "legendFormat": "builder · precheck · {{cause}}",
-          "range": true,
-          "refId": "C"
-        }
-      ],
-      "title": "Admission, Invalidation & Precheck Pressure",
-      "type": "timeseries"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 35
       },
       "id": 102,
       "panels": [],
@@ -1006,7 +917,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 26
+        "y": 36
       },
       "id": 11,
       "options": {
@@ -1116,7 +1027,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 26
+        "y": 36
       },
       "id": 12,
       "options": {
@@ -1215,7 +1126,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 26
+        "y": 36
       },
       "id": 13,
       "options": {
@@ -1314,7 +1225,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 44
       },
       "id": 14,
       "options": {
@@ -1351,16 +1262,19 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 41
+        "y": 9
       },
       "id": 103,
-      "panels": [
-        {
+      "panels": [],
+      "title": "Predicate detail · Are validity conditions cheap, fully evaluated, and becoming satisfiable?",
+      "type": "row"
+    },
+    {
           "datasource": {
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
@@ -1412,7 +1326,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 10
           },
           "id": 15,
           "options": {
@@ -1449,7 +1363,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_validity_predicate_rescan_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "expr": "reth_base_builder_validity_predicate_rescan_duration{job=\"l2_builder\",quantile=\"$quantile\"} or on() (0 * max(up{job=\"l2_builder\"}))",
               "legendFormat": "rescan · p$quantile",
               "range": true,
               "refId": "B"
@@ -1490,7 +1404,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 10
           },
           "id": 16,
           "options": {
@@ -1557,18 +1471,386 @@
           ],
           "title": "Predicate State Reads per Active Build",
           "type": "timeseries"
-        }
-      ],
-      "title": "Predicate detail · Are validity conditions cheap, readable, and becoming satisfiable?",
-      "type": "row"
-    },
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Share of supported primary-scan validity candidates that the builder evaluated instead of deferring after exhausting its predicate budget. Weighted coverage works with existing builders; the selected per-build quantile appears with the new instrumentation. Rescans and unsupported Flashblock-index predicates are excluded.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#F2495C",
+                    "value": null
+                  },
+                  {
+                    "color": "#F2B84B",
+                    "value": 95
+                  },
+                  {
+                    "color": "#3BD671",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/weighted/i"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#5794F2",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/per-build/i"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#B877D9",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 18
+          },
+          "id": 35,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "asc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "100 * sum(rate(reth_base_builder_validity_predicate_evaluations_total{job=\"l2_builder\",outcome=~\"matched|not_satisfied|expired|read_error\"}[$window])) / (sum(rate(reth_base_builder_validity_predicate_evaluations_total{job=\"l2_builder\",outcome=~\"matched|not_satisfied|expired|read_error\"}[$window])) + (sum(rate(reth_base_builder_validity_predicate_evaluations_total{job=\"l2_builder\",outcome=\"budget_exhausted\"}[$window])) or vector(0)))",
+              "legendFormat": "weighted coverage",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "100 * reth_base_builder_validity_predicate_evaluation_coverage_per_build{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "per-build · p$quantile",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Predicate Evaluation Coverage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Raw supported primary-scan validity candidate counts per build. New builders show the selected per-build quantile; older builders fall back to the window mean derived from outcome counters. Any deferred value above zero means the 10 ms predicate-evaluation cutoff blocked work.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "bars",
+                "fillOpacity": 35,
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "min": 0,
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/evaluated/i"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#3BD671",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/deferred/i"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 18
+          },
+          "id": 36,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_validity_predicate_candidates_evaluated_per_build{job=\"l2_builder\",quantile=\"$quantile\"} or on() (sum(rate(reth_base_builder_validity_predicate_evaluations_total{job=\"l2_builder\",outcome=~\"matched|not_satisfied|expired|read_error\"}[$window])) / sum(rate(reth_base_builder_total_block_built_duration_count{job=\"l2_builder\"}[$window])))",
+              "legendFormat": "evaluated · p$quantile / mean fallback",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "reth_base_builder_validity_predicate_candidates_deferred_per_build{job=\"l2_builder\",quantile=\"$quantile\"} or on() ((sum(rate(reth_base_builder_validity_predicate_evaluations_total{job=\"l2_builder\",outcome=\"budget_exhausted\"}[$window])) or vector(0)) / sum(rate(reth_base_builder_total_block_built_duration_count{job=\"l2_builder\"}[$window])))",
+              "legendFormat": "deferred · p$quantile / mean fallback",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Validity Candidates per Build",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Exact percentage of completed builds that deferred primary or rescan work after exhausting the predicate budget, available with the new per-build instrumentation. The binary fallback is 100% whenever an older builder reports any primary candidate deferred in the selected window, identifying when cutoff pressure occurred without claiming a frequency.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 25,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#3BD671",
+                    "value": null
+                  },
+                  {
+                    "color": "#F2B84B",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "#F2495C",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/exact/i"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2495C",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/observed/i"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F2B84B",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 18
+          },
+          "id": 37,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "100 * (sum(rate(reth_base_builder_validity_predicate_eval_cutoff_builds_total{job=\"l2_builder\"}[$window])) or vector(0)) / sum(rate(reth_base_builder_validity_predicate_candidates_evaluated_per_build_count{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "cutoff builds · exact",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "100 * ((sum(rate(reth_base_builder_validity_predicate_evaluations_total{job=\"l2_builder\",outcome=\"budget_exhausted\"}[$window])) or vector(0)) > bool 0)",
+              "legendFormat": "cutoff observed · window",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Predicate Cutoff Pressure",
+          "type": "timeseries"
+        },
     {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 51
       },
       "id": 104,
       "panels": [
@@ -1604,7 +1886,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 52
           },
           "id": 17,
           "options": {
@@ -1630,7 +1912,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_txpool_reader_txs_read{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "sum by (job) (rate((reth_txpool_reader_txs_read{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))",
               "legendFormat": "{{job}} · read",
               "range": true,
               "refId": "A"
@@ -1641,7 +1923,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_txpool_reader_txs_sent{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "sum by (job) (rate((reth_txpool_reader_txs_sent{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))",
               "legendFormat": "{{job}} · queued",
               "range": true,
               "refId": "B"
@@ -1652,7 +1934,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_txpool_forwarder_txs_forwarded{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "sum by (job) (rate((reth_txpool_forwarder_txs_forwarded{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))",
               "legendFormat": "{{job}} · forwarded",
               "range": true,
               "refId": "C"
@@ -1663,7 +1945,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_txpool_forwarder_num_tx_rejected_in_batch{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "sum by (job) (rate((reth_txpool_forwarder_num_tx_rejected_in_batch{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))",
               "legendFormat": "{{job}} · builder rejected",
               "range": true,
               "refId": "D"
@@ -1704,7 +1986,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 52
           },
           "id": 18,
           "options": {
@@ -1783,7 +2065,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 60
           },
           "id": 19,
           "options": {
@@ -1809,7 +2091,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job, reason) (rate(reth_txpool_forwarder_rpc_errors{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "(sum by (job, reason) (rate((reth_txpool_forwarder_rpc_errors{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))) or on() label_replace(label_replace(0 * sum(up{job=~\"l2_client|l2_base_rpc\"}), \"job\", \"all\", \"\", \"\"), \"reason\", \"none\", \"\", \"\")",
               "legendFormat": "{{job}} · {{reason}}",
               "range": true,
               "refId": "A"
@@ -1820,7 +2102,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_txpool_forwarder_num_tx_rejected_in_batch{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "sum by (job) (rate((reth_txpool_forwarder_num_tx_rejected_in_batch{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))",
               "legendFormat": "{{job}} · builder item rejection",
               "range": true,
               "refId": "B"
@@ -1861,7 +2143,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 60
           },
           "id": 20,
           "options": {
@@ -1917,7 +2199,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 52
       },
       "id": 105,
       "panels": [
@@ -1926,7 +2208,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Observation-weighted mean cumulative gas headroom by Flashblock index. Headroom should decline as a block fills; early exhaustion indicates capacity pressure.",
+          "description": "Selected total-build latency quantile as a percentage of the local 200 ms block budget. Sustained growth above 50% erodes headroom; 80% or more is urgent deadline pressure.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1952,16 +2234,16 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "#F2495C",
+                    "color": "#3BD671",
                     "value": null
                   },
                   {
                     "color": "#F2B84B",
-                    "value": 5
+                    "value": 50
                   },
                   {
-                    "color": "#3BD671",
-                    "value": 15
+                    "color": "#F2495C",
+                    "value": 80
                   }
                 ]
               },
@@ -1973,7 +2255,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 53
           },
           "id": 21,
           "options": {
@@ -1999,13 +2281,13 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (flashblock_index) (rate(reth_base_builder_flashblock_gas_headroom_pct_sum{job=\"l2_builder\"}[$window])) / sum by (flashblock_index) (rate(reth_base_builder_flashblock_gas_headroom_pct_count{job=\"l2_builder\"}[$window]))",
-              "legendFormat": "FB {{flashblock_index}}",
+              "expr": "reth_base_builder_total_block_built_duration{job=\"l2_builder\",quantile=\"$quantile\"} / 0.2 * 100",
+              "legendFormat": "budget used · p$quantile",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Mean Gas Headroom by Flashblock",
+          "title": "Build Budget Used · p$quantile",
           "type": "timeseries"
         },
         {
@@ -2013,7 +2295,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Direct selection rejection rates by Flashblock index and reason. Deferred candidates are separate; do not derive rejection by subtracting considered and included transactions.",
+          "description": "Completed block builds per second from the post-Denim payload-builder path. The local target is 5 blocks/s; a sustained drop with the builder target online indicates construction pressure or a stall.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2027,7 +2309,7 @@
                 "spanNulls": false,
                 "stacking": {
                   "group": "A",
-                  "mode": "normal"
+                  "mode": "none"
                 }
               },
               "decimals": 3,
@@ -2040,7 +2322,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 53
           },
           "id": 22,
           "options": {
@@ -2066,13 +2348,13 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (flashblock_index, reason) (rate(reth_base_builder_flashblock_rejections_total{job=\"l2_builder\"}[$window]))",
-              "legendFormat": "FB {{flashblock_index}} · {{reason}}",
+              "expr": "sum(rate(reth_base_builder_total_block_built_duration_count{job=\"l2_builder\"}[$window]))",
+              "legendFormat": "blocks / s",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Rejections by Flashblock & Reason",
+          "title": "Block Build Throughput",
           "type": "timeseries"
         },
         {
@@ -2080,7 +2362,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Selected local summary quantile for builder stages that consume the 200 ms local Flashblock budget. The red threshold marks the configured interval, not a universal production limit.",
+          "description": "Selected local summary quantile for active post-Denim construction stages. Total build includes the other stages; compare components rather than adding them. The red threshold marks the local 200 ms block interval.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2127,7 +2409,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 61
           },
           "id": 23,
           "options": {
@@ -2153,8 +2435,8 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_flashblock_build_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
-              "legendFormat": "build · p$quantile",
+              "expr": "reth_base_builder_total_block_built_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "total build · p$quantile",
               "range": true,
               "refId": "A"
             },
@@ -2164,8 +2446,8 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_transaction_pool_fetch_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
-              "legendFormat": "pool fetch · p$quantile",
+              "expr": "reth_base_builder_state_root_calculation_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "state root · p$quantile",
               "range": true,
               "refId": "B"
             },
@@ -2175,13 +2457,13 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_payload_transaction_simulation_duration{job=\"l2_builder\",quantile=\"$quantile\"}",
-              "legendFormat": "payload simulation · p$quantile",
+              "expr": "reth_base_builder_validity_predicate_eval_duration_per_block{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "legendFormat": "predicate eval · p$quantile",
               "range": true,
               "refId": "C"
             }
           ],
-          "title": "Flashblock Critical Path · p$quantile",
+          "title": "Block Construction Critical Path · p$quantile",
           "type": "timeseries"
         },
         {
@@ -2189,7 +2471,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Selected summary quantile of Flashblocks omitted because construction started late or missed its schedule. Zero is healthy; sustained non-zero values indicate deadline pressure.",
+          "description": "Exceptional events in the selected window: invalid built blocks and enforced resource-metering throttles. Zero is healthy; either series becoming non-zero is immediately actionable.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2214,7 +2496,7 @@
               {
                 "matcher": {
                   "id": "byRegexp",
-                  "options": "/missing/i"
+                  "options": "/invalid/i"
                 },
                 "properties": [
                   {
@@ -2229,7 +2511,7 @@
               {
                 "matcher": {
                   "id": "byRegexp",
-                  "options": "/reduced/i"
+                  "options": "/throttled/i"
                 },
                 "properties": [
                   {
@@ -2247,7 +2529,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 61
           },
           "id": 24,
           "options": {
@@ -2273,8 +2555,8 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_missing_flashblocks_count{job=\"l2_builder\",quantile=\"$quantile\"}",
-              "legendFormat": "missing · p$quantile",
+              "expr": "sum(increase(reth_base_builder_invalid_built_blocks_count{job=\"l2_builder\"}[$window])) or on() (0 * sum(up{job=\"l2_builder\"}))",
+              "legendFormat": "invalid blocks",
               "range": true,
               "refId": "A"
             },
@@ -2284,17 +2566,17 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_reduced_flashblocks_number{job=\"l2_builder\",quantile=\"$quantile\"}",
-              "legendFormat": "reduced · p$quantile",
+              "expr": "sum(increase(reth_base_payload_resource_metering_throttled_total{job=\"l2_builder\"}[$window])) or on() (0 * sum(up{job=\"l2_builder\"}))",
+              "legendFormat": "resource throttles",
               "range": true,
               "refId": "B"
             }
           ],
-          "title": "Missing or Reduced Flashblocks",
+          "title": "Builder Faults in Window",
           "type": "timeseries"
         }
       ],
-      "title": "Flashblock capacity · Are selection passes on time and using gas efficiently?",
+      "title": "Block construction · Is the 200 ms builder on time and healthy?",
       "type": "row"
     },
     {
@@ -2303,7 +2585,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 53
       },
       "id": 106,
       "panels": [
@@ -2312,16 +2594,26 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Share of observed included transactions with metering information. The value is absent when no metering decisions occurred; pending skips and late arrivals expose delivery races.",
+          "description": "Share of observed transactions with external execution-metering information. INACTIVE means no metering decisions occurred in the selected window; pending skips and late arrivals expose delivery races.",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
               "decimals": 1,
-              "mappings": [],
+              "mappings": [
+                {
+                  "options": {
+                    "-1": {
+                      "color": "#8A95A5",
+                      "text": "INACTIVE"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
               "max": 1,
-              "min": 0,
+              "min": -1,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -2347,7 +2639,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 45
+            "y": 54
           },
           "id": 25,
           "options": {
@@ -2374,7 +2666,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "((sum(rate(reth_base_builder_metering_known_transaction{job=\"l2_builder\"}[$window])) / (sum(rate(reth_base_builder_metering_known_transaction{job=\"l2_builder\"}[$window])) + sum(rate(reth_base_builder_metering_unknown_transaction{job=\"l2_builder\"}[$window])))) and on() ((sum(rate(reth_base_builder_metering_known_transaction{job=\"l2_builder\"}[$window])) + sum(rate(reth_base_builder_metering_unknown_transaction{job=\"l2_builder\"}[$window]))) > 0))",
+              "expr": "(((sum(rate((reth_base_builder_metering_known_transaction{job=\"l2_builder\"} * 1)[$window:])) / (sum(rate((reth_base_builder_metering_known_transaction{job=\"l2_builder\"} * 1)[$window:])) + sum(rate((reth_base_builder_metering_unknown_transaction{job=\"l2_builder\"} * 1)[$window:])))) and on() ((sum(rate((reth_base_builder_metering_known_transaction{job=\"l2_builder\"} * 1)[$window:])) + sum(rate((reth_base_builder_metering_unknown_transaction{job=\"l2_builder\"} * 1)[$window:]))) > 0))) or on() (-1 * max(up{job=\"l2_builder\"}))",
               "legendFormat": "known share",
               "range": true,
               "refId": "A"
@@ -2388,7 +2680,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Rates of known/unknown metering decisions, pending skips, and late arrivals. Unknown, pending, or late events are degradation signals.",
+          "description": "Rates of known/unknown external metering decisions, pending skips, and late arrivals. Explicit zero baselines mean the builder is healthy but the corresponding counter has not fired.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2415,7 +2707,7 @@
             "h": 7,
             "w": 18,
             "x": 6,
-            "y": 45
+            "y": 54
           },
           "id": 26,
           "options": {
@@ -2441,7 +2733,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum(rate(reth_base_builder_metering_known_transaction{job=\"l2_builder\"}[$window]))",
+              "expr": "sum(rate((reth_base_builder_metering_known_transaction{job=\"l2_builder\"} * 1)[$window:])) or on() (0 * max(up{job=\"l2_builder\"}))",
               "legendFormat": "known",
               "range": true,
               "refId": "A"
@@ -2452,7 +2744,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum(rate(reth_base_builder_metering_unknown_transaction{job=\"l2_builder\"}[$window]))",
+              "expr": "sum(rate((reth_base_builder_metering_unknown_transaction{job=\"l2_builder\"} * 1)[$window:])) or on() (0 * max(up{job=\"l2_builder\"}))",
               "legendFormat": "unknown",
               "range": true,
               "refId": "B"
@@ -2463,7 +2755,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum(rate(reth_base_builder_metering_data_pending_skip{job=\"l2_builder\"}[$window]))",
+              "expr": "sum(rate((reth_base_builder_metering_data_pending_skip{job=\"l2_builder\"} * 1)[$window:])) or on() (0 * max(up{job=\"l2_builder\"}))",
               "legendFormat": "pending skip",
               "range": true,
               "refId": "C"
@@ -2474,7 +2766,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum(rate(reth_base_builder_metering_late_arrival_total{job=\"l2_builder\"}[$window]))",
+              "expr": "sum(rate(reth_base_builder_metering_late_arrival_total{job=\"l2_builder\"}[$window])) or on() (0 * max(up{job=\"l2_builder\"}))",
               "legendFormat": "late arrival",
               "range": true,
               "refId": "D"
@@ -2488,7 +2780,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Potential and enforced resource-budget violations by dimension and transaction/block scope. Limit-exceeded includes enforced throttles, so the series overlap and are not stacked.",
+          "description": "Potential and enforced resource-budget violations by dimension and transaction/block scope. Limit-exceeded includes enforced throttles, so the series overlap and are not stacked. Zero means no violation while the builder is healthy.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2515,7 +2807,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 61
           },
           "id": 27,
           "options": {
@@ -2541,7 +2833,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (dimension, scope) (rate(reth_base_payload_resource_metering_limit_exceeded_total{job=\"l2_builder\"}[$window]))",
+              "expr": "(sum by (dimension, scope) (rate(reth_base_payload_resource_metering_limit_exceeded_total{job=\"l2_builder\"}[$window]))) or on() label_replace(label_replace(0 * sum(up{job=\"l2_builder\"}), \"dimension\", \"none\", \"\", \"\"), \"scope\", \"none\", \"\", \"\")",
               "legendFormat": "would exceed · {{scope}} · {{dimension}}",
               "range": true,
               "refId": "A"
@@ -2552,7 +2844,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (dimension, scope) (rate(reth_base_payload_resource_metering_throttled_total{job=\"l2_builder\"}[$window]))",
+              "expr": "(sum by (dimension, scope) (rate(reth_base_payload_resource_metering_throttled_total{job=\"l2_builder\"}[$window]))) or on() label_replace(label_replace(0 * sum(up{job=\"l2_builder\"}), \"dimension\", \"none\", \"\", \"\"), \"scope\", \"none\", \"\", \"\")",
               "legendFormat": "throttled · {{scope}} · {{dimension}}",
               "range": true,
               "refId": "B"
@@ -2566,7 +2858,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Selected local summary quantile for predicted execution time, signed prediction error, and actual execution time of unmetered transactions. All values are microseconds.",
+          "description": "Selected local summary quantile for predicted execution time, signed prediction error, and actual execution time of unmetered transactions. Zero baselines mean no samples were observed in the selected execution path.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2593,7 +2885,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 61
           },
           "id": 28,
           "options": {
@@ -2619,7 +2911,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_tx_predicted_execution_time_us{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "expr": "reth_base_builder_tx_predicted_execution_time_us{job=\"l2_builder\",quantile=\"$quantile\"} or on() (0 * max(up{job=\"l2_builder\"}))",
               "legendFormat": "predicted · p$quantile",
               "range": true,
               "refId": "A"
@@ -2630,7 +2922,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_execution_time_prediction_error_us{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "expr": "reth_base_builder_execution_time_prediction_error_us{job=\"l2_builder\",quantile=\"$quantile\"} or on() (0 * max(up{job=\"l2_builder\"}))",
               "legendFormat": "prediction error · p$quantile",
               "range": true,
               "refId": "B"
@@ -2641,7 +2933,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "reth_base_builder_unmetered_tx_actual_execution_time_us{job=\"l2_builder\",quantile=\"$quantile\"}",
+              "expr": "reth_base_builder_unmetered_tx_actual_execution_time_us{job=\"l2_builder\",quantile=\"$quantile\"} or on() (0 * max(up{job=\"l2_builder\"}))",
               "legendFormat": "unmetered actual · p$quantile",
               "range": true,
               "refId": "C"
@@ -2651,7 +2943,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "Metering & execution · Is the builder informed, accurate, and resource-safe?",
+      "title": "Optional external metering & resource limits · Is the builder informed and resource-safe?",
       "type": "row"
     },
     {
@@ -2660,7 +2952,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 54
       },
       "id": 107,
       "panels": [
@@ -2669,7 +2961,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Messages received from the builder Flashblock stream by consumer node. A drop to zero with targets up suggests a disconnected or stalled stream.",
+          "description": "Messages received from the legacy pre-Denim Flashblock stream by consumer node. Near-zero traffic is expected after the payload-builder cutover; use this row only for compatibility-mode diagnosis.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2696,7 +2988,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 46
+            "y": 55
           },
           "id": 29,
           "options": {
@@ -2722,13 +3014,13 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_reth_flashblocks_upstream_messages{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "sum by (job) (rate((reth_reth_flashblocks_upstream_messages{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))",
               "legendFormat": "{{job}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Flashblock Receive Rate",
+          "title": "Legacy Flashblock Receive Rate",
           "type": "timeseries"
         },
         {
@@ -2736,7 +3028,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Upstream errors, processing failures, unexpected order, reconnects, and stale drops. These should remain zero outside deliberate fault testing.",
+          "description": "Legacy stream errors, processing failures, unexpected order, reconnects, and stale drops. Explicit zero baselines mean no event while the consumer targets are healthy.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2764,7 +3056,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 46
+            "y": 55
           },
           "id": 30,
           "options": {
@@ -2790,7 +3082,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_reth_flashblocks_upstream_errors{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "(sum by (job) (rate((reth_reth_flashblocks_upstream_errors{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))) or on() label_replace(0 * sum(up{job=~\"l2_client|l2_base_rpc\"}), \"job\", \"all\", \"\", \"\")",
               "legendFormat": "{{job}} · upstream error",
               "range": true,
               "refId": "A"
@@ -2801,7 +3093,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_reth_flashblocks_block_processing_error{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "(sum by (job) (rate((reth_reth_flashblocks_block_processing_error{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))) or on() label_replace(0 * sum(up{job=~\"l2_client|l2_base_rpc\"}), \"job\", \"all\", \"\", \"\")",
               "legendFormat": "{{job}} · processing error",
               "range": true,
               "refId": "B"
@@ -2812,7 +3104,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_reth_flashblocks_unexpected_block_order{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "(sum by (job) (rate((reth_reth_flashblocks_unexpected_block_order{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))) or on() label_replace(0 * sum(up{job=~\"l2_client|l2_base_rpc\"}), \"job\", \"all\", \"\", \"\")",
               "legendFormat": "{{job}} · unexpected order",
               "range": true,
               "refId": "C"
@@ -2823,7 +3115,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_reth_flashblocks_reconnect_attempts{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "(sum by (job) (rate((reth_reth_flashblocks_reconnect_attempts{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))) or on() label_replace(0 * sum(up{job=~\"l2_client|l2_base_rpc\"}), \"job\", \"all\", \"\", \"\")",
               "legendFormat": "{{job}} · reconnect",
               "range": true,
               "refId": "D"
@@ -2834,7 +3126,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "sum by (job) (rate(reth_reth_flashblocks_pending_drop_stale{job=~\"l2_client|l2_base_rpc\"}[$window]))",
+              "expr": "(sum by (job) (rate((reth_reth_flashblocks_pending_drop_stale{job=~\"l2_client|l2_base_rpc\"} * 1)[$window:]))) or on() label_replace(0 * sum(up{job=~\"l2_client|l2_base_rpc\"}), \"job\", \"all\", \"\", \"\")",
               "legendFormat": "{{job}} · stale drop",
               "range": true,
               "refId": "E"
@@ -2848,7 +3140,7 @@
             "type": "prometheus",
             "uid": "PBFA97CFB590B2093"
           },
-          "description": "Selected local summary quantile for Flashblock processing by consumer. Keep each node separate because exporter summary quantiles are not aggregatable.",
+          "description": "Selected local summary quantile for legacy Flashblock processing. Zero is expected when the pre-Denim stream is inactive; keep each node separate because exporter summary quantiles are not aggregatable.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2875,7 +3167,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 46
+            "y": 55
           },
           "id": 31,
           "options": {
@@ -2911,7 +3203,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "Consumer integrity · Do clients receive and process Flashblocks cleanly?",
+      "title": "Legacy Flashblock compatibility · Is the pre-Denim consumer stream healthy when active?",
       "type": "row"
     },
     {
@@ -2920,7 +3212,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 55
       },
       "id": 108,
       "panels": [
@@ -2956,7 +3248,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 47
+            "y": 56
           },
           "id": 32,
           "options": {
@@ -3056,7 +3348,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 47
+            "y": 56
           },
           "id": 33,
           "options": {
@@ -3134,7 +3426,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 55
+            "y": 64
           },
           "id": 34,
           "options": {

--- a/etc/scripts/devnet/grafana/dashboards/devnet.json
+++ b/etc/scripts/devnet/grafana/dashboards/devnet.json
@@ -24,6 +24,18 @@
     {
       "asDropdown": false,
       "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Base MEV",
+      "tooltip": "Open the validity transaction and MEV dashboard",
+      "type": "link",
+      "url": "/d/base-mev"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
       "includeVars": true,
       "keepTime": true,
       "tags": [],

--- a/etc/scripts/devnet/prometheus.yml
+++ b/etc/scripts/devnet/prometheus.yml
@@ -27,6 +27,11 @@ scrape_configs:
     static_configs:
       - targets: ['op-conductor-0:6090', 'op-conductor-1:6091', 'op-conductor-2:6092']
 
+  - job_name: 'tips_ingress'
+    scrape_timeout: 2s
+    static_configs:
+      - targets: ['ingress-rpc:9002']
+
   - job_name: 'batcher'
     static_configs:
       - targets: ['base-batcher:6060']


### PR DESCRIPTION
## Summary

Adds a provisioned Base MEV dashboard for the local Docker devnet with dense, color-coded views of validity transaction admission, predicate evaluation, forwarding, inclusion economics, Flashblock capacity, resource metering, and consumer integrity. The dashboard keeps high-signal triage and flow economics expanded while grouping deeper diagnostics into focused collapsible rows. Prometheus now scrapes the optional Tips ingress service, and the existing devnet dashboard links directly to the new view. Validation covered all 67 PromQL expressions, Prometheus and Compose configuration, dashboard structure, and an isolated Grafana 10.4 provisioning and rendering smoke test.

<img width="2048" height="1769" alt="image" src="https://github.com/user-attachments/assets/a1c0b8cb-55b0-4b74-bb88-5b6b6ff64854" />
