### PR TITLE
refactor(txpool-rpc): rename base_sendRawTransactionValidity to base_sendTransactionValidity

### DIFF
--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -15,7 +15,7 @@ use base_execution_cli::{
     ExecutionNodeConfigArgs, StandardBaseRethNode, chainspec::chain_value_parser,
 };
 use base_node_runner::BaseNodeRunner;
-use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{SendTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
 use base_upgrade_signal::UpgradeSignalStartupMode;
 use clap::Args;
 use reth_cli_runner::CliRunner;
@@ -116,7 +116,7 @@ impl SequencerCommand {
             runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig { sequencer_rpc });
             runner.install_ext::<BuilderApiExtension>(builder_api_config);
             if builder_api_config.accept_experimental_validity_transactions {
-                runner.install_ext::<SendRawTransactionValidityExtension>(
+                runner.install_ext::<SendTransactionValidityExtension>(
                     builder_api_config.max_validity_predicates,
                 );
             }

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -13,7 +13,7 @@ use base_execution_cli::{Cli, StandardBaseRethNode};
 use base_node_runner::BaseNodeRunner;
 use base_observability_events::GlobalTransactionEventWriter;
 use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
-use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{SendTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
 
 type BuilderCli = Cli<Args>;
 
@@ -63,7 +63,7 @@ fn main() {
         runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
         runner.install_ext::<BuilderApiExtension>(builder_api_config);
         if builder_api_config.accept_experimental_validity_transactions {
-            runner.install_ext::<SendRawTransactionValidityExtension>(
+            runner.install_ext::<SendTransactionValidityExtension>(
                 builder_api_config.max_validity_predicates,
             );
         }

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -187,7 +187,7 @@ pub struct Args {
 
     /// Enable experimental validity-bearing transactions on this builder.
     ///
-    /// Registers `base_sendRawTransactionValidity` for direct ingress and accepts
+    /// Registers `base_sendTransactionValidity` for direct ingress and accepts
     /// validity metadata on `base_insertValidatedTransaction` from forwarding nodes.
     /// Predicates are preserved and enforced during block construction.
     #[arg(long = "builder.enable-experimental-validity-transactions", default_value = "false")]

--- a/crates/builder/core/tests/rpc.rs
+++ b/crates/builder/core/tests/rpc.rs
@@ -15,7 +15,7 @@ use base_execution_txpool::{
 };
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::Account;
-use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityRequest};
+use base_txpool_rpc::{SendTransactionValidityExtension, SendTransactionValidityRequest};
 
 /// Sets up a test harness with the `BuilderApiExtension` installed.
 async fn setup(
@@ -54,7 +54,7 @@ async fn setup_with_validity_ingress(
     let config = BuilderApiExtensionConfig::new(accept_validity, max_validity_predicates);
     let mut builder = TestHarness::builder().with_ext::<BuilderApiExtension>(config);
     if accept_validity {
-        builder = builder.with_ext::<SendRawTransactionValidityExtension>(max_validity_predicates);
+        builder = builder.with_ext::<SendTransactionValidityExtension>(max_validity_predicates);
     }
     let harness = builder.build().await?;
     let client = harness.rpc_client()?;
@@ -226,19 +226,19 @@ async fn test_validity_transactions_enforce_configured_limit() -> eyre::Result<(
 
 /// Verifies builders do not expose public validity ingress unless explicitly opted in.
 #[tokio::test]
-async fn test_send_raw_transaction_validity_requires_explicit_opt_in() -> eyre::Result<()> {
+async fn test_send_transaction_validity_requires_explicit_opt_in() -> eyre::Result<()> {
     let (disabled_harness, disabled_client) = setup(false, DEFAULT_MAX_VALIDITY_PREDICATES).await?;
     let disabled: Result<TxHash, _> = disabled_client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest {
                 tx: signed_eip1559_tx(disabled_harness.chain_id()),
                 validity: Vec::new(),
             },),
         )
         .await;
     let disabled_error = disabled
-        .expect_err("disabled builder should not expose base_sendRawTransactionValidity")
+        .expect_err("disabled builder should not expose base_sendTransactionValidity")
         .to_string();
     assert!(
         disabled_error.contains("-32601") || disabled_error.to_ascii_lowercase().contains("method"),
@@ -249,8 +249,8 @@ async fn test_send_raw_transaction_validity_requires_explicit_opt_in() -> eyre::
         setup_with_validity_ingress(true, DEFAULT_MAX_VALIDITY_PREDICATES).await?;
     let enabled: Result<TxHash, _> = enabled_client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest {
                 tx: signed_eip1559_tx(enabled_harness.chain_id()),
                 validity: vec![ValidityPredicate::Balance {
                     address: Account::Alice.address(),
@@ -267,7 +267,7 @@ async fn test_send_raw_transaction_validity_requires_explicit_opt_in() -> eyre::
 
 /// Verifies public validity ingress enforces the builder's configured predicate limit.
 #[tokio::test]
-async fn test_send_raw_transaction_validity_enforces_configured_limit() -> eyre::Result<()> {
+async fn test_send_transaction_validity_enforces_configured_limit() -> eyre::Result<()> {
     let (harness, client) = setup_with_validity_ingress(true, 1).await?;
     let predicate = ValidityPredicate::Balance {
         address: Account::Alice.address(),
@@ -276,8 +276,8 @@ async fn test_send_raw_transaction_validity_enforces_configured_limit() -> eyre:
     };
     let result: Result<TxHash, _> = client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest {
                 tx: signed_eip1559_tx(harness.chain_id()),
                 validity: vec![predicate; 2],
             },),

--- a/crates/common/observability-events/src/emit.rs
+++ b/crates/common/observability-events/src/emit.rs
@@ -500,19 +500,19 @@ mod tests {
 
         let result = transaction_event!(
             producer: TransactionEventProducer::BaseRethNode,
-            event_type: TransactionEventType::TxpoolSendRawTransactionValidity,
+            event_type: TransactionEventType::TxpoolSendTransactionValidity,
             tx_hash: tx_hash,
             data: {
-                "rpc_method" => "base_sendRawTransactionValidity",
+                "rpc_method" => "base_sendTransactionValidity",
             },
         );
 
         assert_eq!(result.unwrap(), TransactionEventEmitOutcome::Emitted);
         let events = capture.events();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, TransactionEventType::TxpoolSendRawTransactionValidity);
+        assert_eq!(events[0].event_type, TransactionEventType::TxpoolSendTransactionValidity);
         assert_eq!(events[0].tx_hash, Some(tx_hash));
-        assert_eq!(events[0].data["rpc_method"], "base_sendRawTransactionValidity");
+        assert_eq!(events[0].data["rpc_method"], "base_sendTransactionValidity");
     }
 
     #[test]

--- a/crates/common/observability-events/src/event.rs
+++ b/crates/common/observability-events/src/event.rs
@@ -155,14 +155,14 @@ pub enum TransactionEventType {
     /// which records later pending-subpool membership.
     #[serde(rename = "TXPOOL_SEND_RAW_TRANSACTION")]
     TxpoolSendRawTransaction,
-    /// A transaction was submitted through `base_sendRawTransactionValidity`.
+    /// A transaction was submitted through `base_sendTransactionValidity`.
     ///
     /// Emitted once per RPC admission after the transaction is decoded and its
     /// predicate list is attached, before pool insertion. Downstream lifecycle
     /// events join back by `tx_hash` and must not repeat
     /// `data.validity_predicates`.
-    #[serde(rename = "TXPOOL_SEND_RAW_TRANSACTION_VALIDITY")]
-    TxpoolSendRawTransactionValidity,
+    #[serde(rename = "TXPOOL_SEND_TRANSACTION_VALIDITY")]
+    TxpoolSendTransactionValidity,
     /// The builder considered a transaction for payload inclusion.
     #[serde(rename = "BUILDER_CONSIDERED")]
     BuilderConsidered,
@@ -238,7 +238,7 @@ impl fmt::Display for TransactionEventType {
             Self::TxpoolValidatedInsertAccepted => "TXPOOL_VALIDATED_INSERT_ACCEPTED",
             Self::TxpoolValidatedInsertRejected => "TXPOOL_VALIDATED_INSERT_REJECTED",
             Self::TxpoolSendRawTransaction => "TXPOOL_SEND_RAW_TRANSACTION",
-            Self::TxpoolSendRawTransactionValidity => "TXPOOL_SEND_RAW_TRANSACTION_VALIDITY",
+            Self::TxpoolSendTransactionValidity => "TXPOOL_SEND_TRANSACTION_VALIDITY",
             Self::BuilderConsidered => "BUILDER_CONSIDERED",
             Self::BuilderAccepted => "BUILDER_ACCEPTED",
             Self::BuilderRejected => "BUILDER_REJECTED",

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -22,7 +22,7 @@ use base_tx_forwarding::{
     TxForwardingExtension,
 };
 use base_txpool_rpc::{
-    DEFAULT_MAX_VALIDITY_PREDICATES, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    DEFAULT_MAX_VALIDITY_PREDICATES, SendTransactionValidityExtension, TxPoolRpcConfig,
     TxPoolRpcExtension,
 };
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
@@ -626,7 +626,7 @@ impl StandardBaseRethNode {
         runner.install_ext::<ShadowIndexerExtension>((&args.shadow_indexer).try_into()?);
         let tx_forwarding_config: TxForwardingConfig = (&args).into();
         if args.rpc.enable_experimental_validity_transactions {
-            runner.install_ext::<SendRawTransactionValidityExtension>(
+            runner.install_ext::<SendTransactionValidityExtension>(
                 args.rpc.experimental_validity_max_predicates,
             );
         }

--- a/crates/execution/tx-forwarding/tests/forwarding.rs
+++ b/crates/execution/tx-forwarding/tests/forwarding.rs
@@ -16,7 +16,7 @@ use base_execution_txpool::{
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::{Account, DEVNET_CHAIN_ID, build_test_genesis};
 use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
-use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityRequest};
+use base_txpool_rpc::{SendTransactionValidityExtension, SendTransactionValidityRequest};
 use eyre::{Result, WrapErr};
 use jsonrpsee::{
     RpcModule,
@@ -157,7 +157,7 @@ async fn forwards_validity_to_every_builder() -> Result<()> {
     // exercises the flow against a pre-Cobalt genesis.
     let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis()));
     let harness = TestHarness::builder()
-        .with_ext::<SendRawTransactionValidityExtension>(DEFAULT_MAX_VALIDITY_PREDICATES)
+        .with_ext::<SendTransactionValidityExtension>(DEFAULT_MAX_VALIDITY_PREDICATES)
         .with_ext::<TxForwardingExtension>(config)
         .with_chain_spec(chain_spec)
         .build()
@@ -176,8 +176,8 @@ async fn forwards_validity_to_every_builder() -> Result<()> {
     let client = harness.rpc_client()?;
     let _: alloy_primitives::TxHash = client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest { tx: raw.clone(), validity: expected.clone() },),
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest { tx: raw.clone(), validity: expected.clone() },),
         )
         .await?;
 

--- a/crates/execution/txpool-rpc/README.md
+++ b/crates/execution/txpool-rpc/README.md
@@ -10,8 +10,8 @@ transaction pool.
 Exposes JSON-RPC APIs for transaction pool administration and transaction lifecycle tracking.
 `AdminTxPoolApiImpl` provides admin-level pool management, while `TransactionStatusApiImpl`
 allows clients to query the current status of individual transactions by hash. The separate
-`SendRawTransactionValidityExtension` registers local ingress through
-`base_sendRawTransactionValidity` on both mempool/client nodes and builder nodes. Typed
+`SendTransactionValidityExtension` registers local ingress through
+`base_sendTransactionValidity` on both mempool/client nodes and builder nodes. Typed
 validity predicates are preserved in the pool (and while forwarding to builders). This endpoint
 is experimental, but predicates are evaluated and enforced by the builder during block
 construction: a transaction is only included at a point where all of its predicates hold, and
@@ -28,14 +28,14 @@ base-txpool-rpc = { workspace = true }
 
 ```rust,ignore
 use base_txpool_rpc::{
-    DEFAULT_MAX_VALIDITY_PREDICATES, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    DEFAULT_MAX_VALIDITY_PREDICATES, SendTransactionValidityExtension, TxPoolRpcConfig,
     TxPoolRpcExtension,
 };
 
 runner.install_ext::<TxPoolRpcExtension>(TxPoolRpcConfig::default());
 // Install only when the node's explicit experimental validity flag is enabled.
 // The config is the maximum number of validity predicates accepted per transaction.
-runner.install_ext::<SendRawTransactionValidityExtension>(DEFAULT_MAX_VALIDITY_PREDICATES);
+runner.install_ext::<SendTransactionValidityExtension>(DEFAULT_MAX_VALIDITY_PREDICATES);
 ```
 
 ## License

--- a/crates/execution/txpool-rpc/src/extension.rs
+++ b/crates/execution/txpool-rpc/src/extension.rs
@@ -5,8 +5,8 @@ use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, N
 use reth_rpc_server_types::RethRpcModule;
 
 use crate::{
-    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendRawTransactionValidityApiImpl,
-    SendRawTransactionValidityApiServer, TransactionStatusApiImpl, TransactionStatusApiServer,
+    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendTransactionValidityApiImpl,
+    SendTransactionValidityApiServer, TransactionStatusApiImpl, TransactionStatusApiServer,
 };
 
 /// Configuration for the `TxPool` RPC extension.
@@ -45,21 +45,21 @@ impl BaseNodeExtension for TxPoolRpcExtension {
 
 /// Extension registering local validity-bearing transaction ingress.
 #[derive(Debug)]
-pub struct SendRawTransactionValidityExtension {
+pub struct SendTransactionValidityExtension {
     max_validity_predicates: usize,
 }
 
-impl Default for SendRawTransactionValidityExtension {
+impl Default for SendTransactionValidityExtension {
     fn default() -> Self {
         Self { max_validity_predicates: DEFAULT_MAX_VALIDITY_PREDICATES }
     }
 }
 
-impl BaseNodeExtension for SendRawTransactionValidityExtension {
+impl BaseNodeExtension for SendTransactionValidityExtension {
     fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
         let max_validity_predicates = self.max_validity_predicates;
         builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
-            let api = SendRawTransactionValidityApiImpl::with_max_validity_predicates(
+            let api = SendTransactionValidityApiImpl::with_max_validity_predicates(
                 ctx.pool().clone(),
                 ctx.provider().clone(),
                 max_validity_predicates,
@@ -70,7 +70,7 @@ impl BaseNodeExtension for SendRawTransactionValidityExtension {
     }
 }
 
-impl FromExtensionConfig for SendRawTransactionValidityExtension {
+impl FromExtensionConfig for SendTransactionValidityExtension {
     type Config = usize;
 
     fn from_config(max_validity_predicates: Self::Config) -> Self {

--- a/crates/execution/txpool-rpc/src/lib.rs
+++ b/crates/execution/txpool-rpc/src/lib.rs
@@ -9,14 +9,14 @@
 
 mod rpc;
 pub use rpc::{
-    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendRawTransactionValidityApiImpl,
-    SendRawTransactionValidityApiServer, SendRawTransactionValidityRequest, Status,
+    AdminTxPoolApiImpl, AdminTxPoolApiServer, SendTransactionValidityApiImpl,
+    SendTransactionValidityApiServer, SendTransactionValidityRequest, Status,
     TransactionStatusApiImpl, TransactionStatusApiServer, TransactionStatusResponse,
     VALIDITY_TX_PRE_COBALT_RPC_ERROR,
 };
 
 mod extension;
 pub use extension::{
-    DEFAULT_MAX_VALIDITY_PREDICATES, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    DEFAULT_MAX_VALIDITY_PREDICATES, SendTransactionValidityExtension, TxPoolRpcConfig,
     TxPoolRpcExtension,
 };

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -48,9 +48,9 @@ pub struct TransactionStatusResponse {
     pub status: Status,
 }
 
-/// Request for `base_sendRawTransactionValidity`.
+/// Request for `base_sendTransactionValidity`.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
-pub struct SendRawTransactionValidityRequest {
+pub struct SendTransactionValidityRequest {
     /// EIP-2718 encoded signed transaction.
     pub tx: Bytes,
     /// Experimental predicates transported to builders alongside the transaction.
@@ -67,12 +67,12 @@ pub trait TransactionStatusApi {
 
 /// Experimental RPC API for submitting a raw transaction with validity criteria.
 #[rpc(server, namespace = "base")]
-pub trait SendRawTransactionValidityApi {
+pub trait SendTransactionValidityApi {
     /// Submits a raw transaction and transports its currently unenforced validity criteria.
-    #[method(name = "sendRawTransactionValidity")]
-    async fn send_raw_transaction_validity(
+    #[method(name = "sendTransactionValidity")]
+    async fn send_transaction_validity(
         &self,
-        request: SendRawTransactionValidityRequest,
+        request: SendTransactionValidityRequest,
     ) -> RpcResult<TxHash>;
 }
 
@@ -100,13 +100,13 @@ pub struct TransactionStatusApiImpl<Pool: TransactionPool> {
 
 /// Local mempool-ingress implementation for validity-bearing transactions.
 #[derive(Debug, Clone)]
-pub struct SendRawTransactionValidityApiImpl<Pool, Provider> {
+pub struct SendTransactionValidityApiImpl<Pool, Provider> {
     pool: Pool,
     provider: Provider,
     max_validity_predicates: usize,
 }
 
-impl<Pool, Provider> SendRawTransactionValidityApiImpl<Pool, Provider> {
+impl<Pool, Provider> SendTransactionValidityApiImpl<Pool, Provider> {
     /// Creates a validity transaction ingress backed by the given pool and default predicate limit.
     ///
     /// The provider fork-gates the RPC method on the Cobalt hard fork.
@@ -126,7 +126,7 @@ impl<Pool, Provider> SendRawTransactionValidityApiImpl<Pool, Provider> {
     }
 }
 
-impl<Pool, Provider> SendRawTransactionValidityApiImpl<Pool, Provider>
+impl<Pool, Provider> SendTransactionValidityApiImpl<Pool, Provider>
 where
     Provider: BlockReaderIdExt + ChainSpecProvider<ChainSpec: Upgrades>,
 {
@@ -200,15 +200,15 @@ impl<Pool: TransactionPool + 'static> TransactionStatusApiServer
 }
 
 #[async_trait]
-impl<Pool, Provider> SendRawTransactionValidityApiServer
-    for SendRawTransactionValidityApiImpl<Pool, Provider>
+impl<Pool, Provider> SendTransactionValidityApiServer
+    for SendTransactionValidityApiImpl<Pool, Provider>
 where
     Pool: TransactionPool<Transaction = BasePooledTransaction> + 'static,
     Provider: BlockReaderIdExt + ChainSpecProvider<ChainSpec: Upgrades> + 'static,
 {
-    async fn send_raw_transaction_validity(
+    async fn send_transaction_validity(
         &self,
-        request: SendRawTransactionValidityRequest,
+        request: SendTransactionValidityRequest,
     ) -> RpcResult<TxHash> {
         ValidityPredicate::validate_batch(&request.validity, self.max_validity_predicates)
             .map_err(|error| {
@@ -242,10 +242,10 @@ where
         let tx_hash = *transaction.hash();
         let _ = transaction_event!(
             producer: TransactionEventProducer::BaseRethNode,
-            event_type: TransactionEventType::TxpoolSendRawTransactionValidity,
+            event_type: TransactionEventType::TxpoolSendTransactionValidity,
             tx_hash: tx_hash,
             data: {
-                "rpc_method" => "base_sendRawTransactionValidity",
+                "rpc_method" => "base_sendTransactionValidity",
                 "validity_predicates" => &request.validity,
             },
         );
@@ -343,8 +343,8 @@ mod tests {
         NoopTransactionPool::<BasePooledTransaction>::new()
     }
 
-    fn validity_request(tx: Bytes) -> SendRawTransactionValidityRequest {
-        SendRawTransactionValidityRequest {
+    fn validity_request(tx: Bytes) -> SendTransactionValidityRequest {
+        SendTransactionValidityRequest {
             tx,
             validity: vec![ValidityPredicate::Storage {
                 address: Address::repeat_byte(0xab),
@@ -426,7 +426,7 @@ mod tests {
     }
 
     #[test]
-    fn send_raw_transaction_validity_request_uses_top_level_keys() {
+    fn send_transaction_validity_request_uses_top_level_keys() {
         let request = validity_request(Bytes::from_static(&[0x02]));
         let value = serde_json::to_value(request).expect("request should serialize");
 
@@ -436,7 +436,7 @@ mod tests {
     }
 
     #[test]
-    fn send_raw_transaction_validity_event_data_serializes_all_predicate_variants() {
+    fn send_transaction_validity_event_data_serializes_all_predicate_variants() {
         assert_eq!(
             serde_json::to_value(all_predicate_variants()).unwrap(),
             json!([
@@ -477,33 +477,33 @@ mod tests {
     }
 
     #[test]
-    fn send_raw_transaction_validity_event_envelope_joins_on_tx_hash() {
+    fn send_transaction_validity_event_envelope_joins_on_tx_hash() {
         let tx_hash = TxHash::repeat_byte(0x11);
         let event = TransactionEventBuilder::new(
             TransactionEventProducer::BaseRethNode,
-            TransactionEventType::TxpoolSendRawTransactionValidity,
+            TransactionEventType::TxpoolSendTransactionValidity,
         )
         .tx_hash(tx_hash)
-        .data_field("rpc_method", json!("base_sendRawTransactionValidity"))
+        .data_field("rpc_method", json!("base_sendTransactionValidity"))
         .data_field("validity_predicates", json!(all_predicate_variants()))
         .build_with_network("base-devnet");
 
         event.validate().expect("admission event should be valid");
-        assert_eq!(event.event_type.to_string(), "TXPOOL_SEND_RAW_TRANSACTION_VALIDITY");
+        assert_eq!(event.event_type.to_string(), "TXPOOL_SEND_TRANSACTION_VALIDITY");
         assert_eq!(event.tx_hash, Some(tx_hash));
         assert!(event.data.contains_key("validity_predicates"));
     }
 
     #[tokio::test]
-    async fn send_raw_transaction_validity_emits_predicate_list_on_admission() {
+    async fn send_transaction_validity_emits_predicate_list_on_admission() {
         let capture = TransactionEventCapture::install();
         let signer = PrivateKeySigner::random();
         let raw = signed_eip1559(&signer, 0, 1);
-        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
+        let rpc = SendTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
         let request =
-            SendRawTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
+            SendTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
 
-        let tx_hash = rpc.send_raw_transaction_validity(request).await.unwrap_or_else(|_| {
+        let tx_hash = rpc.send_transaction_validity(request).await.unwrap_or_else(|_| {
             capture.events().first().and_then(|event| event.tx_hash).expect(
                 "admission event should fire before pool insertion even if the noop pool rejects",
             )
@@ -513,12 +513,12 @@ mod tests {
             .events()
             .into_iter()
             .filter(|event| {
-                event.event_type == TransactionEventType::TxpoolSendRawTransactionValidity
+                event.event_type == TransactionEventType::TxpoolSendTransactionValidity
                     && event.tx_hash == Some(tx_hash)
             })
             .collect();
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].data["rpc_method"], "base_sendRawTransactionValidity");
+        assert_eq!(events[0].data["rpc_method"], "base_sendTransactionValidity");
         assert_eq!(
             events[0].data["validity_predicates"],
             serde_json::to_value(all_predicate_variants()).unwrap()
@@ -526,23 +526,23 @@ mod tests {
     }
 
     #[test]
-    fn send_raw_transaction_validity_method_is_registered() {
-        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
-        let module = SendRawTransactionValidityApiServer::into_rpc(rpc);
+    fn send_transaction_validity_method_is_registered() {
+        let rpc = SendTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
+        let module = SendTransactionValidityApiServer::into_rpc(rpc);
 
-        assert!(module.method_names().any(|name| name == "base_sendRawTransactionValidity"));
+        assert!(module.method_names().any(|name| name == "base_sendTransactionValidity"));
     }
 
     #[tokio::test]
-    async fn send_raw_transaction_validity_rejects_eip8130_before_cobalt() {
+    async fn send_transaction_validity_rejects_eip8130_before_cobalt() {
         let signer = PrivateKeySigner::random();
         let raw = signed_eip8130(&signer);
-        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), pre_cobalt_provider());
+        let rpc = SendTransactionValidityApiImpl::new(validity_pool(), pre_cobalt_provider());
         let request =
-            SendRawTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
+            SendTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_transaction_validity(request)
             .await
             .expect_err("EIP-8130 validity transactions should be rejected before Cobalt");
 
@@ -551,19 +551,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_raw_transaction_validity_accepts_eip1559_before_cobalt() {
+    async fn send_transaction_validity_accepts_eip1559_before_cobalt() {
         // EIP-1559 validity transactions are gated by the experimental flag alone, not by Cobalt,
         // so they clear the fork gate before Cobalt activates. The admission event fires only once
         // the gate is cleared; the noop pool then rejects insertion.
         let capture = TransactionEventCapture::install();
         let signer = PrivateKeySigner::random();
         let raw = signed_eip1559(&signer, 0, 1);
-        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), pre_cobalt_provider());
+        let rpc = SendTransactionValidityApiImpl::new(validity_pool(), pre_cobalt_provider());
         let request =
-            SendRawTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
+            SendTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_transaction_validity(request)
             .await
             .expect_err("the noop pool rejects insertion after the fork gate is cleared");
 
@@ -573,17 +573,17 @@ mod tests {
                 .events()
                 .iter()
                 .any(|event| event.event_type
-                    == TransactionEventType::TxpoolSendRawTransactionValidity),
+                    == TransactionEventType::TxpoolSendTransactionValidity),
             "admission event should fire once the Cobalt gate is cleared for EIP-1559"
         );
     }
 
     #[tokio::test]
-    async fn send_raw_transaction_validity_rejects_malformed_transaction() {
-        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
+    async fn send_transaction_validity_rejects_malformed_transaction() {
+        let rpc = SendTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
 
         let error = rpc
-            .send_raw_transaction_validity(validity_request(Bytes::from_static(&[0xff])))
+            .send_transaction_validity(validity_request(Bytes::from_static(&[0xff])))
             .await
             .expect_err("malformed transaction should be rejected");
 
@@ -592,8 +592,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_raw_transaction_validity_enforces_configured_predicate_limit() {
-        let rpc = SendRawTransactionValidityApiImpl::with_max_validity_predicates(
+    async fn send_transaction_validity_enforces_configured_predicate_limit() {
+        let rpc = SendTransactionValidityApiImpl::with_max_validity_predicates(
             validity_pool(),
             cobalt_provider(),
             2,
@@ -602,7 +602,7 @@ mod tests {
         request.validity = vec![request.validity[0].clone(); 3];
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_transaction_validity(request)
             .await
             .expect_err("oversized validity should be rejected before transaction decoding");
 
@@ -612,13 +612,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_raw_transaction_validity_rejects_empty_predicates() {
-        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
+    async fn send_transaction_validity_rejects_empty_predicates() {
+        let rpc = SendTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
         let mut request = validity_request(Bytes::from_static(&[0x02]));
         request.validity.clear();
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_transaction_validity(request)
             .await
             .expect_err("empty validity should be rejected before transaction decoding");
 
@@ -627,8 +627,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_raw_transaction_validity_rejects_storage_value_outside_mask() {
-        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
+    async fn send_transaction_validity_rejects_storage_value_outside_mask() {
+        let rpc = SendTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
         let mut request = validity_request(Bytes::from_static(&[0x02]));
         request.validity = vec![ValidityPredicate::Storage {
             address: Address::repeat_byte(0xab),
@@ -639,7 +639,7 @@ mod tests {
         }];
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_transaction_validity(request)
             .await
             .expect_err("storage value outside its mask should be rejected");
 
@@ -648,8 +648,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_raw_transaction_validity_rejects_unsatisfiable_flashblock_index() {
-        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
+    async fn send_transaction_validity_rejects_unsatisfiable_flashblock_index() {
+        let rpc = SendTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
         let mut request = validity_request(Bytes::from_static(&[0x02]));
         // A flashblock-index predicate that only holds at index 0, which pooled
         // transactions never reach, would park forever if admitted.
@@ -659,7 +659,7 @@ mod tests {
         }];
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_transaction_validity(request)
             .await
             .expect_err("an unsatisfiable flashblock-index predicate should be rejected");
 

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -569,11 +569,9 @@ mod tests {
 
         assert_ne!(error.message(), VALIDITY_TX_PRE_COBALT_RPC_ERROR);
         assert!(
-            capture
-                .events()
-                .iter()
-                .any(|event| event.event_type
-                    == TransactionEventType::TxpoolSendTransactionValidity),
+            capture.events().iter().any(
+                |event| event.event_type == TransactionEventType::TxpoolSendTransactionValidity
+            ),
             "admission event should fire once the Cobalt gate is cleared for EIP-1559"
         );
     }

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -378,7 +378,7 @@ impl ValidatedTransactionExtensions<BasePooledTransaction> for TransactionValidi
     /// Applies the predicates to the builder-inbound transaction.
     ///
     /// This is the builder RPC ingress path, distinct from the mempool node's
-    /// `base_sendRawTransactionValidity`. The count bound is enforced separately
+    /// `base_sendTransactionValidity`. The count bound is enforced separately
     /// by [`Self::validate`]; here each predicate's parameters are re-checked as
     /// defense-in-depth against a misbehaving upstream. Unlike the mempool
     /// ingress, an empty predicate set is not rejected: the builder legitimately

--- a/crates/infra/audit/src/transaction_events.rs
+++ b/crates/infra/audit/src/transaction_events.rs
@@ -195,7 +195,7 @@ impl TransactionEventRetentionClass {
             | TransactionEventType::TxpoolBuilderConsumed
             | TransactionEventType::TxpoolValidatedInsertAccepted
             | TransactionEventType::TxpoolSendRawTransaction
-            | TransactionEventType::TxpoolSendRawTransactionValidity => Self::Warm,
+            | TransactionEventType::TxpoolSendTransactionValidity => Self::Warm,
             TransactionEventType::ProxyRejected
             | TransactionEventType::ProxyValidationRejected
             | TransactionEventType::ProxyBackendFailure
@@ -1768,7 +1768,7 @@ mod tests {
         );
         assert_eq!(
             TransactionEventRetentionClass::for_event_type(
-                TransactionEventType::TxpoolSendRawTransactionValidity
+                TransactionEventType::TxpoolSendTransactionValidity
             ),
             TransactionEventRetentionClass::Warm
         );
@@ -1916,9 +1916,9 @@ mod tests {
         let state = state(Arc::new(FakeSink::default()));
         let mut admission = event("at-admission");
         admission["producer"] = json!("base-reth-node");
-        admission["event_type"] = json!("TXPOOL_SEND_RAW_TRANSACTION_VALIDITY");
+        admission["event_type"] = json!("TXPOOL_SEND_TRANSACTION_VALIDITY");
         admission["data"] = json!({
-            "rpc_method": "base_sendRawTransactionValidity",
+            "rpc_method": "base_sendTransactionValidity",
             "validity_predicates": [{
                 "type": "block_number",
                 "params": { "op": ">=", "value": "0x64" }
@@ -1941,7 +1941,7 @@ mod tests {
         assert_eq!(response.rejected, 0);
         assert_eq!(
             TransactionEventRetentionClass::for_event_type(
-                TransactionEventType::TxpoolSendRawTransactionValidity
+                TransactionEventType::TxpoolSendTransactionValidity
             ),
             TransactionEventRetentionClass::for_event_type(
                 TransactionEventType::TxpoolSendRawTransaction

--- a/crates/infra/audit/tests/postgres_transaction_events.rs
+++ b/crates/infra/audit/tests/postgres_transaction_events.rs
@@ -324,7 +324,7 @@ async fn postgres_expires_at_lifecycle_events_with_peer_classes() -> anyhow::Res
         event_with_type(&format!("{event_prefix}-admission"), "TXPOOL_SEND_RAW_TRANSACTION"),
         event_with_type(
             &format!("{event_prefix}-validity-admission"),
-            "TXPOOL_SEND_RAW_TRANSACTION_VALIDITY",
+            "TXPOOL_SEND_TRANSACTION_VALIDITY",
         ),
         event_with_type(&format!("{event_prefix}-rejected"), "BUILDER_REJECTED"),
         event_with_type(&format!("{event_prefix}-deferred"), "BUILDER_DEFERRED"),

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -142,7 +142,7 @@ delay is measured for logging but is no longer included in the JSON output.
 | Config | Target | Notes |
 |--------|--------|-------|
 | `devnet.yaml` | Local devnet | Uses Anvil Account #1 |
-| `validity-devnet.yaml` | Local devnet | Validity (conditional) workload; routes half the senders through `base_sendRawTransactionValidity`. Run with `FUNDER_KEY=... just load-test run validity-devnet`. Requires the node validity flags for end-to-end enforcement |
+| `validity-devnet.yaml` | Local devnet | Validity (conditional) workload; routes half the senders through `base_sendTransactionValidity`. Run with `FUNDER_KEY=... just load-test run validity-devnet`. Requires the node validity flags for end-to-end enforcement |
 | `real-token-devnet.yaml.template` | Local devnet | Rendered by `just load-test real-token` after deploying the devnet WETH/USDC harness |
 | `sepolia.yaml` | Base Sepolia | Requires `FUNDER_KEY` |
 | `real-token-sepolia.yaml` | Base Sepolia | Uses predeployed WETH/USDC and the Uniswap V3 swap router; run with `just load-test real-token sepolia`; recover with `just load-test real-token-recover sepolia` |
@@ -297,7 +297,7 @@ Recipient keys are always positioned with a runtime-random seed/offset (never th
 #### Validity (Conditional) Transactions
 
 A configurable fraction of *senders* can route their entire traffic through the
-`base_sendRawTransactionValidity` endpoint, attaching validity predicates to
+`base_sendTransactionValidity` endpoint, attaching validity predicates to
 every transaction they submit. All four server predicate types are supported:
 the state-based `balance` and `storage` conditions, and the build-position
 `block_number` and `flashblock_index` conditions (compared against the block and
@@ -420,11 +420,11 @@ that:
    `--enable-experimental-validity-transactions`. This flag hard-requires
    transaction forwarding, so it must be accompanied by `--enable-tx-forwarding`
    and at least one `--builder-rpc-urls=<url>`; the node refuses to start
-   otherwise. Only with this flag set is the `base_sendRawTransactionValidity`
+   otherwise. Only with this flag set is the `base_sendTransactionValidity`
    endpoint registered.
 2. The builder is started with
    `--builder.enable-experimental-validity-transactions`. That flag both
-   registers `base_sendRawTransactionValidity` on the builder and accepts
+   registers `base_sendTransactionValidity` on the builder and accepts
    forwarded validity metadata. If it is not set, forwarded transactions that
    carry predicates are **rejected** ("transaction extensions are disabled"), so
    a misconfiguration fails loudly rather than silently dropping predicates.
@@ -432,7 +432,7 @@ that:
    the shipped binaries), which is where predicates are evaluated against state.
 
 If `validity.ratio > 0` but the ingress endpoint does not serve
-`base_sendRawTransactionValidity`, the run fails loudly at startup rather than
+`base_sendTransactionValidity`, the run fails loudly at startup rather than
 silently degrading to plain submission.
 
 **Interpreting the results.** There is no validity-specific builder rejection

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -11,7 +11,7 @@ use crate::{
 /// Validity-transaction workload configuration.
 ///
 /// A fraction of *senders* route their entire traffic through
-/// `base_sendRawTransactionValidity`, carrying the configured predicates.
+/// `base_sendTransactionValidity`, carrying the configured predicates.
 /// Routing is per sender (not per transaction) so each sender's nonce stream
 /// stays on a single submission origin.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/infra/load-tests/src/rpc/client.rs
+++ b/crates/infra/load-tests/src/rpc/client.rs
@@ -175,21 +175,21 @@ pub const MAX_BATCH_RPC_SIZE: usize = 100;
 /// JSON-RPC standard error code for an unrecognized method (method not found).
 ///
 /// Used to detect when a submission endpoint does not serve
-/// `base_sendRawTransactionValidity`, so the load tester can fail loudly rather
+/// `base_sendTransactionValidity`, so the load tester can fail loudly rather
 /// than silently degrade to plain submission.
 pub const JSON_RPC_METHOD_NOT_FOUND: i64 = -32601;
 
 /// The `eth_sendRawTransaction` JSON-RPC method name.
 const ETH_SEND_RAW_TRANSACTION: &str = "eth_sendRawTransaction";
 
-/// The `base_sendRawTransactionValidity` JSON-RPC method name.
-const BASE_SEND_RAW_TRANSACTION_VALIDITY: &str = "base_sendRawTransactionValidity";
+/// The `base_sendTransactionValidity` JSON-RPC method name.
+const BASE_SEND_TRANSACTION_VALIDITY: &str = "base_sendTransactionValidity";
 
 /// A single transaction to submit within a batch, along with any validity
 /// predicates that determine its submission method.
 ///
 /// An empty `validity` list is submitted via `eth_sendRawTransaction`; a
-/// non-empty list is submitted via `base_sendRawTransactionValidity` carrying
+/// non-empty list is submitted via `base_sendTransactionValidity` carrying
 /// the predicates. Mixed batches are supported: the method is selected
 /// per element, and responses are correlated by JSON-RPC `id`.
 #[derive(Debug, Clone)]
@@ -212,7 +212,7 @@ impl SubmitItem {
         Self { raw, validity }
     }
 
-    /// Returns true when this item submits via `base_sendRawTransactionValidity`.
+    /// Returns true when this item submits via `base_sendTransactionValidity`.
     pub const fn is_validity(&self) -> bool {
         !self.validity.is_empty()
     }
@@ -303,7 +303,7 @@ impl BatchRpcClient {
     ///
     /// Each [`SubmitItem`] selects its own method: items without validity
     /// predicates use `eth_sendRawTransaction`, items carrying predicates use
-    /// `base_sendRawTransactionValidity`. A single HTTP batch may mix both;
+    /// `base_sendTransactionValidity`. A single HTTP batch may mix both;
     /// responses are correlated back to inputs by JSON-RPC `id`.
     ///
     /// Large requests are automatically split into configured sub-batches and
@@ -354,7 +354,7 @@ impl BatchRpcClient {
                     serde_json::json!({
                         "jsonrpc": "2.0",
                         "id": i,
-                        "method": BASE_SEND_RAW_TRANSACTION_VALIDITY,
+                        "method": BASE_SEND_TRANSACTION_VALIDITY,
                         "params": [{ "tx": item.raw, "validity": item.validity }]
                     })
                 } else {
@@ -522,9 +522,9 @@ mod tests {
         assert_eq!(body[0]["method"], ETH_SEND_RAW_TRANSACTION);
         assert_eq!(body[0]["params"][0], "0xaa");
 
-        // Validity element: base_sendRawTransactionValidity with { tx, validity }.
+        // Validity element: base_sendTransactionValidity with { tx, validity }.
         assert_eq!(body[1]["id"], 1);
-        assert_eq!(body[1]["method"], BASE_SEND_RAW_TRANSACTION_VALIDITY);
+        assert_eq!(body[1]["method"], BASE_SEND_TRANSACTION_VALIDITY);
         assert_eq!(body[1]["params"][0]["tx"], "0xbb");
         assert_eq!(body[1]["params"][0]["validity"][0]["type"], "balance");
         assert_eq!(body[1]["params"][0]["validity"][0]["params"]["op"], ">=");

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -267,7 +267,7 @@ pub struct LoadConfig {
     /// Fraction of transactions that draw a fresh recipient address instead of cycling through
     /// the sender pool. Used to drive account-trie fan-out for account-create workloads.
     pub fresh_recipient_ratio: f64,
-    /// Fraction `0.0..=1.0` of senders routed through `base_sendRawTransactionValidity`.
+    /// Fraction `0.0..=1.0` of senders routed through `base_sendTransactionValidity`.
     pub validity_ratio: f64,
     /// Predicate templates attached to each validity-bearing transaction.
     pub validity_predicates: Vec<ValidityPredicateTemplate>,

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -214,7 +214,7 @@ impl LoadRunner {
 
     /// Probes each submission endpoint for validity-transaction support.
     ///
-    /// Sends a throwaway `base_sendRawTransactionValidity` request; a
+    /// Sends a throwaway `base_sendTransactionValidity` request; a
     /// method-not-found response means the node was not started with validity
     /// transactions enabled, so the run aborts loudly rather than silently
     /// degrading to plain submission. Any other response (including a rejection
@@ -225,7 +225,7 @@ impl LoadRunner {
             let result: std::result::Result<TxHash, _> = provider
                 .client()
                 .request(
-                    "base_sendRawTransactionValidity",
+                    "base_sendTransactionValidity",
                     (serde_json::json!({ "tx": "0x", "validity": [] }),),
                 )
                 .await;
@@ -234,7 +234,7 @@ impl LoadRunner {
                 && payload.code == JSON_RPC_METHOD_NOT_FOUND
             {
                 return Err(BaselineError::Config(format!(
-                    "submission endpoint {url} does not serve base_sendRawTransactionValidity; \
+                    "submission endpoint {url} does not serve base_sendTransactionValidity; \
                      start the node with --enable-experimental-validity-transactions"
                 )));
             }

--- a/docs/transaction-events/README.md
+++ b/docs/transaction-events/README.md
@@ -16,7 +16,7 @@ not the long-term archive. A background worker deletes rows by event type:
 high-volume proxy and builder-decision events default to 3 days, ingress and
 forwarding events default to 7 days, and failures, drops, inclusion, and
 flashblock events default to 30 days. Autovacuum reclaims the resulting table
-bloat. `TXPOOL_SEND_RAW_TRANSACTION_VALIDITY` uses the same warm window as
+bloat. `TXPOOL_SEND_TRANSACTION_VALIDITY` uses the same warm window as
 `TXPOOL_SEND_RAW_TRANSACTION`. `BUILDER_DEFERRED` and `BUILDER_EXPIRED` use the
 same hot window as the other per-attempt builder decisions; deferral can fire
 once per flashblock for a parked validity transaction.
@@ -192,14 +192,14 @@ Mempool/node:
 - `TXPOOL_REPLACED`
 - `TXPOOL_TRACKING_OVERFLOWED`
 - `TXPOOL_SEND_RAW_TRANSACTION`
-- `TXPOOL_SEND_RAW_TRANSACTION_VALIDITY`
+- `TXPOOL_SEND_TRANSACTION_VALIDITY`
 
-`TXPOOL_SEND_RAW_TRANSACTION` and `TXPOOL_SEND_RAW_TRANSACTION_VALIDITY` are
+`TXPOOL_SEND_RAW_TRANSACTION` and `TXPOOL_SEND_TRANSACTION_VALIDITY` are
 one-time RPC-admission events, one per unique submit path. They fire after the
 transaction is decoded and before sequencer forwarding or pool insertion.
 `tx_hash` is the join key. They are distinct from `TXPOOL_PENDING` /
 `TXPOOL_QUEUED`, which record later subpool membership.
-`TXPOOL_SEND_RAW_TRANSACTION_VALIDITY` is the **only** event that records
+`TXPOOL_SEND_TRANSACTION_VALIDITY` is the **only** event that records
 `data.validity_predicates` (the serialized `balance`, `storage`,
 `block_number`, and `flashblock_index` list). Downstream lifecycle events —
 including `BUILDER_DEFERRED`, `BUILDER_EXPIRED`, `BUILDER_ACCEPTED`, and
@@ -372,7 +372,7 @@ Join later park, expiry, accept, and include events by `tx_hash`:
   "event_id": "0x4c6d...",
   "event_time": "2026-06-02T00:00:00.000000000Z",
   "producer": "base-reth-node",
-  "event_type": "TXPOOL_SEND_RAW_TRANSACTION_VALIDITY",
+  "event_type": "TXPOOL_SEND_TRANSACTION_VALIDITY",
   "network": "base-mainnet",
   "tx_hash": "0x3333333333333333333333333333333333333333333333333333333333333333",
   "block_hash": null,
@@ -380,7 +380,7 @@ Join later park, expiry, accept, and include events by `tx_hash`:
   "payload_id": null,
   "request_id": null,
   "data": {
-    "rpc_method": "base_sendRawTransactionValidity",
+    "rpc_method": "base_sendTransactionValidity",
     "validity_predicates": [
       {
         "type": "storage",

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -91,7 +91,7 @@ the forwarding path:
 
 - builder: `--builder.enable-experimental-validity-transactions` and
   `--builder.payload-builder-cutover`. The builder flag also registers
-  `base_sendRawTransactionValidity` for direct ingress.
+  `base_sendTransactionValidity` for direct ingress.
 - ingress/client: `--enable-experimental-validity-transactions` and a
   `--builder-rpc-urls` endpoint targeting the builder
 

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -17,7 +17,7 @@ use base_execution_txpool::{
 };
 use base_node_core::{args::RollupArgs, node::BasePoolBuilder};
 use base_node_runner::{BaseNode, BaseNodeExtension, FromExtensionConfig, NodeHooks};
-use base_txpool_rpc::SendRawTransactionValidityExtension;
+use base_txpool_rpc::SendTransactionValidityExtension;
 use eyre::{Result, WrapErr, eyre};
 use reth_db::{
     ClientVersion, DatabaseEnv, init_db,
@@ -58,7 +58,7 @@ pub struct InProcessBuilderConfig {
     /// Optional fixed Prometheus metrics port (uses random if None).
     pub metrics_port: Option<u16>,
     /// Whether to accept experimental validity-bearing transactions and expose
-    /// `base_sendRawTransactionValidity`.
+    /// `base_sendTransactionValidity`.
     pub enable_experimental_validity_transactions: bool,
     /// Whether to run both payload builders and cut over to basic at Denim.
     pub payload_builder_cutover: bool,
@@ -188,7 +188,7 @@ impl InProcessBuilder {
         let extra_extensions = config.extra_extensions;
         let mut hooks = NodeHooks::new();
         if accept_validity_transactions {
-            hooks = Box::new(SendRawTransactionValidityExtension::from_config(
+            hooks = Box::new(SendTransactionValidityExtension::from_config(
                 DEFAULT_MAX_VALIDITY_PREDICATES,
             ))
             .apply(hooks);

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -17,7 +17,7 @@ use base_flashblocks_node::FlashblocksExtension;
 use base_node_core::args::RollupArgs;
 use base_node_runner::{BaseNode, BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
-use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{SendTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 use eyre::{Context, Result, eyre};
 use reth_db::{ClientVersion, DatabaseEnv, init_db, mdbx::DatabaseArguments};
@@ -413,7 +413,7 @@ impl InProcessClient {
                 && tx_fwd_config.enabled
                 && !tx_fwd_config.builder_urls.is_empty()
             {
-                extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(
+                extensions.push(Box::new(SendTransactionValidityExtension::from_config(
                     DEFAULT_MAX_VALIDITY_PREDICATES,
                 )));
             }

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -80,7 +80,7 @@ pub struct L2StackConfig {
     /// When set, the client will forward transactions to builder RPC endpoints.
     pub tx_forwarding_config: Option<TxForwardingConfig>,
     /// Whether both L2 nodes enable experimental validity transaction transport,
-    /// including `base_sendRawTransactionValidity` on the builder.
+    /// including `base_sendTransactionValidity` on the builder.
     pub enable_experimental_validity_transactions: bool,
     /// Whether the active builder cuts over from flashblocks to basic at Denim.
     pub payload_builder_cutover: bool,

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -26,7 +26,7 @@ use base_system_tests::{
     SystemTestStack, SystemTestStackBuilder,
 };
 use base_tx_forwarding::TxForwardingConfig;
-use base_txpool_rpc::SendRawTransactionValidityRequest;
+use base_txpool_rpc::SendTransactionValidityRequest;
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
 
@@ -360,8 +360,8 @@ async fn test_matching_validity_predicates_are_forwarded_and_included() -> Resul
 
     let tx_hash: B256 = rpc_client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest { tx: raw_tx, validity },),
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest { tx: raw_tx, validity },),
         )
         .await?;
 
@@ -402,8 +402,8 @@ async fn test_validity_transaction_submitted_directly_to_builder_is_included() -
     let rpc_client = RpcClient::builder().http(system.l2_rpc_url()?);
     let tx_hash: B256 = rpc_client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest {
                 tx: raw_tx,
                 validity: vec![ValidityPredicate::Balance {
                     address: sender,
@@ -447,8 +447,8 @@ async fn test_eip8130_validity_transaction_is_included_by_native_builder() -> Re
     let rpc_client = RpcClient::builder().http(system.l2_client_rpc_url()?);
     let tx_hash: B256 = rpc_client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest {
                 tx: raw_tx,
                 validity: vec![ValidityPredicate::Balance {
                     address: sender,
@@ -492,8 +492,8 @@ async fn test_validity_transaction_lands_after_balance_predicate_becomes_true() 
     let rpc_client = RpcClient::builder().http(system.l2_client_rpc_url()?);
     let submitted_hash: B256 = rpc_client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest {
                 tx: raw_validity_tx,
                 validity: vec![ValidityPredicate::Balance {
                     address: watched,
@@ -570,8 +570,8 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
 
     let submitted_future: B256 = rpc_client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest {
                 tx: raw_future_tx,
                 validity: vec![ValidityPredicate::BlockNumber {
                     op: ValidityOperator::GreaterThanOrEqual,
@@ -584,8 +584,8 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
 
     let submitted_expiring: B256 = rpc_client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest {
                 tx: raw_expiring_tx,
                 validity: vec![
                     ValidityPredicate::BlockNumber {
@@ -604,8 +604,8 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
 
     let submitted_storage: B256 = rpc_client
         .request(
-            "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
+            "base_sendTransactionValidity",
+            (SendTransactionValidityRequest {
                 tx: raw_storage_tx,
                 validity: vec![ValidityPredicate::Storage {
                     address: recipient,
@@ -698,8 +698,8 @@ async fn test_invalid_validity_batches_are_rejected_at_mempool_ingress() -> Resu
     for (validity, expected_error) in invalid_batches {
         let error = rpc_client
             .request::<_, B256>(
-                "base_sendRawTransactionValidity",
-                (SendRawTransactionValidityRequest { tx: raw_tx.clone(), validity },),
+                "base_sendTransactionValidity",
+                (SendTransactionValidityRequest { tx: raw_tx.clone(), validity },),
             )
             .await
             .expect_err("invalid validity batch should be rejected");


### PR DESCRIPTION
## Summary

This is one of two alternative approaches to Brian's request to conform the validity-submission RPC to standard JSON-RPC method shapes; reviewers should pick one. This variant performs a full rename of the method `base_sendRawTransactionValidity` to `base_sendTransactionValidity`, along with every associated Rust identifier (`SendRawTransactionValidityApi`/`...Server`, `SendRawTransactionValidityApiImpl`, `SendRawTransactionValidityRequest`, `SendRawTransactionValidityExtension`, and `send_raw_transaction_validity`), all doc comments, install sites, integration tests, load-test clients, and docs.

The request param shape is intentionally unchanged and remains `[{ "tx": "0x...", "validity": [...] }]`. Because the method is no longer named "raw", the object-shaped param now reads coherently without any wire-format change.

Note for reviewers: unlike the alternative, this variant also renames the telemetry event identifier `TXPOOL_SEND_RAW_TRANSACTION_VALIDITY` to `TXPOOL_SEND_TRANSACTION_VALIDITY` and the emitted `rpc_method` data-field value to `base_sendTransactionValidity`. This is a breaking change for any downstream dashboards, alerts, or log queries that match on the old event string or rpc_method value, so it needs explicit awareness before merge.

Verification: `cargo check -p base-txpool-rpc --all-targets` and `cargo test -p base-txpool-rpc` (20 passing), `cargo check -p base-observability-events --all-targets` and `cargo test -p base-observability-events` (25 passing), plus lib/bin checks across builder-core, tx-forwarding, load-tests (all-targets), audit, execution-cli, builder-cli, builder-bin, and bin/base all pass. The system-tests integration targets could not be compiled locally due to a pre-existing missing-Foundry-artifact prerequisite unrelated to this rename.