### PR TITLE
feat(load-tests): Stress Validity Predicate Limits

### DIFF
--- a/crates/infra/load-tests/Justfile
+++ b/crates/infra/load-tests/Justfile
@@ -7,6 +7,7 @@
 #   just load-test continuous sepolia                    - Load test sepolia indefinitely
 #   just load-test real-token                            - Real-token swap load test on devnet
 #   just load-test real-token sepolia                    - Real-token swap load test on sepolia
+#   just load-test validity-stress                       - 64-predicate local devnet stress test
 #   just load-test recover                               - Recover funds from devnet test accounts
 #   just load-test recover sepolia                       - Recover funds from sepolia test accounts
 #   just load-test real-token-recover sepolia            - Recover real-token funds from sepolia test accounts
@@ -81,6 +82,76 @@ real-token network='devnet' *args:
         "$template" > "$rendered_config"
 
     echo "Running real-token devnet load test with rendered config: $rendered_config"
+    cargo run -p base-load-tester-bin --bin base-load-tester -- "$rendered_config" {{args}}
+
+# Deploy DoubleCounter and run the local 64-predicate validity stress profile.
+validity-stress *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ -z "${FUNDER_KEY:-}" ]; then
+        export FUNDER_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+    fi
+
+    contracts_dir="crates/utilities/test-utils/contracts"
+    template="crates/infra/load-tests/examples/validity-stress.yaml.template"
+    rendered_config="$(mktemp "${TMPDIR:-/tmp}/base-validity-stress.XXXXXX.yaml")"
+    mutator_pid=""
+    cleanup() {
+        if [ -n "$mutator_pid" ]; then
+            kill "$mutator_pid" 2>/dev/null || true
+            wait "$mutator_pid" 2>/dev/null || true
+        fi
+        rm -f "$rendered_config"
+    }
+    trap cleanup EXIT
+
+    echo "Installing and building Foundry dependencies..."
+    (cd "$contracts_dir" && forge soldeer install && forge build)
+
+    echo "Deploying DoubleCounter to the running devnet..."
+    deploy_output="$(
+        cd "$contracts_dir"
+        forge script script/DeployDoubleCounter.s.sol:DeployDoubleCounter \
+            --rpc-url http://localhost:7545 \
+            --private-key "$FUNDER_KEY" \
+            --broadcast 2>&1
+    )"
+    printf '%s\n' "$deploy_output"
+    counter="$(printf '%s\n' "$deploy_output" | awk '$1 == "DoubleCounter:" { print $2; exit }')"
+    if [[ ! "$counter" =~ ^0x[[:xdigit:]]{40}$ ]]; then
+        echo "failed to parse DoubleCounter address from forge output" >&2
+        exit 1
+    fi
+
+    cargo run --quiet -p base-load-tests --example render_validity_stress -- \
+        "$template" "$counter" "$rendered_config"
+
+    mutator_key="${VALIDITY_STRESS_MUTATOR_KEY:-0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a}"
+    mutator_interval="${VALIDITY_STRESS_MUTATOR_INTERVAL_SECONDS:-30}"
+    if [[ ! "$mutator_interval" =~ ^[1-9][0-9]*$ ]]; then
+        echo "VALIDITY_STRESS_MUTATOR_INTERVAL_SECONDS must be a positive integer" >&2
+        exit 1
+    fi
+    mutate_counter() {
+        while true; do
+            if ! cast send \
+                --rpc-url http://localhost:7545 \
+                --private-key "$mutator_key" \
+                --gas-limit 100000 \
+                --gas-price 2000000000 \
+                --priority-gas-price 100000000 \
+                --timeout 10 \
+                "$counter" "increment()" >/dev/null 2>&1; then
+                echo "validity stress mutator transaction failed; retrying after interval" >&2
+            fi
+            sleep "$mutator_interval"
+        done
+    }
+    mutate_counter &
+    mutator_pid=$!
+
+    echo "Running validity stress test with rendered config: $rendered_config"
     cargo run -p base-load-tester-bin --bin base-load-tester -- "$rendered_config" {{args}}
 
 # Run load test against a network indefinitely (Ctrl-C to stop)

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -24,6 +24,9 @@ just load-test run
 # Deploy the devnet WETH/USDC harness and run real-token swaps
 just load-test real-token
 
+# Deploy DoubleCounter and run the 64-predicate validity stress profile
+just load-test validity-stress
+
 # Run real-token swaps against a network with predeployed contracts
 FUNDER_KEY=0x... just load-test real-token sepolia
 
@@ -144,6 +147,7 @@ delay is measured for logging but is no longer included in the JSON output.
 | `devnet.yaml` | Local devnet | Uses Anvil Account #1 |
 | `validity-devnet.yaml` | Local devnet | Validity (conditional) workload; routes half the senders through `base_sendRawTransactionValidity`. Run with `FUNDER_KEY=... just load-test run validity-devnet`. Requires the node validity flags for end-to-end enforcement |
 | `real-token-devnet.yaml.template` | Local devnet | Rendered by `just load-test real-token` after deploying the devnet WETH/USDC harness |
+| `validity-stress.yaml.template` | Local devnet | Rendered by `just load-test validity-stress` with a freshly deployed `DoubleCounter` |
 | `sepolia.yaml` | Base Sepolia | Requires `FUNDER_KEY` |
 | `real-token-sepolia.yaml` | Base Sepolia | Uses predeployed WETH/USDC and the Uniswap V3 swap router; run with `just load-test real-token sepolia`; recover with `just load-test real-token-recover sepolia` |
 | `real-token-mainnet-snapshot.yaml` | Local/shadow Base mainnet snapshot | Wraps funded ETH into WETH, acquires USDC, then runs random-direction Uniswap V3 and Aerodrome CL swaps; run with `just load-test real-token mainnet-snapshot` |
