### PR TITLE
feat(load-tests): Add Cold Validity Predicate Stress

### DIFF
--- a/crates/infra/load-tests/Justfile
+++ b/crates/infra/load-tests/Justfile
@@ -7,7 +7,8 @@
 #   just load-test continuous sepolia                    - Load test sepolia indefinitely
 #   just load-test real-token                            - Real-token swap load test on devnet
 #   just load-test real-token sepolia                    - Real-token swap load test on sepolia
-#   just load-test validity-stress                       - 64-predicate local devnet stress test
+#   just load-test validity-stress                       - Cold 64-predicate local devnet stress test
+#   just load-test validity-stress-warm                  - Fixed-slot warm comparison
 #   just load-test recover                               - Recover funds from devnet test accounts
 #   just load-test recover sepolia                       - Recover funds from sepolia test accounts
 #   just load-test real-token-recover sepolia            - Recover real-token funds from sepolia test accounts
@@ -84,13 +85,33 @@ real-token network='devnet' *args:
     echo "Running real-token devnet load test with rendered config: $rendered_config"
     cargo run -p base-load-tester-bin --bin base-load-tester -- "$rendered_config" {{args}}
 
+# Run the original fixed-slot profile as an apples-to-apples warm-read comparison.
+validity-stress-warm *args:
+    VALIDITY_STRESS_PREDICATE_PROFILE=warm just --justfile {{source_file()}} validity-stress {{args}}
+
 # Deploy DoubleCounter and run the local 64-predicate validity stress profile.
 validity-stress *args:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    if ! command -v flock >/dev/null 2>&1; then
+        echo "validity-stress requires the flock command" >&2
+        exit 1
+    fi
+    lock_file="${XDG_RUNTIME_DIR:-/tmp}/base-validity-stress.lock"
+    exec 9>"$lock_file"
+    if ! flock -n 9; then
+        echo "another validity-stress recipe is already running (lock: $lock_file)" >&2
+        exit 1
+    fi
+
     if [ -z "${FUNDER_KEY:-}" ]; then
         export FUNDER_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
+    fi
+    predicate_profile="${VALIDITY_STRESS_PREDICATE_PROFILE:-cold}"
+    if [ "$predicate_profile" != "cold" ] && [ "$predicate_profile" != "warm" ]; then
+        echo "VALIDITY_STRESS_PREDICATE_PROFILE must be 'cold' or 'warm'" >&2
+        exit 1
     fi
 
     contracts_dir="crates/utilities/test-utils/contracts"
@@ -125,7 +146,7 @@ validity-stress *args:
     fi
 
     cargo run --quiet -p base-load-tests --example render_validity_stress -- \
-        "$template" "$counter" "$rendered_config"
+        "$template" "$counter" "$predicate_profile" "$rendered_config"
 
     mutator_key="${VALIDITY_STRESS_MUTATOR_KEY:-0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a}"
     mutator_interval="${VALIDITY_STRESS_MUTATOR_INTERVAL_SECONDS:-30}"
@@ -151,7 +172,7 @@ validity-stress *args:
     mutate_counter &
     mutator_pid=$!
 
-    echo "Running validity stress test with rendered config: $rendered_config"
+    echo "Running $predicate_profile-read validity stress test with rendered config: $rendered_config"
     cargo run -p base-load-tester-bin --bin base-load-tester -- "$rendered_config" {{args}}
 
 # Run load test against a network indefinitely (Ctrl-C to stop)

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -24,8 +24,11 @@ just load-test run
 # Deploy the devnet WETH/USDC harness and run real-token swaps
 just load-test real-token
 
-# Deploy DoubleCounter and run the 64-predicate validity stress profile
+# Deploy DoubleCounter and run the cold 64-predicate validity stress profile
 just load-test validity-stress
+
+# Run the otherwise-identical fixed-slot warm-read comparison
+just load-test validity-stress-warm
 
 # Run real-token swaps against a network with predeployed contracts
 FUNDER_KEY=0x... just load-test real-token sepolia
@@ -147,7 +150,7 @@ delay is measured for logging but is no longer included in the JSON output.
 | `devnet.yaml` | Local devnet | Uses Anvil Account #1 |
 | `validity-devnet.yaml` | Local devnet | Validity (conditional) workload; routes half the senders through `base_sendRawTransactionValidity`. Run with `FUNDER_KEY=... just load-test run validity-devnet`. Requires the node validity flags for end-to-end enforcement |
 | `real-token-devnet.yaml.template` | Local devnet | Rendered by `just load-test real-token` after deploying the devnet WETH/USDC harness |
-| `validity-stress.yaml.template` | Local devnet | Rendered by `just load-test validity-stress` with a freshly deployed `DoubleCounter` |
+| `validity-stress.yaml.template` | Local devnet | Rendered with cold transaction-specific slots by `just load-test validity-stress`, or fixed slots by `just load-test validity-stress-warm` |
 | `sepolia.yaml` | Base Sepolia | Requires `FUNDER_KEY` |
 | `real-token-sepolia.yaml` | Base Sepolia | Uses predeployed WETH/USDC and the Uniswap V3 swap router; run with `just load-test real-token sepolia`; recover with `just load-test real-token-recover sepolia` |
 | `real-token-mainnet-snapshot.yaml` | Local/shadow Base mainnet snapshot | Wraps funded ETH into WETH, acquires USDC, then runs random-direction Uniswap V3 and Aerodrome CL swaps; run with `just load-test real-token mainnet-snapshot` |
