### PR TITLE
chore(reth): pin base-v2.5.2.3 for pending-handoff liveness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6748,7 +6748,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -6768,7 +6768,7 @@ dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -9779,8 +9779,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -10672,7 +10672,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -10708,7 +10708,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -13201,7 +13201,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14891,7 +14891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -14924,7 +14924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -14937,7 +14937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -15050,7 +15050,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls 0.23.43",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -15090,7 +15090,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -15683,7 +15683,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15710,7 +15710,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15741,7 +15741,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15761,7 +15761,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -15774,7 +15774,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -15863,7 +15863,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -15873,7 +15873,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -15924,7 +15924,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -15941,7 +15941,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -15955,7 +15955,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15968,7 +15968,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -15993,7 +15993,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16022,7 +16022,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16048,7 +16048,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16078,7 +16078,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16093,7 +16093,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16118,7 +16118,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16142,7 +16142,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16166,7 +16166,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16201,7 +16201,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16258,7 +16258,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16285,7 +16285,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16308,7 +16308,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16335,7 +16335,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16391,7 +16391,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16421,7 +16421,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16439,7 +16439,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16455,7 +16455,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16479,7 +16479,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16490,7 +16490,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16519,7 +16519,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16545,7 +16545,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16561,7 +16561,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16577,7 +16577,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -16591,7 +16591,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16621,7 +16621,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16635,7 +16635,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -16645,7 +16645,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16671,7 +16671,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16691,7 +16691,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -16709,7 +16709,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -16722,7 +16722,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16741,7 +16741,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16779,7 +16779,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -16811,7 +16811,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16825,7 +16825,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "serde",
  "serde_json",
@@ -16835,7 +16835,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16861,7 +16861,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "bytes",
  "futures",
@@ -16881,7 +16881,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -16898,7 +16898,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -16907,7 +16907,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "futures",
  "libc",
@@ -16921,7 +16921,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -16930,7 +16930,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -16944,7 +16944,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17003,7 +17003,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17028,7 +17028,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17052,7 +17052,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17067,7 +17067,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17081,7 +17081,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17098,7 +17098,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17122,7 +17122,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17190,7 +17190,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17245,7 +17245,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17294,7 +17294,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17318,7 +17318,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17342,7 +17342,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "bytes",
  "eyre",
@@ -17371,7 +17371,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17383,7 +17383,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17407,7 +17407,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17419,7 +17419,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17442,7 +17442,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17452,7 +17452,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17495,7 +17495,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17545,7 +17545,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17572,7 +17572,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -17588,7 +17588,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17603,7 +17603,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17679,7 +17679,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -17709,7 +17709,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -17752,7 +17752,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -17772,7 +17772,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17803,7 +17803,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -17850,7 +17850,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -17901,7 +17901,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -17915,7 +17915,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17946,7 +17946,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17997,7 +17997,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18025,7 +18025,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18039,7 +18039,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18059,7 +18059,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18074,7 +18074,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18100,7 +18100,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18117,7 +18117,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18144,7 +18144,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18165,7 +18165,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18181,7 +18181,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18191,7 +18191,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "clap",
  "eyre",
@@ -18211,7 +18211,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18230,7 +18230,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18273,7 +18273,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18299,7 +18299,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18326,7 +18326,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18342,7 +18342,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18366,7 +18366,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.2#966744f917711b2a4553653bd407653d7577e633"
+source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -22812,7 +22812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -23717,7 +23717,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,71 +309,71 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
-reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2", default-features = false }
-reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.2.2" }
+reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
+reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
 
 # tokio
 tokio = "1.53.1"


### PR DESCRIPTION
## Summary
- v1.3.1 currently pins `base-v2.5.2.2`, which kept [paradigmxyz/reth#26766](https://github.com/paradigmxyz/reth/pull/26766) and dropped [paradigmxyz/reth#26708](https://github.com/paradigmxyz/reth/pull/26708).
- This points the release line at `base-v2.5.2.3` (`76a826109009c936c2ea98766e0b6b50d2803d26`), the same tag as [base/base#4860](https://github.com/base/base/pull/4860) on main.
- `#26708` keeps Engine API messages responsive while a persisted-state handoff is waiting for payload-build leases.

## Test plan
- Confirm `Cargo.toml` and `Cargo.lock` pin `base/reth` tag `base-v2.5.2.3` at `76a826109009c936c2ea98766e0b6b50d2803d26`.
- `cargo metadata --format-version 1 --no-deps --locked` succeeds on this branch.

type=routine
risk=low
impact=sev5