### PR TITLE
fix(system-tests): keep builder API registered alongside validity ingress

### DIFF
--- a/.depot/workflows/ci-pr.yml
+++ b/.depot/workflows/ci-pr.yml
@@ -19,7 +19,7 @@ jobs:
         just build::affected-ci "${DIFF_BASE:?}"
       clippy_command: >-
         just check::clippy-affected-ci "${DIFF_BASE:?}"
-      run_system_tests: false
+      run_system_tests: true
       run_sigsegv: false
       test_command: >-
         just test-affected-ci "${DIFF_BASE:?}"

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -193,6 +193,20 @@ impl InProcessBuilder {
             ))
             .apply(hooks);
         }
+        // Reth's `extend_rpc_modules` is a single-slot hook that silently replaces whatever was
+        // registered before it, and `NodeHooks::apply_to` claims that slot for every extension
+        // RPC module. Registering the builder API here instead keeps both in one closure.
+        let hooks = hooks.add_rpc_module(move |ctx| {
+            let api =
+                BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
+                    ctx.pool().clone(),
+                    accept_validity_transactions,
+                    DEFAULT_MAX_VALIDITY_PREDICATES,
+                );
+            ctx.modules.merge_configured(api.into_rpc())?;
+            Ok(())
+        });
+
         let node_builder = NodeBuilder::new(node_config.clone())
             .with_database(db)
             .with_launch_context(runtime.clone())
@@ -210,16 +224,7 @@ impl InProcessBuilder {
                         ),
                     )
                     .with_add_ons(addons)
-                    .on_component_initialized(move |_ctx| Ok(()))
-                    .extend_rpc_modules(move |ctx| {
-                        let api = BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
-                            ctx.pool().clone(),
-                            accept_validity_transactions,
-                            DEFAULT_MAX_VALIDITY_PREDICATES,
-                        );
-                        ctx.modules.merge_configured(api.into_rpc())?;
-                        Ok(())
-                    }),
+                    .on_component_initialized(move |_ctx| Ok(())),
             )
             .launch()
             .await;

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -427,6 +427,8 @@ async fn test_validity_transaction_submitted_directly_to_builder_is_included() -
         "direct builder ingress must not alter the signed transaction's state transition"
     );
 
+    system.shutdown().await?;
+
     Ok(())
 }
 


### PR DESCRIPTION

### What broke
Five `base-system-tests::tx_forwarding` tests fail on `main`, both attempts — exactly the five calling `start_validity_system()`. Three time out waiting for a receipt, two never see the transaction go pending, one is terminated with no error.

### Why
Reth's `extend_rpc_modules` is one slot, not a list:

```rust
self.extend_rpc_modules = Box::new(hook);   // replaces; does not chain
```

`InProcessBuilder::launch` called it twice: directly, to register `BuilderApiImpl` (`base_insertValidatedTransaction`), and again via `NodeHooks::apply_to`. `apply_to` only claims the slot when some extension registered an RPC module, and none did — until #4819 began installing `SendRawTransactionValidityExtension` whenever validity is enabled. The builder API was then silently discarded on those stacks:

```
batch item rejected error=ErrorObject { code: MethodNotFound, ... }
```

One missing method covers both symptoms. Nothing reaches the builder, so satisfied predicates get no receipt and false ones never go pending.

Fix: register the builder API through `NodeHooks::add_rpc_module` so both accumulate.

### Second bug
`test_validity_transaction_submitted_directly_to_builder_is_included` never calls `system.shutdown()`. Its assertions pass, then runtime drop blocks in `BlockingPool::shutdown` because the forwarding reader threads are never cancelled. That is the test CI reports without an error. Added the missing shutdown.

### Scope
Harness only. `bin/builder` and `bin/base` install everything via `install_ext`, so they issue one `extend_rpc_modules` call and were never affected.

### Testing
`9 passed; 0 failed` (serial, 609s). Before the fix, two forwarding tests failed in isolation and the direct-ingress test hung.

### Not addressed
Three SIGSEGVs in the same run (`activation_registry`, `eip8130`, `in_process_zk`) are unrelated and unreproduced.
