### PR TITLE
fix(precompiles): meter B-20 permit hashing and signature recovery (Cobalt)

### DIFF
--- a/crates/common/precompile-macros/src/accounting.rs
+++ b/crates/common/precompile-macros/src/accounting.rs
@@ -296,6 +296,17 @@ fn expand_token(input: DeriveInput) -> syn::Result<TokenStream> {
             ) -> ::base_precompile_storage::Result<()> {
                 self.emit_event(log)
             }
+
+            fn metered_keccak256(
+                &self,
+                data: &[u8],
+            ) -> ::base_precompile_storage::Result<::alloy_primitives::B256> {
+                ::base_precompile_storage::ContractStorage::storage(self).metered_keccak256(data)
+            }
+
+            fn deduct_gas(&self, gas: u64) -> ::base_precompile_storage::Result<()> {
+                ::base_precompile_storage::ContractStorage::storage(self).deduct_gas(gas)
+            }
         }
     })
 }

--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -989,6 +989,12 @@ mod tests {
             self.events.push(log);
             Ok(())
         }
+        fn metered_keccak256(&self, data: &[u8]) -> Result<B256> {
+            Ok(keccak256(data))
+        }
+        fn deduct_gas(&self, _gas: u64) -> Result<()> {
+            Ok(())
+        }
     }
 
     impl AssetAccounting for FakeAccounting {

--- a/crates/common/precompiles/src/b20_asset/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v2.rs
@@ -14,7 +14,7 @@ use alloc::{
     vec::Vec,
 };
 
-use alloy_primitives::{Address, B256, FixedBytes, U256, b256, keccak256};
+use alloy_primitives::{Address, B256, FixedBytes, U256, b256};
 use alloy_sol_types::{SolEvent, SolValue};
 use base_precompile_storage::{BasePrecompileError, Result};
 
@@ -709,8 +709,8 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
         }
         let domain_sep = self.domain_separator(token, chain_id)?;
         let nonce = token.accounting().nonce(args.owner)?;
-        let signing_hash = args.signing_hash(domain_sep, nonce);
-        let recovered = args.recover_signer(signing_hash)?;
+        let signing_hash = args.metered_signing_hash(token.accounting(), domain_sep, nonce)?;
+        let recovered = args.metered_recover_signer(token.accounting(), signing_hash)?;
         PermitArgs::validate_recovered_address(recovered, args.owner)?;
         token.accounting_mut().increment_nonce(args.owner)?;
         self.approve(token, args.owner, args.spender, args.value)
@@ -872,12 +872,12 @@ impl<S: AssetAccounting, A: PolicyAccounting> Asset<S, A> for AssetV2 {
 
     fn domain_separator(&self, token: &B20AssetToken<S, A>, chain_id: u64) -> Result<B256> {
         let name = token.accounting().name()?;
-        let name_hash = keccak256(name.as_bytes());
-        let version_hash = keccak256(VERSION);
+        let name_hash = token.accounting().metered_keccak256(name.as_bytes())?;
+        let version_hash = token.accounting().metered_keccak256(VERSION)?;
         let encoded =
             (DOMAIN_TYPEHASH, name_hash, version_hash, U256::from(chain_id), token.token_address())
                 .abi_encode();
-        Ok(keccak256(&encoded))
+        token.accounting().metered_keccak256(&encoded)
     }
 
     fn eip712_domain(&self, token: &B20AssetToken<S, A>, chain_id: u64) -> Result<Eip712Domain> {
@@ -1113,6 +1113,10 @@ mod tests {
         extra_metadata: BTreeMap<String, String>,
         used_announcement_ids: BTreeSet<String>,
         events: Vec<LogData>,
+        /// Number of `metered_keccak256` calls (interior-mutable so `&self` metering can record).
+        keccak_charges: core::cell::Cell<u64>,
+        /// Cumulative gas passed to `deduct_gas`.
+        gas_deducted: core::cell::Cell<u64>,
     }
 
     impl FakeAccounting {
@@ -1140,6 +1144,8 @@ mod tests {
                 extra_metadata: BTreeMap::new(),
                 used_announcement_ids: BTreeSet::new(),
                 events: Vec::new(),
+                keccak_charges: core::cell::Cell::new(0),
+                gas_deducted: core::cell::Cell::new(0),
             }
         }
     }
@@ -1252,6 +1258,14 @@ mod tests {
         }
         fn emit_event(&mut self, log: LogData) -> Result<()> {
             self.events.push(log);
+            Ok(())
+        }
+        fn metered_keccak256(&self, data: &[u8]) -> Result<B256> {
+            self.keccak_charges.set(self.keccak_charges.get() + 1);
+            Ok(keccak256(data))
+        }
+        fn deduct_gas(&self, gas: u64) -> Result<()> {
+            self.gas_deducted.set(self.gas_deducted.get() + gas);
             Ok(())
         }
     }
