### PR TITLE
ci(release): keep patch release tooling current

### DIFF
--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: main
           fetch-depth: 0
           fetch-tags: true
 

--- a/docs/guides/RELEASE.md
+++ b/docs/guides/RELEASE.md
@@ -14,9 +14,11 @@ Releases are managed through two manual workflows and one automatic trigger:
 
 Run the **Start Release** workflow (`Actions → Start Release → Run workflow`):
 
+- Leave **Use workflow from** set to `main` so the latest release automation is used
 - Select the bump type: `minor` (new feature release), `patch` (bug fixes), or `major` (breaking changes)
 - The workflow computes the next version from the latest final tag and creates the `releases/vX.Y.Z` branch
 - For `patch` bumps, the base is the latest existing `releases/vX.Y.*` branch; for `major`/`minor`, the base is `main`
+- Patch branches keep the prior release's application code while syncing release workflows and scripts from `main`
 
 After the branch is created, the **Release Version Sync** workflow fires automatically and opens a PR to update `Cargo.toml` to the new version.
 

--- a/etc/scripts/release/start-release.sh
+++ b/etc/scripts/release/start-release.sh
@@ -10,6 +10,18 @@ source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
 BUMP_TYPE="${1:-}"
 
+# Patch releases inherit application code from the previous patch branch, but
+# release automation must stay current so fixes to the build and publish jobs
+# are not lost when the next patch branch is cut.
+RELEASE_TOOLING_PATHS=(
+    .github/workflows/build-release.yml
+    .github/workflows/create-rc.yml
+    .github/workflows/publish-release.yml
+    .github/workflows/start-release.yml
+    .github/workflows/verify-release.yml
+    etc/scripts/release
+)
+
 if [[ -z "$BUMP_TYPE" ]]; then
     echo "Usage: $0 <bump_type>" >&2
     echo "  bump_type: major, minor, or patch" >&2
@@ -68,8 +80,16 @@ main() {
     fi
 
     configure_git
-    git fetch origin "$base"
+    git fetch origin "$base" main
     git checkout -b "$RELEASE_BRANCH" "origin/$base"
+
+    if [[ "$BUMP_TYPE" == "patch" ]]; then
+        git restore --source origin/main --staged --worktree -- "${RELEASE_TOOLING_PATHS[@]}"
+        if ! git diff --cached --quiet -- "${RELEASE_TOOLING_PATHS[@]}"; then
+            git commit -m "ci(release): sync release tooling from main"
+        fi
+    fi
+
     git push origin "$RELEASE_BRANCH"
 
     # Write outputs for workflow step summary


### PR DESCRIPTION
## Summary

- always check out `main` when the Start Release workflow runs, regardless of the workflow-dispatch ref selected in the UI
- when cutting a patch release from the previous patch branch, sync the release workflows and scripts from `origin/main` before pushing the new branch
- document that patch releases retain the prior release's application code but use current release automation

## Failure analysis

Create RC run https://github.com/base/base/actions/runs/33772030969 used the workflow committed to `releases/v1.3.2`. That patch branch was created from `releases/v1.3.1`, whose code line diverged from `main` on August 18, 2026.

As a result, it did not include the release-build fixes merged to `main` on August 31, 2026 in #4807, #4809, and #4814:

- Linux amd64/arm64 `basectl` failed because `protoc` was not installed.
- macOS arm64 `basectl` failed because Go was not installed.
- Linux arm64 `base-consensus` failed with unresolved `blst_*` symbols.

The release workflow fixes already exist on `main`; the regression happened because patch releases inherit both application code **and stale release automation** from the previous release branch.

## Fix rationale

Patch releases should continue to inherit application code from the previous patch branch, but release orchestration is operational tooling and needs fixes independently of the released application code. Syncing only the release workflows/scripts preserves the patch code line while carrying forward CI dependency, runner, signing, and packaging fixes.

The explicit `ref: main` also prevents selecting an older release branch in the workflow-dispatch UI from running an old copy of `start-release.sh`.

This prevents the issue for newly-created patch branches. The already-created `releases/v1.3.2` branch still needs the current release tooling synced/backported before its RC build is retried.

## Validation

- `git diff --check`
- `bash -n etc/scripts/release/start-release.sh`
- temporary local Git integration test:
  - created a patch branch from a release branch with stale tooling
  - verified application code stayed on the release version
  - verified changed, added, and deleted release-tooling files exactly matched `main`
  - verified the tooling sync commit was pushed on the new patch branch
