### PR TITLE
feat(b20): parallel storage prefetch on transfer methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,6 +4258,7 @@ dependencies = [
  "base-execution-eip8130-rpc-node",
  "base-execution-evm",
  "base-execution-payload-builder",
+ "base-execution-state-prefetch",
  "base-execution-trie",
  "base-flashblocks",
  "base-flashblocks-node",
@@ -4587,6 +4588,17 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tower 0.5.3",
+ "tracing",
+]
+
+[[package]]
+name = "base-execution-state-prefetch"
+version = "0.0.0"
+dependencies = [
+ "alloy-primitives",
+ "base-node-runner",
+ "base-precompile-storage",
+ "reth-provider",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ base-txpool-tracing = { path = "crates/execution/txpool-tracing" }
 base-execution-payload-builder = { path = "crates/execution/payload" }
 base-flashblocks-node = { path = "crates/execution/flashblocks-node" }
 base-execution-eip8130-rpc = { path = "crates/execution/eip8130-rpc" }
+base-execution-state-prefetch = { path = "crates/execution/state-prefetch" }
 base-execution-eip8130-rpc-node = { path = "crates/execution/eip8130-rpc-node" }
 base-execution-eip8130 = { path = "crates/execution/eip8130", default-features = false }
 

--- a/bin/base/src/commands/rpc.rs
+++ b/bin/base/src/commands/rpc.rs
@@ -555,6 +555,32 @@ mod tests {
     }
 
     #[test]
+    fn parses_rpc_state_prefetch_args() {
+        let cli = BaseCli::parse_from(rpc_args(&["base", "rpc", "--state.prefetch-workers", "8"]));
+
+        let BaseCommand::Rpc(rpc) = cli.command else {
+            panic!("expected rpc command");
+        };
+
+        let launch_config = rpc.execution.into_launch_config(BaseChainSpec::devnet().into());
+
+        assert_eq!(launch_config.standard.state_prefetch.state_prefetch_workers, 8);
+    }
+
+    #[test]
+    fn state_prefetch_workers_defaults_to_disabled() {
+        let cli = BaseCli::parse_from(rpc_args(&["base", "rpc"]));
+
+        let BaseCommand::Rpc(rpc) = cli.command else {
+            panic!("expected rpc command");
+        };
+
+        let launch_config = rpc.execution.into_launch_config(BaseChainSpec::devnet().into());
+
+        assert_eq!(launch_config.standard.state_prefetch.state_prefetch_workers, 0);
+    }
+
+    #[test]
     fn parses_rpc_validity_forwarding_args() {
         let cli = BaseCli::parse_from(rpc_args(&[
             "base",

--- a/crates/common/precompile-storage/src/lib.rs
+++ b/crates/common/precompile-storage/src/lib.rs
@@ -20,6 +20,9 @@ pub use packing::{
     calc_packed_slot_count,
 };
 
+mod prefetch;
+pub use prefetch::{PrefetchHint, PrefetchRequest, StatePrefetcher};
+
 mod provider;
 pub use provider::{
     ContractStorage, FromWord, Handler, Layout, LayoutCtx, Packable, PrecompileStorageProvider,

--- a/crates/common/precompile-storage/src/prefetch.rs
+++ b/crates/common/precompile-storage/src/prefetch.rs
@@ -1,0 +1,110 @@
+//! Fire-and-forget state prefetch hints for native precompiles.
+//!
+//! Native precompiles can know the storage slots an operation will touch before
+//! executing it, while the journaled EVM read path resolves those reads one at
+//! a time. [`PrefetchHint`] forwards slot batches to a process-wide
+//! [`StatePrefetcher`] installed by the node at startup. Prefetched values are
+//! discarded and the metered journaled reads remain unchanged.
+//!
+//! When no prefetcher is installed — tests, tools, and `no_std` proof
+//! environments — sending a hint is a no-op atomic load.
+
+use alloc::{sync::Arc, vec::Vec};
+
+use alloy_primitives::{Address, U256};
+use revm::primitives::OnceLock;
+
+/// One storage slot a producer expects to read shortly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PrefetchRequest {
+    /// The account whose storage will be read.
+    pub address: Address,
+    /// The storage slot key.
+    pub slot: U256,
+}
+
+/// Sink for state prefetch hints.
+pub trait StatePrefetcher: Send + Sync + core::fmt::Debug {
+    /// Hints that the given state is about to be read.
+    ///
+    /// Implementations must not block because this is called from the hot
+    /// execution path.
+    fn prefetch(&self, requests: &[PrefetchRequest]);
+}
+
+/// The process-wide prefetcher. Never uninstalled once set.
+static PREFETCHER: OnceLock<Arc<dyn StatePrefetcher>> = OnceLock::new();
+
+/// Entry point for issuing state prefetch hints.
+#[derive(Debug, Clone, Copy)]
+pub struct PrefetchHint;
+
+impl PrefetchHint {
+    /// Installs the process-wide prefetcher.
+    ///
+    /// The first install wins; returns `false` if a prefetcher was already
+    /// installed.
+    pub fn install(prefetcher: Arc<dyn StatePrefetcher>) -> bool {
+        PREFETCHER.set(prefetcher).is_ok()
+    }
+
+    /// Forwards storage-slot hints for one address if a prefetcher is installed.
+    pub fn send_slots(address: Address, slots: &[U256]) {
+        let Some(prefetcher) = PREFETCHER.get() else {
+            return;
+        };
+        let requests: Vec<_> =
+            slots.iter().map(|&slot| PrefetchRequest { address, slot }).collect();
+        prefetcher.prefetch(&requests);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The recording double below is hand-rolled rather than `automock`ed:
+    //! the prefetcher under test lives in a process-global static that is
+    //! never dropped, so mockall's drop-time expectation checking would never
+    //! run. Recording into shared state and asserting from the test body
+    //! sidesteps that.
+
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct RecordingPrefetcher {
+        calls: Mutex<Vec<Vec<PrefetchRequest>>>,
+    }
+
+    impl StatePrefetcher for RecordingPrefetcher {
+        fn prefetch(&self, requests: &[PrefetchRequest]) {
+            self.calls.lock().unwrap().push(requests.to_vec());
+        }
+    }
+
+    #[test]
+    fn send_forwards_to_installed_prefetcher() {
+        let address = Address::repeat_byte(0xB2);
+        let slots = [U256::from(11u64), U256::from(9u64)];
+
+        PrefetchHint::send_slots(address, &slots);
+
+        let recorder = Arc::new(RecordingPrefetcher::default());
+        let recorder_for_prefetcher = Arc::<RecordingPrefetcher>::clone(&recorder);
+        let prefetcher: Arc<dyn StatePrefetcher> = recorder_for_prefetcher;
+        assert!(PrefetchHint::install(prefetcher));
+
+        PrefetchHint::send_slots(address, &slots);
+        assert_eq!(
+            *recorder.calls.lock().unwrap(),
+            vec![vec![
+                PrefetchRequest { address, slot: slots[0] },
+                PrefetchRequest { address, slot: slots[1] },
+            ]],
+        );
+
+        assert!(!PrefetchHint::install(Arc::new(RecordingPrefetcher::default())));
+        PrefetchHint::send_slots(address, &slots[..1]);
+        assert_eq!(recorder.calls.lock().unwrap().len(), 2);
+    }
+}

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -6,10 +6,11 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_sol_types::SolValue;
 use base_common_genesis::BaseUpgrade;
 use base_common_precompiles::{
-    Asset, AssetV1, B20AssetStorage, B20AssetToken, B20FactoryStorage, B20TokenRole, B20Variant,
-    IB20, IB20Factory, PolicyRegistryStorage, PolicyVersion, Token, TokenAccounting,
+    Asset, AssetV1, B20AssetStorage, B20AssetToken, B20CoreStorage, B20FactoryStorage,
+    B20TokenRole, B20Variant, IB20, IB20Factory, PolicyRegistryStorage, PolicyVersion, Token,
+    TokenAccounting,
 };
-use base_precompile_storage::{HashMapStorageProvider, StorageCtx};
+use base_precompile_storage::{HashMapStorageProvider, PrefetchHint, StorageCtx};
 use criterion::{Criterion, criterion_group, criterion_main};
 
 struct BaseTokenBenchSetup;
@@ -503,6 +504,24 @@ fn base_b20_factory_view(c: &mut Criterion) {
     });
 }
 
+fn base_prefetch_hint_disabled(c: &mut Criterion) {
+    let token = Address::repeat_byte(0xb2);
+    let from = Address::repeat_byte(0x01);
+    let to = Address::repeat_byte(0x02);
+    let spender = Address::repeat_byte(0x03);
+
+    c.bench_function("base_prefetch_hint_disabled", |b| {
+        b.iter(|| {
+            let slots = B20CoreStorage::transfer_hint_slots(
+                black_box(from),
+                black_box(to),
+                Some(black_box(spender)),
+            );
+            PrefetchHint::send_slots(black_box(token), black_box(&slots));
+        });
+    });
+}
+
 criterion_group!(
     benches,
     base_token_metadata,
@@ -510,5 +529,6 @@ criterion_group!(
     base_token_mutate,
     base_b20_factory_mutate,
     base_b20_factory_view,
+    base_prefetch_hint_disabled,
 );
 criterion_main!(benches);

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -13,15 +13,15 @@ use alloc::{string::String, vec::Vec};
 use alloy_primitives::{Bytes, U256};
 use alloy_sol_types::{SolCall, SolType, SolValue, abi};
 use base_common_genesis::BaseUpgrade;
-use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
+use base_precompile_storage::{BasePrecompileError, PrecompileResult, PrefetchHint, StorageCtx};
 
 use crate::{
     AssetAccounting, AssetCall, AssetVersion, AssetVersions, B20AssetStorage, B20AssetToken,
-    B20PolicyType, B20TokenRole,
+    B20CoreStorage, B20PolicyType, B20TokenRole,
     IB20::{self, IB20Calls as C},
     IB20Asset::{self, IB20AssetCalls as SC},
     NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileAuxiliaryMetrics,
-    PrecompileCallObserver, PrecompileCallRecorder, PrecompileMetricLabels,
+    PrecompileCallObserver, PrecompileCallRecorder, PrecompileMetricLabels, Token,
 };
 
 impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
@@ -217,10 +217,18 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
 
             // --- ERC-20 mutating ---
             C::transfer(c) => {
+                PrefetchHint::send_slots(
+                    self.token_address(),
+                    &B20CoreStorage::transfer_hint_slots(caller, c.to, None),
+                );
                 logic.transfer(self, caller, c.to, c.amount, privileged)?;
                 true.abi_encode().into()
             }
             C::transferFrom(c) => {
+                PrefetchHint::send_slots(
+                    self.token_address(),
+                    &B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller)),
+                );
                 logic.transfer_from(self, caller, c.from, c.to, c.amount, privileged)?;
                 true.abi_encode().into()
             }
@@ -229,11 +237,19 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
                 true.abi_encode().into()
             }
             C::transferWithMemo(c) => {
+                PrefetchHint::send_slots(
+                    self.token_address(),
+                    &B20CoreStorage::transfer_hint_slots(caller, c.to, None),
+                );
                 logic.transfer(self, caller, c.to, c.amount, privileged)?;
                 logic.emit_memo(self, caller, c.memo)?;
                 true.abi_encode().into()
             }
             C::transferFromWithMemo(c) => {
+                PrefetchHint::send_slots(
+                    self.token_address(),
+                    &B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller)),
+                );
                 logic.transfer_from(self, caller, c.from, c.to, c.amount, privileged)?;
                 logic.emit_memo(self, caller, c.memo)?;
                 true.abi_encode().into()

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -11,15 +11,15 @@ use alloc::string::ToString;
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
 use base_common_genesis::BaseUpgrade;
-use base_precompile_storage::{BasePrecompileError, PrecompileResult, StorageCtx};
+use base_precompile_storage::{BasePrecompileError, PrecompileResult, PrefetchHint, StorageCtx};
 
 use crate::{
-    B20PolicyType, B20StablecoinToken, B20TokenRole, B20Variant,
+    B20CoreStorage, B20PolicyType, B20StablecoinToken, B20TokenRole, B20Variant,
     IB20::{self, IB20Calls as C},
     IB20Stablecoin::{self, IB20StablecoinCalls as SC},
     NoopPrecompileCallObserver, PermitArgs, PolicyAccounting, PrecompileCallObserver,
     PrecompileCallRecorder, PrecompileMetricLabels, PrecompileSelector, StablecoinAccounting,
-    StablecoinVersion, StablecoinVersions,
+    StablecoinVersion, StablecoinVersions, Token,
 };
 
 impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
@@ -197,11 +197,19 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                 // --- Mutating operations: routed to the active version's logic ---
                 C::transfer(c) => {
                     let caller = ctx.caller();
+                    PrefetchHint::send_slots(
+                        self.token_address(),
+                        &B20CoreStorage::transfer_hint_slots(caller, c.to, None),
+                    );
                     logic.transfer(self, caller, c.to, c.amount, privileged)?;
                     true.abi_encode().into()
                 }
                 C::transferFrom(c) => {
                     let caller = ctx.caller();
+                    PrefetchHint::send_slots(
+                        self.token_address(),
+                        &B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller)),
+                    );
                     logic.transfer_from(self, caller, c.from, c.to, c.amount, privileged)?;
                     true.abi_encode().into()
                 }