@@ -1953,6 +1967,50 @@ mod tests {
         assert_eq!(
             err,
             BasePrecompileError::revert(IB20::ExpiredSignature { deadline: U256::from(10u64) })
+        );
+    }
+
+    #[test]
+    fn permit_charges_metered_hashing_and_fixed_recovery() {
+        let mut tok = token();
+        let owner = anvil_owner();
+        let args = signed_permit(&tok, owner, BOB, U256::from(500u64), U256::MAX);
+
+        // `signed_permit` computes the domain separator during setup, so measure deltas.
+        let keccak_before = tok.accounting().keccak_charges.get();
+        let gas_before = tok.accounting().gas_deducted.get();
+
+        LOGIC.permit(&mut tok, CHAIN_ID, U256::ZERO, args).unwrap();
+
+        // domain separator (name, version, encoded) + signing digest (struct hash, digest) = 5.
+        assert_eq!(tok.accounting().keccak_charges.get() - keccak_before, 5);
+        // Fixed ECRECOVER-comparable recovery charge, applied exactly once.
+        assert_eq!(tok.accounting().gas_deducted.get() - gas_before, PermitArgs::RECOVER_GAS);
+    }
+
+    #[test]
+    fn caught_revert_permit_loop_charges_each_iteration() {
+        let mut tok = token();
+        let owner = anvil_owner();
+        // Realistic DoS shape: a valid, recoverable signature but an unrelated `owner`, so every
+        // call performs the full EIP-712 hashing and secp256k1 recovery and then reverts
+        // `InvalidSigner` (before the nonce is bumped, so the same args replays each iteration).
+        let mut args = signed_permit(&tok, owner, BOB, U256::from(1u64), U256::MAX);
+        args.owner = Address::repeat_byte(0xcc);
+
+        const ITERATIONS: u64 = 8;
+        let keccak_before = tok.accounting().keccak_charges.get();
+        let gas_before = tok.accounting().gas_deducted.get();
+        for _ in 0..ITERATIONS {
+            assert!(LOGIC.permit(&mut tok, CHAIN_ID, U256::ZERO, args.clone()).is_err());
+        }
+
+        // A caught-revert loop no longer runs for free: hashing and recovery metering scale
+        // linearly with the number of calls.
+        assert_eq!(tok.accounting().keccak_charges.get() - keccak_before, 5 * ITERATIONS);
+        assert_eq!(
+            tok.accounting().gas_deducted.get() - gas_before,
+            PermitArgs::RECOVER_GAS * ITERATIONS
         );
     }
 

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -856,6 +856,12 @@ mod tests {
             self.events.push(log);
             Ok(())
         }
+        fn metered_keccak256(&self, data: &[u8]) -> Result<B256> {
+            Ok(keccak256(data))
+        }
+        fn deduct_gas(&self, _gas: u64) -> Result<()> {
+            Ok(())
+        }
     }
 
     impl StablecoinAccounting for FakeAccounting {

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v2.rs
@@ -6,7 +6,7 @@ use alloc::{
     vec::Vec,
 };
 
-use alloy_primitives::{Address, B256, FixedBytes, U256, b256, keccak256};
+use alloy_primitives::{Address, B256, FixedBytes, U256, b256};
 use alloy_sol_types::{SolEvent, SolValue};
 use base_precompile_storage::{BasePrecompileError, Result};
 
@@ -672,8 +672,8 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
         }
         let domain_sep = self.domain_separator(token, chain_id)?;
         let nonce = token.accounting().nonce(args.owner)?;
