### PR TITLE
fix(prover): publish standalone requester RPC on loopback

### DIFF
--- a/bin/prover/service/README.md
+++ b/bin/prover/service/README.md
@@ -14,4 +14,18 @@ API.
 
 The unauthenticated requester and worker APIs are internal service endpoints.
 Restrict them to trusted components with private-network controls; never expose
-them publicly. Wildcard binds support container networking.
+them publicly. Wildcard binds support container networking: the in-container
+listener must accept forwarded traffic, so the deployment — not
+`RPC_LISTEN_ADDR` — decides who can reach it.
+
+The requester API is the more sensitive of the two. It accepts a
+caller-controlled `zk_backend`, including the paid `network` variant, so a
+reachable port lets any caller spend the deployment's requester funds, with no
+cumulative cap. It also exposes `deleteProofRequest`, `deleteProofsByTeeSigner`,
+and `listProofs`, so a reachable port allows deleting proofs already paid for.
+
+The standalone Compose stack therefore publishes the requester port on
+`127.0.0.1` only (see `etc/docker/docker-compose.prover.yml`). Reaching it from
+another host requires putting your own authenticated proxy in front of the
+loopback port, not republishing the port on a public interface. See
+[docs/guides/STANDALONE_PROVING.md](../../../docs/guides/STANDALONE_PROVING.md).

--- a/bin/prover/service/README.md
+++ b/bin/prover/service/README.md
@@ -30,4 +30,4 @@ bridge network rather than `routed` or `nat-unprotected`, and `just prover up`
 rejects reused networks with direct-routing options. Reaching it from another
 host requires putting your own authenticated proxy in front of the loopback
 port, not republishing the port on a public interface. See
-[docs/guides/STANDALONE_PROVING.md](../../../docs/guides/STANDALONE_PROVING.md).
+[`docs/guides/STANDALONE_PROVING.md`](../../../docs/guides/STANDALONE_PROVING.md).

--- a/bin/prover/service/README.md
+++ b/bin/prover/service/README.md
@@ -25,7 +25,9 @@ cumulative cap. It also exposes `deleteProofRequest`, `deleteProofsByTeeSigner`,
 and `listProofs`, so a reachable port allows deleting proofs already paid for.
 
 The standalone Compose stack therefore publishes the requester port on
-`127.0.0.1` only (see `etc/docker/docker-compose.prover.yml`). Reaching it from
-another host requires putting your own authenticated proxy in front of the
-loopback port, not republishing the port on a public interface. See
+`127.0.0.1` only (see `etc/docker/docker-compose.prover.yml`). It uses a NAT
+bridge network rather than `routed` or `nat-unprotected`, and `just prover up`
+rejects reused networks with direct-routing options. Reaching it from another
+host requires putting your own authenticated proxy in front of the loopback
+port, not republishing the port on a public interface. See
 [docs/guides/STANDALONE_PROVING.md](../../../docs/guides/STANDALONE_PROVING.md).

--- a/docs/guides/STANDALONE_PROVING.md
+++ b/docs/guides/STANDALONE_PROVING.md
@@ -7,6 +7,12 @@ mainnet) using your own RPC endpoints and your own funded
 requester key.
 
 The stack is three containers managed by `just prover up|down|logs <network>`.
+It requires Docker Engine 28.3.3 or later: earlier releases can leak a port
+published on `127.0.0.1` to the local network, which is how this stack keeps
+its unauthenticated requester RPC host-local. `just prover up` checks the
+daemon version and rejects a reused Docker network whose options would permit
+direct routing.
+
 The network label isolates each local control plane and its persisted jobs:
 
 - `prover-service-postgres` — session storage (persisted under `.zk-prover/<network>/`)
@@ -166,9 +172,12 @@ host-port position of a `127.0.0.1:<port>:9000` mapping.
 
 ## Requester RPC exposure
 
-The requester RPC is published on `127.0.0.1` only, so it is reachable from the
-machine running the stack and nowhere else. Keep it that way unless you add
-access control yourself.
+The requester RPC is published on `127.0.0.1` only. The Compose network
+explicitly uses Docker's `nat` gateway mode, so a daemon default of `routed` or
+`nat-unprotected` cannot leave the container address reachable from the local
+network, and `just prover up` rejects a reused network whose options would
+permit direct routing. Run the stack through `just prover up`: invoking Compose
+directly skips the daemon version and network checks.
 
 The API is unauthenticated. Any caller that reaches it can request proofs on
 the paid `network` backend against your deposited PROVE, and can also call

--- a/docs/guides/STANDALONE_PROVING.md
+++ b/docs/guides/STANDALONE_PROVING.md
@@ -172,12 +172,25 @@ host-port position of a `127.0.0.1:<port>:9000` mapping.
 
 ## Requester RPC exposure
 
