### PR TITLE
fix(system-tests): keep builder API registered alongside validity ingress

### DIFF
--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -193,6 +193,20 @@ impl InProcessBuilder {
             ))
             .apply(hooks);
         }
+        // Reth's `extend_rpc_modules` is a single-slot hook that silently replaces whatever was
+        // registered before it, and `NodeHooks::apply_to` claims that slot for every extension
+        // RPC module. Registering the builder API here instead keeps both in one closure.
+        let hooks = hooks.add_rpc_module(move |ctx| {
+            let api =
+                BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
+                    ctx.pool().clone(),
+                    accept_validity_transactions,
+                    DEFAULT_MAX_VALIDITY_PREDICATES,
+                );
+            ctx.modules.merge_configured(api.into_rpc())?;
+            Ok(())
+        });
+
         let node_builder = NodeBuilder::new(node_config.clone())
             .with_database(db)
             .with_launch_context(runtime.clone())
@@ -210,16 +224,7 @@ impl InProcessBuilder {
                         ),
                     )
                     .with_add_ons(addons)
-                    .on_component_initialized(move |_ctx| Ok(()))
-                    .extend_rpc_modules(move |ctx| {
-                        let api = BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
-                            ctx.pool().clone(),
-                            accept_validity_transactions,
-                            DEFAULT_MAX_VALIDITY_PREDICATES,
-                        );
-                        ctx.modules.merge_configured(api.into_rpc())?;
-                        Ok(())
-                    }),
+                    .on_component_initialized(move |_ctx| Ok(())),
             )
             .launch()
             .await;

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -427,6 +427,8 @@ async fn test_validity_transaction_submitted_directly_to_builder_is_included() -
         "direct builder ingress must not alter the signed transaction's state transition"
     );
 
+    system.shutdown().await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Stack 2/3, based on #4893.

Four `tx_forwarding` tests fail on `main` — every one that calls `start_validity_system()` and relies on forwarding. Three time out waiting for a receipt, two never see the transaction go pending.

### Cause

Reth `extend_rpc_modules` is one slot, not a list:

```rust
fn set_extend_rpc_modules<F>(&mut self, hook: F) -> &mut Self {
    self.extend_rpc_modules = Box::new(hook);   // replaces; does not chain
}
```

`InProcessBuilder::launch` called it twice: directly, to register `BuilderApiImpl` (`base_insertValidatedTransaction`), and again via `NodeHooks::apply_to`. `apply_to` only claims the slot when some extension registered an RPC module, and none did — until #4819 began installing `SendRawTransactionValidityExtension` whenever validity transactions are enabled. The builder API was then silently discarded on exactly those stacks:

```
batch item rejected error=ErrorObject { code: MethodNotFound, message: "Method not found" }
```

One missing method covers both symptoms. Nothing reaches the builder, so satisfied predicates never get a receipt and unsatisfied ones never go pending.

Registering the builder API through `NodeHooks` puts both in one closure.

### Scope

Harness only. `bin/builder` and `bin/base` install every extension via `install_ext`, so they issue one `extend_rpc_modules` call and were never affected. No production node lost the method.

### Testing

Whole binary, serially: `9 passed; 0 failed` (609s).

CI on the combined branch, against the same suite: 8 failures to 3, removing exactly the five `tx_forwarding` ones.

| Run | Result |
|---|---|
| before | 90 run, 82 passed, 8 failed |
| after | 90 run, 87 passed, 3 failed |

The remaining 3 are pre-existing SIGSEGVs in `activation_registry`, `eip8130`, and `in_process_zk` — unrelated to this change, failing identically before it. #4895 adds diagnostics for them.
