### PR TITLE
build: add release-symbols profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,17 @@ inherits = "maxperf"
 debug = "line-tables-only"
 strip = "none"
 
+# `release` sets `strip = "symbols"` (see above), so the base-metal shadow
+# builder — which ships under the plain `release` profile, not `maxperf` — has
+# no symbols for a CPU profiler. This profile keeps `release` codegen identical
+# (opt-level=3, lto="thin", codegen-units=16, panic="unwind") while restoring
+# symbols. Debug info is not loaded at runtime, so it costs nothing but binary
+# size.
+[profile.release-symbols]
+inherits = "release"
+debug = "line-tables-only"
+strip = "none"
+
 # `cargo bench` inherits `release`, which strips symbols. iai-callgrind drives Callgrind,
 # which needs the symbol table and debug info to locate the benchmark function it toggles
 # collection on — without them every counter reads zero. Keep optimizations, restore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,9 +131,7 @@ inherits = "maxperf"
 debug = "line-tables-only"
 strip = "none"
 
-# `release` sets `strip = "symbols"` (see above), so the base-metal shadow
-# builder — which ships under the plain `release` profile, not `maxperf` — has
-# no symbols for a CPU profiler. This profile keeps `release` codegen identical
+# `release` sets `strip = "symbols"` (see above). This profile keeps `release` codegen identical
 # (opt-level=3, lto="thin", codegen-units=16, panic="unwind") while restoring
 # symbols. Debug info is not loaded at runtime, so it costs nothing but binary
 # size.


### PR DESCRIPTION
Related to:
https://github.com/base/base/pull/4863

Adds a `release-symbols` cargo profile (inherits `release`, sets `debug=line-tables-only` + `strip=none`) so a binary built under the plain `release` profile can be CPU-profiled while codegen stays byte-identical. The base-metal shadow builder deploys via `docker buildx bake ... builder consensus` with no PROFILE override, so it ships under `release` (thin LTO), not `maxperf`; this profile lets it be profiled against its actual deployed codegen. Mirrors the existing `maxperf-symbols`/`maxperf` relationship.