### PR TITLE
feat(consensus): support validator batch inbox override

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -352,9 +352,6 @@ where
     }
 
     /// Drop buffered pipeline state, recording why it was dropped.
-    ///
-    /// Every reset re-encodes and re-submits blocks that were already paid for on L1, so a
-    /// pipeline looping here burns DA fees while every other signal stays healthy.
     fn reset_pipeline(&mut self, reason: &'static str) {
         BatcherMetrics::pipeline_reset_total(reason).increment(1);
         self.submissions.discard();

--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -2,7 +2,9 @@
 
 use std::time::Duration;
 
-use base_batcher_encoder::{BatchPipeline, DerivationReconciliation, StepError, StepResult};
+use base_batcher_encoder::{
+    BatchPipeline, BatcherMetrics, DerivationReconciliation, StepError, StepResult,
+};
 use base_batcher_source::{
     L1HeadEvent, L1HeadSource, L2BlockEvent, SourceError, UnsafeBlockSource,
 };
@@ -298,7 +300,7 @@ where
                 }
                 DriverEvent::Reorg => {
                     warn!("L2 reorg detected, resetting pipeline and catching up from safe head");
-                    self.reset_to_safe_head();
+                    self.reset_to_safe_head(BatcherMetrics::RESET_SOURCE_REORG);
                 }
                 DriverEvent::Receipt(ids, o) => {
                     self.submissions.handle_outcome(&mut self.pipeline, ids, o);
@@ -349,16 +351,24 @@ where
         Ok(idle)
     }
 
-    /// Reset volatile state and restart delivery above the latest safe head.
-    fn reset_to_safe_head(&mut self) {
+    /// Drop buffered pipeline state, recording why it was dropped.
+    ///
+    /// Every reset re-encodes and re-submits blocks that were already paid for on L1, so a
+    /// pipeline looping here burns DA fees while every other signal stays healthy.
+    fn reset_pipeline(&mut self, reason: &'static str) {
+        BatcherMetrics::pipeline_reset_total(reason).increment(1);
         self.submissions.discard();
         self.pipeline.reset();
+        self.discard_pending_flush_acks();
+    }
+
+    /// Reset volatile state and restart delivery above the latest safe head.
+    fn reset_to_safe_head(&mut self, reason: &'static str) {
+        self.reset_pipeline(reason);
 
         if let Some(safe_head) = self.safe_head {
             self.source.reset_catchup(safe_head);
         }
-
-        self.discard_pending_flush_acks();
     }
 
     /// Reconcile buffered state with an ordered derivation-progress snapshot.
@@ -377,7 +387,7 @@ where
                 safe_hash = %head.hash,
                 "safe L2 head changed chain, resetting pipeline"
             );
-            self.reset_to_safe_head();
+            self.reset_to_safe_head(BatcherMetrics::RESET_SAFE_HEAD_REORG);
             return;
         }
 
@@ -392,7 +402,7 @@ where
                     safe_hash = %head.hash,
                     "safe L2 head does not match buffered chain, resetting pipeline"
                 );
-                self.reset_to_safe_head();
+                self.reset_to_safe_head(BatcherMetrics::RESET_SAFE_HEAD_MISMATCH);
             }
             DerivationReconciliation::StalledChannel => {
                 warn!(
@@ -400,7 +410,7 @@ where
                     safe_l2 = %head.number,
                     "rollup node passed a fully confirmed channel without deriving it, resetting pipeline"
                 );
-                self.reset_to_safe_head();
+                self.reset_to_safe_head(BatcherMetrics::RESET_STALLED_CHANNEL);
             }
         }
     }
@@ -447,7 +457,7 @@ where
                     error = %e,
                     "reorg detected during block ingestion, resetting pipeline and catching up from safe head"
                 );
-                self.reset_to_safe_head();
+                self.reset_to_safe_head(BatcherMetrics::RESET_INGEST_REORG);
             }
         }
     }
