### PR TITLE
feat(shadow-indexer-db): mirror the hash columns as hex text

### DIFF
--- a/crates/execution/shadow-indexer-db/Cargo.toml
+++ b/crates/execution/shadow-indexer-db/Cargo.toml
@@ -18,6 +18,7 @@ sqlx = { workspace = true, features = ["runtime-tokio", "postgres", "chrono", "j
 # primitives
 reth-primitives-traits = { workspace = true, features = ["serde"] }
 base-common-consensus = { workspace = true, features = ["reth"] }
+alloy-primitives.workspace = true
 
 # serialization
 serde.workspace = true
@@ -34,5 +35,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 alloy-consensus.workspace = true
-alloy-primitives.workspace = true
 serde_json.workspace = true

--- a/crates/execution/shadow-indexer-db/migrations/0010_hash_hex_columns.sql
+++ b/crates/execution/shadow-indexer-db/migrations/0010_hash_hex_columns.sql
@@ -1,0 +1,63 @@
+-- Adds hex-string mirrors of the two BYTEA hash columns.
+--
+-- The Snowflake ETL reads this table with psycopg, which hands back a
+-- `memoryview` for a BYTEA column. Nothing in the pipeline unwraps it, so what
+-- lands in the warehouse is the repr of the Python object -- `<memory at
+-- 0x74b086814b80>` -- and not a block hash. The hashes are the join key for
+-- every downstream shadow-block query, so they have to arrive as text.
+--
+-- `hash_hex` and `canonical_hash_hex` carry the same values as their BYTEA
+-- counterparts, formatted as `0x`-prefixed lowercase hex. That is already what
+-- the shadow-metrics JSON API emits and what every other EVM hash in Snowflake
+-- looks like, so the values join without a normalization step.
+--
+-- Converting the existing columns in place was considered and rejected. A
+-- `BYTEA -> TEXT` change is not binary-coercible, so `ALTER COLUMN ... TYPE`
+-- rewrites the whole heap and every index while holding ACCESS EXCLUSIVE. On a
+-- 50k-row copy of this schema that rewrite took 580ms and changed the
+-- relfilenode; on mainnet, where migration 0007's single DELETE ran for over an
+-- hour and a table copy exhausted the volume, it is an outage and a disk-space
+-- failure at once.
+--
+-- Adding nullable columns with no default is a catalog-only change instead: no
+-- rewrite, no scan, ACCESS EXCLUSIVE held for microseconds.
+--
+-- Rows written from here on carry both representations, because the writer
+-- populates the hex columns in the same statement that binds the bytes. Rows
+-- already stored hold NULL until the out-of-band backfill runs. Nothing reads
+-- these columns yet, so a half-finished backfill is not observable.
+
+ALTER TABLE shadow_blocks
+  ADD COLUMN IF NOT EXISTS hash_hex TEXT,
+  ADD COLUMN IF NOT EXISTS canonical_hash_hex TEXT;
+
+-- The writer and the reader agree on a hash by string equality, so a stray
+-- uppercase digit or a missing `0x` is a silent lookup miss rather than an
+-- error. These constraints turn that into a write failure.
+--
+-- NOT VALID records the constraint for new and updated rows without scanning
+-- the table, which keeps this migration catalog-only. The backfill step
+-- validates them afterwards, out of band.
+--
+-- Guarded on the catalog rather than stated bare: this table has already been
+-- migrated by hand on mainnet with the `_sqlx_migrations` checksum written
+-- after the fact, and a re-run must not fail on a constraint that already
+-- exists.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'shadow_blocks_hash_hex_format'
+  ) THEN
+    ALTER TABLE shadow_blocks
+      ADD CONSTRAINT shadow_blocks_hash_hex_format
+      CHECK (hash_hex IS NULL OR hash_hex ~ '^0x[0-9a-f]{64}$') NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'shadow_blocks_canonical_hash_hex_format'
+  ) THEN
+    ALTER TABLE shadow_blocks
+      ADD CONSTRAINT shadow_blocks_canonical_hash_hex_format
+      CHECK (canonical_hash_hex IS NULL OR canonical_hash_hex ~ '^0x[0-9a-f]{64}$') NOT VALID;
+  END IF;
+END $$;

--- a/crates/execution/shadow-indexer-db/src/hash.rs
+++ b/crates/execution/shadow-indexer-db/src/hash.rs
@@ -18,15 +18,6 @@ impl ShadowHash {
     pub fn encode(bytes: &[u8]) -> String {
         hex::encode_prefixed(bytes)
     }
-
-    /// Formats an absent-or-present hash, preserving absence.
-    ///
-    /// `canonical_hash` is NULL until the chain names a replacement, and the hex mirror has to
-    /// stay NULL with it: an empty string would read as a resolved row that points nowhere.
-    #[must_use]
-    pub fn encode_optional(bytes: Option<&Vec<u8>>) -> Option<String> {
-        bytes.map(|bytes| Self::encode(bytes))
-    }
 }
 
 #[cfg(test)]