-        let signing_hash = args.signing_hash(domain_sep, nonce);
-        let recovered = args.recover_signer(signing_hash)?;
+        let signing_hash = args.metered_signing_hash(token.accounting(), domain_sep, nonce)?;
+        let recovered = args.metered_recover_signer(token.accounting(), signing_hash)?;
         PermitArgs::validate_recovered_address(recovered, args.owner)?;
         token.accounting_mut().increment_nonce(args.owner)?;
         self.approve(token, args.owner, args.spender, args.value)
@@ -714,12 +714,12 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> Stablecoin<S, A> for Stableco
 
     fn domain_separator(&self, token: &B20StablecoinToken<S, A>, chain_id: u64) -> Result<B256> {
         let name = token.accounting().name()?;
-        let name_hash = keccak256(name.as_bytes());
-        let version_hash = keccak256(VERSION);
+        let name_hash = token.accounting().metered_keccak256(name.as_bytes())?;
+        let version_hash = token.accounting().metered_keccak256(VERSION)?;
         let encoded =
             (DOMAIN_TYPEHASH, name_hash, version_hash, U256::from(chain_id), token.token_address())
                 .abi_encode();
-        Ok(keccak256(&encoded))
+        token.accounting().metered_keccak256(&encoded)
     }
 
     fn eip712_domain(
@@ -799,6 +799,10 @@ mod tests {
         role_admins: BTreeMap<B256, B256>,
         policy_ids: BTreeMap<B256, u64>,
         events: Vec<LogData>,
+        /// Number of `metered_keccak256` calls (interior-mutable so `&self` metering can record).
+        keccak_charges: core::cell::Cell<u64>,
+        /// Cumulative gas passed to `deduct_gas`.
+        gas_deducted: core::cell::Cell<u64>,
     }
 
     impl FakeAccounting {
@@ -820,6 +824,8 @@ mod tests {
                 role_admins: BTreeMap::new(),
                 policy_ids: BTreeMap::new(),
                 events: Vec::new(),
+                keccak_charges: core::cell::Cell::new(0),
+                gas_deducted: core::cell::Cell::new(0),
             }
         }
     }
@@ -932,6 +938,14 @@ mod tests {
         }
         fn emit_event(&mut self, log: LogData) -> Result<()> {
             self.events.push(log);
+            Ok(())
+        }
+        fn metered_keccak256(&self, data: &[u8]) -> Result<B256> {
+            self.keccak_charges.set(self.keccak_charges.get() + 1);
+            Ok(keccak256(data))
+        }
+        fn deduct_gas(&self, gas: u64) -> Result<()> {
+            self.gas_deducted.set(self.gas_deducted.get() + gas);
             Ok(())
         }
     }