@@ -489,10 +499,8 @@ where
                     match cmd {
                         AdminCommand::Flush { ack } => return Ok(DriverEvent::Flush(ack)),
                         AdminCommand::Pause => {
-                            self.submissions.discard();
-                            self.pipeline.reset();
+                            self.reset_pipeline(BatcherMetrics::RESET_ADMIN_PAUSE);
                             self.stopped = true;
-                            self.discard_pending_flush_acks();
                             info!(stopped = true, "batcher paused via admin");
                         }
                         AdminCommand::Resume => {

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -4,8 +4,8 @@ use std::{future::Future, pin::Pin, sync::Arc};
 
 use alloy_primitives::{Address, Bytes, U256};
 use base_batcher_encoder::{
-    BatchPipeline, BatcherMetrics, BlobPayload, DaType, EncoderConfig, FrameEncoder, SubmissionId,
-    SubmissionPayload,
+    BatchPipeline, BatcherMetrics, BlobPayload, DaEgress, DaType, EncoderConfig, FrameEncoder,
+    SubmissionId, SubmissionPayload,
 };
 use base_blobs::{BlobEncodeError, BlobEncoder};
 use base_tx_manager::{TxCandidate, TxManager, TxManagerError};
@@ -61,11 +61,7 @@ impl BatchTxCandidateBuilder {
         // Encode each packed payload independently; blob boundaries are already
         // fixed by the encoder and must remain visible to the transaction sidecar.
         for payload in payloads {
-            payload_size += 1 + payload
-                .frames()
-                .iter()
-                .map(|frame| BlobEncoder::FRAME_OVERHEAD + frame.data.len())
-                .sum::<usize>();
+            payload_size += 1 + payload.frame_bytes();
             blobs.push(BlobEncoder::encode_packed(payload.frames())?);
         }
 
@@ -150,6 +146,12 @@ impl<TM: TxManager> SubmissionQueue<TM> {
                     match BatchTxCandidateBuilder::blob_tx_candidate(self.inbox, payloads) {
                         Ok((candidate, payload_size)) => {
                             blob_payload_bytes = Some(payload_size);
+                            BatcherMetrics::blobs_per_tx().record(payloads.len() as f64);
+                            for payload in payloads {
+                                BatcherMetrics::blob_fill_ratio().record(
+                                    payload.frame_bytes() as f64 / DaEgress::BLOB_CAPACITY as f64,
+                                );
+                            }
                             candidate
                         }
                         Err(e) => {

--- a/crates/batcher/encoder/src/channel.rs
+++ b/crates/batcher/encoder/src/channel.rs
@@ -66,13 +66,25 @@ pub enum ChannelCloseReason {
 }
 
 impl ChannelCloseReason {
-    /// Returns the bounded metric label for this reason.
-    pub const fn metric_label(self) -> &'static str {
+    /// Returns the label for `channel_closed_total`.
+    ///
+    /// Both size-driven closes collapse onto `size_full` because that series predates the
+    /// soft-target and protocol-limit split. Use [`Self::cause_label`] for the finer view.
+    pub const fn reason_label(self) -> &'static str {
         match self {
-            Self::SoftTarget => BatcherMetrics::REASON_SOFT_TARGET,
-            Self::ProtocolLimit => BatcherMetrics::REASON_PROTOCOL_LIMIT,
+            Self::SoftTarget | Self::ProtocolLimit => BatcherMetrics::REASON_SIZE_FULL,
             Self::Timeout => BatcherMetrics::REASON_TIMEOUT,
-            Self::Flush => BatcherMetrics::REASON_FLUSH,
+            Self::Flush => BatcherMetrics::REASON_FORCE,
+        }
+    }
+
+    /// Returns the label for `channel_close_cause_total`.
+    pub const fn cause_label(self) -> &'static str {
+        match self {
+            Self::SoftTarget => BatcherMetrics::CAUSE_SOFT_TARGET,
+            Self::ProtocolLimit => BatcherMetrics::CAUSE_PROTOCOL_LIMIT,
+            Self::Timeout => BatcherMetrics::CAUSE_TIMEOUT,
+            Self::Flush => BatcherMetrics::CAUSE_FLUSH,
         }
     }
 }

--- a/crates/batcher/encoder/src/channel.rs
+++ b/crates/batcher/encoder/src/channel.rs
@@ -66,25 +66,13 @@ pub enum ChannelCloseReason {
 }
 
 impl ChannelCloseReason {
-    /// Returns the label for `channel_closed_total`.
-    ///
-    /// Both size-driven closes collapse onto `size_full` because that series predates the
-    /// soft-target and protocol-limit split. Use [`Self::cause_label`] for the finer view.
-    pub const fn reason_label(self) -> &'static str {
+    /// Returns the bounded metric label for this reason.
+    pub const fn metric_label(self) -> &'static str {
         match self {
-            Self::SoftTarget | Self::ProtocolLimit => BatcherMetrics::REASON_SIZE_FULL,
+            Self::SoftTarget => BatcherMetrics::REASON_SOFT_TARGET,
+            Self::ProtocolLimit => BatcherMetrics::REASON_PROTOCOL_LIMIT,
             Self::Timeout => BatcherMetrics::REASON_TIMEOUT,
-            Self::Flush => BatcherMetrics::REASON_FORCE,
-        }
-    }
-
-    /// Returns the label for `channel_close_cause_total`.
-    pub const fn cause_label(self) -> &'static str {
-        match self {
-            Self::SoftTarget => BatcherMetrics::CAUSE_SOFT_TARGET,
-            Self::ProtocolLimit => BatcherMetrics::CAUSE_PROTOCOL_LIMIT,
-            Self::Timeout => BatcherMetrics::CAUSE_TIMEOUT,
-            Self::Flush => BatcherMetrics::CAUSE_FLUSH,
+            Self::Flush => BatcherMetrics::REASON_FLUSH,
         }
     }
 }

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -161,8 +161,6 @@ impl BatchEncoder {
         BatcherMetrics::channel_closed_total(close_reason.metric_label()).increment(1);
         BatcherMetrics::channel_duration_blocks().record(duration_blocks as f64);
         BatcherMetrics::l2_blocks_per_channel().record(blocks_added as f64);
-        BatcherMetrics::input_bytes(BatcherMetrics::STAGE_CLOSED).set(input_bytes as f64);
-        BatcherMetrics::output_bytes().set(compressed_bytes as f64);
         BatcherMetrics::input_bytes_total().increment(input_bytes);
         BatcherMetrics::output_bytes_total().increment(compressed_bytes);
         if input_bytes > 0 {
@@ -494,8 +492,6 @@ impl BatchPipeline for BatchEncoder {
         match outcome {
             accepted @ (ChannelAddOutcome::Accepted | ChannelAddOutcome::TargetReached) => {
                 // Cursor advances only after accept, so a later reject retries this block.
-                BatcherMetrics::input_bytes(BatcherMetrics::STAGE_ADDED)
-                    .set(channel.input_bytes() as f64);
                 self.block_cursor += 1;
                 if accepted == ChannelAddOutcome::TargetReached {
                     self.close_current_channel(ChannelCloseReason::SoftTarget)?;
@@ -543,10 +539,6 @@ impl BatchPipeline for BatchEncoder {
         let frame_count = submission.frame_count();
         let blob_count = submission.blob_count();
         BatcherMetrics::pending_frames().set(self.egress.artifacts().ready_frame_count() as f64);
-        if let Some(channel) = self.channels.iter().rev().find(|channel| channel.framing_complete())
-        {
-            BatcherMetrics::channel_num_frames().set(channel.frame_count() as f64);
-        }
         debug!(
             id = %id.0,
             frame_count = %frame_count,

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -150,7 +150,7 @@ impl BatchEncoder {
             frames_emitted = %frames_emitted,
             encoded_block_range_start = %channel.block_range().start,
             encoded_block_range_end = %channel.block_range().end,
-            close_reason = %close_reason.cause_label(),
+            close_reason = %close_reason.metric_label(),
             duration_blocks = %duration_blocks,
             input_bytes = %input_bytes,
             compressed_bytes = %compressed_bytes,
@@ -158,13 +158,9 @@ impl BatchEncoder {
         );
 
         // Close metrics.
-        BatcherMetrics::channel_closed_total(close_reason.reason_label()).increment(1);
-        BatcherMetrics::channel_close_cause_total(close_reason.cause_label()).increment(1);
+        BatcherMetrics::channel_closed_total(close_reason.metric_label()).increment(1);
         BatcherMetrics::channel_duration_blocks().record(duration_blocks as f64);
         BatcherMetrics::l2_blocks_per_channel().record(blocks_added as f64);
-        BatcherMetrics::input_bytes(BatcherMetrics::STAGE_CLOSED).set(input_bytes as f64);
-        BatcherMetrics::output_bytes().set(compressed_bytes as f64);
-        BatcherMetrics::channel_num_frames().set(frames_emitted as f64);
         BatcherMetrics::input_bytes_total().increment(input_bytes);
         BatcherMetrics::output_bytes_total().increment(compressed_bytes);
         if input_bytes > 0 {
@@ -495,8 +491,6 @@ impl BatchPipeline for BatchEncoder {
 
         match outcome {
             accepted @ (ChannelAddOutcome::Accepted | ChannelAddOutcome::TargetReached) => {
-                BatcherMetrics::input_bytes(BatcherMetrics::STAGE_ADDED)
-                    .set(channel.input_bytes() as f64);
                 // Cursor advances only after accept, so a later reject retries this block.
                 self.block_cursor += 1;
                 if accepted == ChannelAddOutcome::TargetReached {
@@ -511,8 +505,6 @@ impl BatchPipeline for BatchEncoder {
                 if channel.is_empty() {
                     self.channels.pop_back();
                     BatcherMetrics::channel_closed_total(BatcherMetrics::REASON_DISCARD)
-                        .increment(1);
-                    BatcherMetrics::channel_close_cause_total(BatcherMetrics::CAUSE_DISCARD)
                         .increment(1);
                     return Err(StepError::BlockExceedsChannelLimit {
                         cursor: self.block_cursor,

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -150,7 +150,7 @@ impl BatchEncoder {
             frames_emitted = %frames_emitted,
             encoded_block_range_start = %channel.block_range().start,
             encoded_block_range_end = %channel.block_range().end,
-            close_reason = %close_reason.metric_label(),
+            close_reason = %close_reason.cause_label(),
             duration_blocks = %duration_blocks,
             input_bytes = %input_bytes,
             compressed_bytes = %compressed_bytes,
@@ -158,9 +158,13 @@ impl BatchEncoder {
         );
 
         // Close metrics.
-        BatcherMetrics::channel_closed_total(close_reason.metric_label()).increment(1);
+        BatcherMetrics::channel_closed_total(close_reason.reason_label()).increment(1);
+        BatcherMetrics::channel_close_cause_total(close_reason.cause_label()).increment(1);
         BatcherMetrics::channel_duration_blocks().record(duration_blocks as f64);
         BatcherMetrics::l2_blocks_per_channel().record(blocks_added as f64);
+        BatcherMetrics::input_bytes(BatcherMetrics::STAGE_CLOSED).set(input_bytes as f64);
+        BatcherMetrics::output_bytes().set(compressed_bytes as f64);
+        BatcherMetrics::channel_num_frames().set(frames_emitted as f64);
         BatcherMetrics::input_bytes_total().increment(input_bytes);
         BatcherMetrics::output_bytes_total().increment(compressed_bytes);
         if input_bytes > 0 {
@@ -491,6 +495,8 @@ impl BatchPipeline for BatchEncoder {
 
         match outcome {
             accepted @ (ChannelAddOutcome::Accepted | ChannelAddOutcome::TargetReached) => {
+                BatcherMetrics::input_bytes(BatcherMetrics::STAGE_ADDED)
+                    .set(channel.input_bytes() as f64);
                 // Cursor advances only after accept, so a later reject retries this block.
                 self.block_cursor += 1;
                 if accepted == ChannelAddOutcome::TargetReached {
@@ -505,6 +511,8 @@ impl BatchPipeline for BatchEncoder {
                 if channel.is_empty() {
                     self.channels.pop_back();
                     BatcherMetrics::channel_closed_total(BatcherMetrics::REASON_DISCARD)
+                        .increment(1);
+                    BatcherMetrics::channel_close_cause_total(BatcherMetrics::CAUSE_DISCARD)
                         .increment(1);
                     return Err(StepError::BlockExceedsChannelLimit {
                         cursor: self.block_cursor,

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -311,6 +311,7 @@ impl BatchEncoder {
             "confirmed channel exceeded derivation timeout, replaying blocks"
         );
 
+        BatcherMetrics::channel_replay_total().increment(1);
         self.egress.invalidate_artifacts(&affected_artifacts);
         BatcherMetrics::pending_frames().set(self.egress.artifacts().ready_frame_count() as f64);
         self.channels.truncate(replay_idx);

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -13,6 +13,10 @@ base_metrics::define_metrics! {
     channel_closed_total: counter,
     #[describe("Total number of channels for which every frame was confirmed on L1")]
     channel_fully_submitted_total: counter,
+    #[describe(
+        "Total channel replay operations caused by an expired derivation confirmation window"
+    )]
+    channel_replay_total: counter,
     #[describe("Total number of batcher pipeline resets, by reason")]
     #[label(
         name = "reason",

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -73,6 +73,14 @@ base_metrics::define_metrics! {
         ]
     )]
     pipeline_reset_total: counter,
+    #[describe(
+        "EIP-4844 blobs carried by one blob batch transaction, sampled once per submission attempt"
+    )]
+    blobs_per_tx: histogram,
+    #[describe(
+        "Share of one blob's frame capacity filled by its packed frames, sampled per blob per submission attempt"
+    )]
+    blob_fill_ratio: histogram,
 }
 
 impl BatcherMetrics {

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -6,29 +6,25 @@ base_metrics::define_metrics! {
     #[describe("Total number of encoding channels opened")]
     channel_opened_total: counter,
     #[describe("Total number of encoding channels closed")]
-    #[label(reason)]
+    #[label(
+        name = "reason",
+        default = ["soft_target", "protocol_limit", "timeout", "flush", "discard"]
+    )]
     channel_closed_total: counter,
     #[describe("Total number of channels for which every frame was confirmed on L1")]
     channel_fully_submitted_total: counter,
     #[describe("Total number of L1 batch submissions")]
-    #[label(outcome)]
+    #[label(name = "outcome", default = ["submitted", "confirmed", "failed", "requeued"])]
     submission_total: counter,
     #[describe("Total bytes of frame payload submitted to the DA layer")]
-    #[label(da_type)]
+    #[label(name = "da_type", default = ["blob", "calldata"])]
     da_bytes_submitted_total: counter,
     #[describe("Total bytes of frame payload packed into EIP-4844 blobs")]
     blob_used_bytes_total: counter,
-    #[describe("Number of input bytes to a channel")]
-    #[label(name = "stage", default = ["added", "closed"])]
-    input_bytes: gauge,
-    #[describe("Number of compressed output bytes from a channel")]
-    output_bytes: gauge,
     #[describe("Total number of input bytes to channels")]
     input_bytes_total: counter,
     #[describe("Total number of compressed output bytes from channels")]
     output_bytes_total: counter,
-    #[describe("Total number of frames assigned when channel framing completes")]
-    channel_num_frames: gauge,
     #[describe("Batcher signer account balance in ether")]
     #[no_zero]
     balance: gauge,
@@ -61,12 +57,6 @@ impl BatcherMetrics {
 
     /// Channel discarded because its first block exceeded channel limits.
     pub const REASON_DISCARD: &'static str = "discard";
-
-    /// Channel input bytes after blocks have been added.
-    pub const STAGE_ADDED: &'static str = "added";
-
-    /// Channel input bytes after the channel has been closed.
-    pub const STAGE_CLOSED: &'static str = "closed";
 
     /// Submission accepted and handed to the tx manager.
     pub const OUTCOME_SUBMITTED: &'static str = "submitted";

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -13,6 +13,19 @@ base_metrics::define_metrics! {
     channel_closed_total: counter,
     #[describe("Total number of channels for which every frame was confirmed on L1")]
     channel_fully_submitted_total: counter,
+    #[describe("Total number of times buffered pipeline state was dropped and rebuilt")]
+    #[label(
+        name = "reason",
+        default = [
+            "source_reorg",
+            "ingest_reorg",
+            "safe_head_reorg",
+            "safe_head_mismatch",
+            "stalled_channel",
+            "admin_pause",
+        ]
+    )]
+    pipeline_reset_total: counter,
     #[describe("Total number of L1 batch submissions")]
     #[label(name = "outcome", default = ["submitted", "confirmed", "failed", "requeued"])]
     submission_total: counter,
@@ -57,6 +70,24 @@ impl BatcherMetrics {
 
     /// Channel discarded because its first block exceeded channel limits.
     pub const REASON_DISCARD: &'static str = "discard";
+
+    /// The block source signalled an L2 reorg.
+    pub const RESET_SOURCE_REORG: &'static str = "source_reorg";
+
+    /// A parent-hash mismatch surfaced while adding a block to the pipeline.
+    pub const RESET_INGEST_REORG: &'static str = "ingest_reorg";
+
+    /// The derivation status reported a safe head that moved back or changed hash.
+    pub const RESET_SAFE_HEAD_REORG: &'static str = "safe_head_reorg";
+
+    /// The derived safe head does not match the buffered chain.
+    pub const RESET_SAFE_HEAD_MISMATCH: &'static str = "safe_head_mismatch";
+
+    /// The rollup node passed a fully confirmed channel without deriving it.
+    pub const RESET_STALLED_CHANNEL: &'static str = "stalled_channel";
+
+    /// The batcher was paused through the admin API.
+    pub const RESET_ADMIN_PAUSE: &'static str = "admin_pause";
 
     /// Submission accepted and handed to the tx manager.
     pub const OUTCOME_SUBMITTED: &'static str = "submitted";

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -6,13 +6,60 @@ base_metrics::define_metrics! {
     #[describe("Total number of encoding channels opened")]
     channel_opened_total: counter,
     #[describe("Total number of encoding channels closed")]
-    #[label(
-        name = "reason",
-        default = ["soft_target", "protocol_limit", "timeout", "flush", "discard"]
-    )]
+    #[label(reason)]
     channel_closed_total: counter,
     #[describe("Total number of channels for which every frame was confirmed on L1")]
     channel_fully_submitted_total: counter,
+    #[describe("Total number of L1 batch submissions")]
+    #[label(outcome)]
+    submission_total: counter,
+    #[describe("Total bytes of frame payload submitted to the DA layer")]
+    #[label(da_type)]
+    da_bytes_submitted_total: counter,
+    #[describe("Total bytes of frame payload packed into EIP-4844 blobs")]
+    blob_used_bytes_total: counter,
+    #[describe("Number of input bytes to a channel")]
+    #[label(name = "stage", default = ["added", "closed"])]
+    input_bytes: gauge,
+    #[describe("Number of compressed output bytes from a channel")]
+    output_bytes: gauge,
+    #[describe("Total number of input bytes to channels")]
+    input_bytes_total: counter,
+    #[describe("Total number of compressed output bytes from channels")]
+    output_bytes_total: counter,
+    #[describe("Total number of frames in the closed channel")]
+    channel_num_frames: gauge,
+    #[describe("Batcher signer account balance in ether")]
+    #[no_zero]
+    balance: gauge,
+    #[describe("Number of frames currently waiting for L1 submission")]
+    pending_frames: gauge,
+    #[describe("Number of L2 blocks buffered in the encoder input queue")]
+    pending_blocks: gauge,
+    #[describe("Number of L1 transactions currently in-flight")]
+    in_flight_submissions: gauge,
+    #[describe("Compression ratio for each closed channel")]
+    channel_compression_ratio: histogram,
+    #[describe("Channel lifetime in L1 blocks")]
+    channel_duration_blocks: histogram,
+    #[describe("Number of L2 blocks included in each closed channel")]
+    l2_blocks_per_channel: histogram,
+
+    // ======================================================================
+    // TEMPORARY — shadow base-batcher rollout
+    //
+    // Feeding the shadow batcher Datadog dashboard on Zeronet. Deliberately
+    // additive: some of these duplicate a series above instead of reshaping
+    // it, so nothing already deployed breaks. Revisit once the rollout ends,
+    // either folding them into the metrics above with their owners or dropping
+    // them.
+    // ======================================================================
+    #[describe("Total number of encoding channels closed, by fine-grained cause")]
+    #[label(
+        name = "cause",
+        default = ["soft_target", "protocol_limit", "timeout", "flush", "discard"]
+    )]
+    channel_close_cause_total: counter,
     #[describe("Total number of times buffered pipeline state was dropped and rebuilt")]
     #[label(
         name = "reason",
@@ -26,68 +73,26 @@ base_metrics::define_metrics! {
         ]
     )]
     pipeline_reset_total: counter,
-    #[describe("Total number of L1 batch submissions")]
-    #[label(name = "outcome", default = ["submitted", "confirmed", "failed", "requeued"])]
-    submission_total: counter,
-    #[describe("Total bytes of frame payload submitted to the DA layer")]
-    #[label(name = "da_type", default = ["blob", "calldata"])]
-    da_bytes_submitted_total: counter,
-    #[describe("Total bytes of frame payload packed into EIP-4844 blobs")]
-    blob_used_bytes_total: counter,
-    #[describe("Total number of input bytes to channels")]
-    input_bytes_total: counter,
-    #[describe("Total number of compressed output bytes from channels")]
-    output_bytes_total: counter,
-    #[describe("Batcher signer account balance in ether")]
-    #[no_zero]
-    balance: gauge,
-    #[describe("Number of immutable artifact frames currently ready for L1 submission")]
-    pending_frames: gauge,
-    #[describe("Number of L2 blocks buffered in the encoder input queue")]
-    pending_blocks: gauge,
-    #[describe("Number of L1 transactions currently in-flight")]
-    in_flight_submissions: gauge,
-    #[describe("Compression ratio for each closed channel")]
-    channel_compression_ratio: histogram,
-    #[describe("Channel lifetime in L1 blocks")]
-    channel_duration_blocks: histogram,
-    #[describe("Number of L2 blocks included in each closed channel")]
-    l2_blocks_per_channel: histogram,
 }
 
 impl BatcherMetrics {
-    /// Channel closed because its soft compressed-size target was reached.
-    pub const REASON_SOFT_TARGET: &'static str = "soft_target";
-
-    /// Channel closed before a batch that would exceed a hard protocol limit.
-    pub const REASON_PROTOCOL_LIMIT: &'static str = "protocol_limit";
+    /// Channel closed because the compressed frame data reached the target size.
+    pub const REASON_SIZE_FULL: &'static str = "size_full";
 
     /// Channel closed because it reached `max_channel_duration` L1 blocks.
     pub const REASON_TIMEOUT: &'static str = "timeout";
 
-    /// Channel closed by an explicit flush signal.
-    pub const REASON_FLUSH: &'static str = "flush";
+    /// Channel closed by an explicit force-flush signal.
+    pub const REASON_FORCE: &'static str = "force";
 
     /// Channel discarded because its first block exceeded channel limits.
     pub const REASON_DISCARD: &'static str = "discard";
 
-    /// The block source signalled an L2 reorg.
-    pub const RESET_SOURCE_REORG: &'static str = "source_reorg";
+    /// Channel input bytes after blocks have been added.
+    pub const STAGE_ADDED: &'static str = "added";
 
-    /// A parent-hash mismatch surfaced while adding a block to the pipeline.
-    pub const RESET_INGEST_REORG: &'static str = "ingest_reorg";
-
-    /// The derivation status reported a safe head that moved back or changed hash.
-    pub const RESET_SAFE_HEAD_REORG: &'static str = "safe_head_reorg";
-
-    /// The derived safe head does not match the buffered chain.
-    pub const RESET_SAFE_HEAD_MISMATCH: &'static str = "safe_head_mismatch";
-
-    /// The rollup node passed a fully confirmed channel without deriving it.
-    pub const RESET_STALLED_CHANNEL: &'static str = "stalled_channel";
-
-    /// The batcher was paused through the admin API.
-    pub const RESET_ADMIN_PAUSE: &'static str = "admin_pause";
+    /// Channel input bytes after the channel has been closed.
+    pub const STAGE_CLOSED: &'static str = "closed";
 
     /// Submission accepted and handed to the tx manager.
     pub const OUTCOME_SUBMITTED: &'static str = "submitted";
@@ -106,4 +111,47 @@ impl BatcherMetrics {
 
     /// Calldata DA: frames encoded as L1 transaction calldata.
     pub const DA_TYPE_CALLDATA: &'static str = "calldata";
+
+    // ======================================================================
+    // TEMPORARY — shadow base-batcher rollout: label values for the metrics
+    // added above.
+    // ======================================================================
+
+    /// Channel closed because its soft compressed-size target was reached.
+    ///
+    /// Reported as `size_full` by `channel_closed_total`, which cannot distinguish
+    /// this from a hard protocol limit.
+    pub const CAUSE_SOFT_TARGET: &'static str = "soft_target";
+
+    /// Channel closed before a batch that would exceed a hard protocol limit.
+    ///
+    /// Also reported as `size_full` by `channel_closed_total`.
+    pub const CAUSE_PROTOCOL_LIMIT: &'static str = "protocol_limit";
+
+    /// Channel closed because it reached `max_channel_duration` L1 blocks.
+    pub const CAUSE_TIMEOUT: &'static str = "timeout";
+
+    /// Channel closed by an explicit flush signal.
+    pub const CAUSE_FLUSH: &'static str = "flush";
+
+    /// Channel discarded because its first block exceeded channel limits.
+    pub const CAUSE_DISCARD: &'static str = "discard";
+
+    /// The block source signalled an L2 reorg.
+    pub const RESET_SOURCE_REORG: &'static str = "source_reorg";
+
+    /// A parent-hash mismatch surfaced while adding a block to the pipeline.
+    pub const RESET_INGEST_REORG: &'static str = "ingest_reorg";
+
+    /// The derivation status reported a safe head that moved back or changed hash.
+    pub const RESET_SAFE_HEAD_REORG: &'static str = "safe_head_reorg";
+
+    /// The derived safe head does not match the buffered chain.
+    pub const RESET_SAFE_HEAD_MISMATCH: &'static str = "safe_head_mismatch";
+
+    /// The rollup node passed a fully confirmed channel without deriving it.
+    pub const RESET_STALLED_CHANNEL: &'static str = "stalled_channel";
+
+    /// The batcher was paused through the admin API.
+    pub const RESET_ADMIN_PAUSE: &'static str = "admin_pause";
 }

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -5,62 +5,15 @@ base_metrics::define_metrics! {
     struct = BatcherMetrics,
     #[describe("Total number of encoding channels opened")]
     channel_opened_total: counter,
-    #[describe("Total number of encoding channels closed")]
-    #[label(reason)]
+    #[describe("Total number of encoding channels closed, by reason")]
+    #[label(
+        name = "reason",
+        default = ["soft_target", "protocol_limit", "timeout", "flush", "discard"]
+    )]
     channel_closed_total: counter,
     #[describe("Total number of channels for which every frame was confirmed on L1")]
     channel_fully_submitted_total: counter,
-    #[describe("Total number of L1 batch submissions")]
-    #[label(outcome)]
-    submission_total: counter,
-    #[describe("Total bytes of frame payload submitted to the DA layer")]
-    #[label(da_type)]
-    da_bytes_submitted_total: counter,
-    #[describe("Total bytes of frame payload packed into EIP-4844 blobs")]
-    blob_used_bytes_total: counter,
-    #[describe("Number of input bytes to a channel")]
-    #[label(name = "stage", default = ["added", "closed"])]
-    input_bytes: gauge,
-    #[describe("Number of compressed output bytes from a channel")]
-    output_bytes: gauge,
-    #[describe("Total number of input bytes to channels")]
-    input_bytes_total: counter,
-    #[describe("Total number of compressed output bytes from channels")]
-    output_bytes_total: counter,
-    #[describe("Total number of frames in the closed channel")]
-    channel_num_frames: gauge,
-    #[describe("Batcher signer account balance in ether")]
-    #[no_zero]
-    balance: gauge,
-    #[describe("Number of frames currently waiting for L1 submission")]
-    pending_frames: gauge,
-    #[describe("Number of L2 blocks buffered in the encoder input queue")]
-    pending_blocks: gauge,
-    #[describe("Number of L1 transactions currently in-flight")]
-    in_flight_submissions: gauge,
-    #[describe("Compression ratio for each closed channel")]
-    channel_compression_ratio: histogram,
-    #[describe("Channel lifetime in L1 blocks")]
-    channel_duration_blocks: histogram,
-    #[describe("Number of L2 blocks included in each closed channel")]
-    l2_blocks_per_channel: histogram,
-
-    // ======================================================================
-    // TEMPORARY — shadow base-batcher rollout
-    //
-    // Feeding the shadow batcher Datadog dashboard on Zeronet. Deliberately
-    // additive: some of these duplicate a series above instead of reshaping
-    // it, so nothing already deployed breaks. Revisit once the rollout ends,
-    // either folding them into the metrics above with their owners or dropping
-    // them.
-    // ======================================================================
-    #[describe("Total number of encoding channels closed, by fine-grained cause")]
-    #[label(
-        name = "cause",
-        default = ["soft_target", "protocol_limit", "timeout", "flush", "discard"]
-    )]
-    channel_close_cause_total: counter,
-    #[describe("Total number of times buffered pipeline state was dropped and rebuilt")]
+    #[describe("Total number of batcher pipeline resets, by reason")]
     #[label(
         name = "reason",
         default = [
@@ -73,77 +26,56 @@ base_metrics::define_metrics! {
         ]
     )]
     pipeline_reset_total: counter,
-    #[describe(
-        "EIP-4844 blobs carried by one blob batch transaction, sampled once per submission attempt"
-    )]
+    #[describe("Total number of L1 batch submissions")]
+    #[label(name = "outcome", default = ["submitted", "confirmed", "failed", "requeued"])]
+    submission_total: counter,
+    #[describe("Total bytes of frame payload submitted to the DA layer")]
+    #[label(name = "da_type", default = ["blob", "calldata"])]
+    da_bytes_submitted_total: counter,
+    #[describe("Total bytes of frame payload packed into EIP-4844 blobs")]
+    blob_used_bytes_total: counter,
+    #[describe("Total number of input bytes to channels")]
+    input_bytes_total: counter,
+    #[describe("Total number of compressed output bytes from channels")]
+    output_bytes_total: counter,
+    #[describe("Batcher signer account balance in ether")]
+    #[no_zero]
+    balance: gauge,
+    #[describe("Number of immutable artifact frames currently ready for L1 submission")]
+    pending_frames: gauge,
+    #[describe("Number of L2 blocks buffered in the encoder input queue")]
+    pending_blocks: gauge,
+    #[describe("Number of L1 transactions currently in-flight")]
+    in_flight_submissions: gauge,
+    #[describe("Compression ratio for each closed channel")]
+    channel_compression_ratio: histogram,
+    #[describe("Channel lifetime in L1 blocks")]
+    channel_duration_blocks: histogram,
+    #[describe("Number of L2 blocks included in each closed channel")]
+    l2_blocks_per_channel: histogram,
+    #[describe("Number of EIP-4844 blobs per blob transaction submission attempt")]
     blobs_per_tx: histogram,
     #[describe(
-        "Share of one blob's frame capacity filled by its packed frames, sampled per blob per submission attempt"
+        "Fraction of one blob's frame capacity used, sampled per blob submission attempt"
     )]
     blob_fill_ratio: histogram,
 }
 
 impl BatcherMetrics {
-    /// Channel closed because the compressed frame data reached the target size.
-    pub const REASON_SIZE_FULL: &'static str = "size_full";
+    /// Channel closed because its soft compressed-size target was reached.
+    pub const REASON_SOFT_TARGET: &'static str = "soft_target";
 
-    /// Channel closed because it reached `max_channel_duration` L1 blocks.
+    /// Channel closed before a batch that would exceed a hard protocol limit.
+    pub const REASON_PROTOCOL_LIMIT: &'static str = "protocol_limit";
+
+    /// Channel closed because it reached its configured L1 deadline.
     pub const REASON_TIMEOUT: &'static str = "timeout";
 
-    /// Channel closed by an explicit force-flush signal.
-    pub const REASON_FORCE: &'static str = "force";
+    /// Channel closed by an explicit flush signal.
+    pub const REASON_FLUSH: &'static str = "flush";
 
     /// Channel discarded because its first block exceeded channel limits.
     pub const REASON_DISCARD: &'static str = "discard";
-
-    /// Channel input bytes after blocks have been added.
-    pub const STAGE_ADDED: &'static str = "added";
-
-    /// Channel input bytes after the channel has been closed.
-    pub const STAGE_CLOSED: &'static str = "closed";
-
-    /// Submission accepted and handed to the tx manager.
-    pub const OUTCOME_SUBMITTED: &'static str = "submitted";
-
-    /// Submission confirmed on L1.
-    pub const OUTCOME_CONFIRMED: &'static str = "confirmed";
-
-    /// Submission failed (tx reverted or timed out) and was requeued.
-    pub const OUTCOME_FAILED: &'static str = "failed";
-
-    /// Submission requeued due to txpool blockage.
-    pub const OUTCOME_REQUEUED: &'static str = "requeued";
-
-    /// Blob DA: frames encoded into EIP-4844 blobs.
-    pub const DA_TYPE_BLOB: &'static str = "blob";
-
-    /// Calldata DA: frames encoded as L1 transaction calldata.
-    pub const DA_TYPE_CALLDATA: &'static str = "calldata";
-
-    // ======================================================================
-    // TEMPORARY — shadow base-batcher rollout: label values for the metrics
-    // added above.
-    // ======================================================================
-
-    /// Channel closed because its soft compressed-size target was reached.
-    ///
-    /// Reported as `size_full` by `channel_closed_total`, which cannot distinguish
-    /// this from a hard protocol limit.
-    pub const CAUSE_SOFT_TARGET: &'static str = "soft_target";
-
-    /// Channel closed before a batch that would exceed a hard protocol limit.
-    ///
-    /// Also reported as `size_full` by `channel_closed_total`.
-    pub const CAUSE_PROTOCOL_LIMIT: &'static str = "protocol_limit";
-
-    /// Channel closed because it reached `max_channel_duration` L1 blocks.
-    pub const CAUSE_TIMEOUT: &'static str = "timeout";
-
-    /// Channel closed by an explicit flush signal.
-    pub const CAUSE_FLUSH: &'static str = "flush";
-
-    /// Channel discarded because its first block exceeded channel limits.
-    pub const CAUSE_DISCARD: &'static str = "discard";
 
     /// The block source signalled an L2 reorg.
     pub const RESET_SOURCE_REORG: &'static str = "source_reorg";
@@ -162,4 +94,22 @@ impl BatcherMetrics {
 
     /// The batcher was paused through the admin API.
     pub const RESET_ADMIN_PAUSE: &'static str = "admin_pause";
+
+    /// Submission accepted and handed to the tx manager.
+    pub const OUTCOME_SUBMITTED: &'static str = "submitted";
+
+    /// Submission confirmed on L1.
+    pub const OUTCOME_CONFIRMED: &'static str = "confirmed";
+
+    /// Submission failed (tx reverted or timed out) and was requeued.
+    pub const OUTCOME_FAILED: &'static str = "failed";
+
+    /// Submission requeued due to txpool blockage.
+    pub const OUTCOME_REQUEUED: &'static str = "requeued";
+
+    /// Blob DA: frames encoded into EIP-4844 blobs.
+    pub const DA_TYPE_BLOB: &'static str = "blob";
+
+    /// Calldata DA: frames encoded as L1 transaction calldata.
+    pub const DA_TYPE_CALLDATA: &'static str = "calldata";
 }

--- a/crates/batcher/encoder/src/submission.rs
+++ b/crates/batcher/encoder/src/submission.rs
@@ -40,6 +40,15 @@ impl BlobPayload {
     pub fn frames(&self) -> &[Arc<Frame>] {
         &self.frames
     }
+
+    /// Returns the encoded frame bytes packed into this blob.
+    ///
+    /// Excludes the derivation-version prefix, so the result is directly comparable
+    /// to [`DaEgress::BLOB_CAPACITY`](crate::DaEgress::BLOB_CAPACITY), the budget the
+    /// packer fills.
+    pub fn frame_bytes(&self) -> usize {
+        self.frames.iter().map(|frame| frame.encoded_len()).sum()
+    }
 }
 
 /// Payload carried by one L1 batch transaction.

--- a/crates/batcher/service/src/l2_block_parity.rs
+++ b/crates/batcher/service/src/l2_block_parity.rs
@@ -161,13 +161,6 @@ pub struct L2BlockParityStats {
     pub missing_blocks: usize,
 }
 
-impl L2BlockParityStats {
-    /// Returns true if this pass found no mismatch or missing block.
-    pub const fn is_aligned(self) -> bool {
-        self.mismatches == 0 && self.missing_blocks == 0
-    }
-}
-
 /// One derived L2 block parity comparison result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum L2BlockParityResult {
@@ -244,9 +237,9 @@ where
     ///
     /// Measured against the common unsafe head because a pass never walks past
     /// `min(sequencer, validator)`: a validator trailing the sequencer is already reported by
-    /// `lag_blocks`, so what is left here is the monitor's own progress. A pass advances by
-    /// at most `max_blocks_per_tick`, so this grows both while the monitor is catching up
-    /// and while the cursor is parked on a block it cannot fetch.
+    /// `validator_unsafe_lag_blocks`, so what is left here is the monitor's own progress. A pass
+    /// advances by at most `max_blocks_per_tick`, so this grows both while the monitor is
+    /// catching up and while the cursor is parked on a block it cannot fetch.
     pub const fn verification_backlog(&self, common_unsafe: u64) -> u64 {
         common_unsafe.saturating_add(1).saturating_sub(self.next_block)
     }
@@ -268,8 +261,7 @@ where
             }
 
             if let Err(error) = self.process_once().await {
-                L2BlockParityMetrics::fetch_errors_total().increment(1);
-                L2BlockParityMetrics::scoped_fetch_errors_total(L2BlockParityMetrics::SCOPE_PASS)
+                L2BlockParityMetrics::fetch_errors_total(L2BlockParityMetrics::SCOPE_PASS)
                     .increment(1);
                 error!(error = %error, "derived L2 block parity pass failed");
             }
@@ -289,9 +281,9 @@ where
         let validator_unsafe = self.validator.unsafe_block_number().await?;
         // Metrics gauges are f64-backed; integer block numbers remain exact
         // through 2^53, far above any realistic L2 height for this monitor.
-        L2BlockParityMetrics::sequencer_latest_l2_block().set(sequencer_unsafe as f64);
-        L2BlockParityMetrics::validator_latest_l2_block().set(validator_unsafe as f64);
-        L2BlockParityMetrics::lag_blocks()
+        L2BlockParityMetrics::sequencer_unsafe_l2_block().set(sequencer_unsafe as f64);
+        L2BlockParityMetrics::validator_unsafe_l2_block().set(validator_unsafe as f64);
+        L2BlockParityMetrics::validator_unsafe_lag_blocks()
             .set(sequencer_unsafe.saturating_sub(validator_unsafe) as f64);
         match self.sequencer.safe_block_number().await {
             Ok(number) => L2BlockParityMetrics::sequencer_safe_l2_block().set(number as f64),
@@ -307,8 +299,6 @@ where
             .set(self.verification_backlog(common_unsafe) as f64);
 
         if common_unsafe < self.next_block {
-            let aligned = if sequencer_unsafe == validator_unsafe { 1.0 } else { 0.0 };
-            L2BlockParityMetrics::aligned().set(aligned);
             debug!(
                 next_block = %self.next_block,
                 sequencer_unsafe = %sequencer_unsafe,
@@ -330,11 +320,8 @@ where
                     self.next_block = next_block;
                 }
                 Err(error) => {
-                    L2BlockParityMetrics::fetch_errors_total().increment(1);
-                    L2BlockParityMetrics::scoped_fetch_errors_total(
-                        L2BlockParityMetrics::SCOPE_BLOCK,
-                    )
-                    .increment(1);
+                    L2BlockParityMetrics::fetch_errors_total(L2BlockParityMetrics::SCOPE_BLOCK)
+                        .increment(1);
                     warn!(
                         error = %error,
                         l2_block = %number,
@@ -347,14 +334,6 @@ where
 
         L2BlockParityMetrics::verification_backlog_blocks()
             .set(self.verification_backlog(common_unsafe) as f64);
-
-        let caught_up = self.next_block > common_unsafe;
-        let aligned = if caught_up && stats.is_aligned() && sequencer_unsafe == validator_unsafe {
-            1.0
-        } else {
-            0.0
-        };
-        L2BlockParityMetrics::aligned().set(aligned);
 
         if stats.checked > 0 || stats.missing_blocks > 0 {
             debug!(

--- a/crates/batcher/service/src/l2_block_parity.rs
+++ b/crates/batcher/service/src/l2_block_parity.rs
@@ -244,9 +244,9 @@ where
     ///
     /// Measured against the common unsafe head because a pass never walks past
     /// `min(sequencer, validator)`: a validator trailing the sequencer is already reported by
-    /// `lag_blocks`, so what is left here is the monitor's own progress. It grows only
-    /// while the cursor is parked on a block it cannot fetch, which is otherwise
-    /// indistinguishable from a healthy run that simply found no mismatch.
+    /// `lag_blocks`, so what is left here is the monitor's own progress. A pass advances by
+    /// at most `max_blocks_per_tick`, so this grows both while the monitor is catching up
+    /// and while the cursor is parked on a block it cannot fetch.
     pub const fn verification_backlog(&self, common_unsafe: u64) -> u64 {
         common_unsafe.saturating_add(1).saturating_sub(self.next_block)
     }

--- a/crates/batcher/service/src/l2_block_parity.rs
+++ b/crates/batcher/service/src/l2_block_parity.rs
@@ -148,13 +148,6 @@ pub struct L2BlockParityStats {
     pub missing_blocks: usize,
 }
 
-impl L2BlockParityStats {
-    /// Returns true if this pass found no mismatch or missing block.
-    pub const fn is_aligned(self) -> bool {
-        self.mismatches == 0 && self.missing_blocks == 0
-    }
-}
-
 /// One derived L2 block parity comparison result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum L2BlockParityResult {
@@ -227,9 +220,21 @@ where
         })
     }
 
+    /// Comparable L2 blocks the cursor has not reached yet.
+    ///
+    /// Measured against the common head because a pass never walks past
+    /// `min(sequencer, validator)`: a validator trailing the sequencer is already reported by
+    /// `lag_blocks`, so what is left here is the monitor's own progress. It grows only while the
+    /// cursor is parked on a block it cannot fetch, which is otherwise indistinguishable from a
+    /// healthy run that simply found no mismatch.
+    pub const fn verification_backlog(&self, common_latest: u64) -> u64 {
+        common_latest.saturating_add(1).saturating_sub(self.next_block)
+    }
+
     /// Runs the monitor loop until cancelled.
     pub async fn run(&mut self, cancellation: CancellationToken) {
         L2BlockParityMetrics::enabled().set(1.0);
+        L2BlockParityMetrics::start_l2_block().set(self.next_block as f64);
         info!(
             start_block = %self.next_block,
             poll_interval_ms = %self.config.poll_interval.as_millis(),
@@ -243,7 +248,8 @@ where
             }
 
             if let Err(error) = self.process_once().await {
-                L2BlockParityMetrics::fetch_errors_total().increment(1);
+                L2BlockParityMetrics::fetch_errors_total(L2BlockParityMetrics::SCOPE_PASS)
+                    .increment(1);
                 error!(error = %error, "derived L2 block parity pass failed");
             }
 
@@ -268,9 +274,10 @@ where
             .set(sequencer_latest.saturating_sub(validator_latest) as f64);
 
         let common_latest = sequencer_latest.min(validator_latest);
+        L2BlockParityMetrics::verification_backlog_blocks()
+            .set(self.verification_backlog(common_latest) as f64);
+
         if common_latest < self.next_block {
-            let aligned = if sequencer_latest == validator_latest { 1.0 } else { 0.0 };
-            L2BlockParityMetrics::aligned().set(aligned);
             debug!(
                 next_block = %self.next_block,
                 sequencer_latest = %sequencer_latest,
@@ -292,7 +299,8 @@ where
                     self.next_block = next_block;
                 }
                 Err(error) => {
-                    L2BlockParityMetrics::fetch_errors_total().increment(1);
+                    L2BlockParityMetrics::fetch_errors_total(L2BlockParityMetrics::SCOPE_BLOCK)
+                        .increment(1);
                     warn!(
                         error = %error,
                         l2_block = %number,
@@ -303,13 +311,8 @@ where
             }
         }
 
-        let caught_up = self.next_block > common_latest;
-        let aligned = if caught_up && stats.is_aligned() && sequencer_latest == validator_latest {
-            1.0
-        } else {
-            0.0
-        };
-        L2BlockParityMetrics::aligned().set(aligned);
+        L2BlockParityMetrics::verification_backlog_blocks()
+            .set(self.verification_backlog(common_latest) as f64);
 
         if stats.checked > 0 || stats.missing_blocks > 0 {
             debug!(
@@ -372,6 +375,9 @@ where
                 stats.mismatches += 1;
                 L2BlockParityMetrics::checked_total().increment(1);
                 L2BlockParityMetrics::mismatches_total().increment(1);
+                // Latched for the process lifetime: a divergence is a permanent fact about the
+                // chain, not a condition that clears once the next block happens to match.
+                L2BlockParityMetrics::divergence_detected().set(1.0);
                 L2BlockParityMetrics::last_checked_l2_block().set(sequencer.number as f64);
                 L2BlockParityMetrics::last_mismatch_l2_block().set(sequencer.number as f64);
                 let tx_mismatch = sequencer.first_tx_hash_mismatch(&validator);
@@ -548,6 +554,21 @@ mod tests {
 
         assert_eq!(stats, L2BlockParityStats::default());
         assert_eq!(monitor.next_block, 4);
+    }
+
+    #[tokio::test]
+    async fn verification_backlog_counts_blocks_left_below_the_common_head() {
+        let sequencer = Arc::new(Mutex::new(MockL2BlockProvider::new(9, [])));
+        let validator = Arc::new(Mutex::new(MockL2BlockProvider::new(9, [])));
+        let config = L2BlockParityMonitorConfig::new(7, Duration::from_secs(1));
+        let monitor = L2BlockParityMonitor::new(sequencer, validator, config);
+
+        // Blocks 7, 8 and 9 are comparable and none has been compared yet.
+        assert_eq!(monitor.verification_backlog(9), 3);
+        // Caught up: the cursor sits one past the common head.
+        assert_eq!(monitor.verification_backlog(6), 0);
+        // A common head below the cursor is a validator that has not caught up, not backlog.
+        assert_eq!(monitor.verification_backlog(2), 0);
     }
 
     #[tokio::test]

--- a/crates/batcher/service/src/l2_block_parity.rs
+++ b/crates/batcher/service/src/l2_block_parity.rs
@@ -21,8 +21,11 @@ pub const DEFAULT_MAX_BLOCKS_PER_TICK: usize = 25;
 /// Provider abstraction for derived L2 block parity checks.
 #[async_trait]
 pub trait L2BlockProvider: Send + Sync {
-    /// Fetch the latest L2 block number from this provider.
-    async fn latest_block_number(&self) -> eyre::Result<u64>;
+    /// Fetch the unsafe L2 head number from this provider.
+    async fn unsafe_block_number(&self) -> eyre::Result<u64>;
+
+    /// Fetch the safe L2 head number from this provider.
+    async fn safe_block_number(&self) -> eyre::Result<u64>;
 
     /// Fetch an L2 block snapshot by number.
     async fn block_by_number(&self, number: u64) -> eyre::Result<Option<L2BlockSnapshot>>;
@@ -45,11 +48,21 @@ impl RpcL2BlockProvider {
 
 #[async_trait]
 impl L2BlockProvider for RpcL2BlockProvider {
-    async fn latest_block_number(&self) -> eyre::Result<u64> {
+    async fn unsafe_block_number(&self) -> eyre::Result<u64> {
         self.provider
             .get_block_number()
             .await
-            .map_err(|e| eyre::eyre!("failed to fetch L2 latest block number: {e}"))
+            .map_err(|e| eyre::eyre!("failed to fetch unsafe L2 head number: {e}"))
+    }
+
+    async fn safe_block_number(&self) -> eyre::Result<u64> {
+        let block = self
+            .provider
+            .get_block_by_number(BlockNumberOrTag::Safe)
+            .await
+            .map_err(|e| eyre::eyre!("failed to fetch safe L2 head: {e}"))?
+            .ok_or_else(|| eyre::eyre!("safe L2 head unavailable"))?;
+        Ok(block.header.number)
     }
 
     async fn block_by_number(&self, number: u64) -> eyre::Result<Option<L2BlockSnapshot>> {
@@ -148,6 +161,13 @@ pub struct L2BlockParityStats {
     pub missing_blocks: usize,
 }
 
+impl L2BlockParityStats {
+    /// Returns true if this pass found no mismatch or missing block.
+    pub const fn is_aligned(self) -> bool {
+        self.mismatches == 0 && self.missing_blocks == 0
+    }
+}
+
 /// One derived L2 block parity comparison result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum L2BlockParityResult {
@@ -222,13 +242,13 @@ where
 
     /// Comparable L2 blocks the cursor has not reached yet.
     ///
-    /// Measured against the common head because a pass never walks past
+    /// Measured against the common unsafe head because a pass never walks past
     /// `min(sequencer, validator)`: a validator trailing the sequencer is already reported by
-    /// `lag_blocks`, so what is left here is the monitor's own progress. It grows only while the
-    /// cursor is parked on a block it cannot fetch, which is otherwise indistinguishable from a
-    /// healthy run that simply found no mismatch.
-    pub const fn verification_backlog(&self, common_latest: u64) -> u64 {
-        common_latest.saturating_add(1).saturating_sub(self.next_block)
+    /// `lag_blocks`, so what is left here is the monitor's own progress. It grows only
+    /// while the cursor is parked on a block it cannot fetch, which is otherwise
+    /// indistinguishable from a healthy run that simply found no mismatch.
+    pub const fn verification_backlog(&self, common_unsafe: u64) -> u64 {
+        common_unsafe.saturating_add(1).saturating_sub(self.next_block)
     }
 
     /// Runs the monitor loop until cancelled.
@@ -248,7 +268,8 @@ where
             }
 
             if let Err(error) = self.process_once().await {
-                L2BlockParityMetrics::fetch_errors_total(L2BlockParityMetrics::SCOPE_PASS)
+                L2BlockParityMetrics::fetch_errors_total().increment(1);
+                L2BlockParityMetrics::scoped_fetch_errors_total(L2BlockParityMetrics::SCOPE_PASS)
                     .increment(1);
                 error!(error = %error, "derived L2 block parity pass failed");
             }
@@ -264,31 +285,41 @@ where
 
     /// Processes one parity pass.
     pub async fn process_once(&mut self) -> eyre::Result<L2BlockParityStats> {
-        let sequencer_latest = self.sequencer.latest_block_number().await?;
-        let validator_latest = self.validator.latest_block_number().await?;
+        let sequencer_unsafe = self.sequencer.unsafe_block_number().await?;
+        let validator_unsafe = self.validator.unsafe_block_number().await?;
         // Metrics gauges are f64-backed; integer block numbers remain exact
         // through 2^53, far above any realistic L2 height for this monitor.
-        L2BlockParityMetrics::sequencer_latest_l2_block().set(sequencer_latest as f64);
-        L2BlockParityMetrics::validator_latest_l2_block().set(validator_latest as f64);
+        L2BlockParityMetrics::sequencer_latest_l2_block().set(sequencer_unsafe as f64);
+        L2BlockParityMetrics::validator_latest_l2_block().set(validator_unsafe as f64);
         L2BlockParityMetrics::lag_blocks()
-            .set(sequencer_latest.saturating_sub(validator_latest) as f64);
+            .set(sequencer_unsafe.saturating_sub(validator_unsafe) as f64);
+        match self.sequencer.safe_block_number().await {
+            Ok(number) => L2BlockParityMetrics::sequencer_safe_l2_block().set(number as f64),
+            Err(error) => warn!(error = %error, "failed to fetch sequencer safe L2 head"),
+        }
+        match self.validator.safe_block_number().await {
+            Ok(number) => L2BlockParityMetrics::validator_safe_l2_block().set(number as f64),
+            Err(error) => warn!(error = %error, "failed to fetch validator safe L2 head"),
+        }
 
-        let common_latest = sequencer_latest.min(validator_latest);
+        let common_unsafe = sequencer_unsafe.min(validator_unsafe);
         L2BlockParityMetrics::verification_backlog_blocks()
-            .set(self.verification_backlog(common_latest) as f64);
+            .set(self.verification_backlog(common_unsafe) as f64);
 
-        if common_latest < self.next_block {
+        if common_unsafe < self.next_block {
+            let aligned = if sequencer_unsafe == validator_unsafe { 1.0 } else { 0.0 };
+            L2BlockParityMetrics::aligned().set(aligned);
             debug!(
                 next_block = %self.next_block,
-                sequencer_latest = %sequencer_latest,
-                validator_latest = %validator_latest,
+                sequencer_unsafe = %sequencer_unsafe,
+                validator_unsafe = %validator_unsafe,
                 "waiting for parity validator to reach next comparable L2 block"
             );
             return Ok(L2BlockParityStats::default());
         }
 
         let max_blocks = self.config.validated_max_blocks_per_tick()?;
-        let last_block = common_latest.min(self.next_block.saturating_add(max_blocks - 1));
+        let last_block = common_unsafe.min(self.next_block.saturating_add(max_blocks - 1));
         let mut stats = L2BlockParityStats::default();
 
         for number in self.next_block..=last_block {
@@ -299,8 +330,11 @@ where
                     self.next_block = next_block;
                 }
                 Err(error) => {
-                    L2BlockParityMetrics::fetch_errors_total(L2BlockParityMetrics::SCOPE_BLOCK)
-                        .increment(1);
+                    L2BlockParityMetrics::fetch_errors_total().increment(1);
+                    L2BlockParityMetrics::scoped_fetch_errors_total(
+                        L2BlockParityMetrics::SCOPE_BLOCK,
+                    )
+                    .increment(1);
                     warn!(
                         error = %error,
                         l2_block = %number,
@@ -312,7 +346,15 @@ where
         }
 
         L2BlockParityMetrics::verification_backlog_blocks()
-            .set(self.verification_backlog(common_latest) as f64);
+            .set(self.verification_backlog(common_unsafe) as f64);
+
+        let caught_up = self.next_block > common_unsafe;
+        let aligned = if caught_up && stats.is_aligned() && sequencer_unsafe == validator_unsafe {
+            1.0
+        } else {
+            0.0
+        };
+        L2BlockParityMetrics::aligned().set(aligned);
 
         if stats.checked > 0 || stats.missing_blocks > 0 {
             debug!(
@@ -321,8 +363,8 @@ where
                 mismatches = %stats.mismatches,
                 missing_blocks = %stats.missing_blocks,
                 next_block = %self.next_block,
-                sequencer_latest = %sequencer_latest,
-                validator_latest = %validator_latest,
+                sequencer_unsafe = %sequencer_unsafe,
+                validator_unsafe = %validator_unsafe,
                 "derived L2 block parity pass processed"
             );
         }
@@ -431,15 +473,17 @@ mod tests {
 
     #[derive(Debug, Default)]
     struct MockL2BlockProvider {
-        latest: u64,
+        unsafe_head: u64,
+        safe_head: u64,
         blocks: BTreeMap<u64, L2BlockSnapshot>,
         fail_blocks: BTreeSet<u64>,
     }
 
     impl MockL2BlockProvider {
-        fn new(latest: u64, blocks: impl IntoIterator<Item = L2BlockSnapshot>) -> Self {
+        fn new(unsafe_head: u64, blocks: impl IntoIterator<Item = L2BlockSnapshot>) -> Self {
             Self {
-                latest,
+                unsafe_head,
+                safe_head: unsafe_head,
                 blocks: blocks.into_iter().map(|block| (block.number, block)).collect(),
                 fail_blocks: BTreeSet::new(),
             }
@@ -453,8 +497,12 @@ mod tests {
 
     #[async_trait]
     impl L2BlockProvider for Arc<Mutex<MockL2BlockProvider>> {
-        async fn latest_block_number(&self) -> eyre::Result<u64> {
-            Ok(self.lock().await.latest)
+        async fn unsafe_block_number(&self) -> eyre::Result<u64> {
+            Ok(self.lock().await.unsafe_head)
+        }
+
+        async fn safe_block_number(&self) -> eyre::Result<u64> {
+            Ok(self.lock().await.safe_head)
         }
 
         async fn block_by_number(&self, number: u64) -> eyre::Result<Option<L2BlockSnapshot>> {
@@ -557,7 +605,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn verification_backlog_counts_blocks_left_below_the_common_head() {
+    async fn verification_backlog_counts_blocks_left_below_the_common_unsafe_head() {
         let sequencer = Arc::new(Mutex::new(MockL2BlockProvider::new(9, [])));
         let validator = Arc::new(Mutex::new(MockL2BlockProvider::new(9, [])));
         let config = L2BlockParityMonitorConfig::new(7, Duration::from_secs(1));
@@ -565,9 +613,10 @@ mod tests {
 
         // Blocks 7, 8 and 9 are comparable and none has been compared yet.
         assert_eq!(monitor.verification_backlog(9), 3);
-        // Caught up: the cursor sits one past the common head.
+        // Caught up: the cursor sits one past the common unsafe head.
         assert_eq!(monitor.verification_backlog(6), 0);
-        // A common head below the cursor is a validator that has not caught up, not backlog.
+        // A common unsafe head below the cursor is a validator that has not caught up,
+        // not backlog.
         assert_eq!(monitor.verification_backlog(2), 0);
     }
 

--- a/crates/batcher/service/src/metrics.rs
+++ b/crates/batcher/service/src/metrics.rs
@@ -4,23 +4,12 @@ base_metrics::define_metrics! {
     batcher.l2_block_parity, struct = L2BlockParityMetrics,
     #[describe("Whether derived L2 block parity monitoring is running")]
     enabled: gauge,
-    #[describe("Whether a derived L2 block hash mismatch has been observed since process start")]
-    divergence_detected: gauge,
-    #[describe("L2 block this monitor run started comparing from")]
-    #[no_zero]
-    start_l2_block: gauge,
     #[describe("Latest L2 block reported by the sequencer RPC")]
-    #[no_zero]
     sequencer_latest_l2_block: gauge,
     #[describe("Latest L2 block reported by the shadow parity validator RPC")]
-    #[no_zero]
     validator_latest_l2_block: gauge,
     #[describe("Current sequencer-to-validator L2 block lag")]
-    #[no_zero]
     lag_blocks: gauge,
-    #[describe("Comparable derived L2 blocks not compared yet")]
-    #[no_zero]
-    verification_backlog_blocks: gauge,
     #[describe("Total derived L2 blocks compared")]
     checked_total: counter,
     #[describe("Total derived L2 block hash matches")]
@@ -30,8 +19,9 @@ base_metrics::define_metrics! {
     #[describe("Total derived L2 blocks skipped because one side did not return the block")]
     missing_blocks_total: counter,
     #[describe("Total RPC fetch errors seen by derived L2 block parity monitoring")]
-    #[label(name = "scope", default = ["pass", "block"])]
     fetch_errors_total: counter,
+    #[describe("Latest derived L2 block parity alignment state: 1 for aligned, 0 for mismatch or lag")]
+    aligned: gauge,
     #[describe("Latest L2 block compared by derived block parity monitoring")]
     #[no_zero]
     last_checked_l2_block: gauge,
@@ -41,6 +31,33 @@ base_metrics::define_metrics! {
     #[describe("Latest derived L2 block where parity mismatched")]
     #[no_zero]
     last_mismatch_l2_block: gauge,
+
+    // ======================================================================
+    // TEMPORARY — shadow base-batcher rollout
+    //
+    // Feeding the shadow batcher Datadog dashboard on Zeronet. Deliberately
+    // additive: some of these duplicate a series above instead of reshaping
+    // it, so nothing already deployed breaks. Revisit once the rollout ends,
+    // either folding them into the metrics above with their owners or dropping
+    // them.
+    // ======================================================================
+    #[describe("Whether a derived L2 block hash mismatch has been observed since process start")]
+    divergence_detected: gauge,
+    #[describe("L2 block this monitor run started comparing from")]
+    #[no_zero]
+    start_l2_block: gauge,
+    #[describe("Safe L2 head reported by the sequencer RPC")]
+    #[no_zero]
+    sequencer_safe_l2_block: gauge,
+    #[describe("Safe L2 head reported by the shadow parity validator RPC")]
+    #[no_zero]
+    validator_safe_l2_block: gauge,
+    #[describe("Comparable derived L2 blocks not compared yet")]
+    #[no_zero]
+    verification_backlog_blocks: gauge,
+    #[describe("Total RPC fetch errors seen by derived L2 block parity monitoring, split by scope")]
+    #[label(name = "scope", default = ["pass", "block"])]
+    scoped_fetch_errors_total: counter,
 }
 
 impl L2BlockParityMetrics {

--- a/crates/batcher/service/src/metrics.rs
+++ b/crates/batcher/service/src/metrics.rs
@@ -4,12 +4,29 @@ base_metrics::define_metrics! {
     batcher.l2_block_parity, struct = L2BlockParityMetrics,
     #[describe("Whether derived L2 block parity monitoring is running")]
     enabled: gauge,
-    #[describe("Latest L2 block reported by the sequencer RPC")]
-    sequencer_latest_l2_block: gauge,
-    #[describe("Latest L2 block reported by the shadow parity validator RPC")]
-    validator_latest_l2_block: gauge,
-    #[describe("Current sequencer-to-validator L2 block lag")]
-    lag_blocks: gauge,
+    #[describe("Whether a derived L2 block hash mismatch has been observed since process start")]
+    divergence_detected: gauge,
+    #[describe("L2 block this monitor run started comparing from")]
+    #[no_zero]
+    start_l2_block: gauge,
+    #[describe("Unsafe L2 head reported by the sequencer RPC")]
+    #[no_zero]
+    sequencer_unsafe_l2_block: gauge,
+    #[describe("Safe L2 head reported by the sequencer RPC")]
+    #[no_zero]
+    sequencer_safe_l2_block: gauge,
+    #[describe("Unsafe L2 head reported by the shadow parity validator RPC")]
+    #[no_zero]
+    validator_unsafe_l2_block: gauge,
+    #[describe("Safe L2 head reported by the shadow parity validator RPC")]
+    #[no_zero]
+    validator_safe_l2_block: gauge,
+    #[describe("Blocks the validator unsafe L2 head trails the sequencer unsafe L2 head")]
+    #[no_zero]
+    validator_unsafe_lag_blocks: gauge,
+    #[describe("Comparable derived L2 blocks not compared yet")]
+    #[no_zero]
+    verification_backlog_blocks: gauge,
     #[describe("Total derived L2 blocks compared")]
     checked_total: counter,
     #[describe("Total derived L2 block hash matches")]
@@ -18,10 +35,9 @@ base_metrics::define_metrics! {
     mismatches_total: counter,
     #[describe("Total derived L2 blocks skipped because one side did not return the block")]
     missing_blocks_total: counter,
-    #[describe("Total RPC fetch errors seen by derived L2 block parity monitoring")]
+    #[describe("Total RPC fetch errors seen by derived L2 block parity monitoring, by scope")]
+    #[label(name = "scope", default = ["pass", "block"])]
     fetch_errors_total: counter,
-    #[describe("Latest derived L2 block parity alignment state: 1 for aligned, 0 for mismatch or lag")]
-    aligned: gauge,
     #[describe("Latest L2 block compared by derived block parity monitoring")]
     #[no_zero]
     last_checked_l2_block: gauge,
@@ -31,33 +47,6 @@ base_metrics::define_metrics! {
     #[describe("Latest derived L2 block where parity mismatched")]
     #[no_zero]
     last_mismatch_l2_block: gauge,
-
-    // ======================================================================
-    // TEMPORARY — shadow base-batcher rollout
-    //
-    // Feeding the shadow batcher Datadog dashboard on Zeronet. Deliberately
-    // additive: some of these duplicate a series above instead of reshaping
-    // it, so nothing already deployed breaks. Revisit once the rollout ends,
-    // either folding them into the metrics above with their owners or dropping
-    // them.
-    // ======================================================================
-    #[describe("Whether a derived L2 block hash mismatch has been observed since process start")]
-    divergence_detected: gauge,
-    #[describe("L2 block this monitor run started comparing from")]
-    #[no_zero]
-    start_l2_block: gauge,
-    #[describe("Safe L2 head reported by the sequencer RPC")]
-    #[no_zero]
-    sequencer_safe_l2_block: gauge,
-    #[describe("Safe L2 head reported by the shadow parity validator RPC")]
-    #[no_zero]
-    validator_safe_l2_block: gauge,
-    #[describe("Comparable derived L2 blocks not compared yet")]
-    #[no_zero]
-    verification_backlog_blocks: gauge,
-    #[describe("Total RPC fetch errors seen by derived L2 block parity monitoring, split by scope")]
-    #[label(name = "scope", default = ["pass", "block"])]
-    scoped_fetch_errors_total: counter,
 }
 
 impl L2BlockParityMetrics {

--- a/crates/batcher/service/src/metrics.rs
+++ b/crates/batcher/service/src/metrics.rs
@@ -35,7 +35,9 @@ base_metrics::define_metrics! {
     mismatches_total: counter,
     #[describe("Total derived L2 blocks skipped because one side did not return the block")]
     missing_blocks_total: counter,
-    #[describe("Total RPC fetch errors seen by derived L2 block parity monitoring, by scope")]
+    #[describe(
+        "Total errors that prevent a parity pass or block comparison from completing, by scope"
+    )]
     #[label(name = "scope", default = ["pass", "block"])]
     fetch_errors_total: counter,
     #[describe("Latest L2 block compared by derived block parity monitoring")]
@@ -50,9 +52,9 @@ base_metrics::define_metrics! {
 }
 
 impl L2BlockParityMetrics {
-    /// Chain-head fetch failed, so the pass compared nothing.
+    /// An error aborted the pass before it compared any block.
     pub const SCOPE_PASS: &'static str = "pass";
 
-    /// Block fetch failed mid-pass, leaving the cursor parked on that height.
+    /// An error aborted one block comparison, leaving the cursor parked on that height.
     pub const SCOPE_BLOCK: &'static str = "block";
 }

--- a/crates/batcher/service/src/metrics.rs
+++ b/crates/batcher/service/src/metrics.rs
@@ -4,12 +4,23 @@ base_metrics::define_metrics! {
     batcher.l2_block_parity, struct = L2BlockParityMetrics,
     #[describe("Whether derived L2 block parity monitoring is running")]
     enabled: gauge,
+    #[describe("Whether a derived L2 block hash mismatch has been observed since process start")]
+    divergence_detected: gauge,
+    #[describe("L2 block this monitor run started comparing from")]
+    #[no_zero]
+    start_l2_block: gauge,
     #[describe("Latest L2 block reported by the sequencer RPC")]
+    #[no_zero]
     sequencer_latest_l2_block: gauge,
     #[describe("Latest L2 block reported by the shadow parity validator RPC")]
+    #[no_zero]
     validator_latest_l2_block: gauge,
     #[describe("Current sequencer-to-validator L2 block lag")]
+    #[no_zero]
     lag_blocks: gauge,
+    #[describe("Comparable derived L2 blocks not compared yet")]
+    #[no_zero]
+    verification_backlog_blocks: gauge,
     #[describe("Total derived L2 blocks compared")]
     checked_total: counter,
     #[describe("Total derived L2 block hash matches")]
@@ -19,9 +30,8 @@ base_metrics::define_metrics! {
     #[describe("Total derived L2 blocks skipped because one side did not return the block")]
     missing_blocks_total: counter,
     #[describe("Total RPC fetch errors seen by derived L2 block parity monitoring")]
+    #[label(name = "scope", default = ["pass", "block"])]
     fetch_errors_total: counter,
-    #[describe("Latest derived L2 block parity alignment state: 1 for aligned, 0 for mismatch or lag")]
-    aligned: gauge,
     #[describe("Latest L2 block compared by derived block parity monitoring")]
     #[no_zero]
     last_checked_l2_block: gauge,
@@ -31,4 +41,12 @@ base_metrics::define_metrics! {
     #[describe("Latest derived L2 block where parity mismatched")]
     #[no_zero]
     last_mismatch_l2_block: gauge,
+}
+
+impl L2BlockParityMetrics {
+    /// Chain-head fetch failed, so the pass compared nothing.
+    pub const SCOPE_PASS: &'static str = "pass";
+
+    /// Block fetch failed mid-pass, leaving the cursor parked on that height.
+    pub const SCOPE_BLOCK: &'static str = "block";
 }

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -162,7 +162,10 @@ pub struct ConsensusFollowNodeConfigArgs {
 impl ConsensusFollowNodeArgs {
     /// Loads the configured L2 rollup config.
     pub fn load_rollup_config(&self) -> eyre::Result<RollupConfig> {
-        self.config.l2_config.load(&self.chain.l2_chain_id).map_err(|e| eyre::eyre!(e))
+        let mut config =
+            self.config.l2_config.load(&self.chain.l2_chain_id).map_err(|e| eyre::eyre!(e))?;
+        self.config.l1_rpc_args.apply_da_batch_inbox_override(&mut config);
+        Ok(config)
     }
 
     /// Builds a follow node with default external endpoint configuration.
@@ -288,6 +291,8 @@ impl ConsensusFollowNodeArgs {
 
 #[cfg(test)]
 mod tests {
+    use alloy_chains::Chain;
+    use alloy_primitives::address;
     use clap::Parser;
 
     use super::*;
@@ -316,6 +321,23 @@ mod tests {
     #[test]
     fn proofs_default_to_disabled() {
         assert!(!parse_config(&[]).proofs);
+    }
+
+    #[test]
+    fn applies_da_batch_inbox_override() {
+        let inbox = address!("3333333333333333333333333333333333333333");
+        let config = parse_config(&[
+            "--l1.dangerously-override-da-batch-inbox",
+            "0x3333333333333333333333333333333333333333",
+        ]);
+        let args = ConsensusFollowNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            config,
+        );
+
+        let config = args.load_rollup_config().unwrap();
+
+        assert_eq!(config.batch_inbox_address, inbox);
     }
 
     #[test]

--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -3,7 +3,9 @@
 use std::{num::ParseIntError, time::Duration};
 
 use alloy_primitives::Address;
+use base_common_genesis::RollupConfig;
 use base_consensus_providers::L1_RPC_TIMEOUT;
+use tracing::warn;
 use url::Url;
 
 const DEFAULT_L1_TRUST_RPC: bool = true;
@@ -54,6 +56,13 @@ pub struct L1ClientArgs {
         env = "BASE_NODE_L1_DANGEROUSLY_OVERRIDE_DA_BATCHER_SENDER"
     )]
     pub l1_da_batcher_sender_override: Option<Address>,
+    /// Dangerous validator-only override for the batch inbox accepted by the L1
+    /// data-availability pipeline.
+    #[arg(
+        long = "l1.dangerously-override-da-batch-inbox",
+        env = "BASE_NODE_L1_DANGEROUSLY_OVERRIDE_DA_BATCH_INBOX"
+    )]
+    pub l1_da_batch_inbox_override: Option<Address>,
     /// Number of L1 blocks to keep distance from the L1 head for the verifier (derivation
     /// pipeline). Controlled via `BASE_NODE_VERIFIER_L1_CONFS`. Defaults to 0, meaning
     /// the verifier derives from the latest L1 head with no confirmation delay.
@@ -82,8 +91,26 @@ impl Default for L1ClientArgs {
             l1_beacon: Url::parse("http://localhost:5052").unwrap(),
             l1_slot_duration_override: None,
             l1_da_batcher_sender_override: None,
+            l1_da_batch_inbox_override: None,
             l1_verifier_confs: 0,
             l1_finalized_poll_interval: None,
+        }
+    }
+}
+
+impl L1ClientArgs {
+    /// Applies the configured L1 data-availability batch inbox override.
+    pub fn apply_da_batch_inbox_override(&self, config: &mut RollupConfig) {
+        let Some(inbox) = self.l1_da_batch_inbox_override else {
+            return;
+        };
+        if config.batch_inbox_address != inbox {
+            warn!(
+                configured_inbox = %config.batch_inbox_address,
+                override_inbox = %inbox,
+                "overriding the L1 data-availability batch inbox filter"
+            );
+            config.batch_inbox_address = inbox;
         }
     }
 }

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -351,7 +351,11 @@ impl From<EmbeddedSequencerConsensusNodeConfigArgs> for ConsensusNodeConfigArgs 
 impl ConsensusNodeArgs {
     /// Loads the configured L2 rollup config.
     pub fn load_rollup_config(&self) -> eyre::Result<RollupConfig> {
-        self.config.l2_config.load(&self.chain.l2_chain_id).map_err(|e| eyre::eyre!(e))
+        let mut config =
+            self.config.l2_config.load(&self.chain.l2_chain_id).map_err(|e| eyre::eyre!(e))?;
+        self.validate_da_batch_inbox_override()?;
+        self.config.l1_rpc_args.apply_da_batch_inbox_override(&mut config);
+        Ok(config)
     }
 
     /// Validates that a non-shadow sequencer has a signing key configured.
@@ -407,6 +411,18 @@ impl ConsensusNodeArgs {
         Ok(())
     }
 
+    /// Validates that the dangerous DA batch inbox override is only used by validators.
+    pub fn validate_da_batch_inbox_override(&self) -> eyre::Result<()> {
+        if self.config.l1_rpc_args.l1_da_batch_inbox_override.is_some()
+            && !self.config.node_mode.is_validator()
+        {
+            eyre::bail!(
+                "--l1.dangerously-override-da-batch-inbox is only supported in validator mode"
+            );
+        }
+        Ok(())
+    }
+
     /// Builds a rollup node with default external endpoint configuration.
     pub async fn build_rollup_node(&self) -> eyre::Result<RollupNode> {
         self.build_rollup_node_with_overrides(
@@ -440,6 +456,8 @@ impl ConsensusNodeArgs {
         self.validate_sequencer_key()?;
         self.validate_shadow_funding()?;
         self.validate_da_batcher_sender_override()?;
+        self.validate_da_batch_inbox_override()?;
+        self.config.l1_rpc_args.apply_da_batch_inbox_override(&mut cfg);
         if let Some(sender) = self.config.l1_rpc_args.l1_da_batcher_sender_override {
             warn!(
                 %sender,
@@ -757,6 +775,29 @@ mod tests {
         assert_eq!(config.l1_rpc_args.l1_da_batcher_sender_override, Some(batcher));
     }
 
+    #[test]
+    fn embedded_consensus_applies_da_batch_inbox_override() {
+        let inbox = address!("3333333333333333333333333333333333333333");
+        let args = CommandParser::<EmbeddedConsensusNodeConfigArgs>::parse_from([
+            "base",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+            "--l1.dangerously-override-da-batch-inbox",
+            "0x3333333333333333333333333333333333333333",
+        ])
+        .args;
+        let args = ConsensusNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            ConsensusNodeConfigArgs::from(args),
+        );
+
+        let config = args.load_rollup_config().unwrap();
+
+        assert_eq!(config.batch_inbox_address, inbox);
+    }
+
     fn upgrade_schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
         UpgradeSignalSchedule::new(
             1,
@@ -1030,6 +1071,29 @@ mod tests {
         );
 
         assert!(args.validate_da_batcher_sender_override().is_err());
+    }
+
+    #[test]
+    fn da_batch_inbox_override_is_rejected_in_sequencer_mode() {
+        let args = ConsensusNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            ConsensusNodeConfigArgs {
+                node_mode: NodeMode::Sequencer,
+                l1_rpc_args: L1ClientArgs {
+                    l1_da_batch_inbox_override: Some(address!(
+                        "3333333333333333333333333333333333333333"
+                    )),
+                    ..L1ClientArgs::default()
+                },
+                ..default_node_config_args()
+            },
+        );
+
+        let error = args.load_rollup_config().unwrap_err();
+
+        assert!(error.to_string().contains(
+            "--l1.dangerously-override-da-batch-inbox is only supported in validator mode"
+        ));
     }
 
     #[test]

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -40,7 +40,7 @@ mod queue;
 pub use queue::{SendResult, TxQueue};
 
 mod metrics;
-pub use metrics::{BaseTxMetrics, NoopTxMetrics, TxManagerMetrics, TxMetrics};
+pub use metrics::{BaseTxMetrics, NoopTxMetrics, SendOutcome, TxManagerMetrics, TxMetrics};
 
 mod blob;
 pub use blob::{BlobTxBuilder, MAX_BLOBS_PER_TX};

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -62,8 +62,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     BlobTxBuilder, BumpedFees, FeeCalculator, FeeOverride, GasPriceCaps, NonceManager,
-    RpcErrorClassifier, SendHandle, SendResponse, SendState, SignerConfig, TxCandidate, TxManager,
-    TxManagerConfig, TxManagerError, TxManagerResult, TxMetrics,
+    RpcErrorClassifier, SendHandle, SendOutcome, SendResponse, SendState, SignerConfig,
+    TxCandidate, TxManager, TxManagerConfig, TxManagerError, TxManagerResult, TxMetrics,
 };
 
 /// Number of wei in one gwei (10^9), as `f64` for fractional-precision
@@ -1012,11 +1012,12 @@ where
 
         let latency_ms =
             u64::try_from(self.runtime.now().saturating_sub(start).as_millis()).unwrap_or(u64::MAX);
-        self.metrics.record_send_latency(latency_ms);
 
         if result.is_ok() {
+            self.metrics.record_send_latency(latency_ms, SendOutcome::Confirmed);
             self.metrics.record_tx_confirmed();
         } else {
+            self.metrics.record_send_latency(latency_ms, SendOutcome::Failed);
             self.metrics.record_tx_failed();
         }
 

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -598,7 +598,7 @@ where
                 let raw_blob_cap = FeeCalculator::calc_blob_fee_cap(raw_blob_base_fee);
                 let blob_base_fee = raw_blob_base_fee.max(self.config.min_blob_fee);
                 let blob_cap = FeeCalculator::calc_blob_fee_cap(blob_base_fee);
-                self.metrics.record_blob_fee(blob_cap as f64 / WEI_PER_GWEI);
+                self.metrics.record_blob_fee_cap(blob_cap as f64 / WEI_PER_GWEI);
                 (Some(blob_cap), Some(raw_blob_cap))
             }
             None => (None, None),

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -8,18 +8,19 @@ base_metrics::define_metrics! {
     #[describe("Maximum possible transaction fee in gwei")]
     #[label(name)]
     tx_max_fee_gwei: histogram,
-    #[describe("Number of gas bump events")]
+    #[describe("Total number of gas bump events")]
     #[label(name)]
-    tx_gas_bump_count: counter,
-    #[describe("Send-loop latency in milliseconds")]
+    tx_gas_bump_total: counter,
+    #[describe("Send-loop latency in milliseconds, by outcome")]
     #[label(name)]
+    #[label(name = "outcome")]
     tx_send_latency_ms: histogram,
     #[describe("Current nonce value")]
     #[label(name)]
     current_nonce: gauge,
-    #[describe("Number of transaction publish errors")]
+    #[describe("Total number of transaction publish errors")]
     #[label(name)]
-    tx_publish_error_count: counter,
+    tx_publish_error_total: counter,
     #[describe("Base fee in gwei")]
     #[label(name)]
     basefee_gwei: gauge,
@@ -28,29 +29,18 @@ base_metrics::define_metrics! {
     tipcap_gwei: gauge,
     #[describe("Blob fee cap in gwei")]
     #[label(name)]
-    blob_fee_gwei: gauge,
-    #[describe("Number of RPC errors")]
+    blob_fee_cap_gwei: gauge,
+    #[describe("Total number of RPC errors")]
     #[label(name)]
-    rpc_error_count: counter,
-    #[describe("Number of confirmed transactions")]
+    rpc_error_total: counter,
+    #[describe("Total number of confirmed transactions")]
     #[label(name)]
-    tx_confirmed_count: counter,
-    #[describe("Number of failed send attempts (includes timeouts where the tx may still confirm)")]
+    tx_confirmed_total: counter,
+    #[describe(
+        "Total failed send attempts, including timeouts where the transaction may still confirm"
+    )]
     #[label(name)]
-    tx_failed_count: counter,
-
-    // ======================================================================
-    // TEMPORARY — shadow base-batcher rollout
-    //
-    // Feeding the shadow batcher Datadog dashboard on Zeronet. Duplicates
-    // `tx_send_latency_ms` above rather than adding a label to it, because this
-    // crate also backs the proposer, challenger and TEE registrar. Revisit once
-    // the rollout ends, either folding it in with the owners or dropping it.
-    // ======================================================================
-    #[describe("Send-loop latency in milliseconds, split by how the send ended")]
-    #[label(name)]
-    #[label(name = "outcome")]
-    tx_send_latency_by_outcome_ms: histogram,
+    tx_failed_total: counter,
 }
 
 /// How a send loop ended.
@@ -99,7 +89,7 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
     fn record_tipcap(&self, tipcap_gwei: f64);
 
     /// Record the blob fee cap in gwei (fractional precision preserved).
-    fn record_blob_fee(&self, blob_fee_gwei: f64);
+    fn record_blob_fee_cap(&self, blob_fee_cap_gwei: f64);
 
     /// Record an RPC error.
     fn record_rpc_error(&self);
@@ -133,7 +123,7 @@ impl TxMetrics for NoopTxMetrics {
     fn record_publish_error(&self) {}
     fn record_basefee(&self, _basefee_gwei: f64) {}
     fn record_tipcap(&self, _tipcap_gwei: f64) {}
-    fn record_blob_fee(&self, _blob_fee_gwei: f64) {}
+    fn record_blob_fee_cap(&self, _blob_fee_cap_gwei: f64) {}
     fn record_rpc_error(&self) {}
     fn record_tx_confirmed(&self) {}
     fn record_tx_failed(&self) {}
@@ -162,15 +152,15 @@ impl BaseTxMetrics {
     /// immediately in the metrics endpoint.
     pub fn new(name: &'static str) -> Self {
         let this = Self { name };
-        TxManagerMetrics::tx_gas_bump_count(name).absolute(0);
+        TxManagerMetrics::tx_gas_bump_total(name).absolute(0);
         TxManagerMetrics::current_nonce(name).set(0.0);
-        TxManagerMetrics::tx_publish_error_count(name).absolute(0);
+        TxManagerMetrics::tx_publish_error_total(name).absolute(0);
         TxManagerMetrics::basefee_gwei(name).set(0.0);
         TxManagerMetrics::tipcap_gwei(name).set(0.0);
-        TxManagerMetrics::blob_fee_gwei(name).set(0.0);
-        TxManagerMetrics::rpc_error_count(name).absolute(0);
-        TxManagerMetrics::tx_confirmed_count(name).absolute(0);
-        TxManagerMetrics::tx_failed_count(name).absolute(0);
+        TxManagerMetrics::blob_fee_cap_gwei(name).set(0.0);
+        TxManagerMetrics::rpc_error_total(name).absolute(0);
+        TxManagerMetrics::tx_confirmed_total(name).absolute(0);
+        TxManagerMetrics::tx_failed_total(name).absolute(0);
         this
     }
 }
@@ -181,13 +171,11 @@ impl TxMetrics for BaseTxMetrics {
     }
 
     fn record_gas_bump(&self) {
-        TxManagerMetrics::tx_gas_bump_count(self.name).increment(1);
+        TxManagerMetrics::tx_gas_bump_total(self.name).increment(1);
     }
 
     fn record_send_latency(&self, latency_ms: u64, outcome: SendOutcome) {
-        TxManagerMetrics::tx_send_latency_ms(self.name).record(latency_ms as f64);
-        TxManagerMetrics::tx_send_latency_by_outcome_ms(self.name, outcome.as_str())
-            .record(latency_ms as f64);
+        TxManagerMetrics::tx_send_latency_ms(self.name, outcome.as_str()).record(latency_ms as f64);
     }
 
     fn record_current_nonce(&self, nonce: u64) {
@@ -195,7 +183,7 @@ impl TxMetrics for BaseTxMetrics {
     }
 
     fn record_publish_error(&self) {
-        TxManagerMetrics::tx_publish_error_count(self.name).increment(1);
+        TxManagerMetrics::tx_publish_error_total(self.name).increment(1);
     }
 
     fn record_basefee(&self, basefee_gwei: f64) {
@@ -206,20 +194,20 @@ impl TxMetrics for BaseTxMetrics {
         TxManagerMetrics::tipcap_gwei(self.name).set(tipcap_gwei);
     }
 
-    fn record_blob_fee(&self, blob_fee_gwei: f64) {
-        TxManagerMetrics::blob_fee_gwei(self.name).set(blob_fee_gwei);
+    fn record_blob_fee_cap(&self, blob_fee_cap_gwei: f64) {
+        TxManagerMetrics::blob_fee_cap_gwei(self.name).set(blob_fee_cap_gwei);
     }
 
     fn record_rpc_error(&self) {
-        TxManagerMetrics::rpc_error_count(self.name).increment(1);
+        TxManagerMetrics::rpc_error_total(self.name).increment(1);
     }
 
     fn record_tx_confirmed(&self) {
-        TxManagerMetrics::tx_confirmed_count(self.name).increment(1);
+        TxManagerMetrics::tx_confirmed_total(self.name).increment(1);
     }
 
     fn record_tx_failed(&self) {
-        TxManagerMetrics::tx_failed_count(self.name).increment(1);
+        TxManagerMetrics::tx_failed_total(self.name).increment(1);
     }
 }
 
@@ -237,7 +225,7 @@ mod tests {
         m.record_publish_error();
         m.record_basefee(30.123);
         m.record_tipcap(2.456);
-        m.record_blob_fee(1.0);
+        m.record_blob_fee_cap(1.0);
         m.record_rpc_error();
         m.record_tx_confirmed();
         m.record_tx_failed();
@@ -253,7 +241,7 @@ mod tests {
         m.record_publish_error();
         m.record_basefee(30.123);
         m.record_tipcap(2.456);
-        m.record_blob_fee(1.0);
+        m.record_blob_fee_cap(1.0);
         m.record_rpc_error();
         m.record_tx_confirmed();
         m.record_tx_failed();

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -54,10 +54,6 @@ base_metrics::define_metrics! {
 }
 
 /// How a send loop ended.
-///
-/// A send that gives up waits out the full send timeout, so its latency is bounded by
-/// configuration rather than by the chain. Keeping the two apart stops that ceiling from
-/// dominating the quantiles of sends that actually confirmed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SendOutcome {
     /// The transaction reached the required confirmation depth.

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -13,7 +13,6 @@ base_metrics::define_metrics! {
     tx_gas_bump_count: counter,
     #[describe("Send-loop latency in milliseconds")]
     #[label(name)]
-    #[label(name = "outcome")]
     tx_send_latency_ms: histogram,
     #[describe("Current nonce value")]
     #[label(name)]
@@ -39,6 +38,19 @@ base_metrics::define_metrics! {
     #[describe("Number of failed send attempts (includes timeouts where the tx may still confirm)")]
     #[label(name)]
     tx_failed_count: counter,
+
+    // ======================================================================
+    // TEMPORARY — shadow base-batcher rollout
+    //
+    // Feeding the shadow batcher Datadog dashboard on Zeronet. Duplicates
+    // `tx_send_latency_ms` above rather than adding a label to it, because this
+    // crate also backs the proposer, challenger and TEE registrar. Revisit once
+    // the rollout ends, either folding it in with the owners or dropping it.
+    // ======================================================================
+    #[describe("Send-loop latency in milliseconds, split by how the send ended")]
+    #[label(name)]
+    #[label(name = "outcome")]
+    tx_send_latency_by_outcome_ms: histogram,
 }
 
 /// How a send loop ended.
@@ -177,7 +189,9 @@ impl TxMetrics for BaseTxMetrics {
     }
 
     fn record_send_latency(&self, latency_ms: u64, outcome: SendOutcome) {
-        TxManagerMetrics::tx_send_latency_ms(self.name, outcome.as_str()).record(latency_ms as f64);
+        TxManagerMetrics::tx_send_latency_ms(self.name).record(latency_ms as f64);
+        TxManagerMetrics::tx_send_latency_by_outcome_ms(self.name, outcome.as_str())
+            .record(latency_ms as f64);
     }
 
     fn record_current_nonce(&self, nonce: u64) {

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -13,6 +13,7 @@ base_metrics::define_metrics! {
     tx_gas_bump_count: counter,
     #[describe("Send-loop latency in milliseconds")]
     #[label(name)]
+    #[label(name = "outcome")]
     tx_send_latency_ms: histogram,
     #[describe("Current nonce value")]
     #[label(name)]
@@ -40,6 +41,29 @@ base_metrics::define_metrics! {
     tx_failed_count: counter,
 }
 
+/// How a send loop ended.
+///
+/// A send that gives up waits out the full send timeout, so its latency is bounded by
+/// configuration rather than by the chain. Keeping the two apart stops that ceiling from
+/// dominating the quantiles of sends that actually confirmed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendOutcome {
+    /// The transaction reached the required confirmation depth.
+    Confirmed,
+    /// The send returned an error, including timeouts where the transaction may still confirm.
+    Failed,
+}
+
+impl SendOutcome {
+    /// Returns the metric label value.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Confirmed => "confirmed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
 /// Trait abstracting metrics collection for the transaction manager.
 ///
 /// Implement this trait to plug in your own metrics backend. A [`BaseTxMetrics`]
@@ -51,8 +75,8 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
     /// Record a gas bump event.
     fn record_gas_bump(&self);
 
-    /// Record the send-loop latency in milliseconds (all exit paths).
-    fn record_send_latency(&self, latency_ms: u64);
+    /// Record the send-loop latency in milliseconds, split by how the send ended.
+    fn record_send_latency(&self, latency_ms: u64, outcome: SendOutcome);
 
     /// Record the current nonce.
     fn record_current_nonce(&self, nonce: u64);
@@ -96,7 +120,7 @@ pub struct NoopTxMetrics;
 impl TxMetrics for NoopTxMetrics {
     fn record_tx_max_fee(&self, _fee_gwei: f64) {}
     fn record_gas_bump(&self) {}
-    fn record_send_latency(&self, _latency_ms: u64) {}
+    fn record_send_latency(&self, _latency_ms: u64, _outcome: SendOutcome) {}
     fn record_current_nonce(&self, _nonce: u64) {}
     fn record_publish_error(&self) {}
     fn record_basefee(&self, _basefee_gwei: f64) {}
@@ -152,8 +176,8 @@ impl TxMetrics for BaseTxMetrics {
         TxManagerMetrics::tx_gas_bump_count(self.name).increment(1);
     }
 
-    fn record_send_latency(&self, latency_ms: u64) {
-        TxManagerMetrics::tx_send_latency_ms(self.name).record(latency_ms as f64);
+    fn record_send_latency(&self, latency_ms: u64, outcome: SendOutcome) {
+        TxManagerMetrics::tx_send_latency_ms(self.name, outcome.as_str()).record(latency_ms as f64);
     }
 
     fn record_current_nonce(&self, nonce: u64) {
@@ -198,7 +222,7 @@ mod tests {
         let m = NoopTxMetrics;
         m.record_tx_max_fee(1.5);
         m.record_gas_bump();
-        m.record_send_latency(120);
+        m.record_send_latency(120, SendOutcome::Confirmed);
         m.record_current_nonce(42);
         m.record_publish_error();
         m.record_basefee(30.123);
@@ -214,7 +238,7 @@ mod tests {
         let m = BaseTxMetrics::new("test");
         m.record_tx_max_fee(1.5);
         m.record_gas_bump();
-        m.record_send_latency(120);
+        m.record_send_latency(120, SendOutcome::Failed);
         m.record_current_nonce(42);
         m.record_publish_error();
         m.record_basefee(30.123);


### PR DESCRIPTION
## Summary

- Add a validator-only `--l1.dangerously-override-da-batch-inbox` option and corresponding environment variable.
- Apply the override to the built-in rollup configuration before starting the derivation pipeline.
- Reject the override in sequencer mode, matching the existing DA batcher sender override.
- Allow shadow validators to follow a dedicated batch inbox without maintaining a complete custom rollup configuration.

## Testing

- `cargo test -p base-consensus-cli`
- `cargo test -p base`
- `cargo clippy -p base-consensus-cli -p base --all-targets -- -D warnings`