@@ -303,27 +306,48 @@ Recipient keys are always positioned with a runtime-random seed/offset (never th
 `just load-test validity-stress [--continuous ...]` installs and builds the Foundry fixtures,
 deploys `DoubleCounter` to the already-running devnet on port 7545, renders a temporary config, and
 removes that config on exit. It does not restart the devnet. The profile attaches the maximum 64
-storage predicates: 63 always-true reads of distinct slots 1–63 followed by
-`(slot 0 & 1) == sender_parity`, where `sender_parity` is the low bit of each sender address. This
-keeps approximately half the sender streams matching and half parked at either slot value. All 800
-senders target the same contract and attach predicates. Ten percent use twice the baseline priority
-tip while the bulk uses half the baseline tip. The 600M gas/s target fills the controller's two-block
-mempool ceiling with roughly 4,500 validity transactions. An independent devnet account mutates slot
-0 every 30 seconds while measured transactions increment slot 1, so the two sender halves swap
-between matching and parked. That periodically wakes and rescans the parked set without measured
-transactions self-invalidating the parity gate. Override the cadence with
-`VALIDITY_STRESS_MUTATOR_INTERVAL_SECONDS`. This creates a shared-slot adversary where transactions
-repeatedly park, wake, invalidate, and rescan while each evaluation performs the maximum number of
-distinct storage reads.
+storage predicates: 63 always-true reads whose slots are
+`keccak256(pad32(sender) ++ pad32(nonce) ++ pad32(predicate_salt))`, followed by
+`(slot 0 & 1) == sender_parity`, where `sender_parity` is the low bit of each sender address. Because
+both the nonce and a per-predicate salt contribute to the slot, every new transaction introduces 63
+storage locations that no earlier transaction addressed. The shared final predicate keeps
+approximately half the sender streams matching and half parked at either slot value.
 
-With the workload running, verify sustained pressure from the repository root:
+All 800 senders target the same contract and attach predicates. Ten percent use twice the baseline
+priority tip while the bulk uses half the baseline tip. The 600M gas/s target fills the controller's
+two-block mempool ceiling with roughly 4,500 validity transactions. An independent devnet account
+mutates slot 0 every 30 seconds while measured transactions increment slot 1, so the two sender
+halves swap between matching and parked. That periodically wakes and rescans the parked set without
+measured transactions self-invalidating the parity gate. Override the cadence with
+`VALIDITY_STRESS_MUTATOR_INTERVAL_SECONDS`.
+
+`just load-test validity-stress-warm [--continuous ...]` retains the original profile as an
+apples-to-apples comparison. It uses the same transaction stream, fee cohorts, mutator, and 64
+predicates, but its first 63 predicates repeatedly read fixed slots 1–63. Compare the dashboard's
+total and unique storage-slot series and the `Predicate Storage-Slot Uniqueness` panel between the
+two profiles: the warm profile stays near 64 unique slots per build, while the cold profile should
+keep unique reads close to total reads.
+
+Start the matching gate immediately before each workload in another terminal:
 
 ```bash
+# Cold profile (default)
 etc/scripts/devnet/validity-stress-gate.sh --wait
+
+# Warm profile
+PREDICATE_PROFILE=warm etc/scripts/devnet/validity-stress-gate.sh --wait
 ```
 
-The gate requires cutoff pressure, inclusions, storage reads, parking wakeups, and rescans to hold
-continuously for 60 seconds.
+The gate evaluates one-minute rolling Prometheus aggregates and requires passing samples for 30
+seconds; this is not literal per-second continuity. It preserves the 200 completed-build threshold
+and checks cutoff pressure, inclusions, storage reads, parking wakeups, and rescans. The default cold
+gate requires at least half of predicate slot reads to be unique, while the warm gate requires at
+most 10% to be unique. Override those profile thresholds with
+`COLD_MIN_UNIQUE_PREDICATE_SLOT_FRACTION` and `WARM_MAX_UNIQUE_PREDICATE_SLOT_FRACTION`.
+
+Prometheus metrics do not carry load-test run IDs. After one profile finishes, wait at least one
+full gate window (one minute by default) before starting or gating the other profile so rolling
+aggregates do not mix cold and warm samples.
 
 The stress profile submits directly to the builder RPC on port 7545 so ingress forwarding cannot
 become the bottleneck or leave an asynchronous forwarding backlog between runs. To exercise the
@@ -375,6 +399,14 @@ validity:
         key: sender
       op: ">="
       value: "0x0"
+    # a distinct sparse slot for every sender, nonce, and configured salt:
+    - type: storage
+      address: "0x1234567890123456789012345678901234567890"
+      slot:
+        kind: sender_nonce
+        salt: "0x1"
+      op: ">="
+      value: "0x0"
     # build-position predicates read the block/flashblock being built:
     - type: block_number
       op: ">="
@@ -390,16 +422,16 @@ validity:
 
 Predicate addresses resolve per transaction: `sender` → the tx `from`,
 `recipient` → the tx `to` (falling back to `from` for contract creation), or a
-fixed `0x` address. Storage slots are either a `fixed` slot or a `mapping`
-slot, which computes the Solidity mapping slot `keccak256(key ++ mapping_slot)`
-so `balanceOf(key)` slots are expressible. The `flashblock_index` predicate
-carries an `op` and `value`, and `block_number` carries an `op` plus exactly one
-of `value` (a fixed absolute block number) or `offset` (resolved to
-`current_block + offset` at prepare time); both read the build position rather
-than any address or slot. Storage predicate values may also be `sender_parity`,
-which resolves to the low bit of each transaction sender's address. Fixed values,
-slots, masks, and offsets accept hex (`0x...`) or decimal strings. At most 64
-predicates may be attached per transaction.
+fixed `0x` address. Storage slots can be `fixed`, a Solidity `mapping` slot
+`keccak256(key ++ mapping_slot)`, or a transaction-specific `sender_nonce` slot
+`keccak256(pad32(sender) ++ pad32(nonce) ++ pad32(salt))`. The latter is useful for cold-read
+workloads because every sender and nonce pair addresses new sparse state. The `flashblock_index`
+predicate carries an `op` and `value`, and `block_number` carries an `op` plus exactly one of `value`
+(a fixed absolute block number) or `offset` (resolved to `current_block + offset` at prepare time);
+both read the build position rather than any address or slot. Storage predicate values may also be
+`sender_parity`, which resolves to the low bit of each transaction sender's address. Fixed values,
+slots, masks, and offsets accept hex (`0x...`) or decimal strings. At most 64 predicates may be
+attached per transaction.
 
 The final summary's `by_cohort` breakdown reports confirmed transactions split
 across the `plain` and `validity_pass` cohorts, so plain traffic can be compared

--- a/crates/infra/load-tests/README.md
+++ b/crates/infra/load-tests/README.md
@@ -314,11 +314,13 @@ storage locations that no earlier transaction addressed. The shared final predic
 approximately half the sender streams matching and half parked at either slot value.
 
 All 800 senders target the same contract and attach predicates. Ten percent use twice the baseline
-priority tip while the bulk uses half the baseline tip. The 600M gas/s target fills the controller's
-two-block mempool ceiling with roughly 4,500 validity transactions. An independent devnet account
-mutates slot 0 every 30 seconds while measured transactions increment slot 1, so the two sender
-halves swap between matching and parked. That periodically wakes and rescans the parked set without
-measured transactions self-invalidating the parity gate. Override the cadence with
+priority tip while the bulk uses half the baseline tip. The 600M gas/s target continuously fills an
+explicit 400-transaction aggregate in-flight cap. This keeps hundreds of cold validity candidates
+in contention and maintains predicate-cutoff pressure while bounding each native-builder selection
+scan so 200ms payloads can still seal. An independent devnet account mutates slot 0 every 30 seconds
+while measured transactions increment slot 1, so the two sender halves swap between matching and
+parked. That periodically wakes and rescans the parked set without measured transactions
+self-invalidating the parity gate. Override the cadence with
 `VALIDITY_STRESS_MUTATOR_INTERVAL_SECONDS`.
 
 `just load-test validity-stress-warm [--continuous ...]` retains the original profile as an

--- a/crates/infra/load-tests/examples/render_validity_stress.rs
+++ b/crates/infra/load-tests/examples/render_validity_stress.rs
@@ -6,20 +6,30 @@ use eyre::{Result, WrapErr, ensure};
 
 const CONTRACT_PLACEHOLDER: &str = "__DOUBLE_COUNTER__";
 const PREDICATES_PLACEHOLDER: &str = "__VALIDITY_PREDICATES__";
+const COLD_PROFILE: &str = "cold";
+const WARM_PROFILE: &str = "warm";
 
 struct Renderer;
 
 impl Renderer {
-    fn predicates(address: &str) -> String {
+    fn predicates(address: &str, profile: &str) -> String {
         let mut predicates = String::new();
 
-        // Put the parity gate last so both matching and parked transactions perform 64 distinct
-        // storage reads before the gate decides their outcome.
-        for slot in 1..64 {
-            writeln!(
-                predicates,
-                "    - type: storage\n      address: \"{address}\"\n      slot:\n        kind: fixed\n        value: \"0x{slot:x}\"\n      op: \">=\"\n      value: \"0x0\""
-            )
+        // Put the parity gate last so both matching and parked transactions perform all 63 stress
+        // reads before the gate decides their outcome. Cold slots include the sender and nonce so
+        // every new transaction addresses state that previous transactions did not read.
+        for salt in 1..64 {
+            match profile {
+                COLD_PROFILE => writeln!(
+                    predicates,
+                    "    - type: storage\n      address: \"{address}\"\n      slot:\n        kind: sender_nonce\n        salt: \"0x{salt:x}\"\n      op: \">=\"\n      value: \"0x0\""
+                ),
+                WARM_PROFILE => writeln!(
+                    predicates,
+                    "    - type: storage\n      address: \"{address}\"\n      slot:\n        kind: fixed\n        value: \"0x{salt:x}\"\n      op: \">=\"\n      value: \"0x0\""
+                ),
+                _ => unreachable!("profile is validated before rendering"),
+            }
             .expect("writing to a String cannot fail");
         }
         write!(
@@ -31,7 +41,7 @@ impl Renderer {
         predicates
     }
 
-    fn render(template: &str, address: &str) -> Result<String> {
+    fn render(template: &str, address: &str, profile: &str) -> Result<String> {
         ensure!(
             address.len() == 42
                 && address.starts_with("0x")
@@ -43,41 +53,47 @@ impl Renderer {
                 && template.matches(PREDICATES_PLACEHOLDER).count() == 1,
             "template must contain each validity-stress placeholder exactly once"
         );
+        ensure!(
+            matches!(profile, COLD_PROFILE | WARM_PROFILE),
+            "predicate profile must be 'cold' or 'warm'"
+        );
 
         Ok(template
             .replace(CONTRACT_PLACEHOLDER, address)
-            .replace(PREDICATES_PLACEHOLDER, &Self::predicates(address)))
+            .replace(PREDICATES_PLACEHOLDER, &Self::predicates(address, profile)))
     }
 }
 
 fn main() -> Result<()> {
     let args = env::args().collect::<Vec<_>>();
     ensure!(
-        args.len() == 4,
-        "usage: {} <template> <contract-address> <output>",
+        args.len() == 5,
+        "usage: {} <template> <contract-address> <cold|warm> <output>",
         args.first().map(String::as_str).unwrap_or("render_validity_stress")
     );
 
     let template = fs::read_to_string(Path::new(&args[1]))
         .wrap_err_with(|| format!("failed to read template {}", args[1]))?;
-    let rendered = Renderer::render(&template, &args[2])?;
-    fs::write(Path::new(&args[3]), rendered)
-        .wrap_err_with(|| format!("failed to write rendered config {}", args[3]))?;
+    let rendered = Renderer::render(&template, &args[2], &args[3])?;
+    fs::write(Path::new(&args[4]), rendered)
+        .wrap_err_with(|| format!("failed to write rendered config {}", args[4]))?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{PREDICATES_PLACEHOLDER, Renderer};
+    use super::{COLD_PROFILE, PREDICATES_PLACEHOLDER, Renderer, WARM_PROFILE};
 
     const ADDRESS: &str = "0x1234567890123456789012345678901234567890";
     const TEMPLATE: &str = include_str!("validity-stress.yaml.template");
 
     #[test]
-    fn renders_exactly_64_storage_predicates() {
-        let result = Renderer::render(TEMPLATE, ADDRESS).unwrap();
+    fn renders_cold_profile_with_transaction_unique_slots() {
+        let result = Renderer::render(TEMPLATE, ADDRESS, COLD_PROFILE).unwrap();
 
         assert_eq!(result.matches("    - type: storage").count(), 64);
+        assert_eq!(result.matches("        kind: sender_nonce").count(), 63);
+        assert_eq!(result.matches("        kind: fixed").count(), 1);
         assert_eq!(result.matches("      mask: \"0x1\"").count(), 1);
         assert_eq!(result.matches("      op: \">=\"").count(), 63);
         assert_eq!(result.matches(&format!("      address: \"{ADDRESS}\"")).count(), 64);
@@ -90,8 +106,8 @@ mod tests {
         assert!(result.contains("priority_lead_ratio: 0.10"));
         assert!(result.contains("priority_lead_multiplier: 2"));
         assert!(result.contains("priority_fee_divisor: 2"));
-        for slot in 0..64 {
-            assert_eq!(result.matches(&format!("        value: \"0x{slot:x}\"")).count(), 1);
+        for salt in 1..64 {
+            assert_eq!(result.matches(&format!("        salt: \"0x{salt:x}\"")).count(), 1);
         }
 
         let last_predicate = result.rsplit_once("    - type: storage").unwrap().1;
@@ -104,9 +120,26 @@ mod tests {
     }
 
     #[test]
+    fn renders_fixed_slot_warm_comparison() {
+        let result = Renderer::render(TEMPLATE, ADDRESS, WARM_PROFILE).unwrap();
+
+        assert_eq!(result.matches("    - type: storage").count(), 64);
+        assert_eq!(result.matches("        kind: fixed").count(), 64);
+        assert!(!result.contains("        kind: sender_nonce"));
+        for slot in 0..64 {
+            assert_eq!(result.matches(&format!("        value: \"0x{slot:x}\"")).count(), 1);
+        }
+    }
+
+    #[test]
     fn rejects_address_without_hex_prefix() {
         let address = ADDRESS.trim_start_matches("0x");
 
-        assert!(Renderer::render(TEMPLATE, address).is_err());
+        assert!(Renderer::render(TEMPLATE, address, COLD_PROFILE).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_predicate_profile() {
+        assert!(Renderer::render(TEMPLATE, ADDRESS, "mixed").is_err());
     }
 }

--- a/crates/infra/load-tests/examples/render_validity_stress.rs
+++ b/crates/infra/load-tests/examples/render_validity_stress.rs
@@ -101,7 +101,7 @@ mod tests {
         assert!(result.contains("target_gps: 600000000"));
         assert!(result.contains("transaction_submission_rpcs:\n  - \"http://localhost:7545\""));
         assert!(result.contains("in_flight_per_sender: 12"));
-        assert!(result.contains("max_total_in_flight: 9600"));
+        assert!(result.contains("max_total_in_flight: 400"));
         assert!(result.contains("ratio: 1.0"));
         assert!(result.contains("priority_lead_ratio: 0.10"));
         assert!(result.contains("priority_lead_multiplier: 2"));

--- a/crates/infra/load-tests/examples/render_validity_stress.rs
+++ b/crates/infra/load-tests/examples/render_validity_stress.rs
@@ -1,44 +1,63 @@
 //! Renders the validity-predicate stress profile for a deployed `DoubleCounter` contract.
 
-use std::{env, fmt::Write as _, fs, path::Path};
+use std::{env, fs, path::Path};
 
+use alloy_primitives::U256;
+use base_load_tests::{
+    PredicateAddressConfig, PredicateSlotConfig, PredicateValueConfig, ValidityPredicateConfig,
+};
 use eyre::{Result, WrapErr, ensure};
 
 const CONTRACT_PLACEHOLDER: &str = "__DOUBLE_COUNTER__";
 const PREDICATES_PLACEHOLDER: &str = "__VALIDITY_PREDICATES__";
 const COLD_PROFILE: &str = "cold";
 const WARM_PROFILE: &str = "warm";
+const PREDICATE_COUNT: u64 = 64;
+/// Indentation that nests the serialized predicate list under the template's `predicates:` key.
+const PREDICATE_INDENT: &str = "    ";
 
 struct Renderer;
 
 impl Renderer {
-    fn predicates(address: &str, profile: &str) -> String {
-        let mut predicates = String::new();
-
-        // Put the parity gate last so both matching and parked transactions perform all 63 stress
-        // reads before the gate decides their outcome. Cold slots include the sender and nonce so
-        // every new transaction addresses state that previous transactions did not read.
-        for salt in 1..64 {
-            match profile {
-                COLD_PROFILE => writeln!(
-                    predicates,
-                    "    - type: storage\n      address: \"{address}\"\n      slot:\n        kind: sender_nonce\n        salt: \"0x{salt:x}\"\n      op: \">=\"\n      value: \"0x0\""
-                ),
-                WARM_PROFILE => writeln!(
-                    predicates,
-                    "    - type: storage\n      address: \"{address}\"\n      slot:\n        kind: fixed\n        value: \"0x{salt:x}\"\n      op: \">=\"\n      value: \"0x0\""
-                ),
-                _ => unreachable!("profile is validated before rendering"),
-            }
-            .expect("writing to a String cannot fail");
-        }
-        write!(
-            predicates,
-            "    - type: storage\n      address: \"{address}\"\n      slot:\n        kind: fixed\n        value: \"0x0\"\n      mask: \"0x1\"\n      op: \"=\"\n      value: \"sender_parity\""
-        )
-        .expect("writing to a String cannot fail");
-
+    /// Builds the stress predicate set for `profile`, reading storage on `address`.
+    ///
+    /// Puts the parity gate last so both matching and parked transactions perform all 63 stress
+    /// reads before the gate decides their outcome. Cold slots include the sender and nonce so
+    /// every new transaction addresses state that previous transactions did not read.
+    fn predicates(address: &str, profile: &str) -> Vec<ValidityPredicateConfig> {
+        let contract = PredicateAddressConfig::Fixed(address.to_string());
+        let mut predicates = (1..PREDICATE_COUNT)
+            .map(|salt| ValidityPredicateConfig::Storage {
+                address: contract.clone(),
+                slot: match profile {
+                    COLD_PROFILE => PredicateSlotConfig::SenderNonce { salt: U256::from(salt) },
+                    WARM_PROFILE => PredicateSlotConfig::Fixed { value: U256::from(salt) },
+                    _ => unreachable!("profile is validated before rendering"),
+                },
+                mask: None,
+                op: ">=".to_string(),
+                value: PredicateValueConfig::Fixed(U256::ZERO),
+            })
+            .collect::<Vec<_>>();
+        predicates.push(ValidityPredicateConfig::Storage {
+            address: contract,
+            slot: PredicateSlotConfig::Fixed { value: U256::ZERO },
+            mask: Some(U256::from(1)),
+            op: "=".to_string(),
+            value: PredicateValueConfig::Source("sender_parity".to_string()),
+        });
         predicates
+    }
+
+    /// Serializes `predicates` to YAML, indenting each line to nest under `predicates:`.
+    fn render_predicates(predicates: &[ValidityPredicateConfig]) -> Result<String> {
+        let yaml = serde_yaml::to_string(predicates)
+            .wrap_err("failed to serialize validity predicates")?;
+        Ok(yaml
+            .lines()
+            .map(|line| format!("{PREDICATE_INDENT}{line}"))
+            .collect::<Vec<_>>()
+            .join("\n"))
     }
 
     fn render(template: &str, address: &str, profile: &str) -> Result<String> {
@@ -58,9 +77,10 @@ impl Renderer {
             "predicate profile must be 'cold' or 'warm'"
         );
 
+        let predicates = Self::render_predicates(&Self::predicates(address, profile))?;
         Ok(template
             .replace(CONTRACT_PLACEHOLDER, address)
-            .replace(PREDICATES_PLACEHOLDER, &Self::predicates(address, profile)))
+            .replace(PREDICATES_PLACEHOLDER, &predicates))
     }
 }
 
@@ -82,52 +102,88 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::U256;
+    use base_load_tests::{
+        PredicateSlotConfig, PredicateValueConfig, TestConfig, ValidityConfig,
+        ValidityPredicateConfig,
+    };
+
     use super::{COLD_PROFILE, PREDICATES_PLACEHOLDER, Renderer, WARM_PROFILE};
 
     const ADDRESS: &str = "0x1234567890123456789012345678901234567890";
     const TEMPLATE: &str = include_str!("validity-stress.yaml.template");
 
+    /// Renders `profile` and parses it back through the load tester's real config type, proving
+    /// the serialized YAML is both well-formed and semantically what the profile intends.
+    fn render_validity(profile: &str) -> ValidityConfig {
+        let rendered = Renderer::render(TEMPLATE, ADDRESS, profile).unwrap();
+        assert!(!rendered.contains(PREDICATES_PLACEHOLDER));
+        assert!(!rendered.contains("__DOUBLE_COUNTER__"));
+        let config: TestConfig = serde_yaml::from_str(&rendered).unwrap();
+        config.validity.validate().unwrap();
+        config.validity
+    }
+
+    /// Extracts the storage slot and comparison value from a storage predicate.
+    fn storage_slot_value(
+        predicate: &ValidityPredicateConfig,
+    ) -> (&PredicateSlotConfig, &PredicateValueConfig) {
+        match predicate {
+            ValidityPredicateConfig::Storage { slot, value, .. } => (slot, value),
+            other => panic!("expected storage predicate, got {other:?}"),
+        }
+    }
+
     #[test]
     fn renders_cold_profile_with_transaction_unique_slots() {
-        let result = Renderer::render(TEMPLATE, ADDRESS, COLD_PROFILE).unwrap();
+        let validity = render_validity(COLD_PROFILE);
 
-        assert_eq!(result.matches("    - type: storage").count(), 64);
-        assert_eq!(result.matches("        kind: sender_nonce").count(), 63);
-        assert_eq!(result.matches("        kind: fixed").count(), 1);
-        assert_eq!(result.matches("      mask: \"0x1\"").count(), 1);
-        assert_eq!(result.matches("      op: \">=\"").count(), 63);
-        assert_eq!(result.matches(&format!("      address: \"{ADDRESS}\"")).count(), 64);
-        assert!(result.contains("sender_count: 800"));
-        assert!(result.contains("target_gps: 600000000"));
-        assert!(result.contains("transaction_submission_rpcs:\n  - \"http://localhost:7545\""));
-        assert!(result.contains("in_flight_per_sender: 12"));
-        assert!(result.contains("max_total_in_flight: 400"));
-        assert!(result.contains("ratio: 1.0"));
-        assert!(result.contains("priority_lead_ratio: 0.10"));
-        assert!(result.contains("priority_lead_multiplier: 2"));
-        assert!(result.contains("priority_fee_divisor: 2"));
-        for salt in 1..64 {
-            assert_eq!(result.matches(&format!("        salt: \"0x{salt:x}\"")).count(), 1);
+        assert_eq!(validity.ratio, 1.0);
+        assert_eq!(validity.priority_lead_ratio, 0.10);
+        assert_eq!(validity.priority_lead_multiplier, 2);
+        assert_eq!(validity.priority_fee_divisor, 2);
+        assert_eq!(validity.predicates.len(), 64);
+
+        let (gate, stress) = validity.predicates.split_last().unwrap();
+        for (index, predicate) in stress.iter().enumerate() {
+            let salt = u64::try_from(index + 1).unwrap();
+            match storage_slot_value(predicate) {
+                (PredicateSlotConfig::SenderNonce { salt: got }, PredicateValueConfig::Fixed(v)) => {
+                    assert_eq!(*got, U256::from(salt));
+                    assert_eq!(*v, U256::ZERO);
+                }
+                other => panic!("expected cold sender-nonce predicate, got {other:?}"),
+            }
         }
 
-        let last_predicate = result.rsplit_once("    - type: storage").unwrap().1;
-        assert!(last_predicate.contains("        value: \"0x0\""));
-        assert!(last_predicate.contains("      mask: \"0x1\""));
-        assert!(last_predicate.contains("      op: \"=\""));
-        assert!(last_predicate.contains("      value: \"sender_parity\""));
-        assert!(!result.contains(PREDICATES_PLACEHOLDER));
-        assert!(!result.contains("__DOUBLE_COUNTER__"));
+        match gate {
+            ValidityPredicateConfig::Storage { slot, mask, value, .. } => {
+                assert!(matches!(slot, PredicateSlotConfig::Fixed { value } if *value == U256::ZERO));
+                assert_eq!(*mask, Some(U256::from(1)));
+                assert!(matches!(value, PredicateValueConfig::Source(source) if source == "sender_parity"));
+            }
+            other => panic!("expected storage gate predicate, got {other:?}"),
+        }
     }
 
     #[test]
     fn renders_fixed_slot_warm_comparison() {
-        let result = Renderer::render(TEMPLATE, ADDRESS, WARM_PROFILE).unwrap();
+        let validity = render_validity(WARM_PROFILE);
 
-        assert_eq!(result.matches("    - type: storage").count(), 64);
-        assert_eq!(result.matches("        kind: fixed").count(), 64);
-        assert!(!result.contains("        kind: sender_nonce"));
-        for slot in 0..64 {
-            assert_eq!(result.matches(&format!("        value: \"0x{slot:x}\"")).count(), 1);
+        assert_eq!(validity.predicates.len(), 64);
+        let (_gate, stress) = validity.predicates.split_last().unwrap();
+        for (index, predicate) in stress.iter().enumerate() {
+            let expected = u64::try_from(index + 1).unwrap();
+            match storage_slot_value(predicate) {
+                (PredicateSlotConfig::Fixed { value }, _) => {
+                    assert_eq!(*value, U256::from(expected));
+                }
+                other => panic!("expected warm fixed-slot predicate, got {other:?}"),
+            }
+            assert!(!matches!(
+                predicate,
+                ValidityPredicateConfig::Storage { slot: PredicateSlotConfig::SenderNonce { .. }, .. }
+            ));
         }
     }
 

--- a/crates/infra/load-tests/examples/render_validity_stress.rs
+++ b/crates/infra/load-tests/examples/render_validity_stress.rs
@@ -148,7 +148,10 @@ mod tests {
         for (index, predicate) in stress.iter().enumerate() {
             let salt = u64::try_from(index + 1).unwrap();
             match storage_slot_value(predicate) {
-                (PredicateSlotConfig::SenderNonce { salt: got }, PredicateValueConfig::Fixed(v)) => {
+                (
+                    PredicateSlotConfig::SenderNonce { salt: got },
+                    PredicateValueConfig::Fixed(v),
+                ) => {
                     assert_eq!(*got, U256::from(salt));
                     assert_eq!(*v, U256::ZERO);
                 }
@@ -158,9 +161,13 @@ mod tests {
 
         match gate {
             ValidityPredicateConfig::Storage { slot, mask, value, .. } => {
-                assert!(matches!(slot, PredicateSlotConfig::Fixed { value } if *value == U256::ZERO));
+                assert!(
+                    matches!(slot, PredicateSlotConfig::Fixed { value } if *value == U256::ZERO)
+                );
                 assert_eq!(*mask, Some(U256::from(1)));
-                assert!(matches!(value, PredicateValueConfig::Source(source) if source == "sender_parity"));
+                assert!(
+                    matches!(value, PredicateValueConfig::Source(source) if source == "sender_parity")
+                );
             }
             other => panic!("expected storage gate predicate, got {other:?}"),
         }
@@ -182,7 +189,10 @@ mod tests {
             }
             assert!(!matches!(
                 predicate,
-                ValidityPredicateConfig::Storage { slot: PredicateSlotConfig::SenderNonce { .. }, .. }
+                ValidityPredicateConfig::Storage {
+                    slot: PredicateSlotConfig::SenderNonce { .. },
+                    ..
+                }
             ));
         }
     }

--- a/crates/infra/load-tests/examples/validity-stress.yaml.template
+++ b/crates/infra/load-tests/examples/validity-stress.yaml.template
@@ -14,7 +14,8 @@ sender_count: 800
 target_gps: 600000000
 block_time: "200ms"
 in_flight_per_sender: 12
-max_total_in_flight: 9600
+# Bound each native-builder scan while keeping hundreds of cold validity candidates in contention.
+max_total_in_flight: 400
 max_concurrent_submit_requests: 64
 batch_size: 1
 duration: "90s"

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -197,6 +197,12 @@ pub enum PredicateSlotConfig {
         #[serde(default)]
         key: PredicateAddressConfig,
     },
+    /// A transaction-specific slot
+    /// `keccak256(pad32(sender) ++ pad32(nonce) ++ pad32(salt))`.
+    SenderNonce {
+        /// Domain separator that gives each predicate a distinct slot.
+        salt: U256,
+    },
 }
 
 impl ValidityConfig {
@@ -303,6 +309,7 @@ impl PredicateSlotConfig {
             Self::Mapping { mapping_slot, key } => {
                 Ok(SlotTemplate::Mapping { mapping_slot: *mapping_slot, key: key.to_template()? })
             }
+            Self::SenderNonce { salt } => Ok(SlotTemplate::SenderNonce { salt: *salt }),
         }
     }
 }
@@ -393,6 +400,23 @@ mod tests {
                 assert!(matches!(key, PredicateAddress::Sender));
             }
             other => panic!("expected mapping template, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn storage_predicate_parses_sender_nonce_slot_from_yaml() {
+        let config: ValidityPredicateConfig = serde_yaml::from_str(
+            "type: storage\naddress: sender\nslot:\n  kind: sender_nonce\n  salt: \"0x2a\"\nop: \"=\"\nvalue: \"0x0\"\n",
+        )
+        .unwrap();
+
+        match config.to_template().unwrap() {
+            ValidityPredicateTemplate::Storage { slot, .. } => {
+                assert!(
+                    matches!(slot, SlotTemplate::SenderNonce { salt } if salt == U256::from(0x2a))
+                );
+            }
+            other => panic!("expected storage template, got {other:?}"),
         }
     }
 

--- a/crates/infra/load-tests/src/config/validity.rs
+++ b/crates/infra/load-tests/src/config/validity.rs
@@ -79,7 +79,7 @@ pub enum ValidityPredicateConfig {
         /// Storage slot to read.
         slot: PredicateSlotConfig,
         /// Optional bit mask; defaults to all ones server-side.
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         mask: Option<U256>,
         /// Comparison operator (`<`, `<=`, `=`, `!=`, `>`, `>=`).
         op: String,

--- a/crates/infra/load-tests/src/runner/config.rs
+++ b/crates/infra/load-tests/src/runner/config.rs
@@ -34,6 +34,12 @@ pub enum SlotTemplate {
         /// Mapping key address, resolved per transaction.
         key: PredicateAddress,
     },
+    /// A transaction-specific slot
+    /// `keccak256(pad32(sender) ++ pad32(nonce) ++ pad32(salt))`.
+    SenderNonce {
+        /// Domain separator that gives each predicate a distinct slot.
+        salt: U256,
+    },
 }
 
 /// Source for a storage predicate's comparison value, resolved per transaction.
@@ -78,8 +84,9 @@ pub enum BlockNumberBound {
 /// A runtime validity predicate template with literal values pre-parsed.
 ///
 /// Addresses and slots may remain symbolic ([`PredicateAddress::Sender`],
-/// [`SlotTemplate::Mapping`]) and are resolved into concrete
-/// `ValidityPredicate` values against each transaction at prepare time.
+/// [`SlotTemplate::Mapping`], [`SlotTemplate::SenderNonce`]) and are resolved
+/// into concrete `ValidityPredicate` values against each transaction at prepare
+/// time.
 #[derive(Debug, Clone)]
 pub enum ValidityPredicateTemplate {
     /// Balance comparison template.

--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -1258,8 +1258,19 @@ impl LoadRunner {
         for (sender_index, from) in config.sender_addresses.iter().copied().enumerate() {
             let sender_pool_recipient = config.sender_addresses[(sender_index + 1) % sender_count];
             let cohort = config.validity_router.cohort_for_sender(from);
+            let start_nonce = config.sender_next_nonces[sender_index];
             let mut prepared_txs = Vec::with_capacity(txs_per_sender);
-            for _ in 0..txs_per_sender {
+            for nonce_offset in 0..txs_per_sender {
+                let nonce_offset = u64::try_from(nonce_offset).map_err(|error| {
+                    BaselineError::Transaction(format!(
+                        "failed to convert nonce offset to u64: {error}"
+                    ))
+                })?;
+                let nonce = start_nonce.checked_add(nonce_offset).ok_or_else(|| {
+                    BaselineError::Transaction(format!(
+                        "nonce overflow for sender {from} at offset {nonce_offset}"
+                    ))
+                })?;
                 let payload = generator.select_payload()?;
                 let to = if payload.uses_runner_recipient() {
                     Self::select_recipient(
@@ -1277,8 +1288,13 @@ impl LoadRunner {
                 let value = tx_request.value.unwrap_or(U256::ZERO);
                 let data = tx_request.input.input().cloned().unwrap_or_default();
                 let gas_limit = tx_request.gas.unwrap_or(21_000);
-                let validity =
-                    config.validity_router.predicates_for(cohort, current_block, from, to_addr);
+                let validity = config.validity_router.predicates_for(
+                    cohort,
+                    current_block,
+                    nonce,
+                    from,
+                    to_addr,
+                );
 
                 prepared_txs.push(PreparedTransaction {
                     from,
@@ -1295,7 +1311,7 @@ impl LoadRunner {
             sender_jobs.push(SenderJob {
                 sender_index,
                 from,
-                start_nonce: config.sender_next_nonces[sender_index],
+                start_nonce,
                 generation: config.sender_generations[sender_index],
                 prepared_txs,
             });

--- a/crates/infra/load-tests/src/runner/validity_router.rs
+++ b/crates/infra/load-tests/src/runner/validity_router.rs
@@ -172,7 +172,13 @@ fn resolve_slot(slot: &SlotTemplate, nonce: u64, from: Address, to: Option<Addre
         SlotTemplate::Mapping { mapping_slot, key } => {
             mapping_slot_for(resolve_address(key, from, to), *mapping_slot)
         }
-        SlotTemplate::SenderNonce { salt } => sender_nonce_slot(from, nonce, *salt),
+        SlotTemplate::SenderNonce { salt } => {
+            let mut preimage = [0u8; 96];
+            preimage[12..32].copy_from_slice(from.as_slice());
+            preimage[56..64].copy_from_slice(&nonce.to_be_bytes());
+            preimage[64..96].copy_from_slice(&salt.to_be_bytes::<32>());
+            U256::from_be_bytes::<32>(keccak256(preimage).0)
+        }
     }
 }
 
@@ -182,15 +188,6 @@ fn mapping_slot_for(key: Address, mapping_slot: U256) -> U256 {
     let mut preimage = [0u8; 64];
     preimage[12..32].copy_from_slice(key.as_slice());
     preimage[32..64].copy_from_slice(&mapping_slot.to_be_bytes::<32>());
-    U256::from_be_bytes::<32>(keccak256(preimage).0)
-}
-
-/// Computes `keccak256(pad32(sender) ++ pad32(nonce) ++ pad32(salt))`.
-fn sender_nonce_slot(sender: Address, nonce: u64, salt: U256) -> U256 {
-    let mut preimage = [0u8; 96];
-    preimage[12..32].copy_from_slice(sender.as_slice());
-    preimage[56..64].copy_from_slice(&nonce.to_be_bytes());
-    preimage[64..96].copy_from_slice(&salt.to_be_bytes::<32>());
     U256::from_be_bytes::<32>(keccak256(preimage).0)
 }
 

--- a/crates/infra/load-tests/src/runner/validity_router.rs
+++ b/crates/infra/load-tests/src/runner/validity_router.rs
@@ -90,18 +90,22 @@ impl ValidityRouter {
     ///
     /// `current_block` is the latest chain height at prepare time, used to
     /// resolve any [`BlockNumberBound::Offset`] into an absolute block number
-    /// (`current_block + offset`). Absolute bounds ignore it.
+    /// (`current_block + offset`). `nonce` makes [`SlotTemplate::SenderNonce`]
+    /// storage locations unique to the transaction being prepared.
     pub fn predicates_for(
         &self,
         cohort: SubmitCohort,
         current_block: u64,
+        nonce: u64,
         from: Address,
         to: Option<Address>,
     ) -> Vec<ValidityPredicate> {
         match cohort {
-            SubmitCohort::ValidityPass | SubmitCohort::ValidityPassPriorityLead => {
-                self.predicates.iter().map(|t| Self::resolve(t, current_block, from, to)).collect()
-            }
+            SubmitCohort::ValidityPass | SubmitCohort::ValidityPassPriorityLead => self
+                .predicates
+                .iter()
+                .map(|template| Self::resolve(template, current_block, nonce, from, to))
+                .collect(),
             SubmitCohort::Plain => Vec::new(),
         }
     }
@@ -110,6 +114,7 @@ impl ValidityRouter {
     fn resolve(
         template: &ValidityPredicateTemplate,
         current_block: u64,
+        nonce: u64,
         from: Address,
         to: Option<Address>,
     ) -> ValidityPredicate {
@@ -124,7 +129,7 @@ impl ValidityRouter {
             ValidityPredicateTemplate::Storage { address, slot, mask, op, value } => {
                 ValidityPredicate::Storage {
                     address: resolve_address(address, from, to),
-                    slot: resolve_slot(slot, from, to),
+                    slot: resolve_slot(slot, nonce, from, to),
                     mask: mask.unwrap_or_else(ValidityPredicate::default_mask),
                     op: *op,
                     value: value.resolve(from),
@@ -160,14 +165,14 @@ fn resolve_address(source: &PredicateAddress, from: Address, to: Option<Address>
     }
 }
 
-/// Resolves a storage slot source, computing the Solidity mapping slot when
-/// required.
-fn resolve_slot(slot: &SlotTemplate, from: Address, to: Option<Address>) -> U256 {
+/// Resolves a storage slot source against the transaction being prepared.
+fn resolve_slot(slot: &SlotTemplate, nonce: u64, from: Address, to: Option<Address>) -> U256 {
     match slot {
         SlotTemplate::Fixed(value) => *value,
         SlotTemplate::Mapping { mapping_slot, key } => {
             mapping_slot_for(resolve_address(key, from, to), *mapping_slot)
         }
+        SlotTemplate::SenderNonce { salt } => sender_nonce_slot(from, nonce, *salt),
     }
 }
 
@@ -177,6 +182,15 @@ fn mapping_slot_for(key: Address, mapping_slot: U256) -> U256 {
     let mut preimage = [0u8; 64];
     preimage[12..32].copy_from_slice(key.as_slice());
     preimage[32..64].copy_from_slice(&mapping_slot.to_be_bytes::<32>());
+    U256::from_be_bytes::<32>(keccak256(preimage).0)
+}
+
+/// Computes `keccak256(pad32(sender) ++ pad32(nonce) ++ pad32(salt))`.
+fn sender_nonce_slot(sender: Address, nonce: u64, salt: U256) -> U256 {
+    let mut preimage = [0u8; 96];
+    preimage[12..32].copy_from_slice(sender.as_slice());
+    preimage[56..64].copy_from_slice(&nonce.to_be_bytes());
+    preimage[64..96].copy_from_slice(&salt.to_be_bytes::<32>());
     U256::from_be_bytes::<32>(keccak256(preimage).0)
 }
 
@@ -293,7 +307,7 @@ mod tests {
         let r = router(1.0, templates);
         let from = Address::repeat_byte(0xaa);
         let to = Address::repeat_byte(0xbb);
-        let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, from, Some(to));
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, 0, from, Some(to));
         assert_eq!(predicates.len(), 2);
         match &predicates[0] {
             ValidityPredicate::Balance { address, .. } => assert_eq!(*address, from),
@@ -321,6 +335,7 @@ mod tests {
         let predicates = r.predicates_for(
             SubmitCohort::ValidityPass,
             0,
+            0,
             Address::repeat_byte(0xaa),
             Some(Address::repeat_byte(0xbb)),
         );
@@ -346,8 +361,13 @@ mod tests {
             bound: BlockNumberBound::Absolute(U256::from(12345)),
         }];
         let r = router(1.0, templates);
-        let predicates =
-            r.predicates_for(SubmitCohort::ValidityPass, 9_000, Address::repeat_byte(0xaa), None);
+        let predicates = r.predicates_for(
+            SubmitCohort::ValidityPass,
+            9_000,
+            0,
+            Address::repeat_byte(0xaa),
+            None,
+        );
         assert_eq!(
             predicates,
             vec![ValidityPredicate::BlockNumber {
@@ -364,8 +384,13 @@ mod tests {
             bound: BlockNumberBound::Offset(U256::from(10)),
         }];
         let r = router(1.0, templates);
-        let predicates =
-            r.predicates_for(SubmitCohort::ValidityPass, 1_000, Address::repeat_byte(0xaa), None);
+        let predicates = r.predicates_for(
+            SubmitCohort::ValidityPass,
+            1_000,
+            0,
+            Address::repeat_byte(0xaa),
+            None,
+        );
         assert_eq!(
             predicates,
             vec![ValidityPredicate::BlockNumber {
@@ -382,8 +407,13 @@ mod tests {
             bound: BlockNumberBound::Offset(U256::MAX),
         }];
         let r = router(1.0, templates);
-        let predicates =
-            r.predicates_for(SubmitCohort::ValidityPass, 1_000, Address::repeat_byte(0xaa), None);
+        let predicates = r.predicates_for(
+            SubmitCohort::ValidityPass,
+            1_000,
+            0,
+            Address::repeat_byte(0xaa),
+            None,
+        );
         assert_eq!(
             predicates,
             vec![ValidityPredicate::BlockNumber {
@@ -446,9 +476,15 @@ mod tests {
             value: U256::from(2),
         }];
         let r = router(1.0, templates);
-        let low = r.predicates_for(SubmitCohort::ValidityPass, 0, Address::repeat_byte(0xaa), None);
-        let high =
-            r.predicates_for(SubmitCohort::ValidityPass, 9_999, Address::repeat_byte(0xaa), None);
+        let low =
+            r.predicates_for(SubmitCohort::ValidityPass, 0, 0, Address::repeat_byte(0xaa), None);
+        let high = r.predicates_for(
+            SubmitCohort::ValidityPass,
+            9_999,
+            0,
+            Address::repeat_byte(0xaa),
+            None,
+        );
         assert_eq!(low, high);
         assert_eq!(
             low,
@@ -468,7 +504,7 @@ mod tests {
         }];
         let r = router(1.0, templates);
         let from = Address::repeat_byte(0xaa);
-        assert!(r.predicates_for(SubmitCohort::Plain, 0, from, None).is_empty());
+        assert!(r.predicates_for(SubmitCohort::Plain, 0, 0, from, None).is_empty());
     }
 
     #[test]
@@ -480,7 +516,7 @@ mod tests {
         }];
         let r = router(1.0, templates);
         let from = Address::repeat_byte(0xaa);
-        let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, from, None);
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, 0, from, None);
         match &predicates[0] {
             ValidityPredicate::Balance { address, .. } => assert_eq!(*address, from),
             other => panic!("expected balance, got {other:?}"),
@@ -502,7 +538,7 @@ mod tests {
             value: PredicateValue::Fixed(U256::ZERO),
         }];
         let r = router(1.0, templates);
-        let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, Address::ZERO, None);
+        let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, 0, Address::ZERO, None);
         let expected = {
             let mut preimage = [0u8; 64];
             preimage[12..32].copy_from_slice(key.as_slice());
@@ -519,6 +555,53 @@ mod tests {
     }
 
     #[test]
+    fn sender_nonce_slot_matches_known_vector_and_changes_with_each_input() {
+        let sender = Address::repeat_byte(0x11);
+        let salt = U256::from(7);
+        let templates = vec![ValidityPredicateTemplate::Storage {
+            address: PredicateAddress::Fixed(Address::repeat_byte(0x99)),
+            slot: SlotTemplate::SenderNonce { salt },
+            mask: None,
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: PredicateValue::Fixed(U256::ZERO),
+        }];
+        let r = router(1.0, templates);
+
+        let concrete_slot = |router: &ValidityRouter, sender, nonce| match &router.predicates_for(
+            SubmitCohort::ValidityPass,
+            0,
+            nonce,
+            sender,
+            None,
+        )[0]
+        {
+            ValidityPredicate::Storage { slot, .. } => *slot,
+            other => panic!("expected storage predicate, got {other:?}"),
+        };
+        let slot = concrete_slot(&r, sender, 42);
+        let expected = U256::from_str_radix(
+            "da52651d545e6d5ecd593d763e061ef7a0521fafaac8f10fe44c58a420947341",
+            16,
+        )
+        .unwrap();
+        let different_salt = router(
+            1.0,
+            vec![ValidityPredicateTemplate::Storage {
+                address: PredicateAddress::Fixed(Address::repeat_byte(0x99)),
+                slot: SlotTemplate::SenderNonce { salt: salt + U256::from(1) },
+                mask: None,
+                op: ValidityOperator::GreaterThanOrEqual,
+                value: PredicateValue::Fixed(U256::ZERO),
+            }],
+        );
+
+        assert_eq!(slot, expected);
+        assert_ne!(slot, concrete_slot(&r, Address::repeat_byte(0x12), 42));
+        assert_ne!(slot, concrete_slot(&r, sender, 43));
+        assert_ne!(slot, concrete_slot(&different_salt, sender, 42));
+    }
+
+    #[test]
     fn sender_parity_value_splits_storage_predicates_by_sender() {
         let templates = vec![ValidityPredicateTemplate::Storage {
             address: PredicateAddress::Fixed(Address::repeat_byte(0x99)),
@@ -532,7 +615,7 @@ mod tests {
         for (sender, expected) in
             [(Address::repeat_byte(0x10), U256::ZERO), (Address::repeat_byte(0x11), U256::from(1))]
         {
-            let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, sender, None);
+            let predicates = r.predicates_for(SubmitCohort::ValidityPass, 0, 0, sender, None);
             match &predicates[0] {
                 ValidityPredicate::Storage { value, .. } => assert_eq!(*value, expected),
                 other => panic!("expected storage, got {other:?}"),

--- a/etc/scripts/devnet/grafana/dashboards/base-mev.json
+++ b/etc/scripts/devnet/grafana/dashboards/base-mev.json
@@ -1324,7 +1324,7 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
+            "w": 8,
             "x": 0,
             "y": 10
           },
@@ -1402,8 +1402,8 @@
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
+            "w": 8,
+            "x": 8,
             "y": 10
           },
           "id": 16,
@@ -1470,6 +1470,96 @@
             }
           ],
           "title": "Predicate State Reads per Active Build",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "description": "Weighted percentage of predicate storage-slot reads that are unique over the selected window. Warm fixed-slot stress should remain at or below 10%; cold sender+nonce+salt stress should reach at least 50%. This measures logical state-footprint uniqueness, not direct physical cache or disk misses. Predicate rescans repeat slots and therefore lower the ratio. A zero total-read rate is shown as no data rather than as a misleading percentage.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "decimals": 2,
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#5794F2",
+                    "value": null
+                  },
+                  {
+                    "color": "#F2B84B",
+                    "value": 10
+                  },
+                  {
+                    "color": "#3BD671",
+                    "value": 50
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 10
+          },
+          "id": 201,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "10.4.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "(100 * sum(rate(reth_base_builder_predicate_slots_loaded_unique_sum{job=\"l2_builder\"}[$window])) / sum(rate(reth_base_builder_predicate_slots_loaded_total_sum{job=\"l2_builder\"}[$window]))) and on() (sum(rate(reth_base_builder_predicate_slots_loaded_total_sum{job=\"l2_builder\"}[$window])) > 0)",
+              "legendFormat": "slot uniqueness · warm ≤10% · cold ≥50%",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Predicate Storage-Slot Uniqueness",
           "type": "timeseries"
         },
         {

--- a/etc/scripts/devnet/validity-stress-gate.sh
+++ b/etc/scripts/devnet/validity-stress-gate.sh
@@ -4,14 +4,17 @@ set -uo pipefail
 # Machine-checkable acceptance gate for the validity stress workload.
 
 PROMETHEUS_URL="${PROMETHEUS_URL:-http://localhost:9090}"
-WINDOW="${WINDOW:-2m}"
+WINDOW="${WINDOW:-1m}"
+PREDICATE_PROFILE="${PREDICATE_PROFILE:-cold}"
 MIN_COMPLETED_BUILDS="${MIN_COMPLETED_BUILDS:-200}"
 MIN_CANDIDATES_PER_BUILD="${MIN_CANDIDATES_PER_BUILD:-25}"
 MIN_PREDICATE_SLOT_READS_PER_BUILD="${MIN_PREDICATE_SLOT_READS_PER_BUILD:-25}"
+COLD_MIN_UNIQUE_PREDICATE_SLOT_FRACTION="${COLD_MIN_UNIQUE_PREDICATE_SLOT_FRACTION:-0.50}"
+WARM_MAX_UNIQUE_PREDICATE_SLOT_FRACTION="${WARM_MAX_UNIQUE_PREDICATE_SLOT_FRACTION:-0.10}"
 MIN_DEFERRED_PER_BUILD="${MIN_DEFERRED_PER_BUILD:-5}"
 MAX_PRIMARY_COVERAGE="${MAX_PRIMARY_COVERAGE:-0.90}"
 MIN_CUTOFF_BUILD_FRACTION="${MIN_CUTOFF_BUILD_FRACTION:-0.80}"
-WAIT_CONSECUTIVE_SECONDS="${WAIT_CONSECUTIVE_SECONDS:-60}"
+WAIT_CONSECUTIVE_SECONDS="${WAIT_CONSECUTIVE_SECONDS:-30}"
 WAIT_TIMEOUT_SECONDS="${WAIT_TIMEOUT_SECONDS:-600}"
 POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-15}"
 PROMETHEUS_TIMEOUT_SECONDS="${PROMETHEUS_TIMEOUT_SECONDS:-5}"
@@ -19,7 +22,7 @@ JOB="${BUILDER_JOB:-l2_builder}"
 
 usage() {
   echo "Usage: $0 [--wait]" >&2
-  echo "Thresholds and connection settings are configurable with environment variables." >&2
+  echo "Set PREDICATE_PROFILE=cold|warm (default: cold); thresholds and connection settings use environment variables." >&2
 }
 
 WAIT=false
@@ -35,7 +38,8 @@ for command in curl jq; do
   command -v "$command" >/dev/null 2>&1 || { echo "missing required command: $command" >&2; exit 2; }
 done
 [[ "$WINDOW" =~ ^[1-9][0-9]*(ms|s|m|h|d|w|y)$ ]] || { echo "invalid WINDOW: $WINDOW" >&2; exit 2; }
-for setting in MIN_COMPLETED_BUILDS MIN_CANDIDATES_PER_BUILD MIN_PREDICATE_SLOT_READS_PER_BUILD MIN_DEFERRED_PER_BUILD MAX_PRIMARY_COVERAGE MIN_CUTOFF_BUILD_FRACTION WAIT_CONSECUTIVE_SECONDS WAIT_TIMEOUT_SECONDS POLL_INTERVAL_SECONDS PROMETHEUS_TIMEOUT_SECONDS; do
+[[ "$PREDICATE_PROFILE" == cold || "$PREDICATE_PROFILE" == warm ]] || { echo "invalid PREDICATE_PROFILE: $PREDICATE_PROFILE (expected cold or warm)" >&2; exit 2; }
+for setting in MIN_COMPLETED_BUILDS MIN_CANDIDATES_PER_BUILD MIN_PREDICATE_SLOT_READS_PER_BUILD COLD_MIN_UNIQUE_PREDICATE_SLOT_FRACTION WARM_MAX_UNIQUE_PREDICATE_SLOT_FRACTION MIN_DEFERRED_PER_BUILD MAX_PRIMARY_COVERAGE MIN_CUTOFF_BUILD_FRACTION WAIT_CONSECUTIVE_SECONDS WAIT_TIMEOUT_SECONDS POLL_INTERVAL_SECONDS PROMETHEUS_TIMEOUT_SECONDS; do
   value="${!setting}"
   [[ "$value" =~ ^([0-9]+([.][0-9]*)?|[.][0-9]+)$ ]] || { echo "invalid $setting: $value" >&2; exit 2; }
 done
@@ -61,8 +65,8 @@ number_is() {
 }
 
 run_gate() {
-  local selector="job=\"$JOB\"" builds evaluated deferred slots cutoff wakeups rescans included errors up
-  local candidates_per_build="" slots_per_build="" deferred_per_build="" coverage="" cutoff_fraction=""
+  local selector="job=\"$JOB\"" builds evaluated deferred slots unique_slots cutoff wakeups rescans included errors up
+  local candidates_per_build="" slots_per_build="" unique_slot_fraction="" deferred_per_build="" coverage="" cutoff_fraction=""
   local query_failed=false failed=0
 
   up="$(prometheus_value "max(up{$selector})")" || { up="N/A"; query_failed=true; }
@@ -70,6 +74,7 @@ run_gate() {
   evaluated="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_candidates_evaluated_per_build_sum{$selector}[$WINDOW])) or vector(0)")" || { evaluated="N/A"; query_failed=true; }
   deferred="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_candidates_deferred_per_build_sum{$selector}[$WINDOW])) or vector(0)")" || { deferred="N/A"; query_failed=true; }
   slots="$(prometheus_value "sum(increase(reth_base_builder_predicate_slots_loaded_total_sum{$selector}[$WINDOW])) or vector(0)")" || { slots="N/A"; query_failed=true; }
+  unique_slots="$(prometheus_value "sum(increase(reth_base_builder_predicate_slots_loaded_unique_sum{$selector}[$WINDOW])) or vector(0)")" || { unique_slots="N/A"; query_failed=true; }
   cutoff="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_eval_cutoff_builds_total{$selector}[$WINDOW])) or vector(0)")" || { cutoff="N/A"; query_failed=true; }
   wakeups="$(prometheus_value "sum(increase(reth_base_builder_predicate_bucket_wakeups_sum{$selector}[$WINDOW])) or vector(0)")" || { wakeups="N/A"; query_failed=true; }
   rescans="$(prometheus_value "sum(increase(reth_base_builder_validity_predicate_evaluations_total{$selector,outcome=~\"rescan_matched|rescan_not_satisfied|rescan_budget_exhausted\"}[$WINDOW])) or vector(0)")" || { rescans="N/A"; query_failed=true; }
@@ -79,12 +84,15 @@ run_gate() {
   if [[ "$query_failed" == false ]] && number_is "$builds" '>' 0 && number_is "$(jq -n "$evaluated + $deferred")" '>' 0; then
     candidates_per_build="$(jq -nr "($evaluated + $deferred) / $builds")"
     slots_per_build="$(jq -nr "$slots / $builds")"
+    if number_is "$slots" '>' 0; then
+      unique_slot_fraction="$(jq -nr "$unique_slots / $slots")"
+    fi
     deferred_per_build="$(jq -nr "$deferred / $builds")"
     coverage="$(jq -nr "$evaluated / ($evaluated + $deferred)")"
     cutoff_fraction="$(jq -nr "$cutoff / $builds")"
   fi
 
-  printf '\nValidity stress gate (window=%s, job=%s)\n' "$WINDOW" "$JOB"
+  printf '\nValidity stress gate (profile=%s, window=%s, job=%s)\n' "$PREDICATE_PROFILE" "$WINDOW" "$JOB"
   printf '%-30s %12s %12s %s\n' "goal" "value" "threshold" "result"
   check() {
     local name="$1" value="$2" operator="$3" threshold="$4" status="FAIL"
@@ -95,6 +103,11 @@ run_gate() {
   check "completed builds" "$builds" '>=' "$MIN_COMPLETED_BUILDS"
   check "validity candidates/build" "$candidates_per_build" '>=' "$MIN_CANDIDATES_PER_BUILD"
   check "predicate slot reads/build" "$slots_per_build" '>=' "$MIN_PREDICATE_SLOT_READS_PER_BUILD"
+  if [[ "$PREDICATE_PROFILE" == cold ]]; then
+    check "unique predicate slot fraction" "$unique_slot_fraction" '>=' "$COLD_MIN_UNIQUE_PREDICATE_SLOT_FRACTION"
+  else
+    check "unique predicate slot fraction" "$unique_slot_fraction" '<=' "$WARM_MAX_UNIQUE_PREDICATE_SLOT_FRACTION"
+  fi
   check "deferred/build" "$deferred_per_build" '>=' "$MIN_DEFERRED_PER_BUILD"
   check "primary coverage" "$coverage" '<=' "$MAX_PRIMARY_COVERAGE"
   check "cutoff-build fraction" "$cutoff_fraction" '>=' "$MIN_CUTOFF_BUILD_FRACTION"
@@ -117,7 +130,7 @@ while true; do
   if run_gate; then
     [[ -n "$passing_since" ]] || passing_since="$now"
     if (( now - passing_since >= WAIT_CONSECUTIVE_SECONDS )); then
-      echo "PASS: goals held continuously for at least ${WAIT_CONSECUTIVE_SECONDS}s"
+      echo "PASS: rolling-window goals passed consecutive polls for at least ${WAIT_CONSECUTIVE_SECONDS}s"
       exit 0
     fi
     echo "passing for $((now - passing_since))/${WAIT_CONSECUTIVE_SECONDS}s"


### PR DESCRIPTION
## Summary
- derive 63 predicate slots from sender, nonce, and salt so newly admitted validity transactions read distinct sparse state
- retain an otherwise-identical fixed-slot warm profile and add profile-aware live acceptance gates
- add a Base MEV dashboard panel comparing unique-to-total predicate slot reads