### PR TITLE
feat(devnet): Improve Local Devnet Profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ eif*.bin
 !.env.mainnet
 !.env.sepolia
 /reth-data/
+/profiling-results/
 # SP1 ELF binaries are built on demand and not committed.
 crates/proof/zk/programs/succinct/elf/range-elf-embedded
 crates/proof/zk/programs/succinct/elf/aggregation-elf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2925,6 +2925,7 @@ dependencies = [
  "figment",
  "reth-cli-commands",
  "reth-cli-runner",
+ "reth-cli-util",
  "serde",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,8 +131,8 @@ inherits = "release"
 debug = true
 strip = false
 
-# TODO: add `rustflags = ["-Cforce-frame-pointers=yes"]` here once
-# `profile-rustflags` is stabilized (tracking: rust-lang/cargo#10271)
+# Docker profiling builds add `-Cforce-frame-pointers=yes` in docker-bake.hcl.
+# Move it here once profile-rustflags is stabilized (tracking: rust-lang/cargo#10271).
 [profile.profiling]
 inherits = "release"
 lto = false

--- a/bin/base/Cargo.toml
+++ b/bin/base/Cargo.toml
@@ -39,6 +39,7 @@ alloy-chains = { workspace = true, features = ["std"] }
 # reth
 reth-cli-runner.workspace = true
 reth-cli-commands.workspace = true
+reth-cli-util = { workspace = true, optional = true }
 
 # cli
 clap = { workspace = true, features = ["env"] }
@@ -55,3 +56,11 @@ figment = { workspace = true, features = ["env", "toml"] }
 [dev-dependencies]
 base-common-genesis.workspace = true
 figment = { workspace = true, features = ["test"] }
+
+[features]
+jemalloc-prof = [
+	"base-builder-core/jemalloc-prof",
+	"base-execution-cli/jemalloc-symbols",
+	"dep:reth-cli-util",
+	"reth-cli-util/jemalloc-prof",
+]

--- a/bin/base/src/main.rs
+++ b/bin/base/src/main.rs
@@ -7,6 +7,14 @@ mod cli;
 mod commands;
 mod config;
 
+#[cfg(all(feature = "jemalloc-prof", unix))]
+#[global_allocator]
+static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
+
+#[cfg(all(feature = "jemalloc-prof", unix))]
+#[unsafe(export_name = "malloc_conf")]
+static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
 fn main() {
     base_cli_utils::run_cli_main!(cli::BaseCli);
 }

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -38,4 +38,8 @@ clap.workspace = true
 [features]
 default = [ "jemalloc" ]
 jemalloc = [ "base-builder-core/jemalloc", "base-execution-cli/jemalloc" ]
-jemalloc-prof = [ "jemalloc", "base-builder-core/jemalloc-prof", "base-execution-cli/jemalloc-symbols" ]
+jemalloc-prof = [
+	"base-builder-core/jemalloc-prof",
+	"base-execution-cli/jemalloc-symbols",
+	"jemalloc",
+]

--- a/bin/builder/Cargo.toml
+++ b/bin/builder/Cargo.toml
@@ -38,3 +38,4 @@ clap.workspace = true
 [features]
 default = [ "jemalloc" ]
 jemalloc = [ "base-builder-core/jemalloc", "base-execution-cli/jemalloc" ]
+jemalloc-prof = [ "jemalloc", "base-builder-core/jemalloc-prof", "base-execution-cli/jemalloc-symbols" ]

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -20,6 +20,10 @@ type BuilderCli = Cli<Args>;
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
+#[cfg(all(feature = "jemalloc-prof", unix))]
+#[unsafe(export_name = "malloc_conf")]
+static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
 fn main() {
     base_cli_utils::init_common!();
     base_reth_cli::init_reth!();

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -30,3 +30,4 @@ clap.workspace = true
 [features]
 default = [ "jemalloc" ]
 jemalloc = [ "base-execution-cli/jemalloc", "reth-cli-util/jemalloc" ]
+jemalloc-prof = [ "jemalloc", "base-execution-cli/jemalloc-symbols", "reth-cli-util/jemalloc-prof" ]

--- a/bin/node/Cargo.toml
+++ b/bin/node/Cargo.toml
@@ -30,4 +30,8 @@ clap.workspace = true
 [features]
 default = [ "jemalloc" ]
 jemalloc = [ "base-execution-cli/jemalloc", "reth-cli-util/jemalloc" ]
-jemalloc-prof = [ "jemalloc", "base-execution-cli/jemalloc-symbols", "reth-cli-util/jemalloc-prof" ]
+jemalloc-prof = [
+	"base-execution-cli/jemalloc-symbols",
+	"jemalloc",
+	"reth-cli-util/jemalloc-prof",
+]

--- a/bin/node/src/main.rs
+++ b/bin/node/src/main.rs
@@ -10,6 +10,10 @@ type NodeCli = Cli<StandardNodeArgs>;
 #[global_allocator]
 static ALLOC: reth_cli_util::allocator::Allocator = reth_cli_util::allocator::new_allocator();
 
+#[cfg(all(feature = "jemalloc-prof", unix))]
+#[unsafe(export_name = "malloc_conf")]
+static MALLOC_CONF: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+
 fn main() {
     base_cli_utils::init_common!();
     base_reth_cli::init_reth!();

--- a/etc/docker/Dockerfile.profiling-tools
+++ b/etc/docker/Dockerfile.profiling-tools
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+FROM public.ecr.aws/docker/library/golang:1.24.13-trixie
+
+ARG TARGETARCH
+ARG PROFILECLI_VERSION=1.18.1
+RUN set -eux; \
+    case "$TARGETARCH" in \
+      amd64) PROFILECLI_SHA256=22a3e6f8647768276f8d9ad3aeb0b7ba86151e19ce7b24d7f7fbe78f21941c72 ;; \
+      arm64) PROFILECLI_SHA256=d01c90a819acf4ab853e5b92b36d7923989fcaea96f5cdab12cccae66374f680 ;; \
+      *) echo "unsupported architecture: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    archive="profilecli_${PROFILECLI_VERSION}_linux_${TARGETARCH}.tar.gz"; \
+    curl -fsSL "https://github.com/grafana/pyroscope/releases/download/v${PROFILECLI_VERSION}/${archive}" -o "/tmp/${archive}"; \
+    echo "${PROFILECLI_SHA256}  /tmp/${archive}" | sha256sum -c -; \
+    tar -xzf "/tmp/${archive}" -C /usr/local/bin profilecli; \
+    rm "/tmp/${archive}"
+
+ADD --checksum=sha256:9eb8d6aaf4f2988ced4178ce802a1905f9cb1052069c339d4053a82906f4a4e3 \
+    https://raw.githubusercontent.com/brendangregg/FlameGraph/41fee1f99f9276008b7cd112fca19dc3ea84ac32/stackcollapse-go.pl \
+    /usr/local/bin/stackcollapse-go.pl
+ADD --checksum=sha256:088f82e6848a4f12a56e1e8e8170ee6761fccf12e5615cd64630f6b087c99ea7 \
+    https://raw.githubusercontent.com/brendangregg/FlameGraph/41fee1f99f9276008b7cd112fca19dc3ea84ac32/flamegraph.pl \
+    /usr/local/bin/flamegraph.pl
+ADD --checksum=sha256:55685edab6a33da695474233ff4978865a3e319e906ff27cdcfad0628ea47f5c \
+    https://raw.githubusercontent.com/brendangregg/FlameGraph/41fee1f99f9276008b7cd112fca19dc3ea84ac32/difffolded.pl \
+    /usr/local/bin/difffolded.pl
+
+COPY etc/scripts/devnet/profiling-tools.sh /usr/local/bin/profiling-tools
+RUN chmod 0755 /usr/local/bin/profiling-tools /usr/local/bin/*.pl
+
+ENV HOME=/tmp
+ENV PPROF_TMPDIR=/tmp
+ENTRYPOINT ["profiling-tools"]

--- a/etc/docker/Dockerfile.rust-services
+++ b/etc/docker/Dockerfile.rust-services
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 ARG RUST_VERSION=1.96.0
+ARG RUSTFLAGS="-C link-arg=-fuse-ld=lld"
 FROM public.ecr.aws/docker/library/rust:${RUST_VERSION}-trixie AS rust-builder-base
+ARG RUSTFLAGS
 WORKDIR /app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -13,7 +15,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 ENV RUSTC_WRAPPER=sccache
 ENV SCCACHE_DIR=/sccache
 ENV CARGO_INCREMENTAL=0
-ENV RUSTFLAGS="-C link-arg=-fuse-ld=lld"
+ENV RUSTFLAGS=${RUSTFLAGS}
 
 FROM rust-builder-base AS zk-builder-base
 RUN apt-get update && \
@@ -51,24 +53,26 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM rust-builder-base AS rust-deps
 ARG PROFILE=release
 ARG CARGO_CHEF_ARGS=""
+ARG CARGO_FEATURES=""
 ARG SCCACHE_CACHE_ID=rust-services-sccache
 COPY --from=planner /app/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
-    cargo chef cook --profile "$PROFILE" --recipe-path recipe.json ${CARGO_CHEF_ARGS}
+    cargo chef cook --profile "$PROFILE" --recipe-path recipe.json ${CARGO_CHEF_ARGS} ${CARGO_FEATURES}
 
 FROM rust-deps AS source
 COPY . .
 
 FROM source AS base-image-builder
 ARG PROFILE=release
+ARG CARGO_FEATURES=""
 ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
     set -eux; \
-    cargo build --profile "$PROFILE" \
+    cargo build --profile "$PROFILE" ${CARGO_FEATURES} \
       --package base --bin base \
       --package base-reth-node --bin base-reth-node \
       --package base-consensus --bin base-consensus \
@@ -81,20 +85,22 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 
 FROM source AS base-builder
 ARG PROFILE=release
+ARG CARGO_FEATURES=""
 ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
-    cargo build --profile $PROFILE --package base --bin base && \
+    cargo build --profile "$PROFILE" ${CARGO_FEATURES} --package base --bin base && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base /app/base
 
 FROM source AS execution-builder
 ARG PROFILE=release
+ARG CARGO_FEATURES=""
 ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
-    cargo build --profile $PROFILE --package base-reth-node --bin base-reth-node && \
+    cargo build --profile "$PROFILE" ${CARGO_FEATURES} --package base-reth-node --bin base-reth-node && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-reth-node /app/base-reth-node
 
 FROM source AS consensus-builder
@@ -108,11 +114,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 
 FROM source AS builder-builder
 ARG PROFILE=release
+ARG CARGO_FEATURES=""
 ARG SCCACHE_CACHE_ID=rust-services-sccache
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=${SCCACHE_CACHE_ID},target=/sccache,sharing=locked \
-    cargo build --profile $PROFILE --package base-builder-bin --bin base-builder && \
+    cargo build --profile "$PROFILE" ${CARGO_FEATURES} --package base-builder-bin --bin base-builder && \
     cp /app/target/$([ "$PROFILE" = "dev" ] && echo debug || echo "$PROFILE")/base-builder /app/base-builder
 
 FROM source AS basectl-builder

--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -69,9 +69,93 @@ build-anvil-image source='https://github.com/base/base-anvil.git':
       --build-arg RUST_FEATURES=anvil/cli \
       {{ quote(source) }}
 
-# Stops devnet, deletes data, and starts fresh with profiling (Pyroscope + optimized builds)
-profiling: down _build-setup-image (_build-rust-images "devnet" "profiling")
+# Stops devnet, deletes data, and starts a named profiling run (Pyroscope + optimized builds)
+profiling name='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    run_id={{ quote(name) }}
+    if [ -z "$run_id" ]; then
+      run_id="$(date -u +%Y%m%dT%H%M%SZ)"
+    fi
+    [[ "$run_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+      echo "ERROR: profiling run name must start with a letter or number and contain only letters, numbers, dot, underscore, and dash" >&2
+      exit 1
+    }
+    case "$run_id" in
+      current-run|diffs) echo "ERROR: reserved profiling run name: $run_id" >&2; exit 1 ;;
+    esac
+    run_dir="profiling-results/$run_id"
+    [ ! -e "$run_dir" ] || {
+      echo "ERROR: profiling run already exists: $run_dir" >&2
+      exit 1
+    }
+
+    just --justfile {{ source_file() }} down
+    just --justfile {{ source_file() }} _build-setup-image
+    just --justfile {{ source_file() }} _build-rust-images "devnet" "profiling"
+    just --justfile {{ source_file() }} _build-profiling-tools-image
     docker compose {{ _env }} {{ _ha }} --profile profiling up -d --no-build
+    mkdir -p "$run_dir"
+    date -u +%Y-%m-%dT%H:%M:%SZ > "$run_dir/started-at"
+    git rev-parse HEAD > "$run_dir/git-revision"
+    printf '%s\n' "$run_id" > profiling-results/current-run
+
+    echo "Profiling run '$run_id' started."
+    echo "  Live UI: http://localhost:3000/a/grafana-pyroscope-app/profiles-explorer"
+    echo "  Capture: just devnet profiling-report $run_id"
+
+# Saves CPU and heap pprof, folded stacks, and flame graph SVGs for a profiling run
+profiling-report run='' service='': _build-profiling-tools-image
+    #!/usr/bin/env bash
+    set -euo pipefail
+    run_id={{ quote(run) }}
+    service={{ quote(service) }}
+    if [ -z "$run_id" ]; then
+      [ -s profiling-results/current-run ] || {
+        echo "ERROR: no current profiling run; pass a run name" >&2
+        exit 1
+      }
+      run_id="$(cat profiling-results/current-run)"
+    fi
+    [[ "$run_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+      echo "ERROR: invalid profiling run name: $run_id" >&2
+      exit 1
+    }
+    run_dir="profiling-results/$run_id"
+    [ -s "$run_dir/started-at" ] || {
+      echo "ERROR: profiling run not found: $run_dir" >&2
+      exit 1
+    }
+    profile_from="$(cat "$run_dir/started-at")"
+    profile_to="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    docker compose {{ _env }} {{ _ha }} --profile profiling --profile profiling-tools run \
+      --rm --no-deps --user "$(id -u):$(id -g)" \
+      -e PROFILE_RUN_ID="$run_id" \
+      -e PROFILE_FROM="$profile_from" \
+      -e PROFILE_TO="$profile_to" \
+      -e PROFILE_SERVICE="$service" \
+      profiling-tools report
+    printf '%s\n' "$profile_to" > "$run_dir/captured-at"
+    echo "Static profiles written to $run_dir"
+
+# Produces a differential flame graph (red increased, blue decreased) from two runs
+profiling-diff baseline comparison service kind='cpu': _build-profiling-tools-image
+    #!/usr/bin/env bash
+    set -euo pipefail
+    baseline={{ quote(baseline) }}
+    comparison={{ quote(comparison) }}
+    service={{ quote(service) }}
+    kind={{ quote(kind) }}
+    for value in "$baseline" "$comparison" "$service"; do
+      [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || {
+        echo "ERROR: invalid profiling name: $value" >&2
+        exit 1
+      }
+    done
+    docker compose {{ _env }} {{ _ha }} --profile profiling --profile profiling-tools run \
+      --rm --no-deps --user "$(id -u):$(id -g)" \
+      profiling-tools diff "$baseline" "$comparison" "$service" "$kind"
 
 # Stops devnet and deletes all data
 down:
@@ -196,6 +280,10 @@ _install-nextest:
 [private]
 _build-setup-image:
     docker build --load -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
+
+[private]
+_build-profiling-tools-image:
+    docker buildx bake -f etc/docker/docker-bake.hcl profiling-tools --load
 
 [private]
 _build-rust-images group profile='dev':

--- a/etc/docker/docker-bake.hcl
+++ b/etc/docker/docker-bake.hcl
@@ -53,12 +53,19 @@ group "ingress" {
   targets = INGRESS_TARGETS
 }
 
+target "profiling-tools" {
+  context = "."
+  dockerfile = "etc/docker/Dockerfile.profiling-tools"
+  tags = ["base-profiling-tools:local"]
+}
+
 target "_rust-service-common" {
   context = "."
   dockerfile = "etc/docker/Dockerfile.rust-services"
   args = {
     PROFILE = "${PROFILE}"
     RUST_VERSION = "${RUST_VERSION}"
+    RUSTFLAGS = PROFILE == "profiling" ? "-C link-arg=-fuse-ld=lld -Cforce-frame-pointers=yes" : "-C link-arg=-fuse-ld=lld"
   }
 }
 
@@ -71,6 +78,7 @@ target "base" {
   target = "base"
   args = {
     CARGO_CHEF_ARGS = "--package base --package base-reth-node --package base-consensus --package base-snapshotter-bin"
+    CARGO_FEATURES = PROFILE == "profiling" ? "--features=base/jemalloc-prof,base-reth-node/jemalloc-prof" : ""
     SCCACHE_CACHE_ID = "rust-services-base-sccache"
   }
   tags = ["base:local"]
@@ -81,6 +89,7 @@ target "execution" {
   target = "execution"
   args = {
     CARGO_CHEF_ARGS = "--package base-reth-node"
+    CARGO_FEATURES = PROFILE == "profiling" ? "--features=jemalloc-prof" : ""
     SCCACHE_CACHE_ID = "rust-services-execution-sccache"
   }
   tags = ["base-execution:local"]
@@ -101,6 +110,7 @@ target "builder" {
   target = "builder"
   args = {
     CARGO_CHEF_ARGS = "--package base-builder-bin"
+    CARGO_FEATURES = PROFILE == "profiling" ? "--features=jemalloc-prof" : ""
     SCCACHE_CACHE_ID = "rust-services-builder-sccache"
   }
   tags = ["base-builder:local"]

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -656,6 +656,17 @@ services:
       - pyroscope
     restart: unless-stopped
 
+  profiling-tools:
+    image: base-profiling-tools:local
+    profiles: ["profiling-tools"]
+    build:
+      context: ../..
+      dockerfile: etc/docker/Dockerfile.profiling-tools
+    volumes:
+      - ../../profiling-results:/profiles
+    depends_on:
+      - pyroscope
+
   prometheus:
     image: prom/prometheus:v2.51.0
     container_name: prometheus

--- a/etc/scripts/devnet/alloy.config
+++ b/etc/scripts/devnet/alloy.config
@@ -1,29 +1,65 @@
 discovery.docker "local_containers" {
-  host = "unix:///var/run/docker.sock"
+	host = "unix:///var/run/docker.sock"
 }
 
 discovery.relabel "local_containers" {
-  targets = discovery.docker.local_containers.targets
+	targets = discovery.docker.local_containers.targets
 
-  rule {
-    source_labels = ["__meta_docker_container_name"]
-    target_label  = "service_name"
-  }
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		target_label  = "service_name"
+		regex         = "/(.*)"
+		replacement   = "$1"
+	}
 
-  rule {
-    source_labels = ["__meta_docker_container_id"]
-    target_label  = "__container_id__"
-  }
+	rule {
+		source_labels = ["__meta_docker_container_id"]
+		target_label  = "__container_id__"
+	}
 }
 
 pyroscope.ebpf "instance" {
-  forward_to = [pyroscope.write.endpoint.receiver]
-  targets    = discovery.relabel.local_containers.output
-  demangle   = "rust"
+	forward_to = [pyroscope.write.endpoint.receiver]
+	targets    = discovery.relabel.local_containers.output
+	demangle   = "rust"
+}
+
+pyroscope.scrape "base_heap" {
+	targets = [
+		{"__address__" = "base-builder:7090", "service_name" = "base-builder"},
+		{"__address__" = "base-client:8090", "service_name" = "base-client"},
+		{"__address__" = "base-rpc:8190", "service_name" = "base-rpc"},
+		{"__address__" = "base-sequencer-1:10090", "service_name" = "base-sequencer-1"},
+		{"__address__" = "base-sequencer-2:11090", "service_name" = "base-sequencer-2"},
+	]
+	forward_to      = [pyroscope.write.endpoint.receiver]
+	scrape_interval = "15s"
+
+	profiling_config {
+		profile.memory {
+			path = "/debug/pprof/heap"
+		}
+
+		profile.block {
+			enabled = false
+		}
+
+		profile.goroutine {
+			enabled = false
+		}
+
+		profile.mutex {
+			enabled = false
+		}
+
+		profile.process_cpu {
+			enabled = false
+		}
+	}
 }
 
 pyroscope.write "endpoint" {
-  endpoint {
-    url = "http://pyroscope:4040"
-  }
+	endpoint {
+		url = "http://pyroscope:4040"
+	}
 }

--- a/etc/scripts/devnet/profiling-tools.sh
+++ b/etc/scripts/devnet/profiling-tools.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly PYROSCOPE_URL="${PYROSCOPE_URL:-http://pyroscope:4040}"
+readonly CPU_PROFILE_TYPE="process_cpu:cpu:nanoseconds:cpu:nanoseconds"
+readonly SERVICES=(base-builder base-client base-rpc base-sequencer-1 base-sequencer-2)
+declare -Ar HEAP_ENDPOINTS=(
+    [base-builder]="http://base-builder:7090/debug/pprof/heap"
+    [base-client]="http://base-client:8090/debug/pprof/heap"
+    [base-rpc]="http://base-rpc:8190/debug/pprof/heap"
+    [base-sequencer-1]="http://base-sequencer-1:10090/debug/pprof/heap"
+    [base-sequencer-2]="http://base-sequencer-2:11090/debug/pprof/heap"
+)
+
+is_name() {
+    local candidate="$1"
+    [[ "$candidate" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] &&
+        [[ "$candidate" != current-run ]] &&
+        [[ "$candidate" != diffs ]]
+}
+
+is_service() {
+    local candidate="$1"
+    local service
+    for service in "${SERVICES[@]}"; do
+        [[ "$candidate" == "$service" ]] && return 0
+    done
+    return 1
+}
+
+select_pprof_sample() {
+    local sample_name="$1"
+    local raw_profile="$2"
+
+    awk -v sample_name="$sample_name" '
+        $0 == "Samples:" {
+            in_samples = 1
+            print
+            next
+        }
+        in_samples && !have_header {
+            for (column = 1; column <= NF; column++) {
+                split($column, sample_type, "/")
+                if (sample_type[1] == sample_name) {
+                    sample_column = column
+                }
+            }
+            if (!sample_column) {
+                print "sample type not found: " sample_name > "/dev/stderr"
+                exit 1
+            }
+            print "value/count value/count"
+            have_header = 1
+            next
+        }
+        in_samples && $0 == "Locations" {
+            in_samples = 0
+            print
+            next
+        }
+        in_samples {
+            separator = index($0, ": ")
+            if (separator > 0) {
+                values = substr($0, 1, separator - 1)
+                stack = substr($0, separator + 2)
+                if (stack ~ /^[0-9 ]+$/) {
+                    sub(/^[[:space:]]+/, "", values)
+                    value_count = split(values, sample_values, /[[:space:]]+/)
+                    if (sample_column <= value_count) {
+                        print sample_values[sample_column] " 0: " stack
+                        next
+                    }
+                }
+            }
+        }
+        { print }
+    ' "$raw_profile"
+}
+
+render_pprof() {
+    local service="$1"
+    local kind="$2"
+    local sample_index="$3"
+    local count_name="$4"
+    local color="$5"
+    local output_dir="$6"
+    local title="$service $kind flame graph"
+
+    go tool pprof \
+        -sample_index="$sample_index" \
+        -raw \
+        -output="$output_dir/$kind.raw" \
+        "$output_dir/$kind.pprof"
+    select_pprof_sample "$sample_index" "$output_dir/$kind.raw" | \
+        stackcollapse-go.pl > "$output_dir/$kind.folded"
+    [[ -s "$output_dir/$kind.folded" ]] || {
+        echo "profile contained no stacks: $service $kind" >&2
+        return 1
+    }
+    flamegraph.pl \
+        --hash \
+        --colors="$color" \
+        --countname="$count_name" \
+        --title="$title" \
+        "$output_dir/$kind.folded" > "$output_dir/$kind.svg"
+}
+
+report() {
+    : "${PROFILE_RUN_ID:?PROFILE_RUN_ID is required}"
+    : "${PROFILE_FROM:?PROFILE_FROM is required}"
+    : "${PROFILE_TO:?PROFILE_TO is required}"
+    is_name "$PROFILE_RUN_ID" || {
+        echo "invalid profiling run name: $PROFILE_RUN_ID" >&2
+        return 1
+    }
+
+    local output_dir="/profiles/$PROFILE_RUN_ID"
+    local requested_service="${PROFILE_SERVICE:-}"
+    local selected_services=("${SERVICES[@]}")
+    local service
+
+    if [[ -n "$requested_service" ]]; then
+        is_service "$requested_service" || {
+            echo "unknown service: $requested_service" >&2
+            return 1
+        }
+        selected_services=("$requested_service")
+    fi
+
+    for service in "${selected_services[@]}"; do
+        [[ ! -e "$output_dir/$service" ]] || {
+            echo "report already exists: $output_dir/$service" >&2
+            return 1
+        }
+    done
+
+    local cleanup_command
+    local staging_dir
+    staging_dir="$(mktemp -d "$output_dir/.report.XXXXXX")"
+    printf -v cleanup_command 'rm -rf -- %q' "$staging_dir"
+    # Expand now because this function-local path is unavailable when the EXIT trap runs.
+    # shellcheck disable=SC2064
+    trap "$cleanup_command" EXIT
+
+    for service in "${selected_services[@]}"; do
+        echo "Rendering CPU and heap profiles for $service"
+        mkdir -p "$staging_dir/$service"
+        profilecli query profile \
+            --url="$PYROSCOPE_URL" \
+            --from="$PROFILE_FROM" \
+            --to="$PROFILE_TO" \
+            --query="{service_name=\"$service\"}" \
+            --profile-type="$CPU_PROFILE_TYPE" \
+            --output="pprof=$staging_dir/$service/cpu.pprof"
+        render_pprof "$service" cpu cpu nanoseconds hot "$staging_dir/$service"
+
+        curl --fail --silent --show-error --retry 3 --retry-delay 1 \
+            --output "$staging_dir/$service/heap.pprof" \
+            "${HEAP_ENDPOINTS[$service]}"
+        render_pprof "$service" heap inuse_space bytes mem "$staging_dir/$service"
+    done
+
+    for service in "${selected_services[@]}"; do
+        mv "$staging_dir/$service" "$output_dir/$service"
+    done
+    rmdir "$staging_dir"
+    trap - EXIT
+}
+
+diff_profiles() {
+    local baseline="$1"
+    local comparison="$2"
+    local service="$3"
+    local kind="$4"
+    local baseline_profile="/profiles/$baseline/$service/$kind.folded"
+    local comparison_profile="/profiles/$comparison/$service/$kind.folded"
+    local output_dir="/profiles/diffs/${comparison}-vs-${baseline}/$service"
+    local diff_profile="$output_dir/$kind.folded"
+    local count_name
+    local diff_args=()
+
+    is_name "$baseline" || {
+        echo "invalid baseline run name: $baseline" >&2
+        return 1
+    }
+    is_name "$comparison" || {
+        echo "invalid comparison run name: $comparison" >&2
+        return 1
+    }
+    is_service "$service" || {
+        echo "unknown service: $service" >&2
+        return 1
+    }
+    case "$kind" in
+        cpu)
+            count_name=nanoseconds
+            diff_args=(-n)
+            ;;
+        heap) count_name=bytes ;;
+        *)
+            echo "profile kind must be cpu or heap: $kind" >&2
+            return 1
+            ;;
+    esac
+    [[ -s "$baseline_profile" ]] || {
+        echo "profile not found: $baseline_profile" >&2
+        return 1
+    }
+    [[ -s "$comparison_profile" ]] || {
+        echo "profile not found: $comparison_profile" >&2
+        return 1
+    }
+
+    mkdir -p "$output_dir"
+    difffolded.pl "${diff_args[@]}" "$baseline_profile" "$comparison_profile" > "$diff_profile"
+    flamegraph.pl \
+        --countname="$count_name" \
+        --subtitle="Widths show $comparison; red increased, blue decreased" \
+        --title="$service $kind: $comparison vs $baseline" \
+        "$diff_profile" > "$output_dir/$kind.svg"
+    echo "Wrote $output_dir/$kind.svg"
+}
+
+case "${1:-}" in
+    report) report ;;
+    diff)
+        [[ $# -eq 5 ]] || {
+            echo "usage: profiling-tools diff BASELINE COMPARISON SERVICE cpu|heap" >&2
+            exit 1
+        }
+        diff_profiles "$2" "$3" "$4" "$5"
+        ;;
+    *)
+        echo "usage: profiling-tools report|diff" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

This makes local Docker profiling builds usable for eBPF CPU unwinding and enables symbolized jemalloc heap profiles in Pyroscope and Grafana. It adds named profiling runs that preserve CPU and heap pprof, folded stacks, SVG flamegraphs, and run metadata on the host. It also provides differential CPU and heap flamegraphs for comparing runs.