@@ -212,12 +220,20 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                 }
                 C::transferWithMemo(c) => {
                     let caller = ctx.caller();
+                    PrefetchHint::send_slots(
+                        self.token_address(),
+                        &B20CoreStorage::transfer_hint_slots(caller, c.to, None),
+                    );
                     logic.transfer(self, caller, c.to, c.amount, privileged)?;
                     logic.emit_memo(self, caller, c.memo)?;
                     true.abi_encode().into()
                 }
                 C::transferFromWithMemo(c) => {
                     let caller = ctx.caller();
+                    PrefetchHint::send_slots(
+                        self.token_address(),
+                        &B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller)),
+                    );
                     logic.transfer_from(self, caller, c.from, c.to, c.amount, privileged)?;
                     logic.emit_memo(self, caller, c.memo)?;
                     true.abi_encode().into()

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -1,10 +1,10 @@
 //! Core B-20 EVM storage layout shared by all token variants.
 
-use alloc::string::String;
+use alloc::{string::String, vec, vec::Vec};
 
 use alloy_primitives::{Address, B256, FixedBytes, U256};
 use base_precompile_macros::Storable;
-use base_precompile_storage::{Mapping, Result, StorageOps, Word};
+use base_precompile_storage::{Mapping, Result, StorableType, StorageKey, StorageOps, Word};
 
 use crate::TransferPolicyIds;
 
