### PR TITLE
fix(system-tests): shut down the stack in the direct builder ingress test

### DIFF
--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -427,6 +427,8 @@ async fn test_validity_transaction_submitted_directly_to_builder_is_included() -
         "direct builder ingress must not alter the signed transaction's state transition"
     );
 
+    system.shutdown().await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Stack 1/3.

`test_validity_transaction_submitted_directly_to_builder_is_included` never calls `system.shutdown()`. Its assertions pass, and then the test hangs dropping the runtime:

```
tx_forwarding.rs:430  (Ok(()))
  core::ptr::drop_in_place<tokio::runtime::Runtime>
    tokio::runtime::blocking::pool::BlockingPool::shutdown
      tokio::runtime::blocking::shutdown::Receiver::wait
```

`DestinationReader::run` is a blocking thread looping on `while !self.cancel.is_cancelled()`, and only `system.shutdown()` cancels that token. The blocking pool never drains, so dropping the test runtime blocks forever and nextest eventually terminates the test.

That is why CI reports this one with no error message, while the other `tx_forwarding` failures carry a real deadline error.

Add the missing shutdown, matching every other test in the file and what #4816 did for them.

### Testing

Passes in 66.7s and the process exits (70s wall). Before, it hung indefinitely at teardown.