@@ -1728,6 +1742,50 @@ mod tests {
         LOGIC.permit(&mut tok, CHAIN_ID, U256::ZERO, args.clone()).unwrap();
         // Same (v, r, s): the nonce has advanced, so recovery no longer matches `owner`.
         assert!(LOGIC.permit(&mut tok, CHAIN_ID, U256::ZERO, args).is_err());
+    }
+
+    #[test]
+    fn permit_charges_metered_hashing_and_fixed_recovery() {
+        let mut tok = token();
+        let owner = anvil_owner();
+        let args = signed_permit(&tok, owner, BOB, U256::from(500u64), U256::MAX);
+
+        // `signed_permit` computes the domain separator during setup, so measure deltas.
+        let keccak_before = tok.accounting().keccak_charges.get();
+        let gas_before = tok.accounting().gas_deducted.get();
+
+        LOGIC.permit(&mut tok, CHAIN_ID, U256::ZERO, args).unwrap();
+
+        // domain separator (name, version, encoded) + signing digest (struct hash, digest) = 5.
+        assert_eq!(tok.accounting().keccak_charges.get() - keccak_before, 5);
+        // Fixed ECRECOVER-comparable recovery charge, applied exactly once.
+        assert_eq!(tok.accounting().gas_deducted.get() - gas_before, PermitArgs::RECOVER_GAS);
+    }
+
+    #[test]
+    fn caught_revert_permit_loop_charges_each_iteration() {
+        let mut tok = token();
+        let owner = anvil_owner();
+        // Realistic DoS shape: a valid, recoverable signature but an unrelated `owner`, so every
+        // call performs the full EIP-712 hashing and secp256k1 recovery and then reverts
+        // `InvalidSigner` (before the nonce is bumped, so the same args replays each iteration).
+        let mut args = signed_permit(&tok, owner, BOB, U256::from(1u64), U256::MAX);
+        args.owner = Address::repeat_byte(0xcc);
+
+        const ITERATIONS: u64 = 8;
+        let keccak_before = tok.accounting().keccak_charges.get();
+        let gas_before = tok.accounting().gas_deducted.get();
+        for _ in 0..ITERATIONS {
+            assert!(LOGIC.permit(&mut tok, CHAIN_ID, U256::ZERO, args.clone()).is_err());
+        }
+
+        // A caught-revert loop no longer runs for free: hashing and recovery metering scale
+        // linearly with the number of calls.
+        assert_eq!(tok.accounting().keccak_charges.get() - keccak_before, 5 * ITERATIONS);
+        assert_eq!(
+            tok.accounting().gas_deducted.get() - gas_before,
+            PermitArgs::RECOVER_GAS * ITERATIONS
+        );
     }
 
     // --- reads ---

--- a/crates/common/precompiles/src/common/ops/permit.rs
+++ b/crates/common/precompiles/src/common/ops/permit.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{Address, B256, FixedBytes, U256, keccak256};
 use alloy_sol_types::SolValue;
 use base_precompile_storage::{BasePrecompileError, Result};
 
-use crate::IB20;
+use crate::{IB20, TokenAccounting};
 
 /// ERC-5267 `eip712Domain()` return tuple: (fields, name, version, chainId, verifyingContract, salt, extensions).
 pub type Eip712Domain = (FixedBytes<1>, String, String, U256, Address, B256, Vec<U256>);
@@ -44,6 +44,13 @@ impl PermitArgs {
     pub const RECOVERY_ID_EVEN_Y: u8 = 27;
     /// Legacy `v` value for odd-Y ECDSA recovery (`ecrecover`).
     pub const RECOVERY_ID_ODD_Y: u8 = 28;
+
+    /// Native gas charged for the secp256k1 signer recovery in a metered `permit`.
+    ///
+    /// Priced to the EVM `ECRECOVER` precompile base cost (`ISTANBUL_SIGNATURE`, 3000 gas), which
+    /// charges the same flat amount up front regardless of whether recovery succeeds. Part of the
+    /// gas-used commitment, so it must be identical across all Base execution clients.
+    pub const RECOVER_GAS: u64 = 3000;
 
     /// Hashes the EIP-2612 `Permit` struct for `nonce`.
     pub fn struct_hash(&self, nonce: U256) -> B256 {
@@ -98,6 +105,48 @@ impl PermitArgs {
                 owner: self.owner,
             })
         })