@@ -95,6 +95,32 @@ pub struct B20CoreStorage {
     pub seize_receiver_policy_id: u64, // slot 14, offset 8
     /// Reserved padding to close slot 14.
     pub seize_reserved: FixedBytes<16>, // slot 14, offset 16
+}
+
+impl B20CoreStorage {
+    /// Storage slots a `transfer` (`spender == None`) or `transferFrom` reads, derivable from
+    /// calldata alone: the paused bitmask, the packed transfer-policy-id word, both balances,
+    /// and the `allowances[from][spender]` entry for the `transferFrom` path.
+    ///
+    /// Used to issue a [`base_precompile_storage::PrefetchHint`] before dispatching the
+    /// operation, so the slots can be paged in concurrently instead of faulting one at a time
+    /// during execution. Slot arithmetic mirrors the generated handlers: namespace root plus the
+    /// generated per-field offset, with mapping keys folded in via [`StorageKey::mapping_slot`].
+    pub fn transfer_hint_slots(from: Address, to: Address, spender: Option<Address>) -> Vec<U256> {
+        let root = <Self as StorableType>::STORAGE_NAMESPACE_ROOT;
+        let balances = root.saturating_add(__packing_b20_core_storage::BALANCES);
+        let mut slots = vec![
+            root.saturating_add(__packing_b20_core_storage::PAUSED),
+            root.saturating_add(__packing_b20_core_storage::TRANSFER_SENDER_POLICY_ID),
+            from.mapping_slot(balances),
+        ];
+        slots.push(to.mapping_slot(balances));
+        if let Some(spender) = spender {
+            let allowances = root.saturating_add(__packing_b20_core_storage::ALLOWANCES);
+            slots.push(spender.mapping_slot(from.mapping_slot(allowances)));
+        }
+        slots
+    }
 }
 
 impl B20CoreStorageHandler<'_> {

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -51,6 +51,7 @@ base-txpool-tracing.workspace = true
 base-flashblocks-node.workspace = true
 base-builder-metering.workspace = true
 base-execution-trie.workspace = true