-The requester RPC is published on `127.0.0.1` only. The Compose network
-explicitly uses Docker's `nat` gateway mode, so a daemon default of `routed` or
-`nat-unprotected` cannot leave the container address reachable from the local
-network, and `just prover up` rejects a reused network whose options would
-permit direct routing. Run the stack through `just prover up`: invoking Compose
-directly skips the daemon version and network checks.
+The requester RPC is published on `127.0.0.1` only. That stops a remote host
+reaching it at one of your host's addresses; Docker separately drops packets
+addressed straight to the container. The Compose network pins the two options
+that would undo the second protection: `nat` gateway mode, so a daemon default
+of `routed` or `nat-unprotected` cannot apply, and an empty
+`trusted_host_interfaces`, so a daemon `default-network-opts` entry cannot name
+interfaces allowed to route directly to the container. `just prover up` rejects
+a reused network carrying either option. Run the stack through `just prover
+up`: invoking Compose directly skips the daemon version and network checks.
+
+One case the stack cannot defend against is a daemon running with
+`allow-direct-routing` (in `daemon.json`, or `--allow-direct-routing`). That
+switches off direct-access filtering for every bridge network on the host. The
+loopback publish still hides port 9000 from your host's addresses, but a remote
+host with a route to the bridge subnet can then reach the requester at the
+container's own address. Docker does not report this setting through
+`docker info`, so `just prover up` cannot check it for you. Do not run this
+stack on such a host without your own authenticated proxy and firewall rules in
+front of it.
 
 The API is unauthenticated. Any caller that reaches it can request proofs on
 the paid `network` backend against your deposited PROVE, and can also call

--- a/docs/guides/STANDALONE_PROVING.md
+++ b/docs/guides/STANDALONE_PROVING.md
@@ -161,7 +161,26 @@ Stop the stack with `just prover down sepolia`; Postgres data under
 restarts. Stream logs with `just prover logs sepolia`.
 
 The RPC port defaults to 9000 and can be overridden with
-`PROVER_SERVICE_RPC_PORT`.
+`PROVER_SERVICE_RPC_PORT`. Pass a bare port number: the value fills the
+host-port position of a `127.0.0.1:<port>:9000` mapping.
+
+## Requester RPC exposure
+
+The requester RPC is published on `127.0.0.1` only, so it is reachable from the
+machine running the stack and nowhere else. Keep it that way unless you add
+access control yourself.
+
+The API is unauthenticated. Any caller that reaches it can request proofs on
+the paid `network` backend against your deposited PROVE, and can also call
+`deleteProofRequest`, `deleteProofsByTeeSigner`, and `listProofs` to list or
+delete proofs you already paid for. There is no cumulative spending cap: a
+caller supplying fresh session IDs can queue paid requests without bound.
+
+If you need to drive the stack from another host, do not republish port 9000 on
+a public interface. Put your own authenticated, TLS-terminating reverse proxy
+in front of the loopback port, and restrict which callers and which
+`zk_backend` values you allow through it. The same applies to the worker RPC
+(9001) and Postgres, which are not published to the host at all.
 
 ## Splitting propose and submit
 

--- a/etc/docker/docker-compose.prover.yml
+++ b/etc/docker/docker-compose.prover.yml
@@ -40,9 +40,8 @@ services:
       prover-service-postgres:
         condition: service_healthy
     ports:
-      # Requester RPC, loopback-only: the API is unauthenticated and can spend
-      # the requester key's deposited PROVE, so widening this needs the
-      # operator's own authenticated proxy. The override is a bare port number.
+      # Requester RPC. Loopback plus the NAT-mode network below keep this
+      # unauthenticated API host-local. The override is a bare port number.
       # The worker RPC (9001) and Postgres stay internal.
       - "127.0.0.1:${PROVER_SERVICE_RPC_PORT:-9000}:9000"
     environment:
@@ -88,3 +87,12 @@ services:
       - RUST_LOG=${RUST_LOG:-}
       - OTEL_SERVICE_NAME=base-prover-zk-host
     restart: unless-stopped
+
+networks:
+  default:
+    driver: bridge
+    enable_ipv6: false
+    driver_opts:
+      # Do not inherit a daemon default of `routed` or `nat-unprotected`.
+      com.docker.network.bridge.gateway_mode_ipv4: nat
+      com.docker.network.bridge.gateway_mode_ipv6: nat

--- a/etc/docker/docker-compose.prover.yml
+++ b/etc/docker/docker-compose.prover.yml
@@ -40,8 +40,11 @@ services:
       prover-service-postgres:
         condition: service_healthy
     ports:
