### PR TITLE
build: add symbolizable maxperf profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,16 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 
+# `release` and `maxperf` both set `strip = "symbols"` (see above), which makes
+# every CPU profiler produce address-only output. This profile keeps production
+# codegen identical (opt-level=3, lto="fat", codegen-units=1, panic="unwind")
+# while restoring symbols. Debug info is not loaded at runtime, so it costs
+# nothing but binary size.
+[profile.maxperf-symbols]
+inherits = "maxperf"
+debug = "line-tables-only"
+strip = "none"
+
 # `cargo bench` inherits `release`, which strips symbols. iai-callgrind drives Callgrind,
 # which needs the symbol table and debug info to locate the benchmark function it toggles
 # collection on — without them every counter reads zero. Keep optimizations, restore

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the Dockerfiles and Compose configuration for the **local devnet** and internal Rust services.
 
-The public operator image (`ghcr.io/base/node`) is the `base` target in `Dockerfile.rust-services`. Published images and operator `--build` use `PROFILE=maxperf` (same as `base/node`). The bake/Dockerfile default stays `release`; `just devnet` builds `dev`. Operator entrypoints live in `etc/scripts/node/`; operators edit `.env.mainnet` / `.env.sepolia` at the repo root. Root `docker-compose.yml` pulls the published image, or compiles this tree with `--build`. `just devnet up` overrides the entrypoint to `./base`.
+The public operator image (`ghcr.io/base/node`) is the `base` target in `Dockerfile.rust-services`. Published images and operator `--build` use `PROFILE=maxperf` (same as `base/node`). The bake/Dockerfile default stays `release`; `just devnet` builds `dev`. `PROFILE` is set on the shared `_rust-service-common` target, so passing it as an environment variable applies it to every target in the invocation; to give one target a different profile, override just that target's build arg — `docker buildx bake -f etc/docker/docker-bake.hcl builder consensus --set builder.args.PROFILE=maxperf-symbols --load` builds `builder` with profiling symbols while `consensus` stays on the default `release`. Operator entrypoints live in `etc/scripts/node/`; operators edit `.env.mainnet` / `.env.sepolia` at the repo root. Root `docker-compose.yml` pulls the published image, or compiles this tree with `--build`. `just devnet up` overrides the entrypoint to `./base`.
 
 ## Dockerfiles
 


### PR DESCRIPTION
Adds a `maxperf-symbols` cargo profile (inherits `maxperf`, keeps `debug=line-tables-only` + `strip=none`) so the shadow builder can be CPU-profiled while production codegen stays byte-identical. Documents in the docker README how to scope the profile to a single bake target via `--set builder.args.PROFILE=maxperf-symbols` so consensus stays on `release`.