+base-execution-state-prefetch.workspace = true
 base-execution-eip8130-rpc-node.workspace = true
 base-execution-payload-builder.workspace = true
 base-proofs-extension.workspace = true

--- a/crates/execution/cli/src/lib.rs
+++ b/crates/execution/cli/src/lib.rs
@@ -43,7 +43,7 @@ use reth_node_metrics as _;
 use reth_rpc_server_types::{LenientRpcModuleValidator, RpcModuleValidator};
 pub use standard_node::{
     MeteringArgs, ResourceMeteringArgs, RpcStandardNodeArgs, ShadowIndexerArgs,
-    StandardBaseRethNode, StandardNodeArgs,
+    StandardBaseRethNode, StandardNodeArgs, StatePrefetchArgs,
 };
 mod upgrade_signal;
 pub use upgrade_signal::{

--- a/crates/execution/cli/src/node.rs
+++ b/crates/execution/cli/src/node.rs
@@ -22,7 +22,9 @@ use reth_rpc_server_types::{
 };
 use tracing::info;
 
-use crate::{MeteringArgs, RpcStandardNodeArgs, ShadowIndexerArgs, StandardNodeArgs};
+use crate::{
+    MeteringArgs, RpcStandardNodeArgs, ShadowIndexerArgs, StandardNodeArgs, StatePrefetchArgs,
+};
 
 const DEFAULT_BASE_MAX_INBOUND_EL_PEERS: usize = 80;
 const DEFAULT_BASE_MAX_OUTBOUND_EL_PEERS: usize = 80;
@@ -178,6 +180,10 @@ pub struct ExecutionNodeArgs {
     /// Shadow indexer `ExEx` arguments.
     #[command(flatten)]
     pub shadow_indexer: ShadowIndexerArgs,
+
+    /// State prefetcher arguments.
+    #[command(flatten)]
+    pub state_prefetch: StatePrefetchArgs,
 }
 
 impl ExecutionNodeArgs {
@@ -188,7 +194,8 @@ impl ExecutionNodeArgs {
             node_config: runtime.node_config,
             standard: StandardNodeArgs::from(self.standard)
                 .with_metering(self.metering)
-                .with_shadow_indexer(self.shadow_indexer),
+                .with_shadow_indexer(self.shadow_indexer)
+                .with_state_prefetch(self.state_prefetch),
             with_unused_ports: runtime.with_unused_ports,
             upgrade_signal_startup: runtime.upgrade_signal_startup,
         }

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -11,6 +11,7 @@ use base_execution_payload_builder::{
     NoopMeteringProvider, REJECTION_CACHE_MAX_CAPACITY, REJECTION_CACHE_TTL, RejectionCache,
     ResourceMeteringConfig, SharedMeteringProvider,
 };
+use base_execution_state_prefetch::{StatePrefetchConfig, StatePrefetchExtension};
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_metering::{MeteredOpcodes, MeteringConfig, MeteringExtension};
@@ -41,6 +42,19 @@ use url::Url;
 use crate::upgrade_signal::{
     ExecutionUpgradeSignal, ExecutionUpgradeSignalConfig, ExecutionUpgradeSignalRuntimeExtension,
 };
+
+/// CLI arguments for the state prefetcher.
+#[derive(Debug, Clone, PartialEq, Eq, Default, clap::Args)]
+pub struct StatePrefetchArgs {
+    /// Number of worker threads prefetching hinted state ahead of execution (hints are
+    /// currently produced by the B20 precompiles). 0 disables prefetching entirely.
+    #[arg(
+        long = "state.prefetch-workers",
+        value_name = "STATE_PREFETCH_WORKERS",
+        default_value_t = 0
+    )]
+    pub state_prefetch_workers: usize,
+}
 
 /// CLI arguments for metering RPC.
 #[derive(Debug, Clone, PartialEq, Eq, Default, clap::Args)]
