### PR TITLE
refactor(txpool-rpc): reshape base_sendRawTransactionValidity params to [tx, {validity}]

### DIFF
--- a/crates/builder/core/tests/rpc.rs
+++ b/crates/builder/core/tests/rpc.rs
@@ -15,7 +15,7 @@ use base_execution_txpool::{
 };
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::Account;
-use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityRequest};
+use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityOptions};
 
 /// Sets up a test harness with the `BuilderApiExtension` installed.
 async fn setup(
@@ -231,10 +231,10 @@ async fn test_send_raw_transaction_validity_requires_explicit_opt_in() -> eyre::
     let disabled: Result<TxHash, _> = disabled_client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
-                tx: signed_eip1559_tx(disabled_harness.chain_id()),
-                validity: Vec::new(),
-            },),
+            (
+                signed_eip1559_tx(disabled_harness.chain_id()),
+                SendRawTransactionValidityOptions { validity: Vec::new() },
+            ),
         )
         .await;
     let disabled_error = disabled
@@ -250,14 +250,16 @@ async fn test_send_raw_transaction_validity_requires_explicit_opt_in() -> eyre::
     let enabled: Result<TxHash, _> = enabled_client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
-                tx: signed_eip1559_tx(enabled_harness.chain_id()),
-                validity: vec![ValidityPredicate::Balance {
-                    address: Account::Alice.address(),
-                    op: ValidityOperator::Equal,
-                    value: U256::ZERO,
-                }],
-            },),
+            (
+                signed_eip1559_tx(enabled_harness.chain_id()),
+                SendRawTransactionValidityOptions {
+                    validity: vec![ValidityPredicate::Balance {
+                        address: Account::Alice.address(),
+                        op: ValidityOperator::Equal,
+                        value: U256::ZERO,
+                    }],
+                },
+            ),
         )
         .await;
     assert!(enabled.is_ok(), "enabled builder should accept validity ingress: {enabled:?}");
@@ -277,10 +279,10 @@ async fn test_send_raw_transaction_validity_enforces_configured_limit() -> eyre:
     let result: Result<TxHash, _> = client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
-                tx: signed_eip1559_tx(harness.chain_id()),
-                validity: vec![predicate; 2],
-            },),
+            (
+                signed_eip1559_tx(harness.chain_id()),
+                SendRawTransactionValidityOptions { validity: vec![predicate; 2] },
+            ),
         )
         .await;
     let error = result.expect_err("builder should reject validity above its configured limit");

--- a/crates/execution/tx-forwarding/tests/forwarding.rs
+++ b/crates/execution/tx-forwarding/tests/forwarding.rs
@@ -16,7 +16,7 @@ use base_execution_txpool::{
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::{Account, DEVNET_CHAIN_ID, build_test_genesis};
 use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
-use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityRequest};
+use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityOptions};
 use eyre::{Result, WrapErr};
 use jsonrpsee::{
     RpcModule,
@@ -177,7 +177,7 @@ async fn forwards_validity_to_every_builder() -> Result<()> {
     let _: alloy_primitives::TxHash = client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest { tx: raw.clone(), validity: expected.clone() },),
+            (raw.clone(), SendRawTransactionValidityOptions { validity: expected.clone() }),
         )
         .await?;
 

--- a/crates/execution/txpool-rpc/src/lib.rs
+++ b/crates/execution/txpool-rpc/src/lib.rs
@@ -10,7 +10,7 @@
 mod rpc;
 pub use rpc::{
     AdminTxPoolApiImpl, AdminTxPoolApiServer, SendRawTransactionValidityApiImpl,
-    SendRawTransactionValidityApiServer, SendRawTransactionValidityRequest, Status,
+    SendRawTransactionValidityApiServer, SendRawTransactionValidityOptions, Status,
     TransactionStatusApiImpl, TransactionStatusApiServer, TransactionStatusResponse,
     VALIDITY_TX_PRE_COBALT_RPC_ERROR,
 };

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -48,11 +48,9 @@ pub struct TransactionStatusResponse {
     pub status: Status,
 }
 
