### PR TITLE
feat(builder): emit coinbase-tip revenue per block

### DIFF
--- a/crates/builder/core/src/flashblocks/context.rs
+++ b/crates/builder/core/src/flashblocks/context.rs
@@ -870,9 +870,9 @@ impl BasePayloadBuilderCtx {
             let tx_hash = *tx.hash();
             let replay_independent = tx.eip8130_replay_id().is_some();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
-            let has_coinbase_tip = tx
-                .as_eip8130()
-                .is_some_and(|signed| CoinbaseTip::decode(signed.tx(), tx.sender()).is_some());
+            let coinbase_tip =
+                tx.as_eip8130().and_then(|signed| CoinbaseTip::decode(signed.tx(), tx.sender()));
+            let has_coinbase_tip = coinbase_tip.is_some();
 
             // Defer without evaluating once this flashblock's predicate-eval time budget is
             // exhausted, rather than spending more IO on the naive per-transaction loop. The
@@ -1575,7 +1575,13 @@ impl BasePayloadBuilderCtx {
                 .effective_tip_per_gas(base_fee)
                 .expect("fee is always valid; execution succeeded");
             info.total_fees += U256::from(miner_fee) * U256::from(gas_used);
-            info.inclusion.record(has_validity_predicates, gas_used, miner_fee, base_fee);
+            info.inclusion.record(
+                has_validity_predicates,
+                gas_used,
+                miner_fee,
+                base_fee,
+                coinbase_tip.unwrap_or_default(),
+            );
 
             // Per-tx tip-per-gas distribution (builder priority score), tagged
             // by flow cohort and bid mechanism. `X` for top-X-percentile share is

--- a/crates/builder/core/src/metrics.rs
+++ b/crates/builder/core/src/metrics.rs
@@ -289,6 +289,7 @@ impl BuilderMetrics {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::U256;
     use base_execution_payload_builder::{
         BuilderMetrics as SharedBuilderMetrics, InclusionTracker,
     };
@@ -434,9 +435,9 @@ mod tests {
         let handle = recorder.handle();
 
         let mut tracker = InclusionTracker::default();
-        tracker.record(true, 21_000, 2, 10);
-        tracker.record(false, 10_000, 4, 10);
-        tracker.record(true, 8_000, 9, 10);
+        tracker.record(true, 21_000, 2, 10, U256::from(500));
+        tracker.record(false, 10_000, 4, 10, U256::ZERO);
+        tracker.record(true, 8_000, 9, 10, U256::ZERO);
 
         metrics::with_local_recorder(&recorder, || {
             SharedBuilderMetrics::record_inclusion(&tracker);
@@ -478,11 +479,11 @@ mod tests {
         );
         assert!(
             rendered.contains("base_builder_coinbase_tip_revenue_wei_sum{flow=\"standard\"} 0"),
-            "expected coinbase tips to stay zero until decoded, got: {rendered}"
+            "expected no standard coinbase-tip revenue, got: {rendered}"
         );
         assert!(
-            rendered.contains("base_builder_coinbase_tip_revenue_wei_sum{flow=\"validity\"} 0"),
-            "expected coinbase tips to stay zero until decoded, got: {rendered}"
+            rendered.contains("base_builder_coinbase_tip_revenue_wei_sum{flow=\"validity\"} 500"),
+            "expected 500 validity coinbase-tip wei, got: {rendered}"
         );
     }
 

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -860,9 +860,9 @@ where
 
             let tx_hash = *tx.hash();
             let has_validity_predicates = !tx.validity_predicates().is_empty();
-            let has_coinbase_tip = tx
-                .as_eip8130()
-                .is_some_and(|signed| CoinbaseTip::decode(signed.tx(), tx.sender()).is_some());
+            let coinbase_tip =
+                tx.as_eip8130().and_then(|signed| CoinbaseTip::decode(signed.tx(), tx.sender()));
+            let has_coinbase_tip = coinbase_tip.is_some();
             if has_validity_predicates {
                 validity_consideration_index += 1;
                 emit_native_validity_event!(
@@ -1272,7 +1272,13 @@ where
                 .expect("fee is always valid; execution succeeded");
             let gas_used = gas_output.tx_gas_used();
             info.total_fees += U256::from(miner_fee) * U256::from(gas_used);
-            info.inclusion.record(has_validity_predicates, gas_used, miner_fee, base_fee);
+            info.inclusion.record(
+                has_validity_predicates,
+                gas_used,
+                miner_fee,
+                base_fee,
+                coinbase_tip.unwrap_or_default(),
+            );
             BuilderMetrics::record_tip_per_gas(
                 has_validity_predicates,
                 has_coinbase_tip,

--- a/crates/execution/payload/src/inclusion.rs
+++ b/crates/execution/payload/src/inclusion.rs
@@ -19,18 +19,16 @@ pub struct InclusionFlow {
     /// Priority-fee revenue (`effective_tip * gas_used`), in wei.
     pub priority_fees: U256,
     /// Coinbase-tip revenue from EIP-8130 phase-0 bids, in wei.
-    ///
-    /// TODO: populate from the statically-decoded phase-0 coinbase tip once
-    /// that decoder exists. Remains zero until then.
     pub coinbase_tips: U256,
 }
 
 impl InclusionFlow {
-    fn record(&mut self, gas_used: u64, miner_fee: u128, base_fee: u64) {
+    fn record(&mut self, gas_used: u64, miner_fee: u128, base_fee: u64, coinbase_tip: U256) {
         self.txs += 1;
         self.gas += gas_used;
         self.base_fees += U256::from(base_fee) * U256::from(gas_used);
         self.priority_fees += U256::from(miner_fee) * U256::from(gas_used);
+        self.coinbase_tips += coinbase_tip;
     }
 
     /// Base-fee revenue as `f64` wei for histogram emission.
@@ -62,9 +60,19 @@ impl InclusionTracker {
     /// Records a mempool transaction that was committed to the payload.
     ///
     /// `is_validity` selects the [`Self::validity`] or [`Self::standard`] flow.
-    pub fn record(&mut self, is_validity: bool, gas_used: u64, miner_fee: u128, base_fee: u64) {
+    /// `coinbase_tip` is the statically-decoded EIP-8130 phase-0 tip
+    /// (`base_common_consensus::CoinbaseTip::decode`), or [`U256::ZERO`] when
+    /// the transaction does not carry one.
+    pub fn record(
+        &mut self,
+        is_validity: bool,
+        gas_used: u64,
+        miner_fee: u128,
+        base_fee: u64,
+        coinbase_tip: U256,
+    ) {
         let flow = if is_validity { &mut self.validity } else { &mut self.standard };
-        flow.record(gas_used, miner_fee, base_fee);
+        flow.record(gas_used, miner_fee, base_fee, coinbase_tip);
     }
 }
 
@@ -75,7 +83,7 @@ mod tests {
     #[test]
     fn records_validity_inclusion_gas_and_fees() {
         let mut tracker = InclusionTracker::default();
-        tracker.record(true, 21_000, 2, 10);
+        tracker.record(true, 21_000, 2, 10, U256::ZERO);
 
         assert_eq!(tracker.validity.txs, 1);
         assert_eq!(tracker.validity.gas, 21_000);
@@ -88,7 +96,7 @@ mod tests {
     #[test]
     fn records_standard_fees_without_validity_counts() {
         let mut tracker = InclusionTracker::default();
-        tracker.record(false, 30_000, 3, 10);
+        tracker.record(false, 30_000, 3, 10, U256::ZERO);
 
         assert_eq!(tracker.validity, InclusionFlow::default());
         assert_eq!(tracker.standard.txs, 1);
@@ -99,12 +107,23 @@ mod tests {
     }
 
     #[test]
+    fn records_coinbase_tip_revenue_per_flow() {
+        let mut tracker = InclusionTracker::default();
+        tracker.record(true, 21_000, 0, 10, U256::from(500));
+        tracker.record(true, 8_000, 0, 10, U256::from(250));
+        tracker.record(false, 21_000, 0, 10, U256::from(100));
+
+        assert_eq!(tracker.validity.coinbase_tips_f64(), 750.0);
+        assert_eq!(tracker.standard.coinbase_tips_f64(), 100.0);
+    }
+
+    #[test]
     fn accumulates_mixed_mempool_transactions_across_the_block() {
         let mut tracker = InclusionTracker::default();
-        tracker.record(true, 21_000, 2, 10);
-        tracker.record(false, 10_000, 4, 10);
-        tracker.record(true, 9_000, 1, 10);
-        tracker.record(true, 8_000, 9, 10);
+        tracker.record(true, 21_000, 2, 10, U256::ZERO);
+        tracker.record(false, 10_000, 4, 10, U256::ZERO);
+        tracker.record(true, 9_000, 1, 10, U256::ZERO);
+        tracker.record(true, 8_000, 9, 10, U256::ZERO);
 
         assert_eq!(tracker.validity.txs, 3);
         assert_eq!(tracker.validity.gas, 38_000);


### PR DESCRIPTION
## Summary
- Populates the per-block `coinbase_tip_revenue_wei{flow}` histogram, previously hardcoded to zero pending a static decoder for the EIP-8130 phase-0 coinbase tip.
- Wires the existing `CoinbaseTip::decode` result (already used for `tip_per_gas` bid tagging) into `InclusionTracker::record` in both the flashblocks and native payload builder loops.
- Completes the three-way per-block revenue segmentation (coinbase tips / validity priority fees / ordinary priority fees) alongside BASE-241.

BASE-301

## Test plan
- [x] `cargo test -p base-execution-payload-builder -p base-builder-core --lib` (154 tests pass)
- [x] `cargo clippy -p base-execution-payload-builder -p base-builder-core --all-targets` (clean)