@@ -264,6 +278,10 @@ pub struct StandardNodeArgs {
     /// Shadow indexer `ExEx` arguments.
     #[command(flatten)]
     pub shadow_indexer: ShadowIndexerArgs,
+
+    /// State prefetcher arguments.
+    #[command(flatten)]
+    pub state_prefetch: StatePrefetchArgs,
 }
 
 /// CLI arguments for a Base execution node embedded by the unified RPC command.
@@ -405,6 +423,7 @@ impl From<RpcStandardNodeArgs> for StandardNodeArgs {
             rpc: args,
             metering: MeteringArgs::default(),
             shadow_indexer: ShadowIndexerArgs::default(),
+            state_prefetch: StatePrefetchArgs::default(),
         }
     }
 }
@@ -419,6 +438,12 @@ impl StandardNodeArgs {
     /// Sets the shadow indexer arguments on this standard node configuration.
     pub fn with_shadow_indexer(mut self, shadow_indexer: ShadowIndexerArgs) -> Self {
         self.shadow_indexer = shadow_indexer;
+        self
+    }
+
+    /// Sets the state prefetcher arguments on this standard node configuration.
+    pub const fn with_state_prefetch(mut self, state_prefetch: StatePrefetchArgs) -> Self {
+        self.state_prefetch = state_prefetch;
         self
     }
 }