+    }
+
+    /// [`Self::struct_hash`], charging the keccak work against `accounting` before hashing.
+    pub fn metered_struct_hash(
+        &self,
+        accounting: &impl TokenAccounting,
+        nonce: U256,
+    ) -> Result<B256> {
+        accounting.metered_keccak256(
+            &(Self::TYPEHASH, self.owner, self.spender, self.value, nonce, self.deadline)
+                .abi_encode(),
+        )
+    }
+
+    /// [`Self::signing_hash`], charging both keccak rounds (struct hash and digest) against
+    /// `accounting` before hashing.
+    pub fn metered_signing_hash(
+        &self,
+        accounting: &impl TokenAccounting,
+        domain_separator: B256,
+        nonce: U256,
+    ) -> Result<B256> {
+        let struct_hash = self.metered_struct_hash(accounting, nonce)?;
+        let mut buf = [0u8; 66];
+        buf[..2].copy_from_slice(&Self::EIP712_SIGNING_PREFIX);
+        buf[2..34].copy_from_slice(domain_separator.as_slice());
+        buf[34..66].copy_from_slice(struct_hash.as_slice());
+        accounting.metered_keccak256(&buf)
+    }
+
+    /// [`Self::recover_signer`], charging the fixed [`Self::RECOVER_GAS`] recovery cost against
+    /// `accounting` before recovery.
+    ///
+    /// Mirrors the EVM `ECRECOVER` precompile: the flat cost is charged up front, before the `v`
+    /// validity check, so a caller cannot avoid the charge by supplying an out-of-range `v`.
+    pub fn metered_recover_signer(
+        &self,
+        accounting: &impl TokenAccounting,
+        signing_hash: B256,
+    ) -> Result<Address> {
+        accounting.deduct_gas(Self::RECOVER_GAS)?;
+        self.recover_signer(signing_hash)
     }
 }
 

--- a/crates/common/precompiles/src/common/test_utils.rs
+++ b/crates/common/precompiles/src/common/test_utils.rs
@@ -5,7 +5,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use alloy_primitives::{Address, B256, LogData, U256};
+use alloy_primitives::{Address, B256, LogData, U256, keccak256};
 use base_precompile_storage::Result;
 
 use crate::{
@@ -244,6 +244,18 @@ impl TokenAccounting for InMemoryTokenAccounting {
 
     fn emit_event(&mut self, log: LogData) -> Result<()> {
         self.events.push(log);
+        Ok(())
+    }
+
+    /// In-memory double has no gas meter: hashes without charging. Real gas enforcement is
+    /// exercised against the EVM harness in the dispatch tests.
+    fn metered_keccak256(&self, data: &[u8]) -> Result<B256> {
+        Ok(keccak256(data))
+    }
+
+    /// In-memory double has no gas meter: charging is a no-op. Real `OutOfGas` enforcement is
+    /// exercised against the EVM harness in the dispatch tests.
+    fn deduct_gas(&self, _gas: u64) -> Result<()> {
         Ok(())
     }
 }

--- a/crates/common/precompiles/src/common/token_accounting.rs
+++ b/crates/common/precompiles/src/common/token_accounting.rs
@@ -141,6 +141,22 @@ pub trait TokenAccounting {
 
     /// Publishes a pre-encoded EVM event log from this token's address.
     fn emit_event(&mut self, log: LogData) -> Result<()>;
+
+    // --- Gas metering ---
+
+    /// Computes `keccak256(data)` and charges the EVM keccak schedule
+    /// (`KECCAK256 + KECCAK256WORD * ceil(len / 32)`) against remaining gas.
+    ///
+    /// Used where the logic hashes attacker-controlled input (e.g. EIP-712 permit digests) so the
+    /// native charge reflects the hashing work, matching what the equivalent Solidity `keccak256`
+    /// would pay. Returns `OutOfGas` before hashing when the charge exceeds remaining gas.
+    fn metered_keccak256(&self, data: &[u8]) -> Result<B256>;
+
+    /// Deducts `gas` from remaining gas, returning `OutOfGas` when insufficient.
+    ///
+    /// Used to charge fixed native costs that have no storage or event footprint, such as the
+    /// secp256k1 recovery in `permit` (priced to the EVM `ECRECOVER` precompile).
+    fn deduct_gas(&self, gas: u64) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -1255,6 +1255,30 @@ fn golden_permit_reverts_when_expired() {
     assert_eq!(err, BasePrecompileError::revert(IB20::ExpiredSignature { deadline: u(10) }));
 }
 
+/// V1 `permit` is deliberately UNMETERED (Beryl's gas schedule is frozen): it hashes with plain
+/// `keccak256` and recovers without a `deduct_gas` charge, so `gas_deducted()` stays `0`. The V2
+/// golden pins this at `3000`; that metered/unmetered contrast is the point of this pair.
+#[test]
+fn golden_permit_charges_no_recovery_gas() {
+    let mut s = fresh();
+    let owner = anvil_owner();
+    let calldata =
+        signed_permit(domain_separator(&mut fresh()), U256::ZERO, owner, BOB, u(500), U256::MAX)
+            .abi_encode();
+    s.set_caller(owner);
+    s.set_timestamp(U256::ZERO);
+    StorageCtx::enter(&mut s, |ctx| {
+        B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            FakePolicyAccounting::new(),
+            PolicyVersion::V1,
+        )
+        .route(ctx, &calldata, AssetVersion::V1, true, NoopPrecompileCallObserver)
+    })
+    .expect("permit must succeed");
+    assert_eq!(s.gas_deducted(), 0, "V1 permit must not charge any recovery gas (unmetered)");
+}
+
 // ============================================================================
 // computed reads
 // ============================================================================
@@ -2678,6 +2702,23 @@ fn golden_gas_footprints() {
                 .abi_encode(),
             ),
         ),
