### PR TITLE
feat(ci): share one base-anvil revision across fork-test hardforks

### DIFF
--- a/.depot/workflows/base-anvil-package.yml
+++ b/.depot/workflows/base-anvil-package.yml
@@ -15,7 +15,7 @@ on:
       base_anvil_ref:
         description: "base/base-anvil ref to build from"
         required: false
-        default: 3983d1f5c13592c5074bb47df67fa58f1295d758
+        default: 98e7839c65f64aee9627b69a9b98b79afaeb1fae
       base_std_ref:
         description: "base/base-std ref to smoke test against"
         required: false
@@ -24,7 +24,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 env:
-  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || '3983d1f5c13592c5074bb47df67fa58f1295d758' }}
+  BASE_ANVIL_REF: ${{ github.event.inputs.base_anvil_ref || '98e7839c65f64aee9627b69a9b98b79afaeb1fae' }}
   BASE_STD_REF: ${{ github.event.inputs.base_std_ref || 'main' }}
   CARGO_TERM_COLOR: always
   REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/base-anvil
@@ -329,7 +329,7 @@ jobs:
           primary_tag="sha-$GITHUB_SHA"
           tags=("$REGISTRY_IMAGE:$primary_tag")
 
-          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "3983d1f5c13592c5074bb47df67fa58f1295d758" && "$BASE_STD_REF" == "main" ]]; then
+          if [[ "$GITHUB_REF_NAME" == "main" && "$BASE_ANVIL_REF" == "98e7839c65f64aee9627b69a9b98b79afaeb1fae" && "$BASE_STD_REF" == "main" ]]; then
             tags+=("$REGISTRY_IMAGE:main")
             tags+=("$REGISTRY_IMAGE:main-$commit_date-$short_sha")
           else

--- a/.depot/workflows/base-std-fork-tests.yml
+++ b/.depot/workflows/base-std-fork-tests.yml
@@ -28,21 +28,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Refs may be release tags or commit SHAs. The resolved commit SHA is
-          # recorded in the result artifact and PR comment.
+          # Every entry shares one base-anvil revision (BASE_ANVIL_REF below) and
+          # selects its hardfork at runtime via `--base <upgrade>`, so a single
+          # current base-anvil tests the latest precompile implementation against
+          # each frozen base-std suite. Refs may be release tags or commit SHAs;
+          # the resolved commit SHA is recorded in the result artifact and PR
+          # comment.
           - fork: Beryl
             key: beryl
-            base_anvil_ref: cecddfa558e5ed99db6fd836ab1c8cd0213dce26
+            upgrade: beryl
             base_std_ref: v1.0.0
           - fork: Cobalt
             key: cobalt
-            base_anvil_ref: 3983d1f5c13592c5074bb47df67fa58f1295d758
-            base_std_ref: e30b34212689186b27acd3d340ba0d75d31495e9
+            upgrade: cobalt
+            base_std_ref: 4571b325c1b9c4d6e21c59d2b7f9b4b60f62ec7c
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}
-      BASE_ANVIL_REF: ${{ matrix.base_anvil_ref }}
+      # Shared base-anvil revision across all hardforks, bumped only for
+      # Anvil-compatibility reasons (e.g. an Alloy upgrade). The per-entry
+      # `upgrade` selects the historical fork at runtime via `--base <upgrade>`.
+      BASE_ANVIL_REF: 98e7839c65f64aee9627b69a9b98b79afaeb1fae
       BASE_STD_REF: ${{ matrix.base_std_ref }}
