### PR TITLE
fix(system-tests): give the system-test threads a larger stack

### DIFF
--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -172,13 +172,17 @@ pull-images:
     docker pull ghcr.io/paradigmxyz/reth:v1.11.4
     docker pull sigp/lighthouse:v8.0.1
 
+# Reth's unoptimized node launch overflows the 2 MiB stack libtest gives each test thread,
+# which SIGSEGVs on Linux. Do not move to nextest.toml `[env]`; nextest silently drops it.
+system_test_min_stack := "33554432"
+
 # Runs system tests (requires Docker)
 tests: _install-nextest _build-contracts
-    cargo nextest run -p base-system-tests
+    RUST_MIN_STACK={{ system_test_min_stack }} cargo nextest run -p base-system-tests
 
 # Runs system tests with ci profile for minimal disk usage
 tests-ci: _install-nextest _build-contracts
-    cargo nextest run -P ci --locked -p base-system-tests --cargo-profile ci --no-fail-fast
+    RUST_MIN_STACK={{ system_test_min_stack }} cargo nextest run -P ci --locked -p base-system-tests --cargo-profile ci --no-fail-fast
 
 # Runs system test benchmarks
 bench name:

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -193,6 +193,20 @@ impl InProcessBuilder {
             ))
             .apply(hooks);
         }
+        // Reth's `extend_rpc_modules` is a single-slot hook that silently replaces whatever was
+        // registered before it, and `NodeHooks::apply_to` claims that slot for every extension
+        // RPC module. Registering the builder API here instead keeps both in one closure.
+        let hooks = hooks.add_rpc_module(move |ctx| {
+            let api =
+                BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
+                    ctx.pool().clone(),
+                    accept_validity_transactions,
+                    DEFAULT_MAX_VALIDITY_PREDICATES,
+                );
+            ctx.modules.merge_configured(api.into_rpc())?;
+            Ok(())
+        });
+
         let node_builder = NodeBuilder::new(node_config.clone())
             .with_database(db)
             .with_launch_context(runtime.clone())
@@ -210,16 +224,7 @@ impl InProcessBuilder {
                         ),
                     )
                     .with_add_ons(addons)
-                    .on_component_initialized(move |_ctx| Ok(()))
-                    .extend_rpc_modules(move |ctx| {
-                        let api = BuilderApiImpl::<_, base_execution_txpool::TransactionValidity>::with_extensions(
-                            ctx.pool().clone(),
-                            accept_validity_transactions,
-                            DEFAULT_MAX_VALIDITY_PREDICATES,
-                        );
-                        ctx.modules.merge_configured(api.into_rpc())?;
-                        Ok(())
-                    }),
+                    .on_component_initialized(move |_ctx| Ok(())),
             )
             .launch()
             .await;

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -427,6 +427,8 @@ async fn test_validity_transaction_submitted_directly_to_builder_is_included() -
         "direct builder ingress must not alter the signed transaction's state transition"
     );
 
+    system.shutdown().await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Stack 3/3, based on #4894.

Three Cobalt system tests abort with SIGSEGV on Linux CI:

- `activation_registry::test_activation_registry_cobalt_admin_rotation`
- `eip8130::eip8130_transaction_is_mined`
- `in_process_zk::in_process_prover_and_zk_host_start`

They are unrelated to #4893 / #4894 and failed identically before them.

### Cause

A temporary `SA_SIGINFO` handler reported the fault:

```
fault address: 0x7fa6167fd718 (si_code=2)
```

`si_code=2` is `SEGV_ACCERR` — a mapped page the process may not touch, i.e. a `PROT_NONE` stack guard page. A null or wild pointer would report `SEGV_MAPERR` instead. The address sits in the thread-stack mmap region, and the backtrace runs through reth's node launch on the libtest thread:

```
reth_network::discovery::Discovery::new::{{closure}}
BaseNetworkBuilder::build_network -> ComponentsBuilder::build_components
EngineNodeLauncher::launch_node
InProcessBuilder::start -> L2Stack::start -> SystemTestStackBuilder::build
cobalt::start_cobalt_system
std::sys::thread::unix::Thread::new::thread_start     (libtest thread)
```

Reth's launch chain is a deeply nested set of async state machines. Unoptimized, it overflows the 2 MiB default that libtest's per-test thread inherits. Only the Cobalt tests trip it, because the extra fork widens an already-marginal frame — `activation_registry` is the clincher, with 8 Beryl tests passing and its 1 Cobalt test dying in the same binary. Mainnet is a release build and was never affected.

### Fix

Set `RUST_MIN_STACK` on both `just devnet tests` and `tests-ci`, so local Linux runs get it too. Production already does the equivalent: `bin/prover/zk-host` and `bin/prover/nitro-host` both call `with_thread_stack_size(8 * 1024 * 1024)`.

Setting it in `.config/nextest.toml` under `[env]` does **not** work — nextest accepts the key and silently never passes it to the test process. Reading the variable inside a test gave `Err(NotPresent)` that way and `Ok("33554432")` from the command line. That trap cost a full CI cycle and is called out in a comment.

### Evidence

Full system-test suite, green:

**https://depot.dev/orgs/m722kg9kwb/workflows/p0cj9bh91s?job=8zqgft1s51&repo=base%2Fbase**

```
90 tests run, 90 passed, 0 skipped, 0 failed
```

That run was commit `188b56221`, which additionally flipped `run_system_tests` on so the suite would execute on a PR. **That flag and all diagnostic scaffolding have since been reverted** — this PR now contains only the two-line Justfile change.