+        (
+            "permit",
+            gas(
+                |_t| {},
+                anvil_owner(),
+                FakePolicyAccounting::new(),
+                signed_permit(
+                    domain_separator(&mut fresh()),
+                    U256::ZERO,
+                    anvil_owner(),
+                    BOB,
+                    u(500),
+                    U256::MAX,
+                )
+                .abi_encode(),
+            ),
+        ),
     ];
 
     let expected: &[(&str, (u64, u64, u64))] = &[
@@ -2701,6 +2742,7 @@ fn golden_gas_footprints() {
         ("batch_mint", (11, 4, 0)),
         ("announce", (1, 1, 0)),
         ("update_extra_metadata", (0, 1, 0)),
+        ("permit", (3, 2, 0)),
     ];
 
     bless_or_assert_gas(&actual, expected);

--- a/crates/common/precompiles/tests/b20_asset_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v2_golden.rs
@@ -1868,6 +1868,31 @@ fn golden_permit_reverts_when_expired() {
     assert_eq!(err, BasePrecompileError::revert(IB20::ExpiredSignature { deadline: u(10) }));
 }
 
+/// V2 `permit` charges the fixed ECRECOVER-equivalent recovery cost (`PermitArgs::RECOVER_GAS`,
+/// 3000) on the real provider. The `.route(...)` path bills no calldata gas — that lives in
+/// `dispatch_with_observer` — so the observed `gas_deducted()` is exactly the recovery charge. The
+/// V1 golden pins this at `0`; that metered/unmetered contrast is the point of this pair.
+#[test]
+fn golden_permit_charges_recovery_gas() {
+    let mut s = fresh();
+    let owner = anvil_owner();
+    let calldata =
+        signed_permit(domain_separator(&mut fresh()), U256::ZERO, owner, BOB, u(500), U256::MAX)
+            .abi_encode();
+    s.set_caller(owner);
+    s.set_timestamp(U256::ZERO);
+    StorageCtx::enter(&mut s, |ctx| {
+        B20AssetToken::with_storage_and_policy(
+            B20AssetStorage::from_address(TOKEN, ctx),
+            FakePolicyAccounting::new(),
+            PolicyVersion::V2,
+        )
+        .route(ctx, &calldata, AssetVersion::V2, true, NoopPrecompileCallObserver)
+    })
+    .expect("permit must succeed");
+    assert_eq!(s.gas_deducted(), 3000, "V2 permit must charge the fixed ECRECOVER-equivalent cost");
+}
+
 // ============================================================================
 // computed + direct + constant reads (behavior-preserving: V1 roots reused)
 // ============================================================================
@@ -3453,6 +3478,23 @@ fn golden_gas_footprints() {
                 .abi_encode(),
             ),
         ),