+      # Consumed by base-std's fork harness to launch `anvil --base $BASE_UPGRADE`.
+      BASE_UPGRADE: ${{ matrix.upgrade }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.depot/workflows/base-std-fork-tests.yml
+++ b/.depot/workflows/base-std-fork-tests.yml
@@ -33,7 +33,7 @@ jobs:
           - fork: Beryl
             key: beryl
             upgrade: beryl
-            base_std_ref: 66008b966a5595e3ec49959e5a5454f2789b1af2
+            base_std_ref: v1.0.1
           - fork: Cobalt
             key: cobalt
             upgrade: cobalt

--- a/.depot/workflows/base-std-fork-tests.yml
+++ b/.depot/workflows/base-std-fork-tests.yml
@@ -33,7 +33,7 @@ jobs:
           - fork: Beryl
             key: beryl
             upgrade: beryl
-            base_std_ref: d5c88cb93b2b863c4c2d4fcc747a76cb17f190b3
+            base_std_ref: 66008b966a5595e3ec49959e5a5454f2789b1af2
           - fork: Cobalt
             key: cobalt
             upgrade: cobalt

--- a/.depot/workflows/base-std-fork-tests.yml
+++ b/.depot/workflows/base-std-fork-tests.yml
@@ -29,11 +29,7 @@ jobs:
       matrix:
         include:
           # Every entry shares one base-anvil revision (BASE_ANVIL_REF below) and
-          # selects its hardfork at runtime via `--base <upgrade>`, so a single
-          # current base-anvil tests the latest precompile implementation against
-          # each frozen base-std suite. Refs may be release tags or commit SHAs;
-          # the resolved commit SHA is recorded in the result artifact and PR
-          # comment.
+          # selects its hardfork at runtime via `--base <upgrade>`
           - fork: Beryl
             key: beryl
             upgrade: beryl
@@ -45,9 +41,6 @@ jobs:
     env:
       FORK_NAME: ${{ matrix.fork }}
       FORK_KEY: ${{ matrix.key }}
-      # Shared base-anvil revision across all hardforks, bumped only for
-      # Anvil-compatibility reasons (e.g. an Alloy upgrade). The per-entry
-      # `upgrade` selects the historical fork at runtime via `--base <upgrade>`.
       BASE_ANVIL_REF: 98e7839c65f64aee9627b69a9b98b79afaeb1fae
       BASE_STD_REF: ${{ matrix.base_std_ref }}
       # Consumed by base-std's fork harness to launch `anvil --base $BASE_UPGRADE`.

--- a/.depot/workflows/base-std-fork-tests.yml
+++ b/.depot/workflows/base-std-fork-tests.yml
@@ -33,7 +33,7 @@ jobs:
           - fork: Beryl
             key: beryl
             upgrade: beryl
-            base_std_ref: v1.0.0
+            base_std_ref: d5c88cb93b2b863c4c2d4fcc747a76cb17f190b3
           - fork: Cobalt
             key: cobalt
             upgrade: cobalt


### PR DESCRIPTION
## What

The base-std fork-test matrix pinned a **distinct base-anvil revision per
hardfork**. This collapses those into a single shared `BASE_ANVIL_REF` and
selects the hardfork at runtime:

- Each matrix entry gains an `upgrade` key (`beryl` / `cobalt`), exported as
  `BASE_UPGRADE`.
- The base-std fork harness forwards it as `anvil --base <upgrade>`.
- Cobalt's `base_std_ref` advances to the base-std revision whose harness
  forwards `BASE_UPGRADE`.

## Why

When a dependency bump (e.g. an Alloy upgrade) broke a historical base-anvil
revision's build, the fix was to backport the bump to every affected pinned
revision — increasingly fragile as hardfork releases accumulate. With one shared
revision (bumped only for Anvil-compatibility reasons), a single current
base-anvil tests the latest precompile implementation against each frozen
base-std suite, and the fork under test is chosen at runtime.

## Depends on

- base-anvil: `--base <upgrade>` runtime selection (shared revision `98e7839`).
- base-std: fork harness forwarding `BASE_UPGRADE` (Cobalt pin `4571b32`).

## Known follow-up

The Beryl entry still pins a frozen base-std revision whose harness predates
`BASE_UPGRADE`, so it currently runs the default upgrade rather than `beryl`.
Selecting `beryl` end-to-end needs the harness change on a Beryl-era base-std
ref; tracked separately.

## Testing

Exercised by this workflow itself (`Base Std Interface Tests`) on this PR: each
matrix entry checks out the shared base-anvil revision, patches in this repo's
precompile crates, checks out its `base_std_ref`, and runs the suite.