-      # Requester RPC. The worker RPC (9001) and Postgres stay internal.
-      - "${PROVER_SERVICE_RPC_PORT:-9000}:9000"
+      # Requester RPC, loopback-only: the API is unauthenticated and can spend
+      # the requester key's deposited PROVE, so widening this needs the
+      # operator's own authenticated proxy. The override is a bare port number.
+      # The worker RPC (9001) and Postgres stay internal.
+      - "127.0.0.1:${PROVER_SERVICE_RPC_PORT:-9000}:9000"
     environment:
       - RPC_LISTEN_ADDR=0.0.0.0:9000
       - WORKER_RPC_LISTEN_ADDR=0.0.0.0:9001

--- a/etc/docker/docker-compose.prover.yml
+++ b/etc/docker/docker-compose.prover.yml
@@ -96,3 +96,7 @@ networks:
       # Do not inherit a daemon default of `routed` or `nat-unprotected`.
       com.docker.network.bridge.gateway_mode_ipv4: nat
       com.docker.network.bridge.gateway_mode_ipv6: nat
+      # Set explicitly so a daemon `default-network-opts` entry cannot add
+      # trusted interfaces here. Those would let a remote host reach the
+      # requester port at the container address, past the loopback publish.
+      com.docker.network.bridge.trusted_host_interfaces: ""

--- a/etc/just/prover.just
+++ b/etc/just/prover.just
@@ -19,6 +19,33 @@ up network:
       exit 1
     fi
 
