### PR TITLE
feat(devnet): support arbitrary snapshot chains

### DIFF
--- a/etc/systems/src/devnet_cli.rs
+++ b/etc/systems/src/devnet_cli.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 
 use crate::{
     DevnetBlockInterval, DevnetConfig, DevnetL2State, DevnetPrefund, DevnetSnapshotHead,
-    SnapshotL2Stack, SystemTestStackBuilder,
+    SnapshotChainConfig, SnapshotL2Stack, SystemTestStackBuilder,
 };
 
 /// Local Base development network launcher.
@@ -24,17 +24,23 @@ pub struct DevnetCli {
 /// Supported development network modes.
 #[derive(Debug, Subcommand)]
 pub enum DevnetCommand {
-    /// Continue Base mainnet snapshot datadirs without an L1.
+    /// Continue Base snapshot datadirs without an L1.
     Snapshot(SnapshotArgs),
 }
 
-/// Arguments for an L1-free Base mainnet snapshot network.
+/// Arguments for an L1-free Base snapshot network.
 #[derive(Debug, Args)]
 pub struct SnapshotArgs {
-    /// Writable builder clone of a Base mainnet datadir.
+    /// Built-in Base chain name or path to a Base genesis JSON file.
+    #[arg(long, default_value = "mainnet")]
+    pub chain: String,
+    /// Rollup config JSON for a custom chain JSON whose chain ID is not built in.
+    #[arg(long)]
+    pub rollup_config: Option<PathBuf>,
+    /// Writable builder snapshot datadir.
     #[arg(long, env = "BASE_SNAPSHOT_BUILDER_DATADIR")]
     pub builder_datadir: PathBuf,
-    /// Writable client clone of the same Base mainnet datadir.
+    /// Writable client snapshot datadir for the same chain.
     #[arg(long, env = "BASE_SNAPSHOT_CLIENT_DATADIR")]
     pub client_datadir: PathBuf,
     /// Bind the stable developer ports instead of allocating free ports.
@@ -107,8 +113,11 @@ impl SnapshotArgs {
             (None, None, None) => None,
             _ => unreachable!("clap requires all expected-head fields together"),
         };
-        let mut config =
-            DevnetConfig::base_mainnet_snapshot(self.builder_datadir, self.client_datadir);
+        let mut config = DevnetConfig::snapshot(
+            self.builder_datadir,
+            self.client_datadir,
+            SnapshotChainConfig { chain: self.chain, rollup_config: self.rollup_config },
+        )?;
         config.use_stable_ports = self.stable_ports;
         let DevnetL2State::Snapshot(snapshot) = &mut config.l2_state else {
             unreachable!("snapshot constructor must create snapshot state")
@@ -145,7 +154,7 @@ impl SnapshotRuntime {
         let boundary = stack.boundary();
         Ok(Self {
             status: "ready",
-            chain_id: 8453,
+            chain_id: stack.chain_id(),
             boundary_number: boundary.head.number,
             boundary_hash: boundary.head.hash,
             block_interval_ms: stack.block_interval().duration().as_millis() as u64,
@@ -168,6 +177,8 @@ mod tests {
         let cli = DevnetCli::try_parse_from([
             "base-devnet",
             "snapshot",
+            "--chain",
+            "sepolia",
             "--builder-datadir",
             "/tmp/builder",
             "--client-datadir",
@@ -180,6 +191,7 @@ mod tests {
         .unwrap();
 
         let DevnetCommand::Snapshot(args) = cli.command;
+        assert_eq!(args.chain, "sepolia");
         assert_eq!(args.builder_datadir.to_str(), Some("/tmp/builder"));
         assert!(args.prefund_address.is_some());
         assert_eq!(args.block_interval, DevnetBlockInterval::TwoHundredMilliseconds);

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -71,6 +71,8 @@ pub struct InProcessBuilderConfig {
     pub block_time: Duration,
     /// Optional canonical block persistence threshold.
     pub persistence_threshold: Option<u64>,
+    /// Optional number of unpersisted blocks allowed before Engine API intake is stalled.
+    pub persistence_backpressure_threshold: Option<u64>,
     /// Optional pending/basefee/queued transaction count limit for benchmark workloads.
     pub txpool_max_transactions: Option<usize>,
     /// Optional pending/basefee/queued transaction size limit in megabytes.
@@ -439,9 +441,16 @@ fn create_node_config(
         .with_datadir_args(datadir)
         .with_rpc(rpc)
         .with_network(network);
+    if config.datadir.is_some() {
+        node_config.debug.startup_sync_state_idle = true;
+    }
 
     if let Some(persistence_threshold) = config.persistence_threshold {
         node_config.engine.persistence_threshold = persistence_threshold;
+    }
+    if let Some(persistence_backpressure_threshold) = config.persistence_backpressure_threshold {
+        node_config.engine.persistence_backpressure_threshold =
+            Some(persistence_backpressure_threshold);
     }
     if let Some(max_transactions) = config.txpool_max_transactions {
         node_config.txpool.pending_max_count = max_transactions;

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -71,6 +71,8 @@ pub struct InProcessClientConfig {
     pub metrics_port: Option<u16>,
     /// Optional canonical block persistence threshold.
     pub persistence_threshold: Option<u64>,
+    /// Optional number of unpersisted blocks allowed before Engine API intake is stalled.
+    pub persistence_backpressure_threshold: Option<u64>,
     /// Optional transaction forwarding configuration.
     /// When set, the client will forward transactions to builder RPC endpoints.
     pub tx_forwarding_config: Option<TxForwardingConfig>,
@@ -208,6 +210,9 @@ impl InProcessClient {
         let mut node_config = NodeConfig::new(Arc::clone(&chain_spec))
             .with_network(network_config)
             .with_rpc(rpc_args);
+        if config.datadir.is_some() {
+            node_config.debug.startup_sync_state_idle = true;
+        }
         let metrics_addr = SocketAddr::new(
             std::net::Ipv4Addr::LOCALHOST.into(),
             config.metrics_port.unwrap_or_else(get_available_port),
@@ -222,6 +227,11 @@ impl InProcessClient {
         }
         if let Some(persistence_threshold) = config.persistence_threshold {
             node_config.engine.persistence_threshold = persistence_threshold;
+        }
+        if let Some(persistence_backpressure_threshold) = config.persistence_backpressure_threshold
+        {
+            node_config.engine.persistence_backpressure_threshold =
+                Some(persistence_backpressure_threshold);
         }
 
         let datadir_path = MaybePlatformPath::<DataDirPath>::from(data_dir.clone());

--- a/etc/systems/src/l2/shadow_sequencer.rs
+++ b/etc/systems/src/l2/shadow_sequencer.rs
@@ -97,6 +97,7 @@ impl ShadowSequencer {
             extra_extensions: Vec::new(),
             block_time: Duration::from_secs(config.rollup_config.block_time),
             persistence_threshold: None,
+            persistence_backpressure_threshold: None,
             txpool_max_transactions: None,
             txpool_max_size_mb: None,
             txpool_max_account_slots: None,

--- a/etc/systems/src/l2/snapshot_stack.rs
+++ b/etc/systems/src/l2/snapshot_stack.rs
@@ -7,7 +7,7 @@ use std::{
 
 use alloy_provider::{Provider, RootProvider};
 use alloy_rpc_types_engine::JwtSecret;
-use base_common_chains::ChainConfig;
+use alloy_rpc_types_eth::SyncStatus as EthSyncStatus;
 use base_common_genesis::{BaseUpgrade, RollupConfig};
 use base_common_network::Base;
 use base_consensus_node::StandalonePrefund;
@@ -24,7 +24,19 @@ use super::{
 };
 use crate::{DevnetBlockInterval, DevnetSnapshotConfig};
 
-const SNAPSHOT_STARTUP_LEAD: Duration = Duration::from_secs(10);
+const SNAPSHOT_STARTUP_LEAD: Duration = Duration::from_secs(30);
+const SNAPSHOT_EL_READY_TIMEOUT: Duration = Duration::from_secs(30);
+const SNAPSHOT_ADVANCE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Keeps Reth's default 16-block persistence-backpressure window equivalent in wall-clock time.
+/// At a 200ms cadence, 160 blocks provide the same 32 seconds of persistence headroom as 16
+/// two-second blocks instead of stalling Engine API intake after only 3.2 seconds.
+const fn snapshot_persistence_backpressure_threshold(interval: DevnetBlockInterval) -> u64 {
+    match interval {
+        DevnetBlockInterval::TwoSeconds => 16,
+        DevnetBlockInterval::TwoHundredMilliseconds => 160,
+    }
+}
 
 /// Configuration for an L1-free snapshot-backed L2 stack.
 #[derive(Debug, Clone)]
@@ -45,6 +57,8 @@ pub struct SnapshotL2Stack {
     follow_consensus: Option<InProcessFollowConsensus>,
     follow_config: Option<InProcessFollowConsensusConfig>,
     block_interval: DevnetBlockInterval,
+    rollup_config: Arc<RollupConfig>,
+    chain_id: u64,
 }
 
 impl SnapshotL2Stack {
@@ -64,9 +78,14 @@ impl SnapshotL2Stack {
             .prefund
             .map(|value| StandalonePrefund { address: value.address, amount: value.amount });
         let block_interval = config.snapshot.block_interval;
-        let canonical_rollup_config = Arc::new(ChainConfig::mainnet().rollup_config());
+        let chain = config.snapshot.chain.resolve()?;
+        let canonical_rollup_config = Arc::clone(&chain.rollup_config);
         let first_block_timestamp = Self::schedule_anchor(SystemTime::now())?;
-        let chain_spec = Arc::new(Self::chain_spec(first_block_timestamp, block_interval));
+        let chain_spec = Arc::new(Self::chain_spec(
+            (*chain.chain_spec).clone(),
+            first_block_timestamp,
+            block_interval,
+        ));
         let jwt_secret = JwtSecret::random();
 
         let builder = InProcessBuilder::start(InProcessBuilderConfig {
@@ -84,6 +103,9 @@ impl SnapshotL2Stack {
             payload_builder_cutover: block_interval == DevnetBlockInterval::TwoHundredMilliseconds,
             extra_extensions: Vec::new(),
             persistence_threshold: Some(0),
+            persistence_backpressure_threshold: Some(snapshot_persistence_backpressure_threshold(
+                block_interval,
+            )),
             txpool_max_transactions: Some(150_000),
             txpool_max_size_mb: Some(1_024),
             txpool_max_account_slots: Some(1_024),
@@ -92,8 +114,8 @@ impl SnapshotL2Stack {
         .wrap_err("failed to start snapshot builder")?;
         let boundary = SnapshotBoundary::read(
             builder.rpc_url()?,
-            canonical_rollup_config,
-            config.snapshot.expected_chain_id,
+            Arc::clone(&canonical_rollup_config),
+            chain.l2_chain_id,
             config.snapshot.expected_head,
         )
         .await
@@ -102,8 +124,8 @@ impl SnapshotL2Stack {
             first_block_timestamp > boundary.head.timestamp,
             "snapshot boundary timestamp must be earlier than the local schedule anchor"
         );
-        Self::ensure_schedule_anchor_is_future(first_block_timestamp, SystemTime::now())?;
         let rollup_config = Arc::new(Self::anchored_rollup_config(
+            (*canonical_rollup_config).clone(),
             boundary.head.number,
             first_block_timestamp,
             block_interval,
@@ -123,6 +145,9 @@ impl SnapshotL2Stack {
             p2p_port: container.and_then(|value| value.client_p2p_port),
             metrics_port: None,
             persistence_threshold: Some(0),
+            persistence_backpressure_threshold: Some(snapshot_persistence_backpressure_threshold(
+                block_interval,
+            )),
             tx_forwarding_config: None,
             upgrade_signal: None,
             enable_experimental_validity_transactions: false,
@@ -130,6 +155,11 @@ impl SnapshotL2Stack {
         })
         .await
         .wrap_err("failed to start snapshot client")?;
+        tokio::try_join!(
+            Self::wait_for_el_ready(builder.rpc_url()?, SNAPSHOT_EL_READY_TIMEOUT),
+            Self::wait_for_el_ready(client.rpc_url()?, SNAPSHOT_EL_READY_TIMEOUT),
+        )?;
+        Self::ensure_schedule_anchor_is_future(first_block_timestamp, SystemTime::now())?;
 
         let unused_l1_url = Url::parse("http://127.0.0.1:1").expect("valid unused L1 URL");
         let follow_config = InProcessFollowConsensusConfig {
@@ -164,7 +194,7 @@ impl SnapshotL2Stack {
             .checked_add(2)
             .ok_or_else(|| eyre::eyre!("snapshot boundary block number overflow"))?;
         tokio::select! {
-            result = Self::wait_for_block(builder.rpc_url()?, target, Duration::from_secs(30)) => {
+            result = Self::wait_for_block(builder.rpc_url()?, target, SNAPSHOT_ADVANCE_TIMEOUT) => {
                 result.wrap_err("snapshot builder did not produce two descendants")?;
             }
             error = standalone_consensus.next_error() => {
@@ -180,6 +210,8 @@ impl SnapshotL2Stack {
             follow_consensus: None,
             follow_config: Some(follow_config),
             block_interval,
+            rollup_config: canonical_rollup_config,
+            chain_id: chain.l2_chain_id,
         })
     }
 
@@ -218,11 +250,11 @@ impl SnapshotL2Stack {
 
     /// Anchors the deterministic local block schedule at the first post-snapshot block.
     pub fn anchored_rollup_config(
+        mut config: RollupConfig,
         boundary_number: u64,
         first_block_timestamp: u64,
         block_interval: DevnetBlockInterval,
     ) -> Result<RollupConfig> {
-        let mut config = ChainConfig::mainnet().rollup_config();
         let first_block_number = boundary_number
             .checked_add(1)
             .ok_or_else(|| eyre::eyre!("snapshot boundary block number overflow"))?;
@@ -249,10 +281,10 @@ impl SnapshotL2Stack {
 
     /// Builds the execution chain specification for a local snapshot schedule.
     pub fn chain_spec(
+        mut chain_spec: BaseChainSpec,
         first_block_timestamp: u64,
         block_interval: DevnetBlockInterval,
     ) -> BaseChainSpec {
-        let mut chain_spec = BaseChainSpec::mainnet();
         if block_interval == DevnetBlockInterval::TwoHundredMilliseconds {
             chain_spec
                 .set_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(first_block_timestamp));
@@ -295,6 +327,21 @@ impl SnapshotL2Stack {
         Ok(())
     }
 
+    async fn wait_for_el_ready(rpc_url: Url, timeout: Duration) -> Result<()> {
+        let provider = RootProvider::<Base>::new_http(rpc_url.clone());
+        tokio::time::timeout(timeout, async {
+            loop {
+                if matches!(provider.syncing().await?, EthSyncStatus::None) {
+                    return Ok::<_, eyre::Report>(());
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .wrap_err_with(|| format!("timed out waiting for snapshot EL readiness at {rpc_url}"))??;
+        Ok(())
+    }
+
     /// Returns the validated immutable snapshot boundary.
     pub const fn boundary(&self) -> &SnapshotBoundary {
         &self.boundary
@@ -303,6 +350,11 @@ impl SnapshotL2Stack {
     /// Returns the configured interval between locally produced blocks.
     pub const fn block_interval(&self) -> DevnetBlockInterval {
         self.block_interval
+    }
+
+    /// Returns the L2 chain ID of the continued snapshot.
+    pub const fn chain_id(&self) -> u64 {
+        self.chain_id
     }
 
     /// Returns the builder RPC URL.
@@ -334,8 +386,8 @@ impl SnapshotL2Stack {
     pub async fn current_builder_boundary(&self) -> Result<SnapshotBoundary> {
         SnapshotBoundary::read(
             self.builder.rpc_url()?,
-            Arc::new(ChainConfig::mainnet().rollup_config()),
-            ChainConfig::mainnet().chain_id,
+            Arc::clone(&self.rollup_config),
+            self.chain_id,
             None,
         )
         .await
@@ -366,16 +418,34 @@ impl SnapshotL2Stack {
 
 #[cfg(test)]
 mod tests {
-    use base_common_chains::Upgrades;
+    use base_common_chains::{ChainConfig, Upgrades};
     use base_common_genesis::BaseUpgrade;
+    use base_execution_chainspec::BaseChainSpec;
     use reth_ethereum_forks::ForkCondition;
 
-    use super::SnapshotL2Stack;
+    use super::{
+        SNAPSHOT_STARTUP_LEAD, SnapshotL2Stack, snapshot_persistence_backpressure_threshold,
+    };
     use crate::DevnetBlockInterval;
+
+    #[test]
+    fn persistence_backpressure_window_scales_with_cadence() {
+        assert_eq!(
+            snapshot_persistence_backpressure_threshold(DevnetBlockInterval::TwoSeconds),
+            16
+        );
+        assert_eq!(
+            snapshot_persistence_backpressure_threshold(
+                DevnetBlockInterval::TwoHundredMilliseconds
+            ),
+            160
+        );
+    }
 
     #[test]
     fn anchors_two_second_schedule_at_first_descendant() {
         let config = SnapshotL2Stack::anchored_rollup_config(
+            ChainConfig::mainnet().rollup_config(),
             30_000_000,
             2_000_000_000,
             DevnetBlockInterval::TwoSeconds,
@@ -389,6 +459,7 @@ mod tests {
     #[test]
     fn anchors_subsecond_schedule_with_rollover() {
         let config = SnapshotL2Stack::anchored_rollup_config(
+            ChainConfig::mainnet().rollup_config(),
             30_000_000,
             2_000_000_000,
             DevnetBlockInterval::TwoHundredMilliseconds,
@@ -405,13 +476,17 @@ mod tests {
     fn subsecond_cl_and_el_activate_cobalt_at_same_timestamp() {
         let activation = 2_000_000_000;
         let rollup = SnapshotL2Stack::anchored_rollup_config(
+            ChainConfig::mainnet().rollup_config(),
             30_000_000,
             activation,
             DevnetBlockInterval::TwoHundredMilliseconds,
         )
         .unwrap();
-        let chain_spec =
-            SnapshotL2Stack::chain_spec(activation, DevnetBlockInterval::TwoHundredMilliseconds);
+        let chain_spec = SnapshotL2Stack::chain_spec(
+            BaseChainSpec::mainnet(),
+            activation,
+            DevnetBlockInterval::TwoHundredMilliseconds,
+        );
 
         assert!(!rollup.is_cobalt_active(activation - 1));
         assert!(rollup.is_cobalt_active(activation));
@@ -426,7 +501,7 @@ mod tests {
 
         let anchor = SnapshotL2Stack::schedule_anchor(now).unwrap();
 
-        assert_eq!(anchor, 2_000_000_000 + 10);
+        assert_eq!(anchor, 2_000_000_000 + SNAPSHOT_STARTUP_LEAD.as_secs());
         SnapshotL2Stack::ensure_schedule_anchor_is_future(anchor, now).unwrap();
     }
 

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -227,6 +227,7 @@ impl L2Stack {
             extra_extensions: config.extra_builder_extensions,
             block_time: Duration::from_secs(rollup_config.block_time),
             persistence_threshold: None,
+            persistence_backpressure_threshold: None,
             txpool_max_transactions: None,
             txpool_max_size_mb: None,
             txpool_max_account_slots: None,
@@ -309,6 +310,7 @@ impl L2Stack {
             p2p_port: container_config.and_then(|c| c.client_p2p_port),
             metrics_port: None,
             persistence_threshold: None,
+            persistence_backpressure_threshold: None,
             tx_forwarding_config,
             enable_experimental_validity_transactions: config
                 .enable_experimental_validity_transactions,

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -85,7 +85,8 @@ pub use smoke::{SystemTestStack, SystemTestStackBuilder};
 mod system_config;
 pub use system_config::{
     DevnetBlockInterval, DevnetConfig, DevnetL1Mode, DevnetL2State, DevnetPrefund,
-    DevnetSnapshotConfig, DevnetSnapshotHead, StableSystemTestConfig, SystemTestPorts,
+    DevnetSnapshotConfig, DevnetSnapshotHead, ResolvedSnapshotChain, SnapshotChainConfig,
+    StableSystemTestConfig, SystemTestPorts,
 };
 
 #[cfg(feature = "upgrade-signal")]

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -558,7 +558,11 @@ impl SystemTestStackBuilder {
             }
         });
 
-        SnapshotL2Stack::start_sequencer(SnapshotL2StackConfig { snapshot, container_config }).await
+        SnapshotL2Stack::start_sequencer(SnapshotL2StackConfig {
+            snapshot: *snapshot,
+            container_config,
+        })
+        .await
     }
 
     /// Builds and starts the system test stack.

--- a/etc/systems/src/system_config.rs
+++ b/etc/systems/src/system_config.rs
@@ -2,9 +2,17 @@
 
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
+use alloy_genesis::Genesis;
 use alloy_primitives::{Address, B256};
+use base_common_chains::ChainConfig;
+use base_common_genesis::RollupConfig;
+use base_execution_chainspec::BaseChainSpec;
 use clap::ValueEnum;
 use eyre::{Result, WrapErr, bail, ensure};
 use serde::{Deserialize, Serialize};
@@ -66,12 +74,96 @@ impl DevnetBlockInterval {
     }
 }
 
-/// Writable execution datadirs used to continue a Base mainnet snapshot.
+/// Chain inputs used to continue a Base snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SnapshotChainConfig {
+    /// Built-in Base chain name or path to a Base genesis JSON file.
+    pub chain: String,
+    /// Rollup configuration JSON required for a custom genesis whose chain ID is not built in.
+    pub rollup_config: Option<PathBuf>,
+}
+
+impl Default for SnapshotChainConfig {
+    fn default() -> Self {
+        Self { chain: "mainnet".to_string(), rollup_config: None }
+    }
+}
+
+/// Fully resolved chain configuration used by a snapshot stack.
+#[derive(Debug, Clone)]
+pub struct ResolvedSnapshotChain {
+    /// Execution chain specification.
+    pub chain_spec: Arc<BaseChainSpec>,
+    /// Rollup configuration used to validate and continue the snapshot.
+    pub rollup_config: Arc<RollupConfig>,
+    /// L1 chain ID.
+    pub l1_chain_id: u64,
+    /// L2 chain ID.
+    pub l2_chain_id: u64,
+}
+
+impl SnapshotChainConfig {
+    /// Resolves a built-in chain name or a Base genesis JSON plus its rollup configuration.
+    pub fn resolve(&self) -> Result<ResolvedSnapshotChain> {
+        if let Some(config) =
+            ChainConfig::from_base_chain(&self.chain).or_else(|| ChainConfig::by_name(&self.chain))
+        {
+            return Ok(ResolvedSnapshotChain {
+                chain_spec: Arc::new(BaseChainSpec::try_from(config)?),
+                rollup_config: Arc::new(config.rollup_config()),
+                l1_chain_id: config.l1_chain_id,
+                l2_chain_id: config.chain_id,
+            });
+        }
+
+        let path = Path::new(&self.chain);
+        let contents = std::fs::read(path)
+            .wrap_err_with(|| format!("failed to read snapshot chain JSON {}", path.display()))?;
+        let genesis: Genesis = serde_json::from_slice(&contents)
+            .wrap_err_with(|| format!("failed to parse snapshot chain JSON {}", path.display()))?;
+        let chain_spec = BaseChainSpec::try_from_genesis(genesis)
+            .wrap_err_with(|| format!("invalid Base genesis JSON {}", path.display()))?;
+        let l2_chain_id = chain_spec.chain.id();
+        let rollup_config = if let Some(config) = ChainConfig::by_chain_id(l2_chain_id) {
+            config.rollup_config()
+        } else {
+            let rollup_path = self.rollup_config.as_ref().ok_or_else(|| {
+                eyre::eyre!(
+                    "custom snapshot chain JSON {} requires --rollup-config",
+                    path.display()
+                )
+            })?;
+            let contents = std::fs::read(rollup_path).wrap_err_with(|| {
+                format!("failed to read snapshot rollup config {}", rollup_path.display())
+            })?;
+            let config: RollupConfig = serde_json::from_slice(&contents).wrap_err_with(|| {
+                format!("failed to parse snapshot rollup config {}", rollup_path.display())
+            })?;
+            ensure!(
+                config.l2_chain_id.id() == l2_chain_id,
+                "rollup config L2 chain ID {} does not match chain JSON ID {l2_chain_id}",
+                config.l2_chain_id.id()
+            );
+            config
+        };
+
+        Ok(ResolvedSnapshotChain {
+            chain_spec: Arc::new(chain_spec),
+            l1_chain_id: rollup_config.l1_chain_id,
+            l2_chain_id,
+            rollup_config: Arc::new(rollup_config),
+        })
+    }
+}
+
+/// Writable execution datadirs used to continue a Base snapshot.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DevnetSnapshotConfig {
-    /// Writable Base mainnet datadir used by the builder.
+    /// Built-in chain name or custom chain JSON plus optional rollup configuration.
+    pub chain: SnapshotChainConfig,
+    /// Writable snapshot datadir used by the builder.
     pub builder_datadir: PathBuf,
-    /// Writable Base mainnet datadir used by the client.
+    /// Writable snapshot datadir used by the client.
     pub client_datadir: PathBuf,
     /// Expected L2 chain ID stored in both datadirs.
     pub expected_chain_id: u64,
@@ -90,8 +182,8 @@ pub struct DevnetSnapshotConfig {
 pub enum DevnetL2State {
     /// Generate a fresh local L2 genesis and empty execution databases.
     Fresh,
-    /// Continue from caller-owned writable Base mainnet datadirs.
-    Snapshot(DevnetSnapshotConfig),
+    /// Continue from caller-owned writable Base snapshot datadirs.
+    Snapshot(Box<DevnetSnapshotConfig>),
 }
 
 /// Stable port assignments for system test components.
@@ -237,24 +329,30 @@ impl DevnetConfig {
         }
     }
 
-    /// Returns an L1-free Base mainnet snapshot configuration.
-    pub fn base_mainnet_snapshot(builder_datadir: PathBuf, client_datadir: PathBuf) -> Self {
-        Self {
-            l1_chain_id: 1,
-            l2_chain_id: 8453,
+    /// Returns an L1-free Base snapshot configuration for a resolved chain input.
+    pub fn snapshot(
+        builder_datadir: PathBuf,
+        client_datadir: PathBuf,
+        chain: SnapshotChainConfig,
+    ) -> Result<Self> {
+        let resolved = chain.resolve()?;
+        Ok(Self {
+            l1_chain_id: resolved.l1_chain_id,
+            l2_chain_id: resolved.l2_chain_id,
             l1_slot_duration: DEFAULT_SLOT_DURATION,
             l1_mode: DevnetL1Mode::None,
-            l2_state: DevnetL2State::Snapshot(DevnetSnapshotConfig {
+            l2_state: DevnetL2State::Snapshot(Box::new(DevnetSnapshotConfig {
+                chain,
                 builder_datadir,
                 client_datadir,
-                expected_chain_id: 8453,
+                expected_chain_id: resolved.l2_chain_id,
                 expected_head: None,
                 prefund: None,
                 block_interval: DevnetBlockInterval::default(),
-            }),
+            })),
             stable: StableSystemTestConfig::standard(),
             use_stable_ports: false,
-        }
+        })
     }
 
     /// Validates mode combinations and snapshot identity expectations.
@@ -314,9 +412,13 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
 
+    use alloy_genesis::Genesis;
+    use base_common_genesis::RollupConfig;
     use tempfile::TempDir;
 
-    use super::{DEFAULT_SLOT_DURATION, DevnetConfig, DevnetL1Mode, DevnetL2State};
+    use super::{
+        DEFAULT_SLOT_DURATION, DevnetConfig, DevnetL1Mode, DevnetL2State, SnapshotChainConfig,
+    };
 
     #[test]
     fn standard_config_matches_developer_devnet() {
@@ -341,13 +443,14 @@ mod tests {
     }
 
     #[test]
-    fn base_mainnet_snapshot_is_l1_free() {
+    fn snapshot_is_l1_free() {
         let parent = TempDir::new().unwrap();
         let builder = parent.path().join("builder");
         let client = parent.path().join("client");
         std::fs::create_dir_all(&builder).unwrap();
         std::fs::create_dir_all(&client).unwrap();
-        let config = DevnetConfig::base_mainnet_snapshot(builder, client);
+        let config =
+            DevnetConfig::snapshot(builder, client, SnapshotChainConfig::default()).unwrap();
 
         assert_eq!(config.l1_chain_id, 1);
         assert_eq!(config.l2_chain_id, 8453);
@@ -356,10 +459,53 @@ mod tests {
     }
 
     #[test]
+    fn resolves_builtin_sepolia_snapshot_chain() {
+        let chain = SnapshotChainConfig { chain: "sepolia".to_string(), rollup_config: None }
+            .resolve()
+            .expect("Base Sepolia should resolve as a built-in snapshot chain");
+
+        assert_eq!(chain.l1_chain_id, 11_155_111);
+        assert_eq!(chain.l2_chain_id, 84_532);
+        assert_eq!(chain.rollup_config.l2_chain_id.id(), 84_532);
+        assert_eq!(chain.chain_spec.chain.id(), 84_532);
+    }
+
+    #[test]
+    fn resolves_custom_genesis_with_rollup_config() {
+        const CHAIN_ID: u64 = 123_456;
+        let directory = TempDir::new().unwrap();
+        let chain_path = directory.path().join("genesis.json");
+        let rollup_path = directory.path().join("rollup.json");
+        let mut genesis = Genesis::default();
+        genesis.config.chain_id = CHAIN_ID;
+        std::fs::write(&chain_path, serde_json::to_vec(&genesis).unwrap()).unwrap();
+        let rollup = RollupConfig {
+            l1_chain_id: 11_155_111,
+            l2_chain_id: CHAIN_ID.into(),
+            ..Default::default()
+        };
+        std::fs::write(&rollup_path, serde_json::to_vec(&rollup).unwrap()).unwrap();
+
+        let chain = SnapshotChainConfig {
+            chain: chain_path.to_string_lossy().into_owned(),
+            rollup_config: Some(rollup_path),
+        }
+        .resolve()
+        .expect("custom genesis and matching rollup config should resolve");
+
+        assert_eq!(chain.l1_chain_id, 11_155_111);
+        assert_eq!(chain.l2_chain_id, CHAIN_ID);
+        assert_eq!(chain.rollup_config.l2_chain_id.id(), CHAIN_ID);
+        assert_eq!(chain.chain_spec.chain.id(), CHAIN_ID);
+    }
+
+    #[test]
     fn snapshot_datadirs_must_be_distinct() {
         let datadir = TempDir::new().unwrap();
         let datadir = datadir.path().to_path_buf();
-        let config = DevnetConfig::base_mainnet_snapshot(datadir.clone(), datadir);
+        let config =
+            DevnetConfig::snapshot(datadir.clone(), datadir, SnapshotChainConfig::default())
+                .unwrap();
 
         let error = config.validate().expect_err("shared snapshot datadir should be rejected");
         assert!(error.to_string().contains("must be distinct"));
@@ -372,7 +518,12 @@ mod tests {
         let alias_parent = TempDir::new().unwrap();
         let alias = alias_parent.path().join("alias");
         symlink(datadir.path(), &alias).unwrap();
-        let config = DevnetConfig::base_mainnet_snapshot(datadir.path().to_path_buf(), alias);
+        let config = DevnetConfig::snapshot(
+            datadir.path().to_path_buf(),
+            alias,
+            SnapshotChainConfig::default(),
+        )
+        .unwrap();
 
         let error = config.validate().expect_err("aliased snapshot datadir should be rejected");
         assert!(error.to_string().contains("resolve to the same directory"));

--- a/etc/systems/tests/snapshot_devnet.rs
+++ b/etc/systems/tests/snapshot_devnet.rs
@@ -14,24 +14,29 @@ use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_system_tests::{
     ANVIL_ACCOUNT_1, DevnetBlockInterval, DevnetConfig, DevnetL2State, DevnetPrefund,
-    SnapshotL2Stack, SystemTestStackBuilder,
+    SnapshotChainConfig, SnapshotL2Stack, SystemTestStackBuilder,
 };
 use eyre::{Result, WrapErr};
 use tokio::time::{sleep, timeout};
 
 const TX_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Starts real EL and CL components from caller-owned writable Base mainnet snapshots.
+/// Starts real EL and CL components from caller-owned writable Base snapshots.
 #[tokio::test]
-#[ignore = "requires two writable Base mainnet execution snapshot datadirs"]
+#[ignore = "requires two writable Base execution snapshot datadirs"]
 async fn snapshot_devnet_mines_follows_and_includes_rpc_transaction() -> Result<()> {
     base_node_runner::test_utils::init_silenced_tracing();
     let builder_datadir = std::env::var_os("BASE_SNAPSHOT_BUILDER_DATADIR")
         .expect("BASE_SNAPSHOT_BUILDER_DATADIR must be set");
     let client_datadir = std::env::var_os("BASE_SNAPSHOT_CLIENT_DATADIR")
         .expect("BASE_SNAPSHOT_CLIENT_DATADIR must be set");
-    let mut config =
-        DevnetConfig::base_mainnet_snapshot(builder_datadir.into(), client_datadir.into());
+    let chain = std::env::var("BASE_SNAPSHOT_CHAIN").unwrap_or_else(|_| "mainnet".to_string());
+    let rollup_config = std::env::var_os("BASE_SNAPSHOT_ROLLUP_CONFIG").map(Into::into);
+    let mut config = DevnetConfig::snapshot(
+        builder_datadir.into(),
+        client_datadir.into(),
+        SnapshotChainConfig { chain, rollup_config },
+    )?;
     let signer: PrivateKeySigner =
         format!("0x{}", hex::encode(ANVIL_ACCOUNT_1.private_key.as_slice())).parse()?;
     let DevnetL2State::Snapshot(snapshot) = &mut config.l2_state else {
@@ -114,7 +119,7 @@ async fn send_transaction_and_wait_for_both(
         .with_gas_limit(21_000)
         .with_max_fee_per_gas(10_000_000_000)
         .with_max_priority_fee_per_gas(1_000_000)
-        .with_chain_id(8453)
+        .with_chain_id(stack.chain_id())
         .with_nonce(builder.get_transaction_count(sender).await?)
         .build_typed_tx()
         .map_err(|_| eyre::eyre!("invalid snapshot test transaction"))?;


### PR DESCRIPTION
## Summary

Part 1 of 5. Generalizes the L1-free snapshot devnet from mainnet-only restores to built-in Base networks or custom genesis/rollup-config inputs. It also adds restored-node readiness checks and cadence-scaled persistence backpressure for 200ms runs.

## Included

- Add `--chain` and `--rollup-config` to `base-devnet snapshot`.
- Resolve the chain spec, rollup config, and chain IDs from the selected snapshot chain.
- Ensure the snapshot integration path signs transactions for the selected chain ID.

## Validation

- `cargo check -p base-system-tests --lib --bins --no-default-features`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>