### PR TITLE
chore(reth): restore pending-handoff patch on v2.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6842,7 +6842,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -6862,7 +6862,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -10008,8 +10008,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -10914,7 +10914,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -10986,7 +10986,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.59.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -13483,7 +13483,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15223,7 +15223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -15256,7 +15256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15269,7 +15269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15382,7 +15382,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -15422,7 +15422,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -16015,7 +16015,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16042,7 +16042,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16073,7 +16073,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16093,7 +16093,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -16106,7 +16106,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16195,7 +16195,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -16205,7 +16205,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16256,7 +16256,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -16273,7 +16273,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16287,7 +16287,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16300,7 +16300,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16325,7 +16325,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16354,7 +16354,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16380,7 +16380,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16410,7 +16410,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16425,7 +16425,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16450,7 +16450,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16474,7 +16474,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16498,7 +16498,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16533,7 +16533,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16590,7 +16590,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16617,7 +16617,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16640,7 +16640,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16667,7 +16667,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16723,7 +16723,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16753,7 +16753,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16771,7 +16771,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16787,7 +16787,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16811,7 +16811,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16822,7 +16822,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16851,7 +16851,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16877,7 +16877,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16893,7 +16893,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16909,7 +16909,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -16923,7 +16923,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16953,7 +16953,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16967,7 +16967,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16977,7 +16977,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17003,7 +17003,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17023,7 +17023,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -17041,7 +17041,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -17054,7 +17054,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17073,7 +17073,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17111,7 +17111,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -17143,7 +17143,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17157,7 +17157,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "serde",
  "serde_json",
@@ -17167,7 +17167,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17193,7 +17193,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "bytes",
  "futures",
@@ -17213,7 +17213,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -17230,7 +17230,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -17239,7 +17239,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "futures",
  "libc",
@@ -17253,7 +17253,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -17262,7 +17262,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -17276,7 +17276,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17335,7 +17335,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17360,7 +17360,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17384,7 +17384,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17399,7 +17399,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17413,7 +17413,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17430,7 +17430,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17454,7 +17454,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17522,7 +17522,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17577,7 +17577,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17626,7 +17626,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17650,7 +17650,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17674,7 +17674,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "bytes",
  "eyre",
@@ -17703,7 +17703,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17715,7 +17715,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17739,7 +17739,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17751,7 +17751,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17774,7 +17774,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17784,7 +17784,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17827,7 +17827,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17877,7 +17877,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17904,7 +17904,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17920,7 +17920,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17935,7 +17935,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -18011,7 +18011,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -18041,7 +18041,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -18084,7 +18084,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -18104,7 +18104,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18135,7 +18135,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -18182,7 +18182,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -18233,7 +18233,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -18247,7 +18247,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18278,7 +18278,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18329,7 +18329,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18357,7 +18357,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18371,7 +18371,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18391,7 +18391,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18406,7 +18406,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18432,7 +18432,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18449,7 +18449,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18476,7 +18476,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18497,7 +18497,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18513,7 +18513,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18523,7 +18523,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "clap",
  "eyre",
@@ -18543,7 +18543,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18562,7 +18562,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18605,7 +18605,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18631,7 +18631,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18658,7 +18658,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18674,7 +18674,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18698,7 +18698,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -23199,7 +23199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -24104,7 +24104,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -331,72 +331,72 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-network-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-network-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
 
 # tokio
 tokio = "1.53.1"

--- a/etc/upstream-pins/reth.toml
+++ b/etc/upstream-pins/reth.toml
@@ -7,9 +7,17 @@
 # To return to an official Reth tag, edit this file and run `just pin-reth`.
 
 repository = "https://github.com/base/reth"
-reference = "base-v2.5.2.2"
-rev = "966744f917711b2a4553653bd407653d7577e633"
+reference = "base-v2.5.2.3"
+rev = "76a826109009c936c2ea98766e0b6b50d2803d26"
 
 [upstream_base]
 tag = "v2.5.2"
 rev = "5a6940e351fed80458fe6c9da8581cbe4b8bd036"
+
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26708"
+head = "f213ff930925e0912a2f6907cec0c62d473bc330"
+
+[[patches]]
+pr = "https://github.com/paradigmxyz/reth/pull/26766"
+head = "f47fd63a3762d8add2e07f1d4afa9363e60d0853"


### PR DESCRIPTION
## Summary
- The 1.3.1 reth bump (`base-v2.5.2.2`) kept [paradigmxyz/reth#26766](https://github.com/paradigmxyz/reth/pull/26766) and dropped [paradigmxyz/reth#26708](https://github.com/paradigmxyz/reth/pull/26708). `#26794` is already in upstream `v2.5.2`.
- `#26708` keeps Engine API messages responsive while a persisted-state handoff is waiting for payload-build leases. Without it, a slow payload job can stall `forkchoiceUpdated` / `getPayload`.
- This pin was built with `just reth-prepare-release --upstream v2.5.2 --pr 26708 --pr 26766 --line main`, which published `base/reth` tag `base-v2.5.2.3` (`76a826109009c936c2ea98766e0b6b50d2803d26`) and restored the `[[patches]]` list.

## Test plan
- `python3 etc/scripts/local/pin-reth.py check` on this branch.
- Confirm `etc/upstream-pins/reth.toml` lists `#26708` and `#26766` on upstream `v2.5.2`.
- After merge, backport the same pin to `releases/v1.3.1` if that line should carry the Engine liveness fix.

type=routine
risk=low
impact=sev5