+    docker_engine_version="$(docker version --format '{{ "{{" }}.Server.Version{{ "}}" }}' 2>/dev/null)" || {
+      echo "ERROR: standalone proving requires Docker Engine 28.3.3 or later." >&2
+      echo "Older releases can expose loopback-published ports to the local network." >&2
+      exit 1
+    }
+    if ! [[ "$docker_engine_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(\+[[:alnum:].-]+)?$ ]] ||
+      (( 10#${BASH_REMATCH[1]} < 28 ||
+         (10#${BASH_REMATCH[1]} == 28 &&
+          (10#${BASH_REMATCH[2]} < 3 ||
+           (10#${BASH_REMATCH[2]} == 3 && 10#${BASH_REMATCH[3]} < 3))) )); then
+      echo "ERROR: Docker Engine 28.3.3 or later is required (found '${docker_engine_version}')." >&2
+      echo "Older releases can expose loopback-published ports to the local network." >&2
+      exit 1
+    fi
+
+    prover_network="base-prover-${network}_default"
+    if docker network inspect "$prover_network" >/dev/null 2>&1; then
+      gateway_mode_v4="$(docker network inspect --format '{{ "{{" }} index .Options "com.docker.network.bridge.gateway_mode_ipv4" {{ "}}" }}' "$prover_network")"
+      gateway_mode_v6="$(docker network inspect --format '{{ "{{" }} index .Options "com.docker.network.bridge.gateway_mode_ipv6" {{ "}}" }}' "$prover_network")"
+      trusted_host_interfaces="$(docker network inspect --format '{{ "{{" }} index .Options "com.docker.network.bridge.trusted_host_interfaces" {{ "}}" }}' "$prover_network")"
+      if [[ "$gateway_mode_v4" != "nat" || "$gateway_mode_v6" != "nat" || -n "$trusted_host_interfaces" ]]; then
+        echo "ERROR: existing Docker network '${prover_network}' does not safely restrict direct routing." >&2
+        echo "Run 'just prover down ${network}' to remove it, then retry." >&2
+        exit 1
+      fi
+    fi
+
     missing=()
     for var in L1_NODE_ADDRESS L1_BEACON_ADDRESS L2_NODE_ADDRESS BASE_CONSENSUS_ADDRESS; do
       if [ -z "${!var:-}" ]; then

--- a/etc/just/prover.just
+++ b/etc/just/prover.just
@@ -32,6 +32,15 @@ up network:
       exit 1
     fi
 
+    # The compose file publishes the requester RPC as 127.0.0.1:<port>:9000, so
+    # this override fills the host-port position only.
+    if [ -n "${PROVER_SERVICE_RPC_PORT:-}" ] && ! [[ "$PROVER_SERVICE_RPC_PORT" =~ ^[0-9]+$ ]]; then
+      echo "ERROR: PROVER_SERVICE_RPC_PORT must be a bare port number (got '${PROVER_SERVICE_RPC_PORT}')" >&2
+      echo "The requester RPC is unauthenticated and is published to loopback only." >&2
+      echo "To reach it from another host, front it with your own authenticated proxy." >&2
+      exit 1
+    fi
+
     if [ -z "${NETWORK_PRIVATE_KEY:-}" ]; then
       echo "NOTE: NETWORK_PRIVATE_KEY is not set; starting a dry-run-only stack." >&2
       echo "The paid network backend stays disabled until the stack is restarted with a funded requester key." >&2


### PR DESCRIPTION
Closes CHAIN-4913.

## Summary

`etc/docker/docker-compose.prover.yml` published the prover-service requester RPC with short-syntax and no host IP, so Docker bound it to every host interface. That API is unauthenticated, `zk_backend` is caller-controlled and includes the paid `Network` variant, and fresh session IDs sidestep the per-session retry cap — so for a third-party operator following [STANDALONE_PROVING.md](https://github.com/base/base/blob/main/docs/guides/STANDALONE_PROVING.md) on a host reachable from an untrusted network, any caller could queue paid jobs against their deposited PROVE, or call `deleteProofRequest` / `deleteProofsByTeeSigner` / `listProofs` to list and delete proofs they already paid for.

Base's own prover deployment is not publicly reachable and is unaffected; this is a shipped-default fix for operators running our guide.

**The fix** is `"127.0.0.1:${PROVER_SERVICE_RPC_PORT:-9000}:9000"`. `RPC_LISTEN_ADDR=0.0.0.0:9000` is deliberately unchanged — the in-container listener has to bind a wildcard to receive forwarded traffic.

**Keeping that binding effective** takes three declarative checks, because a loopback publish can be routed past at the daemon level:

- The Compose network pins `gateway_mode_ipv4/ipv6: nat`, so a daemon default of `routed` or `nat-unprotected` cannot leave the container address reachable from the LAN.
- `just prover up` requires Docker Engine >= 28.3.3. [moby#41872](https://github.com/moby/moby/issues/41872) let a LAN peer reach a loopback-published port with a forged packet until 28.0, and [CVE-2025-54388](https://github.com/moby/moby/security/advisories/GHSA-x4rx-4gw3-53p4) drops the protecting rules on a firewalld reload in 28.2.0 through 28.3.2.
- `just prover up` refuses a reused Docker network whose options (non-`nat` gateway mode, or `trusted_host_interfaces`) would permit direct routing.

**Also**: `PROVER_SERVICE_RPC_PORT` now interpolates into the host-port position, so `just prover up` rejects values that are not a bare port number instead of failing with an opaque Compose parse error. A value like `0.0.0.0:9000` was valid before this change.

Requester authentication, per-principal backend authorization, and cumulative PROVE spending caps were recommended in the report but are out of scope — that is real design work, and hard to justify for a stack operators run locally.

## Dropped from an earlier revision

An earlier push of this branch also ran a veth-based probe on every `just prover up` that empirically tested whether a synthetic remote host could reach a loopback-published port. It has been removed. It required `NET_ADMIN` plus the host network and PID namespaces on the operator's machine, refused to run under rootless and userns-remap daemons — configurations the CVE advisory lists as *unaffected* and names as its workaround — was skipped entirely on Docker Desktop, and could not catch a firewalld reload occurring after startup, which is the residual risk the version gate actually covers. The three checks above cover the same ground declaratively.

## Test plan

- [x] `docker compose config` renders `host_ip: 127.0.0.1`, `published: "9000"`, `target: 9000`, and `gateway_mode_ipv4/ipv6: nat` on the default network.
- [x] With `PROVER_SERVICE_RPC_PORT=19000`, the override lands in the host-port position and still binds `127.0.0.1`.
- [x] `RPC_LISTEN_ADDR` / `WORKER_RPC_LISTEN_ADDR` still render as `0.0.0.0:9000` / `0.0.0.0:9001`; neither the worker RPC nor Postgres is published to the host.
- [x] Version gate exercised against a stub daemon: `27.5.1` and `28.3.2` rejected, `28.3.3` (exact boundary) and `29.1.0` accepted.
- [x] Reused-network check exercised against a stub daemon: rejects `nat-unprotected` gateway mode and a non-empty `trusted_host_interfaces`, accepts clean `nat`.
- [x] `PROVER_SERVICE_RPC_PORT=0.0.0.0:9000` fails with the actionable error; a bare port passes and proceeds to the existing ELF check.
- [x] `basectl --prover-rpc http://localhost:9000` still connects: `localhost` resolves to `::1` first on macOS, but clients fall back to `127.0.0.1` (verified against a v4-only listener, 2ms connect).
- [x] The zk-host path is untouched — it reaches the service over the Compose network as `http://base-prover-service:9001`, not through the host-published port.
- [ ] Full `just prover up <network>` end to end with a funded requester key (needs built SP1 ELFs, live RPC endpoints, and PROVE — not runnable here).

## Notes for reviewers

- Running Compose directly rather than through `just prover up` skips the version and reused-network checks. The Compose-level `nat` pinning still applies. This is stated in the guide.
- With no Docker daemon running, the version gate reports "requires Docker Engine 28.3.3 or later" rather than "daemon unreachable". Worth a follow-up if you find that confusing; I left it rather than widen this PR.
- `etc/docker/docker-compose.anvil-l1.yml` publishes the same requester port on a wildcard for the devnet `nitro-local` profile. Left alone: that stack has no funded requester key, so the spending risk does not apply, and every other devnet port there is published the same way.