### PR TITLE
feat(proof): export OTLP traces from the proof services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,7 @@ dependencies = [
  "base-cli-utils",
  "clap",
  "eyre",
+ "reth-node-core",
 ]
 
 [[package]]
@@ -5579,6 +5580,7 @@ dependencies = [
  "clap",
  "eyre",
  "humantime",
+ "reth-node-core",
  "serde",
  "tokio",
  "url",
@@ -5793,6 +5795,7 @@ dependencies = [
  "base-proposer",
  "clap",
  "eyre",
+ "reth-node-core",
  "tokio",
 ]
 
@@ -5857,6 +5860,7 @@ dependencies = [
  "base-prover-service-client",
  "clap",
  "eyre",
+ "reth-node-core",
  "serde",
  "tokio",
  "tokio-util",
@@ -5893,6 +5897,7 @@ dependencies = [
  "clap",
  "eyre",
  "jsonrpsee",
+ "reth-node-core",
  "serde",
  "tokio",
  "tracing",
@@ -5958,6 +5963,7 @@ dependencies = [
  "base-prover-service-client",
  "clap",
  "eyre",
+ "reth-node-core",
  "serde",
  "tokio",
  "tokio-util",

--- a/bin/challenger/Cargo.toml
+++ b/bin/challenger/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 eyre.workspace = true
-base-cli-utils.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
+reth-node-core = { workspace = true, features = ["otlp"] }
+base-cli-utils = { workspace = true, features = ["otlp"] }
 base-challenger = { workspace = true, features = ["metrics"] }

--- a/bin/challenger/src/cli.rs
+++ b/bin/challenger/src/cli.rs
@@ -2,6 +2,7 @@
 
 use clap::Parser;
 use eyre::WrapErr;
+use reth_node_core::args::TraceArgs;
 
 /// Base Challenger.
 #[derive(Parser)]
@@ -10,13 +11,17 @@ use eyre::WrapErr;
 pub(crate) struct Cli {
     #[command(flatten)]
     args: base_challenger::Cli,
+
+    #[command(flatten)]
+    traces: TraceArgs,
 }
 
 impl Cli {
     /// Run the challenger service.
     pub(crate) fn run(self) -> eyre::Result<()> {
-        base_cli_utils::LogConfig::from(self.args.logging.clone()).init_tracing_subscriber()?;
-        let config = base_challenger::ChallengerConfig::from_cli(self.args)?;
+        let Self { args, traces } = self;
+        let logging = args.logging.clone();
+        let config = base_challenger::ChallengerConfig::from_cli(args)?;
         config
             .metrics
             .init_with(|| {
@@ -24,7 +29,9 @@ impl Cli {
                 base_challenger::ChallengerMetrics::up().set(1.0);
             })
             .wrap_err("failed to install Prometheus recorder")?;
-        base_cli_utils::RuntimeManager::new()
-            .run_until_ctrl_c(base_challenger::ChallengerService::run(config))
+        base_cli_utils::RuntimeManager::new().run_until_ctrl_c(async move {
+            base_cli_utils::LogConfig::from(logging).init_with_trace_args(&traces, &[])?;
+            base_challenger::ChallengerService::run(config).await
+        })
     }
 }

--- a/bin/challenger/src/main.rs
+++ b/bin/challenger/src/main.rs
@@ -6,5 +6,8 @@
 mod cli;
 
 fn main() {
+    let _ = reth_node_core::args::DefaultTraceValues::default()
+        .with_service_name("base-challenger")
+        .try_init();
     base_cli_utils::run_cli_main!(cli::Cli);
 }

--- a/bin/proposer/Cargo.toml
+++ b/bin/proposer/Cargo.toml
@@ -17,7 +17,8 @@ workspace = true
 
 [dependencies]
 eyre.workspace = true
-base-cli-utils.workspace = true
-tokio = { workspace = true, features = ["full"] }
 clap = { workspace = true, features = ["derive", "env"] }
+tokio = { workspace = true, features = ["full"] }
+reth-node-core = { workspace = true, features = ["otlp"] }
+base-cli-utils = { workspace = true, features = ["otlp"] }
 base-proposer = { workspace = true, features = ["metrics"] }

--- a/bin/proposer/src/cli.rs
+++ b/bin/proposer/src/cli.rs
@@ -2,6 +2,7 @@
 
 use clap::Parser;
 use eyre::WrapErr;
+use reth_node_core::args::TraceArgs;
 
 /// Base Proposer.
 #[derive(Parser)]
@@ -10,13 +11,16 @@ use eyre::WrapErr;
 pub(crate) struct Cli {
     #[command(flatten)]
     args: base_proposer::Cli,
+
+    #[command(flatten)]
+    traces: TraceArgs,
 }
 
 impl Cli {
     /// Run the proposer service.
     pub(crate) async fn run(self) -> eyre::Result<()> {
         let config = base_proposer::ProposerConfig::from_cli(self.args)?;
-        config.log.init_tracing_subscriber()?;
+        config.log.init_with_trace_args(&self.traces, &[])?;
         config
             .metrics
             .init_with(|| {

--- a/bin/proposer/src/main.rs
+++ b/bin/proposer/src/main.rs
@@ -7,5 +7,8 @@ mod cli;
 
 #[tokio::main]
 async fn main() {
+    let _ = reth_node_core::args::DefaultTraceValues::default()
+        .with_service_name("base-proposer")
+        .try_init();
     base_cli_utils::run_cli_main!(async cli::Cli);
 }

--- a/bin/prover-registrar/Cargo.toml
+++ b/bin/prover-registrar/Cargo.toml
@@ -17,8 +17,9 @@ workspace = true
 
 [dependencies]
 # Internal
-base-cli-utils.workspace = true
 base-tx-manager.workspace = true
+reth-node-core = { workspace = true, features = ["otlp"] }
+base-cli-utils = { workspace = true, features = ["otlp"] }
 base-proof-tee-registrar = { workspace = true, features = ["metrics"] }
 
 # Alloy

--- a/bin/prover-registrar/src/cli.rs
+++ b/bin/prover-registrar/src/cli.rs
@@ -9,6 +9,7 @@ use base_proof_tee_registrar::{
 };
 use base_tx_manager::{SignerConfig, TxManagerConfig};
 use clap::Parser;
+use reth_node_core::args::TraceArgs;
 use url::Url;
 
 // Generate env-var helper and CLI structs with the `BASE_REGISTRAR_` prefix.
@@ -122,6 +123,9 @@ pub(crate) struct Cli {
 
     #[command(flatten)]
     metrics: MetricsArgs,
+
+    #[command(flatten)]
+    pub(crate) traces: TraceArgs,
 }
 
 impl Cli {

--- a/bin/prover-registrar/src/main.rs
+++ b/bin/prover-registrar/src/main.rs
@@ -7,8 +7,14 @@ mod cli;
 
 #[tokio::main]
 async fn main() {
+    let _ = reth_node_core::args::DefaultTraceValues::default()
+        .with_service_name("base-proof-tee-registrar")
+        .try_init();
     let result: eyre::Result<()> = async {
-        let config = cli::Cli::parse().config()?;
+        let cli = cli::Cli::parse();
+        let traces = cli.traces.clone();
+        let config = cli.config()?;
+        config.log_config.init_with_trace_args(&traces, &[])?;
         config.run().await?;
         Ok(())
     }

--- a/bin/prover/nitro-host/Cargo.toml
+++ b/bin/prover/nitro-host/Cargo.toml
@@ -26,9 +26,10 @@ base-proof-tee-nitro-enclave = { workspace = true, optional = true }
 
 # CLI / errors
 eyre.workspace = true
-base-cli-utils.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
+reth-node-core = { workspace = true, features = ["otlp"] }
+base-cli-utils = { workspace = true, features = ["otlp"] }
 
 # Async
 tokio-util.workspace = true

--- a/bin/prover/nitro-host/src/cli.rs
+++ b/bin/prover/nitro-host/src/cli.rs
@@ -33,6 +33,7 @@ use base_prover_service_client::{ProverServiceClientConfig, ProverWorkerClient};
 use clap::{Parser, Subcommand};
 #[cfg(any(target_os = "linux", feature = "local"))]
 use eyre::eyre;
+use reth_node_core::args::TraceArgs;
 #[cfg(any(target_os = "linux", feature = "local"))]
 use tokio_util::sync::CancellationToken;
 #[cfg(any(target_os = "linux", feature = "local"))]
@@ -59,6 +60,10 @@ pub(crate) struct Cli {
     /// Metrics arguments.
     #[command(flatten)]
     metrics: MetricsArgs,
+
+    /// `OpenTelemetry` tracing export configuration.
+    #[command(flatten)]
+    traces: TraceArgs,
 }
 
 /// Nitro host subcommands.
@@ -212,14 +217,14 @@ struct WorkerArgs {
 impl Cli {
     /// Run the selected worker subcommand.
     pub(crate) fn run(self) -> eyre::Result<()> {
-        let Self { command, logging, metrics } = self;
-        LogConfig::from(logging).init_tracing_subscriber()?;
+        let Self { command, logging, metrics, traces } = self;
         base_cli_utils::MetricsConfig::from(metrics).init_with(|| {
             base_cli_utils::register_version_metrics!();
         })?;
 
         RuntimeManager::new().with_thread_stack_size(8 * 1024 * 1024).run_until_shutdown(
             |cancel| async move {
+                LogConfig::from(logging).init_with_trace_args(&traces, &[])?;
                 #[cfg(not(any(target_os = "linux", feature = "local")))]
                 let _ = cancel;
 

--- a/bin/prover/nitro-host/src/main.rs
+++ b/bin/prover/nitro-host/src/main.rs
@@ -25,5 +25,8 @@ use uuid as _;
 mod cli;
 
 fn main() {
+    let _ = reth_node_core::args::DefaultTraceValues::default()
+        .with_service_name("base-prover-nitro-host")
+        .try_init();
     base_cli_utils::run_cli_main!(cli::Cli);
 }

--- a/bin/prover/service/Cargo.toml
+++ b/bin/prover/service/Cargo.toml
@@ -23,9 +23,10 @@ base-prover-service-protocol = { workspace = true, features = ["rpc-server"] }
 
 # CLI
 eyre.workspace = true
-base-cli-utils.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
+reth-node-core = { workspace = true, features = ["otlp"] }
+base-cli-utils = { workspace = true, features = ["otlp"] }
 
 # RPC
 jsonrpsee = { workspace = true, features = ["server"] }

--- a/bin/prover/service/src/cli.rs
+++ b/bin/prover/service/src/cli.rs
@@ -11,6 +11,7 @@ use base_prover_service_protocol::{ProverRequesterApiServer, ProverWorkerApiServ
 use clap::Parser;
 use eyre::eyre;
 use jsonrpsee::server::{Server, ServerConfig as JsonRpcServerConfig};
+use reth_node_core::args::TraceArgs;
 use tracing::info;
 
 base_cli_utils::define_log_args!("BASE_PROVER_SERVICE");
@@ -32,6 +33,10 @@ pub(crate) struct Cli {
     /// Metrics arguments.
     #[command(flatten)]
     metrics: MetricsArgs,
+
+    /// `OpenTelemetry` tracing export configuration.
+    #[command(flatten)]
+    traces: TraceArgs,
 }
 
 /// Prover service for proving Base blocks over JSON-RPC.
@@ -119,13 +124,15 @@ struct ServiceArgs {
 impl Cli {
     /// Run the prover service.
     pub(crate) fn run(self) -> eyre::Result<()> {
-        let Self { args, logging, metrics } = self;
-        LogConfig::from(logging).init_tracing_subscriber()?;
+        let Self { args, logging, metrics, traces } = self;
         base_cli_utils::MetricsConfig::from(metrics).init_with(|| {
             base_cli_utils::register_version_metrics!();
             base_prover_service::ProverMetrics::init();
         })?;
-        RuntimeManager::new().run_until_ctrl_c(async move { args.run().await })
+        RuntimeManager::new().run_until_ctrl_c(async move {
+            LogConfig::from(logging).init_with_trace_args(&traces, &[])?;
+            args.run().await
+        })
     }
 }
 

--- a/bin/prover/service/src/main.rs
+++ b/bin/prover/service/src/main.rs
@@ -8,5 +8,8 @@ use serde as _;
 mod cli;
 
 fn main() {
+    let _ = reth_node_core::args::DefaultTraceValues::default()
+        .with_service_name("base-prover-service")
+        .try_init();
     base_cli_utils::run_cli_main!(cli::Cli);
 }

--- a/bin/prover/zk-host/Cargo.toml
+++ b/bin/prover/zk-host/Cargo.toml
@@ -24,9 +24,10 @@ base-proof-zk-backend = { workspace = true, features = ["metrics"] }
 
 # CLI / errors
 eyre.workspace = true
-base-cli-utils.workspace = true
 clap = { workspace = true, features = ["derive", "env"] }
 serde = { workspace = true, features = ["derive", "std"] }
+reth-node-core = { workspace = true, features = ["otlp"] }
+base-cli-utils = { workspace = true, features = ["otlp"] }
 
 # Async
 tokio-util.workspace = true

--- a/bin/prover/zk-host/src/cli.rs
+++ b/bin/prover/zk-host/src/cli.rs
@@ -15,6 +15,7 @@ use base_proof_zk_host::{
 use base_prover_service_client::{ProverServiceClientConfig, ProverWorkerClient};
 use clap::Parser;
 use eyre::WrapErr;
+use reth_node_core::args::TraceArgs;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use url::Url;
@@ -37,6 +38,10 @@ pub(crate) struct Cli {
     /// Metrics arguments.
     #[command(flatten)]
     metrics: MetricsArgs,
+
+    /// `OpenTelemetry` tracing export configuration.
+    #[command(flatten)]
+    traces: TraceArgs,
 }
 
 /// Worker-mode arguments for claiming and generating ZK proof jobs.
@@ -188,15 +193,17 @@ impl WorkerArgs {
 impl Cli {
     /// Run the worker.
     pub(crate) fn run(self) -> eyre::Result<()> {
-        let Self { worker, logging, metrics } = self;
-        LogConfig::from(logging).init_tracing_subscriber()?;
+        let Self { worker, logging, metrics, traces } = self;
         base_cli_utils::MetricsConfig::from(metrics).init_with(|| {
             base_cli_utils::register_version_metrics!();
         })?;
 
-        RuntimeManager::new()
-            .with_thread_stack_size(8 * 1024 * 1024)
-            .run_until_shutdown(|cancel| async move { worker.run(cancel).await })
+        RuntimeManager::new().with_thread_stack_size(8 * 1024 * 1024).run_until_shutdown(
+            |cancel| async move {
+                LogConfig::from(logging).init_with_trace_args(&traces, &[])?;
+                worker.run(cancel).await
+            },
+        )
     }
 }
 

--- a/bin/prover/zk-host/src/main.rs
+++ b/bin/prover/zk-host/src/main.rs
@@ -9,5 +9,8 @@ use serde as _;
 mod cli;
 
 fn main() {
+    let _ = reth_node_core::args::DefaultTraceValues::default()
+        .with_service_name("base-prover-zk-host")
+        .try_init();
     base_cli_utils::run_cli_main!(cli::Cli);
 }

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -316,7 +316,7 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> Driver<L2, P, T> {
     #[tracing::instrument(
         name = "challenger.process_fraudulent_zk_challenge",
         skip_all,
-        fields(game = %candidate.factory.proxy, challenged_index)
+        fields(game = %candidate.factory.proxy, challenged_index = challenged_index)
     )]
     async fn process_fraudulent_zk_challenge(
         &mut self,

--- a/crates/proof/challenge/src/driver.rs
+++ b/crates/proof/challenge/src/driver.rs
@@ -234,6 +234,11 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> Driver<L2, P, T> {
     }
 
     /// Validates an invalid proposal and starts its proof lifecycle.
+    #[tracing::instrument(
+        name = "challenger.process_invalid_proposal",
+        skip_all,
+        fields(game = %candidate.factory.proxy, intent = ?intent)
+    )]
     async fn process_invalid_proposal(
         &mut self,
         candidate: CandidateGame,
@@ -308,6 +313,11 @@ impl<L2: L2Provider, P: ProofRequesterProvider, T: TxManager> Driver<L2, P, T> {
     }
 
     /// Validates a challenged TEE root and nullifies a fraudulent ZK challenge.
+    #[tracing::instrument(
+        name = "challenger.process_fraudulent_zk_challenge",
+        skip_all,
+        fields(game = %candidate.factory.proxy, challenged_index)
+    )]
     async fn process_fraudulent_zk_challenge(
         &mut self,
         candidate: CandidateGame,

--- a/crates/proof/challenge/src/proof_manager.rs
+++ b/crates/proof/challenge/src/proof_manager.rs
@@ -139,6 +139,11 @@ impl<L2: L2Provider, P: ProofRequesterProvider> DisputeProofManager<L2, P> {
     ///
     /// When `try_tee_first` is `true` and the game has a non-zero TEE prover,
     /// a synchronous TEE proof is attempted before falling back to ZK.
+    #[tracing::instrument(
+        name = "challenger.initiate_proof",
+        skip_all,
+        fields(game = %candidate.factory.proxy, intent = ?intent)
+    )]
     pub async fn initiate_proof(
         &mut self,
         prover_address: Address,

--- a/crates/proof/challenge/src/submitter.rs
+++ b/crates/proof/challenge/src/submitter.rs
@@ -47,6 +47,11 @@ impl<T: TxManager> ChallengeSubmitter<T> {
     ///
     /// Returns the transaction hash on success, or an error if the transaction
     /// manager fails or the transaction reverts on-chain.
+    #[tracing::instrument(
+        name = "challenger.submit_dispute",
+        skip_all,
+        fields(game = %game_address, intent = ?intent)
+    )]
     pub async fn submit_dispute(
         &self,
         game_address: Address,

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -261,6 +261,11 @@ where
         }
     }
 
+    #[tracing::instrument(
+        name = "proposer.collect_submit",
+        skip_all,
+        fields(target_block, session_id)
+    )]
     async fn submit_proof(
         &self,
         target_block: u64,

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -264,7 +264,7 @@ where
     #[tracing::instrument(
         name = "proposer.collect_submit",
         skip_all,
-        fields(target_block, session_id)
+        fields(target_block = target_block, session_id = %session_id)
     )]
     async fn submit_proof(
         &self,

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -135,7 +135,7 @@ impl ProofDispatcher {
         Ok(l1_head)
     }
 
-    #[instrument(name = "proposer.dispatch_request", skip_all, fields(session_id))]
+    #[instrument(name = "proposer.dispatch_request", skip_all, fields(session_id), err(Display))]
     async fn dispatch_request(&self, request: ProofRequest) -> Result<String, ProposerError> {
         let request = ProposerProofAdapter::tee_prove_block_range_request(request);
         let session_id = request.proof.session_id.clone();

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -8,7 +8,7 @@ use base_optimism_rpc::{L1BlockRef, SyncStatus};
 use base_proof_primitives::ProofRequest;
 use base_proof_rpc::{L1Provider, L2Provider, RollupProvider};
 use base_prover_service_client::ProofRequesterProvider;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, instrument, warn};
 
 use crate::{
     Metrics,
@@ -135,9 +135,11 @@ impl ProofDispatcher {
         Ok(l1_head)
     }
 
+    #[instrument(name = "proposer.dispatch_request", skip_all, fields(session_id))]
     async fn dispatch_request(&self, request: ProofRequest) -> Result<String, ProposerError> {
         let request = ProposerProofAdapter::tee_prove_block_range_request(request);
         let session_id = request.proof.session_id.clone();
+        tracing::Span::current().record("session_id", session_id.as_str());
         match self.proof_requester.prove_block_range(request).await {
             Ok(response) if response.session_id == session_id => Ok(response.session_id),
             Ok(response) => Err(ProposerError::Prover(format!(

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -92,7 +92,11 @@ impl ProofSubmitter {
     /// RPC failures, root mismatches, invalid signers, or contract-level
     /// rejections — is mapped to a [`SubmitAction`] variant that tells the
     /// pipeline how to react.
-    #[instrument(skip_all, fields(target_block = target_block, parent_address = %parent_address))]
+    #[instrument(
+        name = "proposer.submit_proof",
+        skip_all,
+        fields(target_block = target_block, parent_address = %parent_address)
+    )]
     pub async fn submit(
         &self,
         aggregate_proposal: &Proposal,

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -6,7 +6,7 @@ use base_prover_service_protocol::{
     ProofRequestIdCollisionMessage, ProveBlockRangeRequest, ProveBlockRangeResponse,
 };
 use jsonrpsee::core::RpcResult;
-use tracing::{info, warn};
+use tracing::{Instrument, info, info_span, warn};
 
 use crate::server::{
     ProverServiceServer, failed_precondition, internal, invalid_argument, record_rpc_result,
@@ -53,13 +53,19 @@ impl ProverServiceServer {
             db_request.intermediate_root_interval,
         )?;
 
+        let span = info_span!(
+            "prover.prove_block_range",
+            session_id = %session_id,
+            start_block = db_request.start_block_number,
+            block_count = db_request.number_of_blocks_to_prove,
+            proof_type = %crate::metrics::api_proof_type_label(db_request.api_proof_type),
+            outcome = tracing::field::Empty,
+        );
+
         let outcome = self
             .repo
-            .create_for_worker_queue(
-                db_request,
-                self.config.max_proof_retries,
-                retry_failed,
-            )
+            .create_for_worker_queue(db_request, self.config.max_proof_retries, retry_failed)
+            .instrument(span.clone())
             .await
             .map_err(|e| match e {
                 CreateProofRequestError::IdCollision { id, field } => {
@@ -82,6 +88,15 @@ impl ProverServiceServer {
                 CreateProofRequestError::Validation(e) => invalid_argument(format!("{e}")),
                 CreateProofRequestError::Sqlx(e) => internal(format!("Database error: {e}")),
             })?;
+
+        let outcome_label = match &outcome {
+            CreateProofRequestOutcome::RetryNotAllowed(_) => "retry_not_allowed",
+            CreateProofRequestOutcome::RetryExhausted(_) => "retry_exhausted",
+            CreateProofRequestOutcome::Created(_) => "created",
+            CreateProofRequestOutcome::Requeued(_) => "requeued",
+            CreateProofRequestOutcome::Replayed(_) => "replayed",
+        };
+        span.record("outcome", outcome_label);
 
         match outcome {
             CreateProofRequestOutcome::RetryNotAllowed(id) => {
@@ -106,22 +121,13 @@ impl ProverServiceServer {
                 )));
             }
             CreateProofRequestOutcome::Created(id) => {
-                info!(
-                    proof_request_id = %id,
-                    "Created proof request for worker queue"
-                );
+                info!(proof_request_id = %id, "Created proof request for worker queue");
             }
             CreateProofRequestOutcome::Requeued(id) => {
-                info!(
-                    proof_request_id = %id,
-                    "Requeued previously failed proof request"
-                );
+                info!(proof_request_id = %id, "Requeued previously failed proof request");
             }
             CreateProofRequestOutcome::Replayed(id) => {
-                info!(
-                    proof_request_id = %id,
-                    "Idempotent replay of non-failed proof request"
-                );
+                info!(proof_request_id = %id, "Idempotent replay of non-failed proof request");
             }
         }
 

--- a/crates/proof/prover-service/src/server/prove_block_range.rs
+++ b/crates/proof/prover-service/src/server/prove_block_range.rs
@@ -62,41 +62,48 @@ impl ProverServiceServer {
             outcome = tracing::field::Empty,
         );
 
-        let outcome = self
+        let result = self
             .repo
             .create_for_worker_queue(db_request, self.config.max_proof_retries, retry_failed)
             .instrument(span.clone())
-            .await
-            .map_err(|e| match e {
-                CreateProofRequestError::IdCollision { id, field } => {
-                    warn!(
-                        proof_request_id = %id,
-                        mismatched_field = field,
-                        "rejected ProveBlockRange: session_id already bound to a different request"
-                    );
-                    failed_precondition(ProofRequestIdCollisionMessage::for_field(id, field))
-                }
-                CreateProofRequestError::SessionRowMissingAfterConflict { id } => {
-                    warn!(
-                        proof_request_id = %id,
-                        "rejected ProveBlockRange: session_id row missing after insert conflict"
-                    );
-                    unavailable(format!(
-                        "session_id {id} is temporarily unavailable after conflict; retry prove_block_range"
-                    ))
-                }
-                CreateProofRequestError::Validation(e) => invalid_argument(format!("{e}")),
-                CreateProofRequestError::Sqlx(e) => internal(format!("Database error: {e}")),
-            })?;
+            .await;
 
-        let outcome_label = match &outcome {
-            CreateProofRequestOutcome::RetryNotAllowed(_) => "retry_not_allowed",
-            CreateProofRequestOutcome::RetryExhausted(_) => "retry_exhausted",
-            CreateProofRequestOutcome::Created(_) => "created",
-            CreateProofRequestOutcome::Requeued(_) => "requeued",
-            CreateProofRequestOutcome::Replayed(_) => "replayed",
+        let outcome_label = match &result {
+            Ok(CreateProofRequestOutcome::RetryNotAllowed(_)) => "retry_not_allowed",
+            Ok(CreateProofRequestOutcome::RetryExhausted(_)) => "retry_exhausted",
+            Ok(CreateProofRequestOutcome::Created(_)) => "created",
+            Ok(CreateProofRequestOutcome::Requeued(_)) => "requeued",
+            Ok(CreateProofRequestOutcome::Replayed(_)) => "replayed",
+            Err(CreateProofRequestError::IdCollision { .. }) => "id_collision",
+            Err(CreateProofRequestError::SessionRowMissingAfterConflict { .. }) => {
+                "session_missing"
+            }
+            Err(CreateProofRequestError::Validation(_)) => "validation",
+            Err(CreateProofRequestError::Sqlx(_)) => "database",
         };
         span.record("outcome", outcome_label);
+
+        let outcome = result.map_err(|e| match e {
+            CreateProofRequestError::IdCollision { id, field } => {
+                warn!(
+                    proof_request_id = %id,
+                    mismatched_field = field,
+                    "rejected ProveBlockRange: session_id already bound to a different request"
+                );
+                failed_precondition(ProofRequestIdCollisionMessage::for_field(id, field))
+            }
+            CreateProofRequestError::SessionRowMissingAfterConflict { id } => {
+                warn!(
+                    proof_request_id = %id,
+                    "rejected ProveBlockRange: session_id row missing after insert conflict"
+                );
+                unavailable(format!(
+                    "session_id {id} is temporarily unavailable after conflict; retry prove_block_range"
+                ))
+            }
+            CreateProofRequestError::Validation(e) => invalid_argument(format!("{e}")),
+            CreateProofRequestError::Sqlx(e) => internal(format!("Database error: {e}")),
+        })?;
 
         match outcome {
             CreateProofRequestOutcome::RetryNotAllowed(id) => {

--- a/crates/proof/prover-service/src/server/worker_api.rs
+++ b/crates/proof/prover-service/src/server/worker_api.rs
@@ -201,6 +201,11 @@ impl ProverServiceServer {
     }
 
     /// Records a worker proof submission and completes the job.
+    #[tracing::instrument(
+        name = "prover.submit_proof",
+        skip_all,
+        fields(session_id = %request.session_id, worker_id = %request.worker_id)
+    )]
     pub async fn submit_proof_impl(
         &self,
         request: WorkerSubmitProofRequest,
@@ -330,6 +335,15 @@ impl ProverServiceServer {
     }
 
     /// Records (inserts or updates) the backend session for a claimed proof job.
+    #[tracing::instrument(
+        name = "prover.record_session",
+        skip_all,
+        fields(
+            session_id = %request.session_id,
+            worker_id = %request.worker_id,
+            session_type = ?request.session_type
+        )
+    )]
     pub async fn record_proof_session_impl(
         &self,
         request: RecordProofSessionRequest,

--- a/crates/proof/prover-service/src/worker/status_poller.rs
+++ b/crates/proof/prover-service/src/worker/status_poller.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use base_prover_service_db::{FailExpiredProofJobs, ProofJob, ProofRequestRepo, RetryOutcome};
 use tokio::time::sleep;
-use tracing::{error, info, warn};
+use tracing::{Instrument, error, info, info_span, warn};
 
 use crate::metrics;
 
@@ -89,6 +89,12 @@ impl StatusPoller {
             );
 
             for request in stuck_requests {
+                let span = info_span!(
+                    "prover.stuck_request",
+                    proof_request_id = %request.id,
+                    status = %request.status,
+                    retry_count = request.retry_count,
+                );
                 let proof_type_label = metrics::api_proof_type_label(request.api_proof_type);
 
                 let error_msg = format!(
@@ -99,6 +105,7 @@ impl StatusPoller {
                 match self
                     .repo
                     .retry_or_fail_stuck_request(request.id, self.max_proof_retries, &error_msg)
+                    .instrument(span)
                     .await
                 {
                     Ok(RetryOutcome::Retried) => {

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -21,7 +21,7 @@ use chrono::{DateTime, Utc};
 use thiserror::Error;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     NitroEnclavePool, NitroEnclavePoolError, ProofSubmitterRequest, ProofSubmitterRequestError,
@@ -91,6 +91,12 @@ where
     pub async fn generate_and_submit(&self, job: ProofJob) -> Result<(), ProofGeneratorError> {
         let request = ProofGeneratorRequest::try_from(job)?;
         let l2_block = request.proof.claimed_l2_block_number;
+        let span = info_span!(
+            "nitro.generate_and_submit",
+            session_id = %request.claim.session_id,
+            worker_id = %request.claim.worker_id,
+            l2_block,
+        );
 
         info!(
             session_id = %request.claim.session_id,
@@ -102,10 +108,19 @@ where
 
         let (proof, permit) = self
             .with_heartbeat_while_generating(&request, async {
-                let proof = self.pool.prove(request.proof.clone()).await?;
+                let proof = self
+                    .pool
+                    .prove(request.proof.clone())
+                    .instrument(info_span!(
+                        "nitro.prove",
+                        session_id = %request.claim.session_id,
+                        l2_block,
+                    ))
+                    .await?;
                 let permit = self.tasks.acquire_submission_permit().await;
                 Ok((proof, permit))
             })
+            .instrument(span)
             .await
             .inspect_err(|error| match error {
                 ProofGeneratorError::Generate { source, .. } => {

--- a/crates/proof/tee/nitro-host/src/proof_generator.rs
+++ b/crates/proof/tee/nitro-host/src/proof_generator.rs
@@ -88,15 +88,18 @@ where
     Client: Clone + ProverWorkerProvider + 'static,
 {
     /// Generate a proof for a claimed worker job and spawn proof submission.
+    #[tracing::instrument(
+        name = "nitro.generate_and_submit",
+        skip_all,
+        fields(session_id, worker_id, l2_block)
+    )]
     pub async fn generate_and_submit(&self, job: ProofJob) -> Result<(), ProofGeneratorError> {
         let request = ProofGeneratorRequest::try_from(job)?;
         let l2_block = request.proof.claimed_l2_block_number;
-        let span = info_span!(
-            "nitro.generate_and_submit",
-            session_id = %request.claim.session_id,
-            worker_id = %request.claim.worker_id,
-            l2_block,
-        );
+        tracing::Span::current()
+            .record("session_id", tracing::field::display(&request.claim.session_id))
+            .record("worker_id", tracing::field::display(&request.claim.worker_id))
+            .record("l2_block", l2_block);
 
         info!(
             session_id = %request.claim.session_id,
@@ -120,7 +123,6 @@ where
                 let permit = self.tasks.acquire_submission_permit().await;
                 Ok((proof, permit))
             })
-            .instrument(span)
             .await
             .inspect_err(|error| match error {
                 ProofGeneratorError::Generate { source, .. } => {
@@ -251,6 +253,7 @@ where
         let submitter = self.submitter.clone();
         let heartbeat_config = self.heartbeat;
 
+        let span = tracing::Span::current();
         tokio::task::spawn_blocking(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -265,7 +268,8 @@ where
                         &request.claim,
                         heartbeat_config,
                         request.lock_expires_at,
-                    ) => Some(source),
+                    )
+                    .instrument(span) => Some(source),
                     () = cancel.cancelled() => None,
                 }
             })

--- a/crates/proof/tee/registrar/src/driver.rs
+++ b/crates/proof/tee/registrar/src/driver.rs
@@ -313,7 +313,7 @@ where
                     };
                 }
                 let span = tracing::info_span!(
-                    "resolve_instance",
+                    "registrar.resolve_instance",
                     instance_id = %instance.instance_id,
                     endpoint = %instance.endpoint,
                     health = ?instance.health_status,

--- a/crates/proof/tee/registrar/src/service.rs
+++ b/crates/proof/tee/registrar/src/service.rs
@@ -102,10 +102,6 @@ impl RegistrarConfig {
     /// Returns an error if service initialization fails or the registration
     /// driver exits with an error.
     pub async fn run(self) -> Result<()> {
-        self.log_config
-            .init_tracing_subscriber()
-            .map_err(|e| RegistrarError::Service(e.to_string()))?;
-
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         info!(version = env!("CARGO_PKG_VERSION"), "Registrar starting");

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -23,7 +23,7 @@ use tokio::{
     task::{self, JoinError, JoinSet},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, instrument, warn};
 
 use crate::{
     AttestationPlanner, CertKind, CertPlan, DiscoveryResolution, P384Hints, PINNED_ROOT_CERT_HASH,
@@ -383,6 +383,11 @@ where
     T: TxManager,
 {
     /// Attempts to register a signer onchain if it is not already registered.
+    #[instrument(
+        name = "registrar.register_signer",
+        skip_all,
+        fields(instance_id = %instance_id, signer = %signer_address)
+    )]
     pub async fn register_signer(
         &self,
         instance_id: &str,
@@ -930,6 +935,11 @@ where
         }
     }
 
+    #[instrument(
+        name = "registrar.submit_registration",
+        skip_all,
+        fields(instance_id = %instance_id, signer = %signer)
+    )]
     async fn submit_registration(
         &self,
         instance_id: &str,

--- a/crates/proof/tee/registrar/src/signer_manager.rs
+++ b/crates/proof/tee/registrar/src/signer_manager.rs
@@ -386,7 +386,8 @@ where
     #[instrument(
         name = "registrar.register_signer",
         skip_all,
-        fields(instance_id = %instance_id, signer = %signer_address)
+        fields(instance_id = %instance_id, signer = %signer_address),
+        err(Display)
     )]
     pub async fn register_signer(
         &self,

--- a/crates/proof/worker/src/task.rs
+++ b/crates/proof/worker/src/task.rs
@@ -10,7 +10,7 @@ use tokio::{
     time::{Duration, timeout},
 };
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
+use tracing::{Instrument, warn};
 
 use crate::{DEFAULT_JOB_DISCOVERY_MAX_CONCURRENT_JOBS, ProofSubmitter, ProofSubmitterError};
 
@@ -122,12 +122,13 @@ impl ProofTaskController {
     {
         let cancel = self.submission_cancel.clone();
         let submitter = submitter.clone();
+        let span = tracing::Span::current();
 
         let mut submissions = self.submissions.lock().await;
         Self::drain_finished_submissions(&mut submissions);
         submissions.spawn(async move {
             let _permit = permit;
-            submitter.submit_until_delivered_or_cancelled(request, &cancel).await
+            submitter.submit_until_delivered_or_cancelled(request, &cancel).instrument(span).await
         });
     }
 

--- a/crates/proof/worker/src/task.rs
+++ b/crates/proof/worker/src/task.rs
@@ -146,7 +146,7 @@ impl ProofTaskController {
             tokio::task::JoinError,
         >,
     ) {
-        match result {
+        tracing::Span::none().in_scope(|| match result {
             Ok(Ok(_)) | Ok(Err(ProofSubmitterError::Cancelled)) => {}
             Ok(Err(error)) => {
                 warn!(error = %error, "proof submission task failed");
@@ -155,7 +155,7 @@ impl ProofTaskController {
             Err(error) => {
                 warn!(error = %error, "proof submission task join failed");
             }
-        }
+        });
     }
 }
 

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -22,7 +22,7 @@ use base_prover_service_protocol::{
 use chrono::{DateTime, Utc};
 use thiserror::Error;
 use tokio::time::{sleep, timeout};
-use tracing::{debug, info, warn};
+use tracing::{Instrument, debug, info, info_span, warn};
 
 use crate::{
     ProofSessionHandle, ProofSubmitterRequest, ZkProofRequestKind, ZkProver, ZkProverError,
@@ -133,6 +133,14 @@ where
     /// Generate a proof for a claimed worker job and spawn proof submission.
     pub async fn generate_and_submit(&self, job: ProofJob) -> Result<(), ProofGeneratorError> {
         let request = ProofGeneratorRequest::try_from(job)?;
+        let span = info_span!(
+            "zk.generate_and_submit",
+            session_id = %request.claim.session_id,
+            worker_id = %request.claim.worker_id,
+            start_block = request.request.start_block_number(),
+            block_count = request.request.number_of_blocks_to_prove(),
+            zk_backend = %request.request.zk_backend(),
+        );
 
         info!(
             session_id = %request.claim.session_id,
@@ -150,6 +158,7 @@ where
                 let permit = self.tasks.acquire_submission_permit().await;
                 Ok((result, permit))
             })
+            .instrument(span)
             .await
             .inspect_err(|error| match error {
                 ProofGeneratorError::Generate { source, .. } => {
@@ -302,7 +311,16 @@ where
             }
         };
 
-        self.poll_to_completion(request, handle, session_type, prover, backend_session_id).await
+        let span = info_span!(
+            "zk.prove_stage",
+            session_id = %request.claim.session_id,
+            session_type = ?session_type,
+            zk_backend = %request.request.zk_backend(),
+            backend_session_id = %backend_session_id,
+        );
+        self.poll_to_completion(request, handle, session_type, prover, backend_session_id)
+            .instrument(span)
+            .await
     }
 
     /// Poll a running backend session until it reaches a terminal state.

--- a/crates/proof/zk/host/src/proof_generator.rs
+++ b/crates/proof/zk/host/src/proof_generator.rs
@@ -131,16 +131,19 @@ where
     Client: Clone + ProverWorkerProvider + 'static,
 {
     /// Generate a proof for a claimed worker job and spawn proof submission.
+    #[tracing::instrument(
+        name = "zk.generate_and_submit",
+        skip_all,
+        fields(session_id, worker_id, start_block, block_count, zk_backend)
+    )]
     pub async fn generate_and_submit(&self, job: ProofJob) -> Result<(), ProofGeneratorError> {
         let request = ProofGeneratorRequest::try_from(job)?;
-        let span = info_span!(
-            "zk.generate_and_submit",
-            session_id = %request.claim.session_id,
-            worker_id = %request.claim.worker_id,
-            start_block = request.request.start_block_number(),
-            block_count = request.request.number_of_blocks_to_prove(),
-            zk_backend = %request.request.zk_backend(),
-        );
+        tracing::Span::current()
+            .record("session_id", tracing::field::display(&request.claim.session_id))
+            .record("worker_id", tracing::field::display(&request.claim.worker_id))
+            .record("start_block", request.request.start_block_number())
+            .record("block_count", request.request.number_of_blocks_to_prove())
+            .record("zk_backend", tracing::field::display(request.request.zk_backend()));
 
         info!(
             session_id = %request.claim.session_id,
@@ -158,7 +161,6 @@ where
                 let permit = self.tasks.acquire_submission_permit().await;
                 Ok((result, permit))
             })
-            .instrument(span)
             .await
             .inspect_err(|error| match error {
                 ProofGeneratorError::Generate { source, .. } => {

--- a/etc/docker/docker-compose.prover.yml
+++ b/etc/docker/docker-compose.prover.yml
@@ -39,6 +39,8 @@ services:
     depends_on:
       prover-service-postgres:
         condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       # Requester RPC. The worker RPC (9001) and Postgres stay internal.
       - "${PROVER_SERVICE_RPC_PORT:-9000}:9000"
@@ -53,6 +55,8 @@ services:
       - POSTGRES_PASSWORD=prover
       - POSTGRES_SSLMODE=disable
       - OTEL_SERVICE_NAME=base-prover-service
+      - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      - OTEL_EXPORTER_OTLP_PROTOCOL
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/9000"]
       interval: 250ms
@@ -84,4 +88,6 @@ services:
       - DEFAULT_SEQUENCE_WINDOW=${DEFAULT_SEQUENCE_WINDOW:-3600}
       - RUST_LOG=${RUST_LOG:-}
       - OTEL_SERVICE_NAME=base-prover-zk-host
+      - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+      - OTEL_EXPORTER_OTLP_PROTOCOL
     restart: unless-stopped

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -624,6 +624,8 @@ services:
     container_name: jaeger
     ports:
       - "3001:16686"  # Jaeger UI
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
     environment:
       - COLLECTOR_OTLP_ENABLED=true
       - MEMORY_MAX_TRACES=1000


### PR DESCRIPTION
## Summary
Wire the same OTLP path used by consensus so prover-service, zk-host, nitro-host, registrar, proposer, and challenger can send spans to Jaeger or Datadog APM when an endpoint is set.
