### PR TITLE
fix(eip8130): bound EIP-8130 call phases

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -274,6 +274,14 @@ impl Eip8130Constants {
     /// the interleaved admission flow is proven out.
     pub const MAX_ACTOR_CHANGES_PER_CONFIG: usize = 5;
 
+    /// Maximum number of call phases accepted in one transaction.
+    ///
+    /// Each phase occupies an in-memory [`alloc::vec::Vec`] even when its RLP
+    /// payload is empty. Bounding the count while decoding prevents a sequence
+    /// of single-byte empty RLP lists from amplifying into unbounded allocations
+    /// before transaction-pool admission limits run.
+    pub const MAX_CALL_PHASES_PER_TX: usize = 1_024;
+
     /// Maximum runtime bytecode size for a create entry, matching EIP-170's
     /// `MAX_CODE_SIZE` limit. EIP-8130 places runtime code directly, so the
     /// mempool rejects oversized code before execution.

--- a/crates/common/consensus/src/transaction/eip8130/tx.rs
+++ b/crates/common/consensus/src/transaction/eip8130/tx.rs
@@ -142,18 +142,19 @@ impl TxEip8130 {
         if !header.list {
             return Err(alloy_rlp::Error::UnexpectedString);
         }
-        let started = buf.len();
+        if buf.len() < header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let (mut payload, rest) = buf.split_at(header.payload_length);
         let mut phases = Vec::new();
-        while started - buf.len() < header.payload_length {
-            phases.push(Vec::<Call>::decode(buf)?);
+        while !payload.is_empty() {
+            if phases.len() >= Eip8130Constants::MAX_CALL_PHASES_PER_TX {
+                return Err(alloy_rlp::Error::Custom("too many EIP-8130 call phases"));
+            }
+            phases.push(Vec::<Call>::decode(&mut payload)?);
         }
-        let consumed = started - buf.len();
-        if consumed != header.payload_length {
-            return Err(alloy_rlp::Error::ListLengthMismatch {
-                expected: header.payload_length,
-                got: consumed,
-            });
-        }
+        *buf = rest;
         Ok(phases)
     }
 
@@ -632,6 +633,35 @@ mod tests {
             metadata: bytes!("c0ffee"),
             payer: None,
         }
+    }
+
+    fn empty_call_phases(count: usize) -> Vec<u8> {
+        let mut encoded = Vec::with_capacity(length_of_length(count) + count);
+        Header { list: true, payload_length: count }.encode(&mut encoded);
+        encoded.resize(encoded.len() + count, 0xc0);
+        encoded
+    }
+
+    #[test]
+    fn decode_calls_accepts_maximum_phase_count() {
+        let encoded = empty_call_phases(Eip8130Constants::MAX_CALL_PHASES_PER_TX);
+        let mut input = encoded.as_slice();
+
+        let phases = TxEip8130::decode_calls(&mut input).unwrap();
+
+        assert_eq!(phases.len(), Eip8130Constants::MAX_CALL_PHASES_PER_TX);
+        assert!(phases.iter().all(Vec::is_empty));
+        assert!(input.is_empty());
+    }
+
+    #[test]
+    fn decode_calls_rejects_excessive_phase_count() {
+        let encoded = empty_call_phases(Eip8130Constants::MAX_CALL_PHASES_PER_TX + 1);
+        let mut input = encoded.as_slice();
+
+        let error = TxEip8130::decode_calls(&mut input).unwrap_err();
+
+        assert_eq!(error, alloy_rlp::Error::Custom("too many EIP-8130 call phases"));
     }
 
     #[test]

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -1680,6 +1680,15 @@ where
         &self,
         signed: &Eip8130Signed,
     ) -> Result<(), InvalidPoolTransactionError> {
+        let size = signed.encode_2718_len();
+        let limit = self.inner.max_tx_input_bytes();
+        if size > limit {
+            return Err(InvalidPoolTransactionError::OversizedData { size, limit });
+        }
+        if signed.tx().calls.len() > Eip8130Constants::MAX_CALL_PHASES_PER_TX {
+            return Err(Self::eip8130_error("call phase count exceeds maximum"));
+        }
+
         // Single read of the head-block timestamp so the fork gate and the
         // expiry check see the same value even when `on_new_head_block` updates
         // the atomic concurrently.
@@ -2199,6 +2208,21 @@ mod tests {
         build_test_validator_with_spec(chain_spec)
     }
 
+    /// Builds a Cobalt-activated validator with a custom encoded transaction-size limit.
+    fn build_test_validator_with_max_tx_input_bytes(max_tx_input_bytes: usize) -> TestValidator {
+        let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().cobalt_activated().build());
+        let client = MockEthProvider::<BasePrimitives>::new()
+            .with_chain_spec(Arc::clone(&chain_spec))
+            .with_genesis_block();
+        let evm_config = BaseEvmConfig::base(Arc::clone(&chain_spec));
+        let inner = EthTransactionValidatorBuilder::new(client, evm_config)
+            .no_shanghai()
+            .no_cancun()
+            .with_max_tx_input_bytes(max_tx_input_bytes)
+            .build(InMemoryBlobStore::default());
+        BaseTransactionValidator::with_block_info(inner, BaseL1BlockInfo::default())
+    }
+
     /// Builds a Cobalt-activated validator with one canonical account seeded.
     fn build_test_validator_with_account(
         address: Address,
@@ -2517,6 +2541,45 @@ mod tests {
         let validator = build_test_validator();
         let signed = sign_eoa_eip8130(minimal_valid_eoa_tx());
         assert!(validator.validate_eip8130_structural(&signed).is_ok());
+    }
+
+    #[test]
+    fn accepts_eip8130_at_encoded_size_limit() {
+        let signed = sign_eoa_eip8130(minimal_valid_eoa_tx());
+        let validator = build_test_validator_with_max_tx_input_bytes(signed.encode_2718_len());
+
+        assert!(validator.validate_eip8130_structural(&signed).is_ok());
+    }
+
+    #[test]
+    fn rejects_eip8130_over_encoded_size_limit() {
+        let signed = sign_eoa_eip8130(minimal_valid_eoa_tx());
+        let size = signed.encode_2718_len();
+        let limit = size - 1;
+        let validator = build_test_validator_with_max_tx_input_bytes(limit);
+
+        assert!(matches!(
+            validator.validate_eip8130_structural(&signed),
+            Err(InvalidPoolTransactionError::OversizedData {
+                size: rejected_size,
+                limit: rejected_limit,
+            }) if rejected_size == size && rejected_limit == limit
+        ));
+    }
+
+    #[test]
+    fn rejects_constructed_eip8130_over_call_phase_limit() {
+        let validator = build_test_validator();
+        let tx = TxEip8130 {
+            calls: vec![Vec::new(); Eip8130Constants::MAX_CALL_PHASES_PER_TX + 1],
+            ..minimal_valid_eoa_tx()
+        };
+        let signed = sign_eoa_eip8130(tx);
+
+        assert_structural_reason(
+            validator.validate_eip8130_structural(&signed),
+            "call phase count exceeds maximum",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- cap EIP-8130 call phases at 1,024 during RLP decoding
- enforce the configured encoded transaction-size limit during EIP-8130 txpool admission
- reject constructed EIP-8130 transactions that bypass decoding and exceed the phase cap

## Testing
- `cargo test -p base-common-consensus transaction::eip8130::tx::tests --lib`
- `cargo test -p base-execution-txpool encoded_size_limit --lib`
- `cargo test -p base-execution-txpool over_call_phase_limit --lib`
- `cargo clippy -p base-common-consensus --lib -- -D warnings`
- `cargo clippy -p base-execution-txpool --lib -- -D warnings`