+        (
+            "permit",
+            gas(
+                |_t| {},
+                anvil_owner(),
+                FakePolicyAccounting::new(),
+                signed_permit(
+                    domain_separator(&mut fresh()),
+                    U256::ZERO,
+                    anvil_owner(),
+                    BOB,
+                    u(500),
+                    U256::MAX,
+                )
+                .abi_encode(),
+            ),
+        ),
     ];
 
     let expected: &[(&str, (u64, u64, u64))] = &[
@@ -3479,6 +3521,7 @@ fn golden_gas_footprints() {
         ("batch_mint", (11, 4, 0)),
         ("announce", (1, 1, 0)),
         ("update_extra_metadata", (1, 1, 0)),
+        ("permit", (3, 2, 5)),
     ];
 
     bless_or_assert_gas(&actual, expected);

--- a/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v1_golden.rs
@@ -1199,6 +1199,30 @@ fn golden_permit_reverts_when_expired() {
     assert_eq!(err, BasePrecompileError::revert(IB20::ExpiredSignature { deadline: u(10) }));
 }
 
+/// V1 `permit` is deliberately UNMETERED (Beryl's gas schedule is frozen): it hashes with plain
+/// `keccak256` and recovers without a `deduct_gas` charge, so `gas_deducted()` stays `0`. The V2
+/// golden pins this at `3000`; that metered/unmetered contrast is the point of this pair.
+#[test]
+fn golden_permit_charges_no_recovery_gas() {
+    let mut s = fresh();
+    let owner = anvil_owner();
+    let calldata =
+        signed_permit(domain_separator(&mut fresh()), U256::ZERO, owner, BOB, u(500), U256::MAX)
+            .abi_encode();
+    s.set_caller(owner);
+    s.set_timestamp(U256::ZERO);
+    StorageCtx::enter(&mut s, |ctx| {
+        B20StablecoinToken::with_storage_and_policy(
+            B20StablecoinStorage::from_address(TOKEN, ctx),
+            FakePolicyAccounting::new(),
+            PolicyVersion::V1,
+        )
+        .route(ctx, &calldata, StablecoinVersion::V1, true, NoopPrecompileCallObserver)
+    })
+    .expect("permit must succeed");
+    assert_eq!(s.gas_deducted(), 0, "V1 permit must not charge any recovery gas (unmetered)");
+}
+
 // ============================================================================
 // computed reads
 // ============================================================================
@@ -2106,6 +2130,23 @@ fn golden_gas_footprints() {
                 .abi_encode(),
             ),
         ),