-/// Request for `base_sendRawTransactionValidity`.
+/// Options for `base_sendRawTransactionValidity` accompanying the raw transaction.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
-pub struct SendRawTransactionValidityRequest {
-    /// EIP-2718 encoded signed transaction.
-    pub tx: Bytes,
+pub struct SendRawTransactionValidityOptions {
     /// Experimental predicates transported to builders alongside the transaction.
     pub validity: Vec<ValidityPredicate>,
 }
@@ -72,7 +70,8 @@ pub trait SendRawTransactionValidityApi {
     #[method(name = "sendRawTransactionValidity")]
     async fn send_raw_transaction_validity(
         &self,
-        request: SendRawTransactionValidityRequest,
+        tx: Bytes,
+        options: SendRawTransactionValidityOptions,
     ) -> RpcResult<TxHash>;
 }
 
@@ -208,9 +207,10 @@ where
 {
     async fn send_raw_transaction_validity(
         &self,
-        request: SendRawTransactionValidityRequest,
+        tx: Bytes,
+        options: SendRawTransactionValidityOptions,
     ) -> RpcResult<TxHash> {
-        ValidityPredicate::validate_batch(&request.validity, self.max_validity_predicates)
+        ValidityPredicate::validate_batch(&options.validity, self.max_validity_predicates)
             .map_err(|error| {
                 ErrorObjectOwned::owned(
                     ErrorCode::InvalidParams.code(),
@@ -219,8 +219,8 @@ where
                 )
             })?;
 
-        let transaction = BasePooledTransaction::recover_raw_transaction(request.tx.as_ref())
-            .map_err(|error| {
+        let transaction =
+            BasePooledTransaction::recover_raw_transaction(tx.as_ref()).map_err(|error| {
                 ErrorObjectOwned::owned(
                     ErrorCode::InvalidParams.code(),
                     format!("failed to decode transaction: {error}"),
@@ -246,7 +246,7 @@ where
             tx_hash: tx_hash,
             data: {
                 "rpc_method" => "base_sendRawTransactionValidity",
-                "validity_predicates" => &request.validity,
+                "validity_predicates" => &options.validity,
             },
         );
 
@@ -254,7 +254,7 @@ where
         self.pool
             .add_transaction(
                 TransactionOrigin::Private,
-                transaction.with_validity_predicates(request.validity),
+                transaction.with_validity_predicates(options.validity),
             )
             .await
             .map_err(|error| ErrorObjectOwned::from(RpcPoolError::from(error)))?;
@@ -343,17 +343,19 @@ mod tests {
         NoopTransactionPool::<BasePooledTransaction>::new()
     }
 
-    fn validity_request(tx: Bytes) -> SendRawTransactionValidityRequest {
-        SendRawTransactionValidityRequest {
+    fn validity_request(tx: Bytes) -> (Bytes, SendRawTransactionValidityOptions) {
+        (
             tx,
-            validity: vec![ValidityPredicate::Storage {
-                address: Address::repeat_byte(0xab),
-                slot: U256::from(1),
-                mask: U256::MAX,
-                op: base_execution_txpool::ValidityOperator::Equal,
-                value: U256::from(0x789),
-            }],
-        }
+            SendRawTransactionValidityOptions {
+                validity: vec![ValidityPredicate::Storage {
+                    address: Address::repeat_byte(0xab),
+                    slot: U256::from(1),
+                    mask: U256::MAX,
+                    op: base_execution_txpool::ValidityOperator::Equal,
+                    value: U256::from(0x789),
+                }],
+            },
+        )
     }
 
     fn all_predicate_variants() -> Vec<ValidityPredicate> {
@@ -426,13 +428,18 @@ mod tests {
     }
 
     #[test]
-    fn send_raw_transaction_validity_request_uses_top_level_keys() {
-        let request = validity_request(Bytes::from_static(&[0x02]));
-        let value = serde_json::to_value(request).expect("request should serialize");
+    fn send_raw_transaction_validity_request_uses_positional_params() {
+        let (tx, options) = validity_request(Bytes::from_static(&[0x02]));
 
-        assert_eq!(value["tx"], "0x02");
-        assert_eq!(value["validity"][0]["type"], "storage");
-        assert_eq!(value["validity"][0]["params"]["slot"], "0x1");
+        // The raw transaction is the leading bare param, serialized as a hex string.
+        let tx_value = serde_json::to_value(tx).expect("tx should serialize");
+        assert_eq!(tx_value, "0x02");
+
+        // The options object carries only `validity` alongside the transaction.
+        let options_value = serde_json::to_value(options).expect("options should serialize");
+        assert!(options_value.get("tx").is_none());
+        assert_eq!(options_value["validity"][0]["type"], "storage");
+        assert_eq!(options_value["validity"][0]["params"]["slot"], "0x1");
     }
 
     #[test]
@@ -500,10 +507,9 @@ mod tests {
         let signer = PrivateKeySigner::random();
         let raw = signed_eip1559(&signer, 0, 1);
         let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
-        let request =
-            SendRawTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
+        let options = SendRawTransactionValidityOptions { validity: all_predicate_variants() };
 
-        let tx_hash = rpc.send_raw_transaction_validity(request).await.unwrap_or_else(|_| {
+        let tx_hash = rpc.send_raw_transaction_validity(raw, options).await.unwrap_or_else(|_| {
             capture.events().first().and_then(|event| event.tx_hash).expect(
                 "admission event should fire before pool insertion even if the noop pool rejects",
             )
@@ -538,11 +544,10 @@ mod tests {
         let signer = PrivateKeySigner::random();
         let raw = signed_eip8130(&signer);
         let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), pre_cobalt_provider());
-        let request =
-            SendRawTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
+        let options = SendRawTransactionValidityOptions { validity: all_predicate_variants() };
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_raw_transaction_validity(raw, options)
             .await
             .expect_err("EIP-8130 validity transactions should be rejected before Cobalt");
 
@@ -559,11 +564,10 @@ mod tests {
         let signer = PrivateKeySigner::random();
         let raw = signed_eip1559(&signer, 0, 1);
         let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), pre_cobalt_provider());
-        let request =
-            SendRawTransactionValidityRequest { tx: raw, validity: all_predicate_variants() };
+        let options = SendRawTransactionValidityOptions { validity: all_predicate_variants() };
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_raw_transaction_validity(raw, options)
             .await
             .expect_err("the noop pool rejects insertion after the fork gate is cleared");
 
@@ -582,8 +586,9 @@ mod tests {
     async fn send_raw_transaction_validity_rejects_malformed_transaction() {
         let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
 
+        let (raw, options) = validity_request(Bytes::from_static(&[0xff]));
         let error = rpc
-            .send_raw_transaction_validity(validity_request(Bytes::from_static(&[0xff])))
+            .send_raw_transaction_validity(raw, options)
             .await
             .expect_err("malformed transaction should be rejected");
 
@@ -598,11 +603,11 @@ mod tests {
             cobalt_provider(),
             2,
         );
-        let mut request = validity_request(Bytes::from_static(&[0x02]));
-        request.validity = vec![request.validity[0].clone(); 3];
+        let (raw, mut options) = validity_request(Bytes::from_static(&[0x02]));
+        options.validity = vec![options.validity[0].clone(); 3];
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_raw_transaction_validity(raw, options)
             .await
             .expect_err("oversized validity should be rejected before transaction decoding");
 
@@ -614,11 +619,11 @@ mod tests {
     #[tokio::test]
     async fn send_raw_transaction_validity_rejects_empty_predicates() {
         let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
-        let mut request = validity_request(Bytes::from_static(&[0x02]));
-        request.validity.clear();
+        let (raw, mut options) = validity_request(Bytes::from_static(&[0x02]));
+        options.validity.clear();
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_raw_transaction_validity(raw, options)
             .await
             .expect_err("empty validity should be rejected before transaction decoding");
 
@@ -629,8 +634,8 @@ mod tests {
     #[tokio::test]
     async fn send_raw_transaction_validity_rejects_storage_value_outside_mask() {
         let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
-        let mut request = validity_request(Bytes::from_static(&[0x02]));
-        request.validity = vec![ValidityPredicate::Storage {
+        let (raw, mut options) = validity_request(Bytes::from_static(&[0x02]));
+        options.validity = vec![ValidityPredicate::Storage {
             address: Address::repeat_byte(0xab),
             slot: U256::from(1),
             mask: U256::from(0xff),
@@ -639,7 +644,7 @@ mod tests {
         }];
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_raw_transaction_validity(raw, options)
             .await
             .expect_err("storage value outside its mask should be rejected");
 
@@ -650,16 +655,16 @@ mod tests {
     #[tokio::test]
     async fn send_raw_transaction_validity_rejects_unsatisfiable_flashblock_index() {
         let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), cobalt_provider());
-        let mut request = validity_request(Bytes::from_static(&[0x02]));
+        let (raw, mut options) = validity_request(Bytes::from_static(&[0x02]));
         // A flashblock-index predicate that only holds at index 0, which pooled
         // transactions never reach, would park forever if admitted.
-        request.validity = vec![ValidityPredicate::FlashblockIndex {
+        options.validity = vec![ValidityPredicate::FlashblockIndex {
             op: base_execution_txpool::ValidityOperator::Equal,
             value: U256::ZERO,
         }];
 
         let error = rpc
-            .send_raw_transaction_validity(request)
+            .send_raw_transaction_validity(raw, options)
             .await
             .expect_err("an unsatisfiable flashblock-index predicate should be rejected");
 

--- a/crates/infra/load-tests/src/rpc/client.rs
+++ b/crates/infra/load-tests/src/rpc/client.rs
@@ -355,7 +355,7 @@ impl BatchRpcClient {
                         "jsonrpc": "2.0",
                         "id": i,
                         "method": BASE_SEND_RAW_TRANSACTION_VALIDITY,
-                        "params": [{ "tx": item.raw, "validity": item.validity }]
+                        "params": [item.raw, { "validity": item.validity }]
                     })
                 } else {
                     serde_json::json!({
@@ -522,12 +522,13 @@ mod tests {
         assert_eq!(body[0]["method"], ETH_SEND_RAW_TRANSACTION);
         assert_eq!(body[0]["params"][0], "0xaa");
 
-        // Validity element: base_sendRawTransactionValidity with { tx, validity }.
+        // Validity element: base_sendRawTransactionValidity with positional
+        // params leading with the raw tx hex string, followed by { validity }.
         assert_eq!(body[1]["id"], 1);
         assert_eq!(body[1]["method"], BASE_SEND_RAW_TRANSACTION_VALIDITY);
-        assert_eq!(body[1]["params"][0]["tx"], "0xbb");
-        assert_eq!(body[1]["params"][0]["validity"][0]["type"], "balance");
-        assert_eq!(body[1]["params"][0]["validity"][0]["params"]["op"], ">=");
+        assert_eq!(body[1]["params"][0], "0xbb");
+        assert_eq!(body[1]["params"][1]["validity"][0]["type"], "balance");
+        assert_eq!(body[1]["params"][1]["validity"][0]["params"]["op"], ">=");
     }
 
     #[test]

--- a/crates/infra/load-tests/src/runner/load_runner.rs
+++ b/crates/infra/load-tests/src/runner/load_runner.rs
@@ -226,7 +226,7 @@ impl LoadRunner {
                 .client()
                 .request(
                     "base_sendRawTransactionValidity",
-                    (serde_json::json!({ "tx": "0x", "validity": [] }),),
+                    (serde_json::json!("0x"), serde_json::json!({ "validity": [] })),
                 )
                 .await;
             if let Err(err) = &result

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -26,7 +26,7 @@ use base_system_tests::{
     SystemTestStack, SystemTestStackBuilder,
 };
 use base_tx_forwarding::TxForwardingConfig;
-use base_txpool_rpc::SendRawTransactionValidityRequest;
+use base_txpool_rpc::SendRawTransactionValidityOptions;
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
 
@@ -361,7 +361,7 @@ async fn test_matching_validity_predicates_are_forwarded_and_included() -> Resul
     let tx_hash: B256 = rpc_client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest { tx: raw_tx, validity },),
+            (raw_tx, SendRawTransactionValidityOptions { validity }),
         )
         .await?;
 
@@ -403,14 +403,16 @@ async fn test_validity_transaction_submitted_directly_to_builder_is_included() -
     let tx_hash: B256 = rpc_client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
-                tx: raw_tx,
-                validity: vec![ValidityPredicate::Balance {
-                    address: sender,
-                    op: ValidityOperator::GreaterThan,
-                    value: U256::ZERO,
-                }],
-            },),
+            (
+                raw_tx,
+                SendRawTransactionValidityOptions {
+                    validity: vec![ValidityPredicate::Balance {
+                        address: sender,
+                        op: ValidityOperator::GreaterThan,
+                        value: U256::ZERO,
+                    }],
+                },
+            ),
         )
         .await?;
 
@@ -448,14 +450,16 @@ async fn test_eip8130_validity_transaction_is_included_by_native_builder() -> Re
     let tx_hash: B256 = rpc_client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
-                tx: raw_tx,
-                validity: vec![ValidityPredicate::Balance {
-                    address: sender,
-                    op: ValidityOperator::GreaterThan,
-                    value: U256::ZERO,
-                }],
-            },),
+            (
+                raw_tx,
+                SendRawTransactionValidityOptions {
+                    validity: vec![ValidityPredicate::Balance {
+                        address: sender,
+                        op: ValidityOperator::GreaterThan,
+                        value: U256::ZERO,
+                    }],
+                },
+            ),
         )
         .await?;
 
@@ -493,14 +497,16 @@ async fn test_validity_transaction_lands_after_balance_predicate_becomes_true() 
     let submitted_hash: B256 = rpc_client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
-                tx: raw_validity_tx,
-                validity: vec![ValidityPredicate::Balance {
-                    address: watched,
-                    op: ValidityOperator::GreaterThanOrEqual,
-                    value: U256::from(1),
-                }],
-            },),
+            (
+                raw_validity_tx,
+                SendRawTransactionValidityOptions {
+                    validity: vec![ValidityPredicate::Balance {
+                        address: watched,
+                        op: ValidityOperator::GreaterThanOrEqual,
+                        value: U256::from(1),
+                    }],
+                },
+            ),
         )
         .await?;
     assert_eq!(submitted_hash, validity_tx_hash);
@@ -571,13 +577,15 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
     let submitted_future: B256 = rpc_client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
-                tx: raw_future_tx,
-                validity: vec![ValidityPredicate::BlockNumber {
-                    op: ValidityOperator::GreaterThanOrEqual,
-                    value: U256::from(target_block),
-                }],
-            },),
+            (
+                raw_future_tx,
+                SendRawTransactionValidityOptions {
+                    validity: vec![ValidityPredicate::BlockNumber {
+                        op: ValidityOperator::GreaterThanOrEqual,
+                        value: U256::from(target_block),
+                    }],
+                },
+            ),
         )
         .await?;
     assert_eq!(submitted_future, future_tx_hash);
@@ -585,19 +593,21 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
     let submitted_expiring: B256 = rpc_client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
-                tx: raw_expiring_tx,
-                validity: vec![
-                    ValidityPredicate::BlockNumber {
-                        op: ValidityOperator::GreaterThanOrEqual,
-                        value: U256::from(target_block + 1),
-                    },
-                    ValidityPredicate::BlockNumber {
-                        op: ValidityOperator::LessThanOrEqual,
-                        value: U256::from(target_block),
-                    },
-                ],
-            },),
+            (
+                raw_expiring_tx,
+                SendRawTransactionValidityOptions {
+                    validity: vec![
+                        ValidityPredicate::BlockNumber {
+                            op: ValidityOperator::GreaterThanOrEqual,
+                            value: U256::from(target_block + 1),
+                        },
+                        ValidityPredicate::BlockNumber {
+                            op: ValidityOperator::LessThanOrEqual,
+                            value: U256::from(target_block),
+                        },
+                    ],
+                },
+            ),
         )
         .await?;
     assert_eq!(submitted_expiring, expiring_tx_hash);
@@ -605,16 +615,18 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
     let submitted_storage: B256 = rpc_client
         .request(
             "base_sendRawTransactionValidity",
-            (SendRawTransactionValidityRequest {
-                tx: raw_storage_tx,
-                validity: vec![ValidityPredicate::Storage {
-                    address: recipient,
-                    slot: U256::from(1),
-                    mask: U256::MAX,
-                    op: ValidityOperator::Equal,
-                    value: U256::from(2),
-                }],
-            },),
+            (
+                raw_storage_tx,
+                SendRawTransactionValidityOptions {
+                    validity: vec![ValidityPredicate::Storage {
+                        address: recipient,
+                        slot: U256::from(1),
+                        mask: U256::MAX,
+                        op: ValidityOperator::Equal,
+                        value: U256::from(2),
+                    }],
+                },
+            ),
         )
         .await?;
     assert_eq!(submitted_storage, storage_tx_hash);
@@ -699,7 +711,7 @@ async fn test_invalid_validity_batches_are_rejected_at_mempool_ingress() -> Resu
         let error = rpc_client
             .request::<_, B256>(
                 "base_sendRawTransactionValidity",
-                (SendRawTransactionValidityRequest { tx: raw_tx.clone(), validity },),
+                (raw_tx.clone(), SendRawTransactionValidityOptions { validity }),
             )
             .await
             .expect_err("invalid validity batch should be rejected");


### PR DESCRIPTION
## Summary

This is one of two alternative approaches to Brian's request to make `base_sendRawTransactionValidity` conform to the "raw transaction sending" shape. The method name is unchanged (`base_sendRawTransactionValidity`), as are all telemetry and event identifiers. The JSON-RPC params now lead with the bare EIP-2718 raw-tx hex string, mirroring `eth_sendRawTransaction`, followed by a `{ validity }` options object.

Before, the method took a single object param `[{ "tx": "0x...", "validity": [...] }]`; it now takes two positional params `[ "0x...", { "validity": [...] } ]`. The request struct `SendRawTransactionValidityRequest` is replaced by `SendRawTransactionValidityOptions`, which drops `tx` and keeps `validity`, and the handler takes two positional params `(tx: Bytes, options: SendRawTransactionValidityOptions)`.

This is a BREAKING wire-format change for existing callers of `base_sendRawTransactionValidity`. Reviewers should pick this PR or the sibling PR, which renames the method instead.