### PR TITLE
fix(grafana): Open Control Room By Default

### DIFF
--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -678,6 +678,7 @@ services:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/devnet.json
       - GF_INSTALL_PLUGINS=grafana-pyroscope-app 0.1.8
     volumes:
       - ../scripts/devnet/grafana/provisioning:/etc/grafana/provisioning:ro


### PR DESCRIPTION
## Summary

Grafana now uses the provisioned Base Devnet Control Room as its default home dashboard. Opening localhost:3000 therefore shows the operational dashboard immediately instead of Grafana's generic home page.