@@ -708,6 +733,9 @@ impl StandardBaseRethNode {
             MeteringConfig::disabled()
         };
         runner.install_ext::<MeteringExtension>(metering_config);
+        runner.install_ext::<StatePrefetchExtension>(StatePrefetchConfig {
+            workers: args.state_prefetch.state_prefetch_workers,
+        });
         runner.install_ext::<ShadowIndexerExtension>((&args.shadow_indexer).try_into()?);
         let tx_forwarding_config: TxForwardingConfig = (&args).into();
         if args.rpc.enable_experimental_validity_transactions {

--- a/crates/execution/state-prefetch/Cargo.toml
+++ b/crates/execution/state-prefetch/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "base-execution-state-prefetch"
+description = "Background state prefetch pool serving precompile hints"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# base
+base-node-runner.workspace = true
+base-precompile-storage = { workspace = true, features = ["std"] }
+
+# reth
+reth-provider.workspace = true
+
+# alloy
+alloy-primitives.workspace = true
+
+# misc
+tracing = { workspace = true, features = ["std"] }
+
+[dev-dependencies]
+reth-provider = { workspace = true, features = ["test-utils"] }

--- a/crates/execution/state-prefetch/README.md
+++ b/crates/execution/state-prefetch/README.md
@@ -1,0 +1,16 @@
+# base-execution-state-prefetch
+
+Background worker pool that resolves state-prefetch hints against the node's
+live state provider.
+
+Some execution paths know the storage slots an operation will read before
+executing it, but the journaled EVM read path resolves those reads one at a
+time. This pool receives hint batches through
+`base_precompile_storage::PrefetchHint` and fans the reads out across worker
+threads with independent state-provider handles, so database pages can fault
+in concurrently.
+
+Prefetching is purely a page-cache warmer: fetched values are discarded and
+the metered journaled reads remain unchanged, so enabling or disabling it has
+no consensus-visible effect. It is disabled unless the node starts with a
+non-zero `--state.prefetch-workers` value.

--- a/crates/execution/state-prefetch/src/extension.rs
+++ b/crates/execution/state-prefetch/src/extension.rs
@@ -1,0 +1,52 @@
+//! Node-builder extension installing the state prefetch pool.
+
+use std::sync::Arc;
+
+use base_node_runner::{BaseNodeExtension, FromExtensionConfig, NodeHooks};
+use base_precompile_storage::PrefetchHint;
+use tracing::{info, warn};
+
+use crate::{MAX_PREFETCH_WORKERS, StatePrefetchPool};
+
+/// Configuration for [`StatePrefetchExtension`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct StatePrefetchConfig {
+    /// Number of prefetch worker threads. Zero disables prefetching entirely.
+    pub workers: usize,
+}
+
+/// Wires the state prefetch pool into the node builder.
+#[derive(Debug)]
+pub struct StatePrefetchExtension {
+    config: StatePrefetchConfig,
+}
+
+impl FromExtensionConfig for StatePrefetchExtension {
+    type Config = StatePrefetchConfig;
+
+    fn from_config(config: Self::Config) -> Self {
+        Self { config }
+    }
+}
+
+impl BaseNodeExtension for StatePrefetchExtension {
+    fn apply(self: Box<Self>, hooks: NodeHooks) -> NodeHooks {
+        let workers = self.config.workers;
+        if workers == 0 {
+            return hooks;
+        }
+        let workers = workers.min(MAX_PREFETCH_WORKERS);
+        if workers < self.config.workers {
+            warn!(requested = %self.config.workers, clamped = %workers, "state prefetch workers clamped to maximum");
+        }
+        hooks.add_node_started_hook(move |node| {
+            let pool = StatePrefetchPool::spawn(node.provider().clone(), workers);
+            if PrefetchHint::install(Arc::new(pool)) {
+                info!(workers = %workers, "installed state prefetcher");
+            } else {
+                warn!("state prefetcher was already installed");
+            }
+            Ok(())
+        })
+    }
+}