@@ -43,11 +34,5 @@ mod tests {
         let encoded = ShadowHash::encode(&[0x0f; 32]);
         assert_eq!(encoded.len(), 66, "0x plus 64 hex digits");
         assert!(encoded.starts_with("0x0f0f"));
-    }
-
-    #[test]
-    fn absent_hashes_stay_absent() {
-        assert_eq!(ShadowHash::encode_optional(None), None);
-        assert_eq!(ShadowHash::encode_optional(Some(&vec![0x01])), Some("0x01".to_string()));
     }
 }

--- a/crates/execution/shadow-indexer-db/src/hash.rs
+++ b/crates/execution/shadow-indexer-db/src/hash.rs
@@ -1,0 +1,53 @@
+//! Hex formatting for the string mirrors of the BYTEA hash columns.
+
+use alloy_primitives::hex;
+
+/// Formats block hashes for the `hash_hex` and `canonical_hash_hex` columns.
+///
+/// The writer stores these and the reader looks rows up by string equality, so the two must agree
+/// on one spelling of a hash or a lookup silently misses instead of failing. That spelling is
+/// `0x`-prefixed lowercase hex: it is what the shadow-metrics JSON API already emits, it is how
+/// every other EVM hash in Snowflake is written, and `shadow_blocks_hash_hex_format` rejects
+/// anything else at the database.
+#[derive(Clone, Copy, Debug)]
+pub struct ShadowHash;
+
+impl ShadowHash {
+    /// Formats raw hash bytes as `0x`-prefixed lowercase hex.
+    #[must_use]
+    pub fn encode(bytes: &[u8]) -> String {
+        hex::encode_prefixed(bytes)
+    }
+
+    /// Formats an absent-or-present hash, preserving absence.
+    ///
+    /// `canonical_hash` is NULL until the chain names a replacement, and the hex mirror has to
+    /// stay NULL with it: an empty string would read as a resolved row that points nowhere.
+    #[must_use]
+    pub fn encode_optional(bytes: Option<&Vec<u8>>) -> Option<String> {
+        bytes.map(|bytes| Self::encode(bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShadowHash;
+
+    #[test]
+    fn encodes_lowercase_with_an_0x_prefix() {
+        assert_eq!(ShadowHash::encode(&[0xAB, 0xCD, 0xEF]), "0xabcdef");
+    }
+
+    #[test]
+    fn encodes_a_full_block_hash_to_the_width_the_check_constraint_expects() {
+        let encoded = ShadowHash::encode(&[0x0f; 32]);
+        assert_eq!(encoded.len(), 66, "0x plus 64 hex digits");
+        assert!(encoded.starts_with("0x0f0f"));
+    }
+
+    #[test]
+    fn absent_hashes_stay_absent() {
+        assert_eq!(ShadowHash::encode_optional(None), None);
+        assert_eq!(ShadowHash::encode_optional(Some(&vec![0x01])), Some("0x01".to_string()));
+    }
+}

--- a/crates/execution/shadow-indexer-db/src/lib.rs
+++ b/crates/execution/shadow-indexer-db/src/lib.rs
@@ -13,3 +13,6 @@ pub use retention::{SHADOW_RETENTION_LOCK_KEY, ShadowRetentionRepo, ShadowRetent
 
 mod models;
 pub use models::{ShadowBlockPayload, ShadowBlockRow, ShadowCanonicalRef, ShadowWrite};
+
+mod hash;
+pub use hash::ShadowHash;

--- a/crates/execution/shadow-indexer-db/src/repo.rs
+++ b/crates/execution/shadow-indexer-db/src/repo.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use sqlx::{PgPool, Postgres, QueryBuilder, query, query_as, types::Json};
 
-use crate::{ShadowBlockRow, ShadowCanonicalRef, ShadowWrite};
+use crate::{ShadowBlockRow, ShadowCanonicalRef, ShadowHash, ShadowWrite};
 
 /// Rows written and rows resolved by a single flush.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -115,7 +115,6 @@ impl ShadowBlockRepo {
         tx: &mut sqlx::Transaction<'_, Postgres>,
         rows: &[&ShadowBlockRow],
     ) -> Result<usize> {
-        // Five binds per row; 4,000 stays below Postgres's 65,535-parameter limit.
         const CHUNK_SIZE: usize = 4_000;
 
         let deduped = Self::dedupe_last_write_wins(rows);
@@ -124,15 +123,19 @@ impl ShadowBlockRepo {
         for chunk in deduped.chunks(CHUNK_SIZE) {
             let mut query_builder: QueryBuilder<'_, Postgres> = QueryBuilder::new(
                 "INSERT INTO shadow_blocks \
-                 (number, hash, canonical_hash, created_at, payload) ",
+                 (number, hash, canonical_hash, created_at, payload, hash_hex, canonical_hash_hex) ",
             );
 
+            // The hex columns are derived from the same `entry` in the same bind, so the two
+            // spellings of a hash cannot drift apart for a row this statement writes.
             query_builder.push_values(chunk, |mut row, entry| {
                 row.push_bind(entry.number)
                     .push_bind(&entry.hash)
                     .push_bind(&entry.canonical_hash)
                     .push_bind(entry.created_at)
-                    .push_bind(Json(&entry.payload));
+                    .push_bind(Json(&entry.payload))
+                    .push_bind(ShadowHash::encode(&entry.hash))
+                    .push_bind(ShadowHash::encode_optional(entry.canonical_hash.as_ref()));
             });
 
             // A new candidate hash lands wholesale. A same-hash conflict only reaches DO UPDATE to
@@ -144,6 +147,8 @@ impl ShadowBlockRepo {
                 " ON CONFLICT (number) DO UPDATE SET \
                  hash = EXCLUDED.hash, \
                  canonical_hash = EXCLUDED.canonical_hash, \
+                 hash_hex = EXCLUDED.hash_hex, \
+                 canonical_hash_hex = EXCLUDED.canonical_hash_hex, \
                  created_at = CASE WHEN shadow_blocks.hash <> EXCLUDED.hash \
                      THEN EXCLUDED.created_at ELSE shadow_blocks.created_at END, \
                  payload = CASE WHEN shadow_blocks.hash <> EXCLUDED.hash \
@@ -174,17 +179,22 @@ impl ShadowBlockRepo {
         }
 
         let (numbers, hashes) = Self::dedupe_canonical_last_write_wins(canonical);
+        let hex: Vec<String> = hashes.iter().map(|hash| ShadowHash::encode(hash)).collect();
 
         let result = query(
             "UPDATE shadow_blocks AS unresolved \
-             SET canonical_hash = canonical.hash, updated_at = now() \
-             FROM UNNEST($1::BIGINT[], $2::BYTEA[]) AS canonical(number, hash) \
+             SET canonical_hash = canonical.hash, \
+                 canonical_hash_hex = canonical.hash_hex, \
+                 updated_at = now() \
+             FROM UNNEST($1::BIGINT[], $2::BYTEA[], $3::TEXT[]) \
+                  AS canonical(number, hash, hash_hex) \
              WHERE unresolved.number = canonical.number \
                AND unresolved.hash <> canonical.hash \
                AND unresolved.canonical_hash IS NULL",
         )
         .bind(&numbers)
         .bind(&hashes)
+        .bind(&hex)
         .execute(&mut **tx)
         .await
         .context("failed to resolve canonical hashes for shadow blocks")?;

--- a/crates/execution/shadow-indexer-db/src/repo.rs
+++ b/crates/execution/shadow-indexer-db/src/repo.rs
@@ -115,6 +115,7 @@ impl ShadowBlockRepo {
         tx: &mut sqlx::Transaction<'_, Postgres>,
         rows: &[&ShadowBlockRow],
     ) -> Result<usize> {
+        // Seven binds per row; 4,000 stays below Postgres's 65,535-parameter limit.
         const CHUNK_SIZE: usize = 4_000;
 
         let deduped = Self::dedupe_last_write_wins(rows);
@@ -135,7 +136,7 @@ impl ShadowBlockRepo {
                     .push_bind(entry.created_at)
                     .push_bind(Json(&entry.payload))
                     .push_bind(ShadowHash::encode(&entry.hash))
-                    .push_bind(ShadowHash::encode_optional(entry.canonical_hash.as_ref()));
+                    .push_bind(entry.canonical_hash.as_deref().map(ShadowHash::encode));
             });
 
             // A new candidate hash lands wholesale. A same-hash conflict only reaches DO UPDATE to

--- a/etc/systems/tests/shadow_blocks_reconciliation.rs
+++ b/etc/systems/tests/shadow_blocks_reconciliation.rs
@@ -262,3 +262,100 @@ async fn list_recent_returns_resolved_rows_newest_first_and_pages_by_before() ->
 
     Ok(())
 }
+
+/// Reads the hex mirror columns straight from the table, the way the Snowflake ETL does.
+async fn hex_columns(pool: &PgPool, number: i64) -> Result<(Option<String>, Option<String>)> {
+    let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
+        "SELECT hash_hex, canonical_hash_hex FROM shadow_blocks WHERE number = $1",
+    )
+    .bind(number)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(row)
+}
+
+#[tokio::test]
+async fn insert_writes_both_spellings_of_every_hash() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    let repo = ShadowBlockRepo::new(database.pool.clone());
+    repo.flush(&reorged([ShadowBlockFixture::new(400).into_row(0xe1, Some(0xe2))])).await?;
+
+    let (hash_hex, canonical_hash_hex) = hex_columns(&database.pool, 400).await?;
+    assert_eq!(hash_hex, Some(format!("0x{}", "e1".repeat(32))));
+    assert_eq!(canonical_hash_hex, Some(format!("0x{}", "e2".repeat(32))));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn an_unresolved_row_leaves_its_canonical_hex_null_rather_than_empty() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    let repo = ShadowBlockRepo::new(database.pool.clone());
+    repo.flush(&reorged([ShadowBlockFixture::new(401).into_row(0xe3, None)])).await?;
+
+    let (hash_hex, canonical_hash_hex) = hex_columns(&database.pool, 401).await?;
+    assert_eq!(hash_hex, Some(format!("0x{}", "e3".repeat(32))));
+    assert_eq!(canonical_hash_hex, None, "NULL, not a string that reads as a resolved row");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn resolving_a_canonical_hash_fills_its_hex_mirror() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    let repo = ShadowBlockRepo::new(database.pool.clone());
+    repo.flush(&reorged([ShadowBlockFixture::new(402).into_row(0xe4, None)])).await?;
+
+    repo.flush(&canonical([ShadowCanonicalRef { number: 402, hash: vec![0xe5; 32] }])).await?;
+
+    let (_, canonical_hash_hex) = hex_columns(&database.pool, 402).await?;
+    assert_eq!(
+        canonical_hash_hex,
+        Some(format!("0x{}", "e5".repeat(32))),
+        "the UNNEST resolve path carries the hex mirror with the bytes"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_replacement_candidate_replaces_both_hash_spellings() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    let repo = ShadowBlockRepo::new(database.pool.clone());
+    repo.flush(&reorged([ShadowBlockFixture::new(403).into_row(0xe6, Some(0xe7))])).await?;
+
+    repo.flush(&reorged([ShadowBlockFixture::new(403).into_row(0xe8, None)])).await?;
+
+    let (hash_hex, canonical_hash_hex) = hex_columns(&database.pool, 403).await?;
+    assert_eq!(hash_hex, Some(format!("0x{}", "e8".repeat(32))));
+    assert_eq!(
+        canonical_hash_hex, None,
+        "the replaced candidate's canonical hex must not carry over, exactly as its bytes do not"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn the_database_rejects_a_hash_that_is_not_lowercase_0x_hex() -> Result<()> {
+    let database = TestDatabase::start().await?;
+
+    let rejected = sqlx::query(
+        "INSERT INTO shadow_blocks (number, hash, created_at, payload, hash_hex) \
+         VALUES ($1, $2, now(), '{}'::jsonb, $3)",
+    )
+    .bind(404_i64)
+    .bind(vec![0xe9_u8; 32])
+    .bind(format!("0X{}", "E9".repeat(32)))
+    .execute(&database.pool)
+    .await;
+
+    let error = rejected.expect_err("uppercase hex is not the spelling the reader looks up");
+    assert!(
+        error.to_string().contains("shadow_blocks_hash_hex_format"),
+        "the format constraint is what rejected it, not something incidental: {error}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Shadow block hashes do not survive the ETL into Snowflake: they arrive as Python `memoryview` reprs like `<memory at 0x74b086814b80>` rather than hashes, which breaks every downstream query that joins on them. This PR starts storing the hashes as text so they land intact. Reads are unchanged, so nothing downstream needs a coordinated deploy.

- Adds `hash_hex` and `canonical_hash_hex` to `shadow_blocks`, populated by the writer alongside the existing byte columns.
- Uses `0x`-prefixed lowercase hex, matching the shadow-metrics API and every other EVM hash in Snowflake, so the values join without normalization.
- Adds CHECK constraints that reject any other spelling at write time.
- Leaves reads on the existing byte columns, so `shadow-metrics` is unaffected by this deploy.
- Fills rows already stored via an online backfill run after this ships; indexing the new columns and dropping the old ones follow in #4910.