@@ -296,6 +300,36 @@ Recipient keys are always positioned with a runtime-random seed/offset (never th
 
 #### Validity (Conditional) Transactions
 
+`just load-test validity-stress [--continuous ...]` installs and builds the Foundry fixtures,
+deploys `DoubleCounter` to the already-running devnet on port 7545, renders a temporary config, and
+removes that config on exit. It does not restart the devnet. The profile attaches the maximum 64
+storage predicates: 63 always-true reads of distinct slots 1–63 followed by
+`(slot 0 & 1) == sender_parity`, where `sender_parity` is the low bit of each sender address. This
+keeps approximately half the sender streams matching and half parked at either slot value. All 800
+senders target the same contract and attach predicates. Ten percent use twice the baseline priority
+tip while the bulk uses half the baseline tip. The 600M gas/s target fills the controller's two-block
+mempool ceiling with roughly 4,500 validity transactions. An independent devnet account mutates slot
+0 every 30 seconds while measured transactions increment slot 1, so the two sender halves swap
+between matching and parked. That periodically wakes and rescans the parked set without measured
+transactions self-invalidating the parity gate. Override the cadence with
+`VALIDITY_STRESS_MUTATOR_INTERVAL_SECONDS`. This creates a shared-slot adversary where transactions
+repeatedly park, wake, invalidate, and rescan while each evaluation performs the maximum number of
+distinct storage reads.
+
+With the workload running, verify sustained pressure from the repository root:
+
+```bash
+etc/scripts/devnet/validity-stress-gate.sh --wait
+```
+
+The gate requires cutoff pressure, inclusions, storage reads, parking wakeups, and rescans to hold
+continuously for 60 seconds.
+
+The stress profile submits directly to the builder RPC on port 7545 so ingress forwarding cannot
+become the bottleneck or leave an asynchronous forwarding backlog between runs. To exercise the
+end-to-end forwarding path instead, override `transaction_submission_rpcs` in a rendered copy to
+port 8545. Both nodes still require the experimental validity flags described below.
+
 A configurable fraction of *senders* can route their entire traffic through the
 `base_sendRawTransactionValidity` endpoint, attaching validity predicates to
 every transaction they submit. All four server predicate types are supported:
@@ -316,6 +350,9 @@ approximates the fraction of transactions.
 ```yaml
 validity:
   ratio: 0.25                 # fraction of senders routed to the validity endpoint
+  priority_lead_ratio: 0.10   # fraction of validity senders priced ahead of plain traffic
+  priority_lead_multiplier: 2 # multiply the priority-lead cohort's tip
+  priority_fee_divisor: 2     # lower the remaining validity senders' tips
   predicates:
     - type: balance
       address: sender          # sender | recipient | 0x-literal
@@ -328,7 +365,7 @@ validity:
         value: "0x1"
       mask: "0xff"             # optional; defaults to all ones server-side
       op: "="
-      value: "0x0"
+      value: sender_parity      # or a fixed hex/decimal value
     # balanceOf(sender) against a seeded token's mapping slot:
     - type: storage
       address: "0xTOKEN000000000000000000000000000000000000"
@@ -359,8 +396,10 @@ so `balanceOf(key)` slots are expressible. The `flashblock_index` predicate
 carries an `op` and `value`, and `block_number` carries an `op` plus exactly one
 of `value` (a fixed absolute block number) or `offset` (resolved to
 `current_block + offset` at prepare time); both read the build position rather
-than any address or slot. Values, slots, masks, and offsets accept hex (`0x...`)
-or decimal strings. At most 64 predicates may be attached per transaction.
+than any address or slot. Storage predicate values may also be `sender_parity`,
+which resolves to the low bit of each transaction sender's address. Fixed values,
+slots, masks, and offsets accept hex (`0x...`) or decimal strings. At most 64
+predicates may be attached per transaction.
 
 The final summary's `by_cohort` breakdown reports confirmed transactions split
 across the `plain` and `validity_pass` cohorts, so plain traffic can be compared

--- a/crates/infra/load-tests/examples/render_validity_stress.rs
+++ b/crates/infra/load-tests/examples/render_validity_stress.rs
@@ -1,0 +1,112 @@
+//! Renders the validity-predicate stress profile for a deployed `DoubleCounter` contract.
+
+use std::{env, fmt::Write as _, fs, path::Path};
+
+use eyre::{Result, WrapErr, ensure};
+
+const CONTRACT_PLACEHOLDER: &str = "__DOUBLE_COUNTER__";
+const PREDICATES_PLACEHOLDER: &str = "__VALIDITY_PREDICATES__";
+
+struct Renderer;
+
+impl Renderer {
+    fn predicates(address: &str) -> String {
+        let mut predicates = String::new();
+
+        // Put the parity gate last so both matching and parked transactions perform 64 distinct
+        // storage reads before the gate decides their outcome.
+        for slot in 1..64 {
+            writeln!(
+                predicates,
+                "    - type: storage\n      address: \"{address}\"\n      slot:\n        kind: fixed\n        value: \"0x{slot:x}\"\n      op: \">=\"\n      value: \"0x0\""
+            )
+            .expect("writing to a String cannot fail");
+        }
+        write!(
+            predicates,
+            "    - type: storage\n      address: \"{address}\"\n      slot:\n        kind: fixed\n        value: \"0x0\"\n      mask: \"0x1\"\n      op: \"=\"\n      value: \"sender_parity\""
+        )
+        .expect("writing to a String cannot fail");
+
+        predicates
+    }
+
+    fn render(template: &str, address: &str) -> Result<String> {
+        ensure!(
+            address.len() == 42
+                && address.starts_with("0x")
+                && address[2..].bytes().all(|byte| byte.is_ascii_hexdigit()),
+            "contract address must be a 20-byte 0x-prefixed hex value"
+        );
+        ensure!(
+            template.matches(CONTRACT_PLACEHOLDER).count() == 1
+                && template.matches(PREDICATES_PLACEHOLDER).count() == 1,
+            "template must contain each validity-stress placeholder exactly once"
+        );
+
+        Ok(template
+            .replace(CONTRACT_PLACEHOLDER, address)
+            .replace(PREDICATES_PLACEHOLDER, &Self::predicates(address)))
+    }
+}
+
+fn main() -> Result<()> {
+    let args = env::args().collect::<Vec<_>>();
+    ensure!(
+        args.len() == 4,
+        "usage: {} <template> <contract-address> <output>",
+        args.first().map(String::as_str).unwrap_or("render_validity_stress")
+    );
+
+    let template = fs::read_to_string(Path::new(&args[1]))
+        .wrap_err_with(|| format!("failed to read template {}", args[1]))?;
+    let rendered = Renderer::render(&template, &args[2])?;
+    fs::write(Path::new(&args[3]), rendered)
+        .wrap_err_with(|| format!("failed to write rendered config {}", args[3]))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PREDICATES_PLACEHOLDER, Renderer};
+
+    const ADDRESS: &str = "0x1234567890123456789012345678901234567890";
+    const TEMPLATE: &str = include_str!("validity-stress.yaml.template");
+
+    #[test]
+    fn renders_exactly_64_storage_predicates() {
+        let result = Renderer::render(TEMPLATE, ADDRESS).unwrap();
+
+        assert_eq!(result.matches("    - type: storage").count(), 64);
+        assert_eq!(result.matches("      mask: \"0x1\"").count(), 1);
+        assert_eq!(result.matches("      op: \">=\"").count(), 63);
+        assert_eq!(result.matches(&format!("      address: \"{ADDRESS}\"")).count(), 64);
+        assert!(result.contains("sender_count: 800"));
+        assert!(result.contains("target_gps: 600000000"));
+        assert!(result.contains("transaction_submission_rpcs:\n  - \"http://localhost:7545\""));
+        assert!(result.contains("in_flight_per_sender: 12"));
+        assert!(result.contains("max_total_in_flight: 9600"));
+        assert!(result.contains("ratio: 1.0"));
+        assert!(result.contains("priority_lead_ratio: 0.10"));
+        assert!(result.contains("priority_lead_multiplier: 2"));
+        assert!(result.contains("priority_fee_divisor: 2"));
+        for slot in 0..64 {
+            assert_eq!(result.matches(&format!("        value: \"0x{slot:x}\"")).count(), 1);
+        }
+
+        let last_predicate = result.rsplit_once("    - type: storage").unwrap().1;
+        assert!(last_predicate.contains("        value: \"0x0\""));
+        assert!(last_predicate.contains("      mask: \"0x1\""));
+        assert!(last_predicate.contains("      op: \"=\""));
+        assert!(last_predicate.contains("      value: \"sender_parity\""));
+        assert!(!result.contains(PREDICATES_PLACEHOLDER));
+        assert!(!result.contains("__DOUBLE_COUNTER__"));
+    }
+
+    #[test]
+    fn rejects_address_without_hex_prefix() {
+        let address = ADDRESS.trim_start_matches("0x");
+
+        assert!(Renderer::render(TEMPLATE, address).is_err());
+    }
+}

--- a/crates/infra/load-tests/examples/validity-stress.yaml.template
+++ b/crates/infra/load-tests/examples/validity-stress.yaml.template
@@ -1,0 +1,35 @@
+# Local devnet validity-predicate stress profile.
+# Rendered by `just load-test validity-stress`; do not run this template directly.
+
+transaction_submission_rpcs:
+  - "http://localhost:7545"
+query_rpc: "http://localhost:7545"
+txpool_nodes:
+  - "http://localhost:7545"
+  - "http://localhost:8545"
+  - "http://localhost:8645"
+flashblocks_ws: "ws://localhost:7111"
+
+sender_count: 800
+target_gps: 600000000
+block_time: "200ms"
+in_flight_per_sender: 12
+max_total_in_flight: 9600
+max_concurrent_submit_requests: 64
+batch_size: 1
+duration: "90s"
+seed: 8675309
+funding_amount: "1000000000000000000"
+
+transactions:
+  - weight: 100
+    type: double_counter
+    contract: "__DOUBLE_COUNTER__"
+
+validity:
+  ratio: 1.0
+  priority_lead_ratio: 0.10
+  priority_lead_multiplier: 2
+  priority_fee_divisor: 2
+  predicates:
+__VALIDITY_PREDICATES__

--- a/crates/infra/load-tests/src/config/mod.rs
+++ b/crates/infra/load-tests/src/config/mod.rs
@@ -16,5 +16,6 @@ pub use test_config::{OsakaTarget, TestConfig, TxTypeConfig, WeightedTxType};
 
 mod validity;
 pub use validity::{
-    PredicateAddressConfig, PredicateSlotConfig, ValidityConfig, ValidityPredicateConfig,
+    PredicateAddressConfig, PredicateSlotConfig, PredicateValueConfig, ValidityConfig,
+    ValidityPredicateConfig,
 };

--- a/crates/infra/load-tests/src/config/real_token.rs
+++ b/crates/infra/load-tests/src/config/real_token.rs
@@ -164,6 +164,7 @@ fn validate_real_token_pair_matches_swaps(
             | TxTypeConfig::B20
             | TxTypeConfig::Precompile { .. }
             | TxTypeConfig::Storage { .. }
+            | TxTypeConfig::DoubleCounter { .. }
             | TxTypeConfig::Osaka { .. } => continue,
         };
         saw_swap = true;

--- a/crates/infra/load-tests/src/config/test_config.rs
+++ b/crates/infra/load-tests/src/config/test_config.rs
@@ -277,6 +277,12 @@ pub enum TxTypeConfig {
         slots_per_tx: u32,
     },
 
+    /// Deterministic `DoubleCounter` `increment()` call.
+    DoubleCounter {
+        /// `DoubleCounter` contract address.
+        contract: Address,
+    },
+
     /// Precompile call.
     Precompile {
         /// Target precompile configuration.
@@ -612,6 +618,9 @@ impl TestConfig {
             fresh_recipient_ratio: self.fresh_recipient_ratio,
             validity_ratio: self.validity.ratio,
             validity_predicate_count: self.validity.predicates.len(),
+            validity_priority_lead_ratio: self.validity.priority_lead_ratio,
+            validity_priority_lead_multiplier: self.validity.priority_lead_multiplier,
+            validity_priority_fee_divisor: self.validity.priority_fee_divisor,
             looper_contract: self.looper_contract.map(|addr| addr.to_string()),
             swap_token_amount: self.swap_token_amount.clone(),
             b20_mint_amount: self.b20_mint_amount.clone(),
@@ -681,6 +690,9 @@ impl TestConfig {
             fresh_recipient_ratio: self.fresh_recipient_ratio,
             validity_ratio: self.validity.ratio,
             validity_predicates: self.validity.to_templates()?,
+            validity_priority_lead_ratio: self.validity.priority_lead_ratio,
+            validity_priority_lead_multiplier: self.validity.priority_lead_multiplier,
+            validity_priority_fee_divisor: self.validity.priority_fee_divisor,
         })
     }
 
@@ -698,6 +710,9 @@ impl TestConfig {
                     )));
                 }
                 TxType::Storage { contract: *contract, slots_per_tx: *slots_per_tx }
+            }
+            TxTypeConfig::DoubleCounter { contract } => {
+                TxType::DoubleCounter { contract: *contract }
             }
             TxTypeConfig::Precompile { target, iterations } => {
                 let looper_contract = if *iterations > 1 {
@@ -1411,6 +1426,64 @@ validity:
 "#;
         let err = TestConfig::from_yaml(yaml).unwrap_err();
         assert!(err.to_string().contains("validity.predicates must be non-empty"));
+    }
+
+    #[test]
+    fn double_counter_and_validity_priority_round_trip_to_runtime_and_summary() {
+        let yaml = r#"
+transaction_submission_rpcs: http://localhost:8545
+transactions:
+  - weight: 100
+    type: double_counter
+    contract: "0x1111111111111111111111111111111111111111"
+validity:
+  priority_lead_ratio: 0.2
+  priority_lead_multiplier: 4
+  priority_fee_divisor: 3
+"#;
+        let config = TestConfig::from_yaml(yaml).unwrap();
+        assert_eq!(config.validity.priority_lead_ratio, 0.2);
+        assert_eq!(config.validity.priority_lead_multiplier, 4);
+        assert_eq!(config.validity.priority_fee_divisor, 3);
+        assert!(matches!(config.transactions[0].tx_type, TxTypeConfig::DoubleCounter { .. }));
+
+        let load = config.to_load_config(Some(1337)).unwrap();
+        assert_eq!(load.validity_priority_lead_ratio, 0.2);
+        assert_eq!(load.validity_priority_lead_multiplier, 4);
+        assert_eq!(load.validity_priority_fee_divisor, 3);
+        assert!(matches!(load.transactions[0].tx_type, TxType::DoubleCounter { .. }));
+        assert_eq!(config.to_summary().validity_priority_fee_divisor, 3);
+        assert_eq!(config.to_summary().validity_priority_lead_ratio, 0.2);
+        assert_eq!(config.to_summary().validity_priority_lead_multiplier, 4);
+    }
+
+    #[test]
+    fn validity_priority_divisor_defaults_to_one_and_rejects_zero() {
+        let config =
+            TestConfig::from_yaml("transaction_submission_rpcs: http://localhost:8545").unwrap();
+        assert_eq!(config.validity.priority_fee_divisor, 1);
+        assert_eq!(config.to_load_config(Some(1337)).unwrap().validity_priority_fee_divisor, 1);
+
+        let error = TestConfig::from_yaml(
+            "transaction_submission_rpcs: http://localhost:8545\nvalidity:\n  priority_fee_divisor: 0",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("priority_fee_divisor must be >= 1"));
+    }
+
+    #[test]
+    fn validity_priority_lead_settings_reject_out_of_range_values() {
+        let error = TestConfig::from_yaml(
+            "transaction_submission_rpcs: http://localhost:8545\nvalidity:\n  priority_lead_ratio: 1.1",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("priority_lead_ratio must be between 0.0 and 1.0"));
+
+        let error = TestConfig::from_yaml(
+            "transaction_submission_rpcs: http://localhost:8545\nvalidity:\n  priority_lead_multiplier: 0",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("priority_lead_multiplier must be >= 1"));
     }
 
     #[test]

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use super::parsing::parse_address;
 use crate::{
-    runner::{BlockNumberBound, PredicateAddress, SlotTemplate, ValidityPredicateTemplate},
+    runner::{
+        BlockNumberBound, PredicateAddress, PredicateValue, SlotTemplate, ValidityPredicateTemplate,
+    },
     utils::{BaselineError, Result},
 };
 
@@ -14,17 +16,42 @@ use crate::{
 /// `base_sendRawTransactionValidity`, carrying the configured predicates.
 /// Routing is per sender (not per transaction) so each sender's nonce stream
 /// stays on a single submission origin.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ValidityConfig {
     /// Fraction `0.0..=1.0` of senders assigned to the validity path.
     pub ratio: f64,
+
+    /// Fraction `0.0..=1.0` of validity senders in the priority-lead cohort.
+    ///
+    /// The remaining validity senders use [`Self::priority_fee_divisor`]. A small lead
+    /// cohort can park predicates before plain transactions mutate
+    /// watched state, while the lower-priority bulk cohort sustains cutoff pressure.
+    pub priority_lead_ratio: f64,
+
+    /// Priority-tip multiplier for senders in the priority-lead cohort.
+    pub priority_lead_multiplier: u128,
+
+    /// Priority-tip divisor for validity-cohort measured transactions.
+    pub priority_fee_divisor: u128,
 
     /// Predicate templates attached to each validity-bearing transaction.
     ///
     /// Must be non-empty when `ratio > 0`, and must contain at most
     /// [`DEFAULT_MAX_VALIDITY_PREDICATES`] entries.
     pub predicates: Vec<ValidityPredicateConfig>,
+}
+
+impl Default for ValidityConfig {
+    fn default() -> Self {
+        Self {
+            ratio: 0.0,
+            priority_lead_ratio: 0.0,
+            priority_lead_multiplier: 1,
+            priority_fee_divisor: 1,
+            predicates: Vec::new(),
+        }
+    }
 }
 
 /// A configured validity predicate template.
@@ -56,8 +83,8 @@ pub enum ValidityPredicateConfig {
         mask: Option<U256>,
         /// Comparison operator (`<`, `<=`, `=`, `!=`, `>`, `>=`).
         op: String,
-        /// Right-hand comparison value.
-        value: U256,
+        /// Right-hand comparison value or the string `sender_parity`.
+        value: PredicateValueConfig,
     },
     /// Compares the number of the block being built with a bound.
     ///
@@ -82,6 +109,32 @@ pub enum ValidityPredicateConfig {
         /// Right-hand comparison value.
         value: U256,
     },
+}
+
+/// Configured source for a storage predicate's comparison value.
+///
+/// Fixed values retain the existing YAML representation (`"0x1"`, `"42"`).
+/// The string `sender_parity` derives zero or one from each sender address.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PredicateValueConfig {
+    /// A fixed comparison value.
+    Fixed(U256),
+    /// A named per-transaction value source.
+    Source(String),
+}
+
+impl PredicateValueConfig {
+    /// Converts this configured value source into its runtime template.
+    pub fn to_template(&self) -> Result<PredicateValue> {
+        match self {
+            Self::Fixed(value) => Ok(PredicateValue::Fixed(*value)),
+            Self::Source(source) if source == "sender_parity" => Ok(PredicateValue::SenderParity),
+            Self::Source(source) => Err(BaselineError::Config(format!(
+                "invalid storage predicate value source '{source}', expected 'sender_parity'"
+            ))),
+        }
+    }
 }
 
 /// Source for a predicate's address, resolved per transaction at prepare time.
@@ -149,8 +202,21 @@ pub enum PredicateSlotConfig {
 impl ValidityConfig {
     /// Validates the validity configuration.
     pub fn validate(&self) -> Result<()> {
+        if self.priority_fee_divisor < 1 {
+            return Err(BaselineError::Config("validity.priority_fee_divisor must be >= 1".into()));
+        }
+        if self.priority_lead_multiplier < 1 {
+            return Err(BaselineError::Config(
+                "validity.priority_lead_multiplier must be >= 1".into(),
+            ));
+        }
         if !(0.0..=1.0).contains(&self.ratio) {
             return Err(BaselineError::Config("validity.ratio must be between 0.0 and 1.0".into()));
+        }
+        if !(0.0..=1.0).contains(&self.priority_lead_ratio) {
+            return Err(BaselineError::Config(
+                "validity.priority_lead_ratio must be between 0.0 and 1.0".into(),
+            ));
         }
         if self.predicates.len() > DEFAULT_MAX_VALIDITY_PREDICATES {
             return Err(BaselineError::Config(format!(
@@ -192,7 +258,7 @@ impl ValidityPredicateConfig {
                     slot: slot.to_template()?,
                     mask: *mask,
                     op: parse_operator(op)?,
-                    value: *value,
+                    value: value.to_template()?,
                 })
             }
             Self::BlockNumber { op, value, offset } => {
@@ -301,7 +367,7 @@ mod tests {
             slot: PredicateSlotConfig::Fixed { value: U256::from(1u64) },
             mask: Some(U256::from(0xffu64)),
             op: "=".into(),
-            value: U256::ZERO,
+            value: PredicateValueConfig::Fixed(U256::ZERO),
         };
         match config.to_template().unwrap() {
             ValidityPredicateTemplate::Storage { address, slot, mask, op, value } => {
@@ -309,7 +375,7 @@ mod tests {
                 assert!(matches!(slot, SlotTemplate::Fixed(s) if s == U256::from(1u64)));
                 assert_eq!(mask, Some(U256::from(0xffu64)));
                 assert_eq!(op, ValidityOperator::Equal);
-                assert_eq!(value, U256::ZERO);
+                assert_eq!(value, PredicateValue::Fixed(U256::ZERO));
             }
             other => panic!("expected storage template, got {other:?}"),
         }
@@ -416,10 +482,36 @@ mod tests {
                 assert!(matches!(slot, SlotTemplate::Fixed(s) if s == U256::from(0x100)));
                 assert_eq!(mask, Some(U256::from(0xffu64)));
                 assert_eq!(op, ValidityOperator::Equal);
-                assert_eq!(value, U256::from(1u64));
+                assert_eq!(value, PredicateValue::Fixed(U256::from(1u64)));
             }
             other => panic!("expected storage template, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn storage_predicate_parses_sender_parity_value() {
+        let config: ValidityPredicateConfig = serde_yaml::from_str(
+            "type: storage\naddress: sender\nslot:\n  kind: fixed\n  value: \"0x0\"\nmask: \"0x1\"\nop: \"=\"\nvalue: sender_parity\n",
+        )
+        .unwrap();
+
+        match config.to_template().unwrap() {
+            ValidityPredicateTemplate::Storage { value, .. } => {
+                assert_eq!(value, PredicateValue::SenderParity);
+            }
+            other => panic!("expected storage template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_predicate_rejects_unknown_value_source() {
+        let config: ValidityPredicateConfig = serde_yaml::from_str(
+            "type: storage\naddress: sender\nslot:\n  kind: fixed\n  value: \"0x0\"\nop: \"=\"\nvalue: sender_hash\n",
+        )
+        .unwrap();
+
+        let error = config.to_template().unwrap_err();
+        assert!(error.to_string().contains("expected 'sender_parity'"));
     }
 
     #[test]
@@ -473,6 +565,9 @@ mod tests {
         };
         let config = ValidityConfig {
             ratio: 1.0,
+            priority_lead_ratio: 0.0,
+            priority_lead_multiplier: 1,
+            priority_fee_divisor: 1,
             predicates: vec![predicate; DEFAULT_MAX_VALIDITY_PREDICATES + 1],
         };
         let err = config.validate().unwrap_err();
@@ -483,6 +578,9 @@ mod tests {
     fn validate_surfaces_bad_operator() {
         let config = ValidityConfig {
             ratio: 1.0,
+            priority_lead_ratio: 0.0,
+            priority_lead_multiplier: 1,
+            priority_fee_divisor: 1,
             predicates: vec![ValidityPredicateConfig::Balance {
                 address: PredicateAddressConfig::Sender,
                 op: "==".into(),

--- a/crates/infra/load-tests/src/lib.rs
+++ b/crates/infra/load-tests/src/lib.rs
@@ -5,8 +5,9 @@
 mod config;
 pub use config::{
     OsakaTarget, PrecompileTarget, PredicateAddressConfig, PredicateSlotConfig,
-    RealTokenAcquisitionConfig, RealTokenPairTokenConfig, RealTokenSetupConfig, TestConfig,
-    TxTypeConfig, ValidityConfig, ValidityPredicateConfig, WeightedTxType, WorkloadConfig,
+    PredicateValueConfig, RealTokenAcquisitionConfig, RealTokenPairTokenConfig,
+    RealTokenSetupConfig, TestConfig, TxTypeConfig, ValidityConfig, ValidityPredicateConfig,
+    WeightedTxType, WorkloadConfig,
 };
 
 mod executor;
@@ -37,10 +38,10 @@ pub use metrics::{
 mod workload;
 pub use workload::{
     AccountPool, AerodromeClPayload, B20TransferPayload, CalldataPayload, ChainPrepContext,
-    ChainPrepOutputs, Erc20Payload, FundedAccount, KeyStream, OsakaPayload, Payload,
-    PrecompileLooper, PrecompilePayload, RealTokenAcquisition, RealTokenPairTokenSetup,
-    RealTokenRecoverySummary, RealTokenSetup, SeededRng, StoragePayload, TransferPayload,
-    UniswapV3Payload, WorkloadGenerator, parse_precompile_id, recover_real_tokens,
+    ChainPrepOutputs, DOUBLE_COUNTER_GAS_LIMIT, DoubleCounterPayload, Erc20Payload, FundedAccount,
+    KeyStream, OsakaPayload, Payload, PrecompileLooper, PrecompilePayload, RealTokenAcquisition,
+    RealTokenPairTokenSetup, RealTokenRecoverySummary, RealTokenSetup, SeededRng, StoragePayload,
+    TransferPayload, UniswapV3Payload, WorkloadGenerator, parse_precompile_id, recover_real_tokens,
 };
 
 mod runner;
@@ -52,9 +53,10 @@ pub use runner::{
     InjectLimit, InjectPlan, LoadConfig, LoadRunner, LoadTestDisplay, LoadTestStage,
     MAX_FEE_BASE_FEE_MULTIPLIER, MAX_SENDER_WORKER_COUNT, MAX_SIGNER_WORKER_COUNT,
     MIN_PRIORITY_FEE, MeasurementWindow, MempoolDepthController, PipelineQueue,
-    PipelineStartConfig, PredicateAddress, PreparedBatch, PreparedTransaction, PresignBuffer,
-    QueuedSubmitFailures, ResultsTracker, SENDER_WORKERS_PER_RPC, SIGNER_WORKERS_PER_RPC,
-    SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext, SentTransaction, SignedBatch,
-    SignedTransaction, SignerContext, SlotTemplate, SubmissionPipeline, SubmitCohort, SubmitEvent,
-    TxConfig, TxType, ValidityPredicateTemplate, ValidityRouter,
+    PipelineStartConfig, PredicateAddress, PredicateValue, PreparedBatch, PreparedTransaction,
+    PresignBuffer, QueuedSubmitFailures, ResultsTracker, SENDER_WORKERS_PER_RPC,
+    SIGNER_WORKERS_PER_RPC, SUBMIT_BATCH_QUEUE_BUFFER, SUBMIT_MAX_ATTEMPTS, SenderContext,
+    SentTransaction, SignedBatch, SignedTransaction, SignerContext, SlotTemplate,
+    SubmissionPipeline, SubmitCohort, SubmitEvent, TxConfig, TxType, ValidityPredicateTemplate,
+    ValidityRouter,
 };

--- a/crates/infra/load-tests/src/metrics/types.rs
+++ b/crates/infra/load-tests/src/metrics/types.rs
@@ -394,6 +394,15 @@ pub struct ConfigSummary {
     /// Number of predicate templates attached to validity transactions.
     #[serde(default)]
     pub validity_predicate_count: usize,
+    /// Fraction of validity senders in the priority-lead cohort.
+    #[serde(default)]
+    pub validity_priority_lead_ratio: f64,
+    /// Priority-tip multiplier for the validity priority-lead cohort.
+    #[serde(default = "ConfigSummary::default_priority_multiplier")]
+    pub validity_priority_lead_multiplier: u128,
+    /// Priority-tip divisor for validity-cohort measured transactions.
+    #[serde(default = "ConfigSummary::default_priority_fee_divisor")]
+    pub validity_priority_fee_divisor: u128,
     /// Address of the precompile looper contract.
     pub looper_contract: Option<String>,
     /// Amount of each swap token per sender (in wei, as string).
@@ -404,4 +413,16 @@ pub struct ConfigSummary {
     /// Real-token setup configuration, when enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub real_token_setup: Option<serde_json::Value>,
+}
+
+impl ConfigSummary {
+    /// Returns the backward-compatible default validity priority multiplier.
+    pub const fn default_priority_multiplier() -> u128 {
+        1
+    }
+
+    /// Returns the backward-compatible default validity priority-fee divisor.
+    pub const fn default_priority_fee_divisor() -> u128 {
+        1
+    }
 }

--- a/crates/infra/load-tests/src/runner/block_watcher.rs
+++ b/crates/infra/load-tests/src/runner/block_watcher.rs
@@ -90,6 +90,9 @@ impl BlockClock {
     ) -> Self {
         let block_timestamp = Duration::from_secs(block_timestamp);
         let system_elapsed = system_now.duration_since(UNIX_EPOCH).unwrap_or_default();
+        if block_timestamp > system_elapsed.saturating_add(block_time) {
+            return Self::from_now(block_time, instant_now);
+        }
         let mut next_elapsed = block_timestamp.saturating_add(block_time);
         while next_elapsed.saturating_add(block_time) <= system_elapsed {
             next_elapsed = next_elapsed.saturating_add(block_time);
@@ -810,6 +813,17 @@ mod tests {
             instant_now.saturating_duration_since(clock.expected_boundary()),
             Duration::from_millis(100)
         );
+    }
+
+    #[test]
+    fn clock_uses_monotonic_interval_when_chain_timestamp_is_far_ahead() {
+        let instant_now = Instant::now();
+        let block_time = Duration::from_millis(200);
+        let system_now = UNIX_EPOCH + Duration::from_millis(100_100);
+
+        let clock = BlockClock::from_block_timestamp(block_time, 105, system_now, instant_now);
+
+        assert_eq!(clock.expected_boundary().duration_since(instant_now), block_time);
     }
 
     #[test]

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -36,6 +36,29 @@ pub enum SlotTemplate {
     },
 }
 
+/// Source for a storage predicate's comparison value, resolved per transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PredicateValue {
+    /// A fixed comparison value used by every transaction.
+    Fixed(U256),
+    /// The low bit of the transaction sender's address.
+    ///
+    /// This deterministically splits senders between values zero and one, which
+    /// lets stress profiles keep both matching and parked transactions in the
+    /// pool while a shared one-bit storage value changes.
+    SenderParity,
+}
+
+impl PredicateValue {
+    /// Resolves the comparison value for `sender`.
+    pub fn resolve(self, sender: Address) -> U256 {
+        match self {
+            Self::Fixed(value) => value,
+            Self::SenderParity => U256::from(sender.as_slice()[19] & 1),
+        }
+    }
+}
+
 /// Bound for a `block_number` validity predicate.
 ///
 /// A block-number predicate may target a fixed absolute block height, or an
@@ -78,8 +101,8 @@ pub enum ValidityPredicateTemplate {
         mask: Option<U256>,
         /// Comparison operator.
         op: ValidityOperator,
-        /// Right-hand comparison value.
-        value: U256,
+        /// Comparison value source.
+        value: PredicateValue,
     },
     /// Block-number comparison template.
     ///
@@ -140,6 +163,11 @@ pub enum TxType {
         contract: Address,
         /// Number of storage slots to write per transaction.
         slots_per_tx: u32,
+    },
+    /// Deterministic `DoubleCounter` `increment()` call.
+    DoubleCounter {
+        /// `DoubleCounter` contract address.
+        contract: Address,
     },
     /// Precompile call.
     Precompile {
@@ -271,6 +299,12 @@ pub struct LoadConfig {
     pub validity_ratio: f64,
     /// Predicate templates attached to each validity-bearing transaction.
     pub validity_predicates: Vec<ValidityPredicateTemplate>,
+    /// Fraction of validity senders in the priority-lead cohort.
+    pub validity_priority_lead_ratio: f64,
+    /// Priority-tip multiplier for the validity priority-lead cohort.
+    pub validity_priority_lead_multiplier: u128,
+    /// Priority-tip divisor for validity-cohort measured transactions.
+    pub validity_priority_fee_divisor: u128,
 }
 
 impl LoadConfig {
@@ -303,6 +337,9 @@ impl LoadConfig {
             fresh_recipient_ratio: 0.0,
             validity_ratio: 0.0,
             validity_predicates: Vec::new(),
+            validity_priority_lead_ratio: 0.0,
+            validity_priority_lead_multiplier: 1,
+            validity_priority_fee_divisor: 1,
         }
     }
 
@@ -356,6 +393,19 @@ impl LoadConfig {
         }
         if !(0.0..=1.0).contains(&self.validity_ratio) {
             return Err(BaselineError::Config("validity_ratio must be between 0.0 and 1.0".into()));
+        }
+        if !(0.0..=1.0).contains(&self.validity_priority_lead_ratio) {
+            return Err(BaselineError::Config(
+                "validity_priority_lead_ratio must be between 0.0 and 1.0".into(),
+            ));
+        }
+        if self.validity_priority_lead_multiplier < 1 {
+            return Err(BaselineError::Config(
+                "validity_priority_lead_multiplier must be >= 1".into(),
+            ));
+        }
+        if self.validity_priority_fee_divisor < 1 {
+            return Err(BaselineError::Config("validity_priority_fee_divisor must be >= 1".into()));
         }
         if self.validity_predicates.len() > base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES {
             return Err(BaselineError::Config(format!(

--- a/crates/infra/load-tests/src/runner/funding.rs
+++ b/crates/infra/load-tests/src/runner/funding.rs
@@ -31,6 +31,7 @@ const FUNDING_REPLACEMENT_FEE_MULTIPLIER: u128 = 3;
 const FUNDING_REPLACEMENT_MAX_ATTEMPTS: u32 = 8;
 
 const TXPOOL_CLEAR_CONCURRENCY: usize = 64;
+const TXPOOL_CLEAR_PASSES: usize = 3;
 const PENDING_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(200);
 
 impl LoadRunner {
@@ -649,6 +650,7 @@ impl LoadRunner {
                 | TxType::Calldata { .. }
                 | TxType::Erc20 { .. }
                 | TxType::Storage { .. }
+                | TxType::DoubleCounter { .. }
                 | TxType::B20
                 | TxType::Precompile { .. }
                 | TxType::Osaka { .. } => {}
@@ -669,6 +671,7 @@ impl LoadRunner {
                 | TxType::Calldata { .. }
                 | TxType::Erc20 { .. }
                 | TxType::Storage { .. }
+                | TxType::DoubleCounter { .. }
                 | TxType::B20
                 | TxType::Precompile { .. }
                 | TxType::Osaka { .. } => {}
@@ -702,47 +705,49 @@ impl LoadRunner {
             .collect::<Result<_>>()?;
         let addresses: Vec<_> =
             self.accounts.accounts().iter().map(|account| account.address).collect();
-        let requests: Vec<_> = clients
-            .iter()
-            .flat_map(|(node, client)| {
-                addresses
-                    .iter()
-                    .copied()
-                    .map(move |address| (node.clone(), client.clone(), address))
-            })
-            .collect();
-
-        let clear_results: Vec<_> =
-            stream::iter(requests.into_iter().map(|(node, client, address)| async move {
-                let removed = client.drop_sender_transactions(address).await.map_err(|e| {
-                    BaselineError::Rpc(format!(
-                        "failed to clear txpool node {node} for sender {address}: {e}"
-                    ))
-                })?;
-                Ok::<_, BaselineError>((node, removed.len() as u64))
-            }))
-            .buffer_unordered(TXPOOL_CLEAR_CONCURRENCY)
-            .collect()
-            .await;
-
-        let mut removed_by_node: HashMap<url::Url, u64> = HashMap::new();
-        for result in clear_results {
-            let (node, removed) = result?;
-            removed_by_node
-                .entry(node)
-                .and_modify(|total| *total = total.saturating_add(removed))
-                .or_insert(removed);
-        }
-
         let mut removed_total = 0u64;
-        for node in &self.config.txpool_nodes {
-            let removed_for_node = removed_by_node.get(node).copied().unwrap_or(0);
-            removed_total = removed_total.saturating_add(removed_for_node);
-            info!(
-                node = %node,
-                removed = removed_for_node,
-                "cleared txpool sender transactions from node"
-            );
+        for pass in 1..=TXPOOL_CLEAR_PASSES {
+            let requests: Vec<_> = clients
+                .iter()
+                .flat_map(|(node, client)| {
+                    addresses
+                        .iter()
+                        .copied()
+                        .map(move |address| (node.clone(), client.clone(), address))
+                })
+                .collect();
+            let clear_results: Vec<_> =
+                stream::iter(requests.into_iter().map(|(node, client, address)| async move {
+                    let removed = client.drop_sender_transactions(address).await.map_err(|e| {
+                        BaselineError::Rpc(format!(
+                            "failed to clear txpool node {node} for sender {address}: {e}"
+                        ))
+                    })?;
+                    Ok::<_, BaselineError>((node, removed.len() as u64))
+                }))
+                .buffer_unordered(TXPOOL_CLEAR_CONCURRENCY)
+                .collect()
+                .await;
+
+            let mut removed_by_node: HashMap<url::Url, u64> = HashMap::new();
+            for result in clear_results {
+                let (node, removed) = result?;
+                removed_by_node
+                    .entry(node)
+                    .and_modify(|total| *total = total.saturating_add(removed))
+                    .or_insert(removed);
+            }
+
+            for node in &self.config.txpool_nodes {
+                let removed_for_node = removed_by_node.get(node).copied().unwrap_or(0);
+                removed_total = removed_total.saturating_add(removed_for_node);
+                info!(
+                    pass,
+                    node = %node,
+                    removed = removed_for_node,
+                    "cleared txpool sender transactions from node"
+                );
+            }
         }
 
         info!(removed = removed_total, "txpool clearing complete");

--- a/crates/infra/load-tests/src/runner/mod.rs
+++ b/crates/infra/load-tests/src/runner/mod.rs
@@ -3,7 +3,7 @@
 mod config;
 pub use config::{
     BlockNumberBound, DEFAULT_MAX_GAS_PRICE, DEFAULT_MAX_IN_FLIGHT_PER_SENDER, LoadConfig,
-    PredicateAddress, SlotTemplate, TxConfig, TxType, ValidityPredicateTemplate,
+    PredicateAddress, PredicateValue, SlotTemplate, TxConfig, TxType, ValidityPredicateTemplate,
 };
 
 mod backoff;

--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -9,13 +9,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_consensus::transaction::SignableTransaction;
-use alloy_eips::Encodable2718;
-use alloy_network::{Ethereum, TransactionBuilder};
-use alloy_primitives::{Address, Bytes, TxHash, U256};
+use alloy_network::Ethereum;
+use alloy_primitives::{Address, TxHash, U256};
 use alloy_provider::{Provider, RootProvider};
-use alloy_rpc_types::{BlockNumberOrTag, TransactionRequest};
-use alloy_signer::SignerSync;
+use alloy_rpc_types::BlockNumberOrTag;
 use alloy_signer_local::PrivateKeySigner;
 use base_common_network::Base;
 use base_tx_manager::NonceManager;
@@ -28,8 +25,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use super::{
-    BlockWatcher, DisplaySnapshot, FlashblockWatcher, InclusionPulse, InclusionSource, LoadRunner,
-    LoadTestDisplay, LoadTestStage, MIN_PRIORITY_FEE, PipelineStartConfig, PreparedTransaction,
+    BlockWatcher, DisplaySnapshot, FlashblockWatcher, GasPricer, InclusionPulse, InclusionSource,
+    LoadRunner, LoadTestDisplay, LoadTestStage, PipelineStartConfig, PreparedTransaction,
     PresignBuffer, QueuedSubmitFailures, ResultsTracker, SignedBatch, SignedTransaction,
     SubmissionPipeline, SubmitEvent, TxType, ValidityRouter,
 };
@@ -99,6 +96,8 @@ struct PresignConfig {
     chain_id: u64,
     base_fee_rx: watch::Receiver<u128>,
     max_gas_price: u128,
+    validity_priority_lead_multiplier: u128,
+    validity_priority_fee_divisor: u128,
     estimated_gas: u64,
     fresh_recipient_ratio: f64,
     signed_chunk_tx: mpsc::Sender<Vec<PresignedSenderBatch>>,
@@ -522,6 +521,8 @@ impl LoadRunner {
             PipelineStartConfig {
                 chain_id: self.config.chain_id,
                 max_gas_price: self.config.max_gas_price,
+                validity_priority_lead_multiplier: self.config.validity_priority_lead_multiplier,
+                validity_priority_fee_divisor: self.config.validity_priority_fee_divisor,
                 max_concurrent_submit_requests: self.config.max_concurrent_submit_requests,
             },
         );
@@ -664,6 +665,8 @@ impl LoadRunner {
                 chain_id: self.config.chain_id,
                 base_fee_rx,
                 max_gas_price: self.config.max_gas_price,
+                validity_priority_lead_multiplier: self.config.validity_priority_lead_multiplier,
+                validity_priority_fee_divisor: self.config.validity_priority_fee_divisor,
                 estimated_gas: initial_avg_gas,
                 fresh_recipient_ratio: self.config.fresh_recipient_ratio,
                 signed_chunk_tx,
@@ -1307,26 +1310,52 @@ impl LoadRunner {
         chain_id: u64,
         base_fee: u128,
         max_gas_price: u128,
+        validity_priority_lead_multiplier: u128,
+        validity_priority_fee_divisor: u128,
     ) -> Result<Vec<PresignedSenderBatch>> {
         let sender_count = sender_jobs.len();
         if sender_count == 0 {
             return Ok(Vec::new());
         }
 
-        let priority_fee =
-            (base_fee / 10).max(MIN_PRIORITY_FEE).min(max_gas_price.saturating_sub(base_fee));
-        let max_fee = SubmissionPipeline::submission_max_fee(base_fee, priority_fee, max_gas_price);
-
-        let mut signing_tasks = Vec::with_capacity(sender_count);
-        for sender_job in sender_jobs {
-            let Some(signer) = signers.get(&sender_job.from).cloned() else {
-                return Err(BaselineError::Transaction(format!(
-                    "missing signer for sender {}",
-                    sender_job.from
-                )));
-            };
+        // Signing is CPU-bound. Chunking work to the available cores avoids growing Tokio's
+        // blocking pool to one thread per sender under high-sender-count stress workloads.
+        let signing_worker_count =
+            std::thread::available_parallelism().map(usize::from).unwrap_or(1).min(sender_count);
+        let jobs_per_task = sender_count.div_ceil(signing_worker_count);
+        let mut sender_jobs = sender_jobs.into_iter();
+        let mut signing_tasks = Vec::with_capacity(signing_worker_count);
+        loop {
+            let jobs = sender_jobs
+                .by_ref()
+                .take(jobs_per_task)
+                .map(|sender_job| {
+                    let signer = signers.get(&sender_job.from).cloned().ok_or_else(|| {
+                        BaselineError::Transaction(format!(
+                            "missing signer for sender {}",
+                            sender_job.from
+                        ))
+                    })?;
+                    Ok((sender_job, signer))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            if jobs.is_empty() {
+                break;
+            }
             signing_tasks.push(task::spawn_blocking(move || {
-                Self::sign_sender_job(sender_job, signer, chain_id, priority_fee, max_fee)
+                jobs.into_iter()
+                    .map(|(sender_job, signer)| {
+                        Self::sign_sender_job(
+                            sender_job,
+                            signer,
+                            chain_id,
+                            base_fee,
+                            max_gas_price,
+                            validity_priority_lead_multiplier,
+                            validity_priority_fee_divisor,
+                        )
+                    })
+                    .collect::<Result<Vec<_>>>()
             }));
         }
 
@@ -1334,17 +1363,18 @@ impl LoadRunner {
             std::iter::repeat_with(|| None).take(sender_count).collect();
 
         for signing_task in signing_tasks {
-            let signed_sender = signing_task.await.map_err(|e| {
+            let signed_senders = signing_task.await.map_err(|e| {
                 BaselineError::Transaction(format!("open-loop signing task failed: {e}"))
             })??;
-
-            let sender_index = signed_sender.sender_index;
-            if signed_by_sender[sender_index].is_some() {
-                return Err(BaselineError::Transaction(format!(
-                    "duplicate signed sender result for index {sender_index}"
-                )));
+            for signed_sender in signed_senders {
+                let sender_index = signed_sender.sender_index;
+                if signed_by_sender[sender_index].is_some() {
+                    return Err(BaselineError::Transaction(format!(
+                        "duplicate signed sender result for index {sender_index}"
+                    )));
+                }
+                signed_by_sender[sender_index] = Some(signed_sender);
             }
-            signed_by_sender[sender_index] = Some(signed_sender);
         }
 
         let mut ordered_signed_txs = Vec::with_capacity(sender_count);
@@ -1409,6 +1439,8 @@ impl LoadRunner {
                 config.chain_id,
                 base_fee,
                 config.max_gas_price,
+                config.validity_priority_lead_multiplier,
+                config.validity_priority_fee_divisor,
             )
             .await?;
 
@@ -1485,8 +1517,10 @@ impl LoadRunner {
         sender_job: SenderJob,
         signer: PrivateKeySigner,
         chain_id: u64,
-        priority_fee: u128,
-        max_fee: u128,
+        base_fee: u128,
+        max_gas_price: u128,
+        validity_priority_lead_multiplier: u128,
+        validity_priority_fee_divisor: u128,
     ) -> Result<SignedSender> {
         let mut signed_txs = Vec::with_capacity(sender_job.prepared_txs.len());
 
@@ -1501,48 +1535,15 @@ impl LoadRunner {
                 ))
             })?;
 
-            let mut tx = TransactionRequest::default()
-                .with_from(prepared.from)
-                .with_value(prepared.value)
-                .with_input(prepared.data)
-                .with_nonce(nonce)
-                .with_chain_id(chain_id)
-                .with_max_fee_per_gas(max_fee)
-                .with_max_priority_fee_per_gas(priority_fee)
-                .with_gas_limit(prepared.gas_limit);
-            if let Some(to) = prepared.to {
-                tx = tx.with_to(to);
-            }
-
-            let typed_tx = tx.build_typed_tx().map_err(|e| {
-                BaselineError::Transaction(format!(
-                    "failed to build typed tx for sender {} nonce {}: {e:?}",
-                    prepared.from, nonce
-                ))
-            })?;
-
-            let sig_hash = typed_tx.signature_hash();
-            let signature = signer.sign_hash_sync(&sig_hash).map_err(|e| {
-                BaselineError::Transaction(format!(
-                    "failed to sign tx for sender {} nonce {}: {e}",
-                    prepared.from, nonce
-                ))
-            })?;
-
-            let signed = typed_tx.into_signed(signature);
-            let tx_hash = *signed.hash();
-            let raw = Bytes::from(signed.encoded_2718());
-
-            signed_txs.push(SignedTransaction {
-                raw,
-                tx_hash,
-                from: prepared.from,
-                nonce,
-                gas_limit: prepared.gas_limit,
-                estimated_gas: prepared.estimated_gas,
-                validity: prepared.validity,
-                cohort: prepared.cohort,
-            });
+            let fees = GasPricer::new(max_gas_price).fees_for_cohort(
+                base_fee,
+                prepared.cohort,
+                validity_priority_fee_divisor,
+                validity_priority_lead_multiplier,
+            );
+            signed_txs.push(SubmissionPipeline::sign_at_nonce(
+                &signer, &prepared, chain_id, nonce, fees,
+            )?);
         }
 
         Ok(SignedSender {
@@ -1621,11 +1622,9 @@ impl LoadRunner {
                     }
                     Self::run_refill_cycle(
                         enqueue_state,
-                        &config.controller,
                         pulse,
                         last_block_gas_limit,
-                        config.max_in_flight_per_sender,
-                        config.max_total_in_flight,
+                        &config,
                         drain_state,
                     )
                     .await?;
@@ -1634,11 +1633,9 @@ impl LoadRunner {
                     if last_pulse_at.elapsed() >= signal_timeout {
                         Self::run_refill_cycle(
                             enqueue_state,
-                            &config.controller,
                             InclusionPulse::safety(Instant::now()),
                             last_block_gas_limit,
-                            config.max_in_flight_per_sender,
-                            config.max_total_in_flight,
+                            &config,
                             drain_state,
                         )
                         .await?;
@@ -1678,16 +1675,17 @@ impl LoadRunner {
 
     async fn run_refill_cycle(
         enqueue_state: &mut PresignEnqueueState<'_>,
-        controller: &MempoolDepthController,
         pulse: InclusionPulse,
         fallback_block_gas_limit: u64,
-        max_in_flight_per_sender: usize,
-        max_total_in_flight: usize,
+        config: &BlockAlignedEnqueueConfig,
         drain_state: &mut EnqueueDrainState<'_>,
     ) -> Result<()> {
         let cycle_started = pulse.observed_at;
         let canonical = pulse.canonical;
-        while let Ok(chunk) = enqueue_state.signed_chunk_rx.try_recv() {
+        while enqueue_state.buffer.buffered_gas() < config.presign_target_gas {
+            let Ok(chunk) = enqueue_state.signed_chunk_rx.try_recv() else {
+                break;
+            };
             Self::buffer_presigned_chunk(enqueue_state.buffer, enqueue_state.progress, chunk);
         }
         drain_state.drain_run_events();
@@ -1725,7 +1723,7 @@ impl LoadRunner {
         let plan_started = Instant::now();
         let depth_gas = drain_state.mempool_depth_gas();
         let block_gas_limit = canonical.map_or(fallback_block_gas_limit, |block| block.gas_limit);
-        let plan = controller.plan(
+        let plan = config.controller.plan(
             cycle_started,
             block_gas_limit,
             depth_gas,
@@ -1741,14 +1739,14 @@ impl LoadRunner {
                     queued.saturating_add(drain_state.results_tracker.in_flight_for(from));
                 (
                     *from,
-                    u64::try_from(max_in_flight_per_sender)
+                    u64::try_from(config.max_in_flight_per_sender)
                         .unwrap_or(u64::MAX)
                         .saturating_sub(occupied),
                 )
             })
             .collect();
         let remaining_transaction_slots =
-            drain_state.remaining_transaction_slots(max_total_in_flight);
+            drain_state.remaining_transaction_slots(config.max_total_in_flight);
         let mut selected = enqueue_state.buffer.take_gas_with_limits(
             plan.inject_gas,
             &mut sender_slots,
@@ -1809,7 +1807,8 @@ impl LoadRunner {
         }
         let resulting_depth_gas = drain_state.mempool_depth_gas();
         drain_state.collector.record_pacing_cycle(PacingCycleObservation {
-            elapsed: cycle_started.saturating_duration_since(controller.measurement_started_at),
+            elapsed: cycle_started
+                .saturating_duration_since(config.controller.measurement_started_at),
             source: match pulse.source {
                 InclusionSource::Canonical => PacingCycleSource::Canonical,
                 InclusionSource::Flashblock => PacingCycleSource::Flashblock,
@@ -2160,6 +2159,8 @@ mod tests {
             PipelineStartConfig {
                 chain_id: 1,
                 max_gas_price: u128::MAX,
+                validity_priority_lead_multiplier: 1,
+                validity_priority_fee_divisor: 1,
                 max_concurrent_submit_requests: None,
             },
         );
@@ -2337,6 +2338,8 @@ mod tests {
             PipelineStartConfig {
                 chain_id: 1,
                 max_gas_price: u128::MAX,
+                validity_priority_lead_multiplier: 1,
+                validity_priority_fee_divisor: 1,
                 max_concurrent_submit_requests: None,
             },
         );
@@ -2467,6 +2470,8 @@ mod tests {
             PipelineStartConfig {
                 chain_id: 1,
                 max_gas_price: u128::MAX,
+                validity_priority_lead_multiplier: 1,
+                validity_priority_fee_divisor: 1,
                 max_concurrent_submit_requests: None,
             },
         );

--- a/crates/infra/load-tests/src/runner/results_tracker.rs
+++ b/crates/infra/load-tests/src/runner/results_tracker.rs
@@ -212,7 +212,7 @@ impl ResultsTracker {
         }
     }
 
-    /// Records transactions accepted by the submission RPC.
+    /// Records signed transactions entering submission.
     pub fn sent_transactions(&self, transactions: Vec<SentTransaction>) {
         let submit_time = Instant::now();
         let mut inner = self.inner.write();
@@ -262,6 +262,19 @@ impl ResultsTracker {
         {
             let _ = pulse_tx.try_send(InclusionPulse::flashblock(Instant::now(), reconciled_gas));
         }
+    }
+
+    /// Removes a transaction that the submission RPC explicitly rejected.
+    pub fn discard_transaction(&self, tx_hash: TxHash) -> bool {
+        let mut inner = self.inner.write();
+        let Some(pending) = inner.pending.remove(&tx_hash) else {
+            return false;
+        };
+        inner.flashblocks.remove(&tx_hash);
+        if !pending.in_flight_released {
+            inner.decrement_in_flight(&pending.from, pending.estimated_gas);
+        }
+        true
     }
 
     /// Records transaction inclusions observed from the flashblock stream.
@@ -661,6 +674,43 @@ mod tests {
             measured,
             cohort: SubmitCohort::Plain,
         }
+    }
+
+    #[test]
+    fn discard_pending_transaction_releases_in_flight_once() {
+        let from = address!("0000000000000000000000000000000000000001");
+        let tx_hash = TxHash::repeat_byte(0xd0);
+        let tracker = ResultsTracker::new(&[from]);
+
+        tracker.sent_transactions(vec![sent(tx_hash, from, true)]);
+        assert_eq!(tracker.pending_count(), 1);
+        assert_eq!(tracker.total_in_flight(), 1);
+        assert_eq!(tracker.unconfirmed_gas(), 21_000);
+
+        assert!(tracker.discard_transaction(tx_hash));
+        assert_eq!(tracker.pending_count(), 0);
+        assert_eq!(tracker.total_in_flight(), 0);
+        assert_eq!(tracker.unconfirmed_gas(), 0);
+
+        assert!(!tracker.discard_transaction(tx_hash), "second discard must be idempotent");
+        assert_eq!(tracker.total_in_flight(), 0);
+    }
+
+    #[test]
+    fn discard_flashblock_released_transaction_does_not_double_decrement() {
+        let from = address!("0000000000000000000000000000000000000001");
+        let tx_hash = TxHash::repeat_byte(0xd1);
+        let tracker = ResultsTracker::new(&[from]);
+
+        tracker.sent_transactions(vec![sent(tx_hash, from, true)]);
+        tracker
+            .on_new_flashblock(vec![FlashblockInclusion { tx_hash, included_at: Instant::now() }]);
+        assert_eq!(tracker.pending_count(), 1);
+        assert_eq!(tracker.total_in_flight(), 0);
+
+        assert!(tracker.discard_transaction(tx_hash));
+        assert_eq!(tracker.pending_count(), 0);
+        assert_eq!(tracker.total_in_flight(), 0);
     }
 
     #[test]

--- a/crates/infra/load-tests/src/runner/submission.rs
+++ b/crates/infra/load-tests/src/runner/submission.rs
@@ -69,6 +69,8 @@ pub enum SubmitCohort {
     Plain,
     /// Validity submission carrying resolved predicates.
     ValidityPass,
+    /// Validity submission priced ahead of the plain cohort.
+    ValidityPassPriorityLead,
 }
 
 impl SubmitCohort {
@@ -82,6 +84,7 @@ impl SubmitCohort {
         match self {
             Self::Plain => "plain",
             Self::ValidityPass => "validity_pass",
+            Self::ValidityPassPriorityLead => "validity_pass_priority_lead",
         }
     }
 
@@ -89,7 +92,9 @@ impl SubmitCohort {
     pub const fn to_metric_label(self) -> crate::metrics::SubmitCohortLabel {
         match self {
             Self::Plain => crate::metrics::SubmitCohortLabel::Plain,
-            Self::ValidityPass => crate::metrics::SubmitCohortLabel::ValidityPass,
+            Self::ValidityPass | Self::ValidityPassPriorityLead => {
+                crate::metrics::SubmitCohortLabel::ValidityPass
+            }
         }
     }
 }
@@ -133,8 +138,26 @@ impl GasPricer {
 
     /// Fees for a measured-load submission at the given base fee.
     pub fn fees_for(&self, base_fee: u128) -> Fees {
+        self.fees_for_cohort(base_fee, SubmitCohort::Plain, 1, 1)
+    }
+
+    /// Fees for measured load, pricing the bulk and priority-lead validity cohorts separately.
+    pub fn fees_for_cohort(
+        &self,
+        base_fee: u128,
+        cohort: SubmitCohort,
+        validity_priority_fee_divisor: u128,
+        validity_priority_lead_multiplier: u128,
+    ) -> Fees {
         let priority_fee =
             (base_fee / 10).max(MIN_PRIORITY_FEE).min(self.max_gas_price.saturating_sub(base_fee));
+        let priority_fee = match cohort {
+            SubmitCohort::Plain => priority_fee,
+            SubmitCohort::ValidityPass => priority_fee / validity_priority_fee_divisor,
+            SubmitCohort::ValidityPassPriorityLead => priority_fee
+                .saturating_mul(validity_priority_lead_multiplier)
+                .min(self.max_gas_price.saturating_sub(base_fee)),
+        };
         let max_fee =
             SubmissionPipeline::submission_max_fee(base_fee, priority_fee, self.max_gas_price);
         Fees { max_fee, priority_fee }
@@ -366,6 +389,10 @@ pub struct SignerContext {
     pub chain_id: u64,
     /// Maximum allowed gas price.
     pub max_gas_price: u128,
+    /// Priority-tip multiplier for the validity priority-lead cohort.
+    pub validity_priority_lead_multiplier: u128,
+    /// Priority-tip divisor for validity-cohort measured transactions.
+    pub validity_priority_fee_divisor: u128,
     /// Sender for signed batches.
     pub signed_batch_tx: mpsc::Sender<SignedBatch>,
     /// Signed queue accounting.
@@ -379,6 +406,8 @@ impl fmt::Debug for SignerContext {
             .field("nonce_managers", &self.nonce_managers.len())
             .field("chain_id", &self.chain_id)
             .field("max_gas_price", &self.max_gas_price)
+            .field("validity_priority_lead_multiplier", &self.validity_priority_lead_multiplier)
+            .field("validity_priority_fee_divisor", &self.validity_priority_fee_divisor)
             .finish_non_exhaustive()
     }
 }
@@ -432,6 +461,10 @@ pub struct PipelineStartConfig {
     pub chain_id: u64,
     /// Maximum allowed gas price.
     pub max_gas_price: u128,
+    /// Priority-tip multiplier for the validity priority-lead cohort.
+    pub validity_priority_lead_multiplier: u128,
+    /// Priority-tip divisor for validity-cohort measured transactions.
+    pub validity_priority_fee_divisor: u128,
     /// Optional cap on concurrent outbound submission RPC requests across all
     /// sender workers and per-batch RPC chunks. `None` leaves those requests
     /// unconstrained by a shared semaphore.
@@ -485,6 +518,8 @@ impl SubmissionPipeline {
                 submit_event_tx: submit_event_tx.clone(),
                 chain_id: config.chain_id,
                 max_gas_price: config.max_gas_price,
+                validity_priority_lead_multiplier: config.validity_priority_lead_multiplier,
+                validity_priority_fee_divisor: config.validity_priority_fee_divisor,
                 signed_batch_tx: signed_batch_tx.clone(),
                 signed_queue: Arc::clone(&signed_queue),
             };
@@ -869,6 +904,22 @@ impl SubmissionPipeline {
         let measured = batch.measured;
         let mut submitted = 0u64;
 
+        // Register deterministic signed hashes before awaiting the RPC response so a very fast
+        // local chain cannot mine a transaction before the block watcher knows about it.
+        ctx.results_tracker.sent_transactions(
+            batch
+                .txs
+                .iter()
+                .map(|signed| SentTransaction {
+                    tx_hash: signed.tx_hash,
+                    from: signed.from,
+                    estimated_gas: signed.estimated_gas,
+                    measured,
+                    cohort: signed.cohort,
+                })
+                .collect(),
+        );
+
         loop {
             if batch.txs.is_empty() {
                 return submitted;
@@ -983,6 +1034,7 @@ impl SubmissionPipeline {
                             if terminal_rejection_error.is_none() {
                                 terminal_rejection_error = Some(message.clone());
                             }
+                            ctx.results_tracker.discard_transaction(signed.tx_hash);
                             Self::return_signed_nonce(&ctx, &signed).await;
                             Self::release_signed(&ctx.submit_event_tx, &signed, false).await;
                             let _ = ctx.submit_event_tx.send(SubmitEvent::Failed(message)).await;
@@ -1086,17 +1138,18 @@ impl SubmissionPipeline {
                 server = %tx_hash,
                 "tx hash mismatch, using server hash"
             );
+            ctx.results_tracker.discard_transaction(signed.tx_hash);
+            ctx.results_tracker.sent_transactions(vec![SentTransaction {
+                tx_hash,
+                from: signed.from,
+                estimated_gas: signed.estimated_gas,
+                measured,
+                cohort: signed.cohort,
+            }]);
             tx_hash
         } else {
             signed.tx_hash
         };
-        ctx.results_tracker.sent_transactions(vec![SentTransaction {
-            tx_hash: tracked_hash,
-            from: signed.from,
-            estimated_gas: signed.estimated_gas,
-            measured,
-            cohort: signed.cohort,
-        }]);
         Self::release_signed(&ctx.submit_event_tx, &signed, true).await;
         let _ = ctx.submit_event_tx.send(SubmitEvent::Submitted(tracked_hash)).await;
         1
@@ -1120,6 +1173,7 @@ impl SubmissionPipeline {
         reason: &'static str,
     ) {
         for signed in signed_txs {
+            ctx.results_tracker.discard_transaction(signed.tx_hash);
             Self::return_signed_nonce(ctx, &signed).await;
             Self::release_signed(submit_event_tx, &signed, false).await;
             let _ = submit_event_tx.send(SubmitEvent::Failed(reason.into())).await;
@@ -1170,7 +1224,12 @@ impl SubmissionPipeline {
         prepared: &PreparedTransaction,
         base_fee: u128,
     ) -> Option<SignedTransaction> {
-        let fees = GasPricer::new(ctx.max_gas_price).fees_for(base_fee);
+        let fees = GasPricer::new(ctx.max_gas_price).fees_for_cohort(
+            base_fee,
+            prepared.cohort,
+            ctx.validity_priority_fee_divisor,
+            ctx.validity_priority_lead_multiplier,
+        );
 
         let Some(signer) = ctx.signers.get(&prepared.from) else {
             warn!(from = %prepared.from, "no signer for sender");
@@ -1376,6 +1435,26 @@ mod tests {
         let fees = capped_pricer.fees_for(1_000_000);
         assert_eq!(fees.max_fee, 500);
         assert_eq!(fees.priority_fee, 0);
+    }
+
+    #[test]
+    fn gas_pricer_divides_only_validity_tip_and_covers_it() {
+        let pricer = GasPricer::new(10_000);
+        let plain = pricer.fees_for_cohort(100, SubmitCohort::Plain, 5, 3);
+        let validity = pricer.fees_for_cohort(100, SubmitCohort::ValidityPass, 5, 3);
+        let priority_lead =
+            pricer.fees_for_cohort(100, SubmitCohort::ValidityPassPriorityLead, 5, 3);
+
+        assert_eq!(plain.priority_fee, 10);
+        assert_eq!(validity.priority_fee, 2);
+        assert_eq!(priority_lead.priority_fee, 30);
+        assert!(validity.max_fee >= 102);
+
+        let capped = GasPricer::new(130).fees_for_cohort(100, SubmitCohort::ValidityPass, 5, 3);
+        assert_eq!(capped, Fees { max_fee: 130, priority_fee: 2 });
+        let capped_lead =
+            GasPricer::new(120).fees_for_cohort(100, SubmitCohort::ValidityPassPriorityLead, 5, 3);
+        assert_eq!(capped_lead, Fees { max_fee: 120, priority_fee: 20 });
     }
 
     #[test]

--- a/crates/infra/load-tests/src/runner/validity_router.rs
+++ b/crates/infra/load-tests/src/runner/validity_router.rs
@@ -16,11 +16,14 @@ use super::{
 
 /// Salt mixed into the per-sender validity routing hash.
 const VALIDITY_SENDER_SALT: u64 = 0x7661_6c69_6469_7479; // "validity"
+/// Salt mixed into the priority-lead validity sub-cohort hash.
+const PRIORITY_LEAD_SENDER_SALT: u64 = 0x6c65_6164_2d74_6970; // "lead-tip"
 
 /// Routes transactions onto submission cohorts and resolves validity predicates.
 #[derive(Debug, Clone)]
 pub struct ValidityRouter {
     ratio: f64,
+    priority_lead_ratio: f64,
     predicates: Vec<ValidityPredicateTemplate>,
     seed: u64,
 }
@@ -30,6 +33,7 @@ impl ValidityRouter {
     pub fn new(config: &LoadConfig) -> Self {
         Self {
             ratio: config.validity_ratio,
+            priority_lead_ratio: config.validity_priority_lead_ratio,
             predicates: config.validity_predicates.clone(),
             seed: config.seed,
         }
@@ -68,7 +72,16 @@ impl ValidityRouter {
         {
             return SubmitCohort::Plain;
         }
-        SubmitCohort::ValidityPass
+        if sender_in_fraction(
+            sender,
+            self.seed,
+            PRIORITY_LEAD_SENDER_SALT,
+            self.priority_lead_ratio,
+        ) {
+            SubmitCohort::ValidityPassPriorityLead
+        } else {
+            SubmitCohort::ValidityPass
+        }
     }
 
     /// Resolves the configured predicate templates into concrete predicates for
@@ -86,7 +99,7 @@ impl ValidityRouter {
         to: Option<Address>,
     ) -> Vec<ValidityPredicate> {
         match cohort {
-            SubmitCohort::ValidityPass => {
+            SubmitCohort::ValidityPass | SubmitCohort::ValidityPassPriorityLead => {
                 self.predicates.iter().map(|t| Self::resolve(t, current_block, from, to)).collect()
             }
             SubmitCohort::Plain => Vec::new(),
@@ -114,7 +127,7 @@ impl ValidityRouter {
                     slot: resolve_slot(slot, from, to),
                     mask: mask.unwrap_or_else(ValidityPredicate::default_mask),
                     op: *op,
-                    value: *value,
+                    value: value.resolve(from),
                 }
             }
             // Position predicates read the build context, not `from`/`to`. An
@@ -191,9 +204,10 @@ mod tests {
     use base_execution_txpool::ValidityOperator;
 
     use super::*;
+    use crate::PredicateValue;
 
     fn router(ratio: f64, predicates: Vec<ValidityPredicateTemplate>) -> ValidityRouter {
-        ValidityRouter { ratio, predicates, seed: 12345 }
+        ValidityRouter { ratio, priority_lead_ratio: 0.0, predicates, seed: 12345 }
     }
 
     #[test]
@@ -238,6 +252,28 @@ mod tests {
             .count();
         let fraction = validity as f64 / total as f64;
         assert!((fraction - 0.3).abs() < 0.05, "fraction {fraction} should be near 0.3");
+    }
+
+    #[test]
+    fn priority_lead_ratio_selects_a_stable_validity_sub_cohort() {
+        let mut r = router(0.8, Vec::new());
+        r.priority_lead_ratio = 0.25;
+        let total = 4_000u32;
+        let cohorts: Vec<SubmitCohort> = (0..total)
+            .map(|i| {
+                let mut bytes = [0u8; 20];
+                bytes[..4].copy_from_slice(&i.to_be_bytes());
+                r.cohort_for_sender(Address::from(bytes))
+            })
+            .collect();
+        let validity = cohorts.iter().filter(|cohort| cohort.is_validity()).count();
+        let priority_lead = cohorts
+            .iter()
+            .filter(|cohort| **cohort == SubmitCohort::ValidityPassPriorityLead)
+            .count();
+
+        assert!((validity as f64 / total as f64 - 0.8).abs() < 0.05);
+        assert!((priority_lead as f64 / validity as f64 - 0.25).abs() < 0.05);
     }
 
     #[test]
@@ -463,7 +499,7 @@ mod tests {
             },
             mask: None,
             op: ValidityOperator::GreaterThanOrEqual,
-            value: U256::ZERO,
+            value: PredicateValue::Fixed(U256::ZERO),
         }];
         let r = router(1.0, templates);
         let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, Address::ZERO, None);
@@ -479,6 +515,28 @@ mod tests {
                 assert_eq!(*mask, ValidityPredicate::default_mask());
             }
             other => panic!("expected storage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sender_parity_value_splits_storage_predicates_by_sender() {
+        let templates = vec![ValidityPredicateTemplate::Storage {
+            address: PredicateAddress::Fixed(Address::repeat_byte(0x99)),
+            slot: SlotTemplate::Fixed(U256::ZERO),
+            mask: Some(U256::from(1)),
+            op: ValidityOperator::Equal,
+            value: PredicateValue::SenderParity,
+        }];
+        let r = router(1.0, templates);
+
+        for (sender, expected) in
+            [(Address::repeat_byte(0x10), U256::ZERO), (Address::repeat_byte(0x11), U256::from(1))]
+        {
+            let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, sender, None);
+            match &predicates[0] {
+                ValidityPredicate::Storage { value, .. } => assert_eq!(*value, expected),
+                other => panic!("expected storage, got {other:?}"),
+            }
         }
     }
 }

--- a/crates/infra/load-tests/src/workload/generator.rs
+++ b/crates/infra/load-tests/src/workload/generator.rs
@@ -7,9 +7,9 @@ use alloy_rpc_types::TransactionRequest;
 use tracing::instrument;
 
 use super::{
-    AerodromeClPayload, B20TransferPayload, CalldataPayload, Erc20Payload, OsakaPayload, Payload,
-    PrecompilePayload, SeededRng, StoragePayload, TransferPayload, UniswapV3Payload,
-    chain_prep::ChainPrepContext,
+    AerodromeClPayload, B20TransferPayload, CalldataPayload, DoubleCounterPayload, Erc20Payload,
+    OsakaPayload, Payload, PrecompilePayload, SeededRng, StoragePayload, TransferPayload,
+    UniswapV3Payload, chain_prep::ChainPrepContext,
 };
 use crate::{
     BaselineError,
@@ -82,6 +82,10 @@ impl WorkloadGenerator {
                 TxType::Storage { contract, slots_per_tx } => {
                     generator = generator
                         .with_payload(StoragePayload::new(*contract, *slots_per_tx), weight_pct);
+                }
+                TxType::DoubleCounter { contract } => {
+                    generator =
+                        generator.with_payload(DoubleCounterPayload::new(*contract), weight_pct);
                 }
                 TxType::Precompile { target, blake2f_rounds, iterations, looper_contract } => {
                     let payload = PrecompilePayload::with_options(

--- a/crates/infra/load-tests/src/workload/mod.rs
+++ b/crates/infra/load-tests/src/workload/mod.rs
@@ -18,9 +18,9 @@ pub(crate) use chain_prep::{PREP_CONCURRENCY, await_token_balances, encode_erc20
 
 mod payloads;
 pub use payloads::{
-    AerodromeClPayload, B20TransferPayload, CalldataPayload, Erc20Payload, OsakaPayload, Payload,
-    PrecompileLooper, PrecompilePayload, StoragePayload, TransferPayload, UniswapV3Payload,
-    parse_precompile_id, recover_real_tokens,
+    AerodromeClPayload, B20TransferPayload, CalldataPayload, DOUBLE_COUNTER_GAS_LIMIT,
+    DoubleCounterPayload, Erc20Payload, OsakaPayload, Payload, PrecompileLooper, PrecompilePayload,
+    StoragePayload, TransferPayload, UniswapV3Payload, parse_precompile_id, recover_real_tokens,
 };
 pub(crate) use payloads::{b20_salt_for, b20_token_for};
 

--- a/crates/infra/load-tests/src/workload/payloads/double_counter.rs
+++ b/crates/infra/load-tests/src/workload/payloads/double_counter.rs
@@ -1,0 +1,73 @@
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, Bytes};
+use alloy_rpc_types::TransactionRequest;
+use alloy_sol_types::{SolCall, sol};
+use async_trait::async_trait;
+
+use super::Payload;
+use crate::workload::SeededRng;
+
+/// Conservative gas limit for a counter increment that updates one storage slot.
+pub const DOUBLE_COUNTER_GAS_LIMIT: u64 = 100_000;
+
+/// Generates deterministic calls to a `DoubleCounter` contract's `increment2()` function.
+#[derive(Debug, Clone)]
+pub struct DoubleCounterPayload {
+    /// `DoubleCounter` contract address.
+    pub contract: Address,
+}
+
+impl DoubleCounterPayload {
+    /// Creates a payload targeting `contract`.
+    pub const fn new(contract: Address) -> Self {
+        Self { contract }
+    }
+
+    /// ABI-encodes `increment2()`.
+    pub fn encode_increment2() -> Bytes {
+        sol! {
+            function increment2() external;
+        }
+        Bytes::from(increment2Call {}.abi_encode())
+    }
+}
+
+#[async_trait]
+impl Payload for DoubleCounterPayload {
+    fn name(&self) -> &'static str {
+        "double_counter"
+    }
+
+    fn uses_runner_recipient(&self) -> bool {
+        false
+    }
+
+    fn generate(&self, _rng: &mut SeededRng, _from: Address, _to: Address) -> TransactionRequest {
+        TransactionRequest::default()
+            .with_to(self.contract)
+            .with_input(Self::encode_increment2())
+            .with_gas_limit(DOUBLE_COUNTER_GAS_LIMIT)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+
+    use super::*;
+
+    #[test]
+    fn generates_increment2_call_for_configured_contract() {
+        let contract = address!("1111111111111111111111111111111111111111");
+        let request = DoubleCounterPayload::new(contract).generate(
+            &mut SeededRng::new(1),
+            Address::ZERO,
+            Address::ZERO,
+        );
+
+        assert_eq!(request.to, Some(contract.into()));
+        let expected = DoubleCounterPayload::encode_increment2();
+        assert_eq!(request.input.input(), Some(&expected));
+        assert_eq!(request.gas, Some(DOUBLE_COUNTER_GAS_LIMIT));
+    }
+}

--- a/crates/infra/load-tests/src/workload/payloads/mod.rs
+++ b/crates/infra/load-tests/src/workload/payloads/mod.rs
@@ -21,6 +21,9 @@ pub use erc20::Erc20Payload;
 mod storage;
 pub use storage::StoragePayload;
 
+mod double_counter;
+pub use double_counter::{DOUBLE_COUNTER_GAS_LIMIT, DoubleCounterPayload};
+
 mod precompile;
 pub use precompile::{PrecompilePayload, parse_precompile_id};
 

--- a/crates/utilities/test-utils/contracts/script/DeployDoubleCounter.s.sol
+++ b/crates/utilities/test-utils/contracts/script/DeployDoubleCounter.s.sol
@@ -5,11 +5,11 @@ import {Script} from "forge-std/Script.sol";
 import {console} from "forge-std/console.sol";
 import {DoubleCounter} from "../src/DoubleCounter.sol";
 
-contract DeployDoubleCounterScript is Script {
+contract DeployDoubleCounter is Script {
     function run() public {
         vm.startBroadcast();
         DoubleCounter counter = new DoubleCounter();
-        console.log("DoubleCounter deployed at: ", address(counter));
+        console.log("DoubleCounter:", address(counter));
         vm.stopBroadcast();
     }
 }

--- a/crates/utilities/test-utils/contracts/test/DoubleCounter.t.sol
+++ b/crates/utilities/test-utils/contracts/test/DoubleCounter.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {DoubleCounter} from "../src/DoubleCounter.sol";
+
+contract DoubleCounterTest is Test {
+    DoubleCounter internal counter;
+
+    function setUp() public {
+        counter = new DoubleCounter();
+    }
+
+    function testCountersOccupyIndependentSequentialSlots() public {
+        assertEq(uint256(vm.load(address(counter), bytes32(uint256(0)))), 1);
+        assertEq(uint256(vm.load(address(counter), bytes32(uint256(1)))), 1);
+
+        counter.increment();
+        assertEq(uint256(vm.load(address(counter), bytes32(uint256(0)))), 2);
+        assertEq(uint256(vm.load(address(counter), bytes32(uint256(1)))), 1);
+
+        counter.increment2();
+        assertEq(uint256(vm.load(address(counter), bytes32(uint256(0)))), 2);
+        assertEq(uint256(vm.load(address(counter), bytes32(uint256(1)))), 2);
+    }
+}

--- a/etc/scripts/devnet/grafana/dashboards/base-mev.json
+++ b/etc/scripts/devnet/grafana/dashboards/base-mev.json
@@ -506,7 +506,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 32
       },
       "id": 101,
       "panels": [],
@@ -576,7 +576,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 27
+        "y": 33
       },
       "id": 7,
       "options": {
@@ -674,7 +674,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 27
+        "y": 33
       },
       "id": 8,
       "options": {
@@ -788,7 +788,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 27
+        "y": 33
       },
       "id": 9,
       "options": {
@@ -829,7 +829,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 41
       },
       "id": 102,
       "panels": [],
@@ -917,7 +917,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 36
+        "y": 42
       },
       "id": 11,
       "options": {
@@ -1027,7 +1027,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 36
+        "y": 42
       },
       "id": 12,
       "options": {
@@ -1126,7 +1126,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 36
+        "y": 42
       },
       "id": 13,
       "options": {
@@ -1225,7 +1225,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 50
       },
       "id": 14,
       "options": {
@@ -1845,12 +1845,152 @@
           "type": "timeseries"
         },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Parking-index pressure over the selected window. Wakeups are index buckets revisited per completed build, sampled depth is parked transactions per non-empty bucket, and rescan evaluations show the resulting predicate recheck rate.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/wakeups/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F2B84B",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/depth/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#B877D9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/evaluations/i"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#5794F2",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "unit",
+                "value": "cps"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(reth_base_builder_predicate_bucket_wakeups_sum{job=\"l2_builder\"}[$window])) / sum(rate(reth_base_builder_predicate_bucket_wakeups_count{job=\"l2_builder\"}[$window]))",
+          "legendFormat": "bucket wakeups · mean/build",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(reth_base_builder_predicate_bucket_depth_sum{job=\"l2_builder\"}[$window])) / sum(rate(reth_base_builder_predicate_bucket_depth_count{job=\"l2_builder\"}[$window]))",
+          "legendFormat": "sampled bucket depth · mean",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(reth_base_builder_validity_predicate_evaluations_total{job=\"l2_builder\",outcome=~\"rescan_matched|rescan_not_satisfied|rescan_read_error|rescan_budget_exhausted\"}[$window]))",
+          "legendFormat": "rescan evaluations · rate",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Predicate Parking & Rescan Pressure",
+      "type": "timeseries"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 57
       },
       "id": 104,
       "panels": [
@@ -2199,7 +2339,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 58
       },
       "id": 105,
       "panels": [
@@ -2585,7 +2725,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 59
       },
       "id": 106,
       "panels": [
@@ -2952,7 +3092,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 60
       },
       "id": 107,
       "panels": [
@@ -3212,7 +3352,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 61
       },
       "id": 108,
       "panels": [

--- a/etc/scripts/devnet/validity-stress-gate.sh
+++ b/etc/scripts/devnet/validity-stress-gate.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Machine-checkable acceptance gate for the validity stress workload.
+
+PROMETHEUS_URL="${PROMETHEUS_URL:-http://localhost:9090}"
+WINDOW="${WINDOW:-2m}"
+MIN_COMPLETED_BUILDS="${MIN_COMPLETED_BUILDS:-200}"
+MIN_CANDIDATES_PER_BUILD="${MIN_CANDIDATES_PER_BUILD:-25}"
+MIN_PREDICATE_SLOT_READS_PER_BUILD="${MIN_PREDICATE_SLOT_READS_PER_BUILD:-25}"
+MIN_DEFERRED_PER_BUILD="${MIN_DEFERRED_PER_BUILD:-5}"
+MAX_PRIMARY_COVERAGE="${MAX_PRIMARY_COVERAGE:-0.90}"
+MIN_CUTOFF_BUILD_FRACTION="${MIN_CUTOFF_BUILD_FRACTION:-0.80}"
+WAIT_CONSECUTIVE_SECONDS="${WAIT_CONSECUTIVE_SECONDS:-60}"
+WAIT_TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-600}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-15}"
+PROMETHEUS_TIMEOUT_SECONDS="${PROMETHEUS_TIMEOUT_SECONDS:-5}"
+JOB="${BUILDER_JOB:-l2_builder}"
+
+usage() {
+  echo "Usage: $0 [--wait]" >&2
+  echo "Thresholds and connection settings are configurable with environment variables." >&2
+}
+
+WAIT=false
+case "${1:-}" in
+  "") ;;
+  --wait) WAIT=true ;;
+  -h|--help) usage; exit 0 ;;
+  *) usage; exit 2 ;;
+esac
+if (( $# > 1 )); then usage; exit 2; fi
+
+for command in curl jq; do
+  command -v "$command" >/dev/null 2>&1 || { echo "missing required command: $command" >&2; exit 2; }
+done
+[[ "$WINDOW" =~ ^[1-9][0-9]*(ms|s|m|h|d|w|y)$ ]] || { echo "invalid WINDOW: $WINDOW" >&2; exit 2; }
+for setting in MIN_COMPLETED_BUILDS MIN_CANDIDATES_PER_BUILD MIN_PREDICATE_SLOT_READS_PER_BUILD MIN_DEFERRED_PER_BUILD MAX_PRIMARY_COVERAGE MIN_CUTOFF_BUILD_FRACTION WAIT_CONSECUTIVE_SECONDS WAIT_TIMEOUT_SECONDS POLL_INTERVAL_SECONDS PROMETHEUS_TIMEOUT_SECONDS; do
+  value="${!setting}"
+  [[ "$value" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] || { echo "invalid $setting: $value" >&2; exit 2; }
+done
+
+prometheus_value() {
+  local query="$1" response value
+  response="$(curl -fsS --max-time "$PROMETHEUS_TIMEOUT_SECONDS" -G \
+    --data-urlencode "query=$query" "$PROMETHEUS_URL/api/v1/query" 2>/dev/null)" || return 1
+  value="$(jq -er '
+    select(.status == "success")
+    | select(.data.result | length == 1)
+    | .data.result[0].value[1]
+    | select(test("^(NaN|[+-]Inf)$") | not)
+    | tonumber
+  ' <<<"$response" 2>/dev/null)" || return 1
+  printf '%s' "$value"
+}
+
+number_is() {
+  local value="$1" operator="$2" threshold="$3"
+  jq -ne --argjson value "$value" --argjson threshold "$threshold" \
+    "\$value $operator \$threshold" >/dev/null
+}
+
+run_gate() {
+  local selector="job=\"$JOB\"" builds evaluated deferred slots cutoff wakeups rescans included errors up
+  local candidates_per_build="" slots_per_build="" deferred_per_build="" coverage="" cutoff_fraction=""
+  local query_failed=false failed=0
+
+  up="$(prometheus_value "max(up{$selector})")" || { up="N/A"; query_failed=true; }
+  builds="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_candidates_evaluated_per_build_count{$selector}[$WINDOW]))")" || { builds="N/A"; query_failed=true; }
+  evaluated="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_candidates_evaluated_per_build_sum{$selector}[$WINDOW])) or vector(0)")" || { evaluated="N/A"; query_failed=true; }
+  deferred="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_candidates_deferred_per_build_sum{$selector}[$WINDOW])) or vector(0)")" || { deferred="N/A"; query_failed=true; }
+  slots="$(prometheus_value "sum(increase(reth_base_builder_predicate_slots_loaded_total_sum{$selector}[$WINDOW])) or vector(0)")" || { slots="N/A"; query_failed=true; }
+  cutoff="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_eval_cutoff_builds_total{$selector}[$WINDOW])) or vector(0)")" || { cutoff="N/A"; query_failed=true; }
+  wakeups="$(prometheus_value "sum(increase(reth_base_builder_predicate_bucket_wakeups_sum{$selector}[$WINDOW])) or vector(0)")" || { wakeups="N/A"; query_failed=true; }
+  rescans="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_evaluations_total{$selector,outcome=~\"rescan_matched|rescan_not_satisfied|rescan_budget_exhausted\"}[$WINDOW])) or vector(0)")" || { rescans="N/A"; query_failed=true; }
+  included="$(prometheus_value "sum(increase(reth_base_builder_txs_included_per_block_sum{$selector,flow=\"validity\"}[$WINDOW])) or vector(0)")" || { included="N/A"; query_failed=true; }
+  errors="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_evaluations_total{$selector,outcome=~\"read_error|rescan_read_error\"}[$WINDOW])) or vector(0)")" || { errors="N/A"; query_failed=true; }
+
+  if [[ "$query_failed" == false ]] && number_is "$builds" '>' 0 && number_is "$(jq -n "$evaluated + $deferred")" '>' 0; then
+    candidates_per_build="$(jq -nr "($evaluated + $deferred) / $builds")"
+    slots_per_build="$(jq -nr "$slots / $builds")"
+    deferred_per_build="$(jq -nr "$deferred / $builds")"
+    coverage="$(jq -nr "$evaluated / ($evaluated + $deferred)")"
+    cutoff_fraction="$(jq -nr "$cutoff / $builds")"
+  fi
+
+  printf '\nValidity stress gate (window=%s, job=%s)\n' "$WINDOW" "$JOB"
+  printf '%-30s %12s %12s %s\n' "goal" "value" "threshold" "result"
+  check() {
+    local name="$1" value="$2" operator="$3" threshold="$4" status="FAIL"
+    if [[ -n "$value" && "$value" != N/A ]] && number_is "$value" "$operator" "$threshold"; then status="PASS"; else failed=1; fi
+    printf '%-30s %12s %12s %s\n' "$name" "${value:-N/A}" "$operator $threshold" "$status"
+  }
+  check "builder up" "$up" '==' 1
+  check "completed builds" "$builds" '>=' "$MIN_COMPLETED_BUILDS"
+  check "validity candidates/build" "$candidates_per_build" '>=' "$MIN_CANDIDATES_PER_BUILD"
+  check "predicate slot reads/build" "$slots_per_build" '>=' "$MIN_PREDICATE_SLOT_READS_PER_BUILD"
+  check "deferred/build" "$deferred_per_build" '>=' "$MIN_DEFERRED_PER_BUILD"
+  check "primary coverage" "$coverage" '<=' "$MAX_PRIMARY_COVERAGE"
+  check "cutoff-build fraction" "$cutoff_fraction" '>=' "$MIN_CUTOFF_BUILD_FRACTION"
+  check "bucket wakeups" "$wakeups" '>' 0
+  check "rescan outcomes" "$rescans" '>' 0
+  check "validity inclusions" "$included" '>' 0
+  check "predicate read errors" "$errors" '==' 0
+  return "$failed"
+}
+
+if [[ "$WAIT" == false ]]; then
+  run_gate
+  exit $?
+fi
+
+started="$(date +%s)"
+passing_since=""
+while true; do
+  now="$(date +%s)"
+  if run_gate; then
+    [[ -n "$passing_since" ]] || passing_since="$now"
+    if (( now - passing_since >= WAIT_CONSECUTIVE_SECONDS )); then
+      echo "PASS: goals held continuously for at least ${WAIT_CONSECUTIVE_SECONDS}s"
+      exit 0
+    fi
+    echo "passing for $((now - passing_since))/${WAIT_CONSECUTIVE_SECONDS}s"
+  else
+    passing_since=""
+  fi
+  if (( now - started >= WAIT_TIMEOUT_SECONDS )); then
+    echo "FAIL: timed out after ${WAIT_TIMEOUT_SECONDS}s" >&2
+    exit 1
+  fi
+  sleep "$POLL_INTERVAL_SECONDS"
+done


### PR DESCRIPTION
## Summary

Adds a reproducible 800-sender validity stress profile that sends 64-predicate transactions directly to the builder and continuously exercises cutoff, parking, wakeup, and rescan paths. It also adds an automated acceptance gate, focused Grafana panels, supporting load-tester capabilities, and a fix for presign-buffer memory growth found during sustained runs. The dashboard reports per-build predicate capacity, evaluation coverage, cutoff pressure, and total build latency; it intentionally does not attach measurements to individual block numbers.

## Local stress benchmark

This snapshot was captured from the sustained local workload at 2026-09-03 12:58:56 UTC with the 10 ms predicate-evaluation cutoff and 200 ms Flashblock interval. Percentiles are Prometheus rolling 10-minute summaries; the saturation assertions below use exact counter increases over the final two minutes.

| Per-build metric | p50 | p90 | p99 |
| --- | ---: | ---: | ---: |
| Predicate evaluation time | 10.023 ms | 10.039 ms | 10.055 ms |
| Validity candidates evaluated | 173 | 179 | 181 |
| Predicate storage-slot reads | 11,071 | 11,456 | 11,583 |
| Unique storage slots read | 64 | 64 | 64 |
| Validity candidates deferred by cutoff | 575 | 597 | 678 |
| Candidate evaluation coverage | 23.16% | 23.96% | 24.23% |
| Total block-build time | 14.065 ms | 17.826 ms | 24.188 ms |
| Validity transactions included | 0 | 1 | 29 |

The final two-minute saturation window completed 600 builds at 5.00 builds/second: all 600 had predicate work and all 600 hit the cutoff, while no primary or rescan predicate read errors occurred during the preceding hour. In practical terms, the builder evaluates about 173–181 full 64-predicate candidates, or 11.1k–11.6k storage reads, inside each 10 ms budget; the p99 cutoff overshoot is only 55 µs, and p99 total build time remains 24.188 ms (12.1% of the 200 ms interval). The deferred counts and roughly 23–24% coverage confirm the workload offers substantially more predicate work than the budget can consume. Inclusion is state/parity dependent, and all candidates intentionally revisit the same 64 slots, so this is a repeatable hot-state builder-path saturation test rather than a cold-state I/O benchmark.

<img width="2048" height="1769" alt="Base MEV Grafana dashboard" src="https://github.com/user-attachments/assets/50bbaf93-c141-47a1-bc3b-55aeee09612a" />