--- a/crates/execution/state-prefetch/src/lib.rs
+++ b/crates/execution/state-prefetch/src/lib.rs
@@ -1,0 +1,10 @@
+#![doc = include_str!("../README.md")]
+#![doc(issue_tracker_base_url = "https://github.com/base/base/issues/")]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+mod extension;
+pub use extension::{StatePrefetchConfig, StatePrefetchExtension};
+
+mod pool;
+pub use pool::{MAX_PREFETCH_WORKERS, StatePrefetchPool};

--- a/crates/execution/state-prefetch/src/pool.rs
+++ b/crates/execution/state-prefetch/src/pool.rs
@@ -1,0 +1,116 @@
+//! Worker pool that resolves state prefetch hints against the live state provider.
+
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc,
+    },
+    thread,
+};
+
+use alloy_primitives::B256;
+use base_precompile_storage::{PrefetchRequest, StatePrefetcher};
+use reth_provider::StateProviderFactory;
+use tracing::trace;
+
+/// Per-worker queue capacity. Overflow drops the hint rather than blocking the
+/// execution path that produced it.
+const WORKER_QUEUE_CAPACITY: usize = 1024;
+
+/// Maximum number of prefetch worker threads a pool will spawn.
+pub const MAX_PREFETCH_WORKERS: usize = 256;
+
+/// Pool of OS threads that read hinted state through independent state-provider handles.
+///
+/// Each hinted request is read once at the latest state and the value discarded. Once installed
+/// as the process-wide prefetcher the pool is never dropped, so its workers live until process
+/// exit; [`Self::join`] exists for owners that want a graceful drain and shutdown.
+#[derive(Debug)]
+pub struct StatePrefetchPool {
+    senders: Vec<mpsc::SyncSender<PrefetchRequest>>,
+    workers: Vec<thread::JoinHandle<()>>,
+    next_worker: AtomicUsize,
+}
+
+impl StatePrefetchPool {
+    /// Spawns `workers` prefetch threads reading the latest state from `provider`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `workers` is zero or a worker thread cannot be spawned.
+    pub fn spawn<P>(provider: P, workers: usize) -> Self
+    where
+        P: StateProviderFactory + Clone + Send + Sync + 'static,
+    {
+        assert!(workers > 0, "prefetch pool requires at least one worker");
+        let mut senders = Vec::with_capacity(workers);
+        let mut handles = Vec::with_capacity(workers);
+        for index in 0..workers {
+            let (sender, receiver) = mpsc::sync_channel(WORKER_QUEUE_CAPACITY);
+            let provider = provider.clone();
+            let handle = thread::Builder::new()
+                .name(format!("state-prefetch-{index}"))
+                .spawn(move || Self::worker_loop(provider, receiver))
+                .expect("failed to spawn state prefetch worker");
+            senders.push(sender);
+            handles.push(handle);
+        }
+        Self { senders, workers: handles, next_worker: AtomicUsize::new(0) }
+    }
+
+    /// Drains all queued hints and waits for every worker to exit.
+    pub fn join(mut self) {
+        self.senders.clear();
+        for handle in self.workers.drain(..) {
+            handle.join().expect("state prefetch worker panicked");
+        }
+    }
+
+    /// Reads hinted state until every sender is dropped.
+    fn worker_loop<P: StateProviderFactory>(
+        provider: P,
+        receiver: mpsc::Receiver<PrefetchRequest>,
+    ) {
+        while let Ok(request) = receiver.recv() {
+            let result = provider.latest().and_then(|state| {
+                state.storage(request.address, B256::from(request.slot)).map(|_| ())
+            });
+            if let Err(error) = result {
+                trace!(
+                    error = %error,
+                    address = %request.address,
+                    slot = %request.slot,
+                    "prefetch read failed"
+                );
+            }
+        }
+    }
+}
+
+impl StatePrefetcher for StatePrefetchPool {
+    fn prefetch(&self, requests: &[PrefetchRequest]) {
+        for &request in requests {
+            let index = self.next_worker.fetch_add(1, Ordering::Relaxed) % self.senders.len();
+            let _ = self.senders[index].try_send(request);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::{Address, U256};
+    use reth_provider::test_utils::MockEthProvider;
+
+    use super::*;
+
+    #[test]
+    fn drains_all_hinted_requests_and_exits_cleanly() {
+        let pool = StatePrefetchPool::spawn(MockEthProvider::default(), 4);
+        let address = Address::repeat_byte(0x01);
+        let requests: Vec<PrefetchRequest> =
+            (0..64u64).map(|slot| PrefetchRequest { address, slot: U256::from(slot) }).collect();
+        pool.prefetch(&requests);
+        pool.prefetch(&requests[..5]);
+        pool.join();
+    }
+}


### PR DESCRIPTION
## Summary

- add a slot-only, process-wide prefetch hint interface for native precompiles
- represent a request as a simple `PrefetchRequest { address, slot }` struct
- issue eager B20 `transfer`, `transferFrom`, and memo-variant hints through a simple `send_slots` API
- add an opt-in node worker pool and `--state.prefetch-workers` CLI flag (default `0`)
- keep the execution path non-blocking with lossy bounded queues; prefetched values are discarded and consensus behavior is unchanged

This first PR intentionally keeps slot derivation eager and excludes fixed buffers, lazy dispatch, provider batching, detailed footprint coverage, metrics, and unused account/code request variants. Performance complexity is added only in later PRs with benchmark evidence.

## Stack

1. **#4877 — minimal B20 storage prefetch implementation**
2. #4914 — global queue bound and benchmarked hint-path optimizations
3. #4974 — benchmarked state-provider batching
4. #4975 — pin hints to the real B20 SLOAD footprint
5. #4976 — add worker metrics

## Testing

- `cargo test -p base-precompile-storage prefetch`
- `cargo test -p base-execution-state-prefetch`
- `cargo test -p base-execution-cli state_prefetch`
- `cargo test -p base --bin base state_prefetch`
- targeted Clippy with `-D warnings`

Generated with Toshi
