### PR TITLE
ci: backport release build fixes to v1.3.2

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,6 +69,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libclang-dev pkg-config protobuf-compiler
 
+      - name: Install system dependencies (macOS)
+        if: matrix.target.os == 'macos' && matrix.binary == 'basectl'
+        run: brew install protobuf
+
       - name: Install Go for basectl
         if: matrix.binary == 'basectl'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -34,10 +34,10 @@ jobs:
       matrix:
         target:
           - triple: x86_64-unknown-linux-gnu
-            runner: ubuntu-24.04
+            runner: depot-ubuntu-24.04-16
             os: linux
           - triple: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            runner: depot-ubuntu-24.04-arm-16
             os: linux
           - triple: aarch64-apple-darwin
             runner: macos-14
@@ -160,9 +160,9 @@ jobs:
       matrix:
         settings:
           - arch: linux/amd64
-            runs-on: ubuntu-24.04
+            runs-on: depot-ubuntu-24.04-16
           - arch: linux/arm64
-            runs-on: ubuntu-24.04-arm
+            runs-on: depot-ubuntu-24.04-arm-16
         image:
           - target: base
             name: node

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -67,7 +67,13 @@ jobs:
         if: matrix.target.os == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libclang-dev pkg-config
+          sudo apt-get install -y libclang-dev pkg-config protobuf-compiler
+
+      - name: Install Go for basectl
+        if: matrix.binary == 'basectl'
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.24.x'
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
@@ -85,6 +91,13 @@ jobs:
 
       - name: Build binary
         run: |
+          if [ "${{ matrix.target.triple }}" = "aarch64-unknown-linux-gnu" ]; then
+            case "${{ matrix.binary }}" in
+              base|base-consensus|basectl)
+                export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-lblst"
+                ;;
+            esac
+          fi
           cargo build --locked --profile maxperf --bin "${{ matrix.binary }}"
 
       - name: Package binary

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -94,8 +94,8 @@ jobs:
           if [ "${{ matrix.target.triple }}" = "aarch64-unknown-linux-gnu" ]; then
             case "${{ matrix.binary }}" in
               base|base-consensus|basectl)
-                export RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=-lblst"
-                ;;
+                cargo rustc --locked --profile maxperf -p "${{ matrix.binary }}" --bin "${{ matrix.binary }}" -- -C link-arg=-lblst
+                exit
             esac
           fi
           cargo build --locked --profile maxperf --bin "${{ matrix.binary }}"


### PR DESCRIPTION
## Summary

Backport the release binary build fixes from `main` to `releases/v1.3.2`:

- install `protoc` for Linux and macOS `basectl` builds
- install Go 1.24.x for `basectl`'s SP1 gnark dependency
- scope the ARM64 `-lblst` workaround to the final affected binaries
- move Linux release jobs to the larger Depot runners

## Failure analysis

Create RC run https://github.com/base/base/actions/runs/33772030969 used the stale `build-release.yml` inherited from `releases/v1.3.1` and failed in four matrix cells:

- Linux x86_64 and ARM64 `basectl`: `sp1-prover-types` could not find `protoc`
- macOS ARM64 `basectl`: `sp1-recursion-gnark-ffi` could not find Go
- Linux ARM64 `base-consensus`: the linker reported unresolved `blst_*` symbols from `libckzg.a`

These fixes are already merged on `main`, but `releases/v1.3.2` was cut from the previous patch branch and did not inherit them.

## Backported commits

- `00e85b4e6` — ci: fix release binary build dependencies (#4807)
- `2ede9e9c6` — ci: scope aarch64 release link arg to final binary (#4809)
- `6d95e18b1` — ci: install protobuf for macos basectl release builds (#4814)
- `d0c66ca72` — ci: run arm64 release binaries on depot (#4820)

## Validation

- `git diff --check refs/remotes/base/releases/v1.3.2..HEAD`
- `git range-diff` confirms all four cherry-picks are patch-identical to their `main` counterparts
- all four backport commits are signed

Merging this PR will push to `releases/v1.3.2` and automatically start a new Create RC run.