+        (
+            "permit",
+            gas(
+                |_t| {},
+                anvil_owner(),
+                FakePolicyAccounting::new(),
+                signed_permit(
+                    domain_separator(&mut fresh()),
+                    U256::ZERO,
+                    anvil_owner(),
+                    BOB,
+                    u(500),
+                    U256::MAX,
+                )
+                .abi_encode(),
+            ),
+        ),
     ];
 
     let expected: &[(&str, (u64, u64, u64))] = &[
@@ -2126,6 +2167,7 @@ fn golden_gas_footprints() {
         ("set_role_admin", (1, 1, 0)),
         ("update_policy", (2, 1, 0)),
         ("update_policy_reverts_missing_policy", (1, 0, 0)),
+        ("permit", (3, 2, 0)),
     ];
 
     bless_or_assert_gas(&actual, expected);

--- a/crates/common/precompiles/tests/b20_stablecoin_v2_golden.rs
+++ b/crates/common/precompiles/tests/b20_stablecoin_v2_golden.rs
@@ -1817,6 +1817,30 @@ fn golden_permit_reverts_when_expired() {
     assert_eq!(err, BasePrecompileError::revert(IB20::ExpiredSignature { deadline: u(10) }));
 }
 
+/// V2 `permit` charges the fixed ECRECOVER-equivalent recovery cost (`PermitArgs::RECOVER_GAS`,
+/// 3000) on the real provider. The `.route(...)` path bills no calldata gas — that lives in
+/// `dispatch_with_observer` — so the observed `gas_deducted()` is exactly the recovery charge. The
+/// V1 golden pins this at `0`; that metered/unmetered contrast is the point of this pair.
+#[test]
+fn golden_permit_charges_recovery_gas() {
+    let mut s = fresh();
+    let owner = anvil_owner();
+    let calldata =
+        signed_permit(domain_separator(&mut fresh()), U256::ZERO, owner, BOB, u(500), U256::MAX)
+            .abi_encode();
+    s.set_caller(owner);
+    StorageCtx::enter(&mut s, |ctx| {
+        B20StablecoinToken::with_storage_and_policy(
+            B20StablecoinStorage::from_address(TOKEN, ctx),
+            FakePolicyAccounting::new(),
+            PolicyVersion::V2,
+        )
+        .route(ctx, &calldata, StablecoinVersion::V2, true, NoopPrecompileCallObserver)
+    })
+    .expect("permit must succeed");
+    assert_eq!(s.gas_deducted(), 3000, "V2 permit must charge the fixed ECRECOVER-equivalent cost");
+}
+
 // ============================================================================
 // computed + direct + constant reads (behavior-preserving: V1 roots reused)
 // ============================================================================
@@ -2304,7 +2328,7 @@ fn golden_gas_footprints() {
         ("burn_with_memo", (4, 2, 0)),
         ("renounce_role", (1, 1, 0)),
         ("renounce_last_admin", (4, 2, 0)),
-        ("permit", (3, 2, 0)),
+        ("permit", (3, 2, 5)),
     ];
 
     bless_or_assert_gas(&actual, expected);


### PR DESCRIPTION
## Summary

Fixes [BOP-627](https://linear.app/coinbase/issue/BOP-627) / Cantina finding #20 (low): the four B-20 `permit` paths (asset & stablecoin, V1 & V2) executed EIP-712 hashing and secp256k1 signer recovery through `common/ops/permit.rs` with **no native gas charge** beyond the dispatcher's per-word calldata cost (`ceil(len/32)*6`).

A permissionless caller can loop `permit` with `deadline = type(uint256).max`, `v = 27`, a recoverable `r`/`s`, and an unrelated `owner` — each child performs the full hashing + curve recovery, reverts `InvalidSigner`, and the caller catches it and continues. This pushes hashing and elliptic-curve work into a transaction for near-zero gas, increasing validator CPU time.

## Approach

Metering is added to the **V2 (Cobalt) logic only**. V1 is the **Beryl** surface and is already live, so changing its gas schedule would be a consensus break — its gas stays frozen and it keeps the pure (unmetered) permit path.

- Add `metered_keccak256` / `deduct_gas` to the `TokenAccounting` trait, generated by `#[derive(TokenAccounting)]` via `ContractStorage::storage`, so versioned logic can charge through `token.accounting()` (mirrors the existing `b20_factory` pattern).
- V2 `domain_separator` charges its three keccak rounds (name, **version hash**, encoded); `permit` uses new `PermitArgs::metered_signing_hash` (2 keccak) and `metered_recover_signer`.
- Charge `PermitArgs::RECOVER_GAS` (3000 — the EVM `ECRECOVER` base cost) **up front, before the `v` check**, matching how `ECRECOVER` bills flat regardless of input validity.
- Net per permit: **5 metered keccaks + 3000 gas**, all charged before the work executes.

## Consensus note

Metering `domain_separator` also reprices the standalone `DOMAIN_SEPARATOR()` view getter on V2 — consistent (it does real hashing work), but a gas change beyond `permit` itself. All charges are gated to V2/Cobalt; V1/Beryl behavior is byte-for-byte unchanged.

## Tests

Added to both V2 variants:
- `permit_charges_metered_hashing_and_fixed_recovery` — exact charge (5 keccak + `RECOVER_GAS`).
- `caught_revert_permit_loop_charges_each_iteration` — N caught `InvalidSigner` reverts each pay the full hashing + recovery charge (metering scales linearly), proving the loop no longer runs for free.

683 lib tests pass; clippy clean on `base-common-precompiles` and `base-precompile-macros`.

Generated with Claude Code