### PR TITLE
feat(bench): run snapshot-backed load benchmarks

### DIFF
--- a/crates/infra/load-tests/src/runner/pacing.rs
+++ b/crates/infra/load-tests/src/runner/pacing.rs
@@ -858,8 +858,9 @@ impl LoadRunner {
         let finished_file = self.config.separate_setup.as_deref().map(|dir| dir.join("finished"));
         Self::publish_handshake(finished_file.as_deref())?;
 
+        // The producer may be blocked sending its next chunk after enqueue stops at the
+        // measurement cutoff. Close its receiver before awaiting it so that send unblocks.
         drop(signed_chunk_rx);
-
         match producer_task.await {
             Ok(Ok(producer_state)) => {
                 self.generator = producer_state.generator;
@@ -903,6 +904,7 @@ impl LoadRunner {
         while self.config.duration.is_none_or(|d| start.elapsed() < d)
             && !self.stop_flag.load(Ordering::SeqCst)
             && open_loop_enqueue_error.is_none()
+            && !results_tracker.measurement_finished()
         {
             // --- Housekeeping (runs once per batch iteration) ---
 
@@ -945,8 +947,10 @@ impl LoadRunner {
 
         submission_pipeline.close_input();
 
+        let stop_at_measurement_cutoff = self.config.measurement_blocks.is_some();
         let drain_started = Instant::now();
         while submission_pipeline.pending_batches() > 0
+            && !stop_at_measurement_cutoff
             && drain_started.elapsed() < SUBMIT_DRAIN_TIMEOUT
         {
             Self::drain_submit_events(
@@ -962,10 +966,14 @@ impl LoadRunner {
 
         let pending_submit_batches = submission_pipeline.pending_batches();
         if pending_submit_batches > 0 {
-            warn!(
-                pending_submit_batches,
-                "timed out waiting for submit queue to drain, closing submit queue"
-            );
+            if stop_at_measurement_cutoff {
+                warn!(pending_submit_batches, "closing submit queue at measured block cutoff");
+            } else {
+                warn!(
+                    pending_submit_batches,
+                    "timed out waiting for submit queue to drain, closing submit queue"
+                );
+            }
             let failures =
                 submission_pipeline.close_and_fail_queued("submit queue abandoned").await;
             Self::apply_queued_submit_failures(
@@ -1592,10 +1600,13 @@ impl LoadRunner {
         let mut safety_tick = tokio::time::interval(safety_interval);
         safety_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         let mut last_block_gas_limit = config.fallback_block_gas_limit;
-        let signal_timeout =
-            config.block_time + (config.block_time / 2).min(Duration::from_millis(250));
+        // Canonical RPC observations are routinely delayed beyond a 200ms block interval. Keep
+        // submitting at the finer safety cadence until one arrives, otherwise a delayed
+        // observation holds the next refill for 300ms and makes transactions miss the payload
+        // build window for the following slot.
+        let fallback_refill_interval = safety_interval;
         let mut last_pulse_at =
-            Instant::now().checked_sub(signal_timeout).unwrap_or_else(Instant::now);
+            Instant::now().checked_sub(fallback_refill_interval).unwrap_or_else(Instant::now);
 
         loop {
             drain_state.drain_run_events();
@@ -1630,7 +1641,7 @@ impl LoadRunner {
                     .await?;
                 }
                 _ = safety_tick.tick() => {
-                    if last_pulse_at.elapsed() >= signal_timeout {
+                    if last_pulse_at.elapsed() >= fallback_refill_interval {
                         Self::run_refill_cycle(
                             enqueue_state,
                             InclusionPulse::safety(Instant::now()),
@@ -2448,7 +2459,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn enqueue_block_aligned_stops_when_duration_deadline_hits_first() {
+    async fn enqueue_block_aligned_refills_at_safety_cadence_when_canonical_pulses_are_late() {
         let sender = Address::repeat_byte(0x22);
         let results_tracker = ResultsTracker::new(&[sender]);
         results_tracker.begin_measurement(10, Some(100));
@@ -2506,7 +2517,11 @@ mod tests {
                     presign_target_gas: 0,
                     max_in_flight_per_sender: 1,
                     max_total_in_flight: 1,
-                    deadline: Some(Instant::now()),
+                    // The 200ms block interval gets a 50ms safety cadence. With no canonical
+                    // pulses, this should perform the immediate safety refill plus a periodic
+                    // refill before the deadline. The old 300ms fallback only
+                    // performed the initial refill here, which allowed 200ms slots to go empty.
+                    deadline: Some(Instant::now() + Duration::from_millis(210)),
                 },
                 &mut pulse_rx,
                 &stop_flag,
@@ -2527,6 +2542,7 @@ mod tests {
 
         let summary = collector.summarize(Duration::from_secs(1), None);
         assert_eq!(summary.pacing.canonical_cycles, 0);
+        assert!(summary.pacing.safety_cycles >= 2);
         assert!(!results_tracker.measurement_finished());
     }
 }

--- a/crates/infra/load-tests/src/runner/submission.rs
+++ b/crates/infra/load-tests/src/runner/submission.rs
@@ -633,6 +633,7 @@ impl SubmissionPipeline {
 
     /// Closes both queues and summarizes queued-but-not-started batch failures.
     pub async fn close_and_fail_queued(&self, reason: &'static str) -> QueuedSubmitFailures {
+        self.shutdown.cancel();
         let mut failures = QueuedSubmitFailures::new(reason);
         let abandoned_prepared = {
             let mut receiver = self.prepared_queue.receiver.lock().await;
@@ -672,8 +673,15 @@ impl SubmissionPipeline {
     pub async fn shutdown_and_join(&mut self, timeout: Duration) {
         self.shutdown.cancel();
 
+        let deadline = Instant::now() + timeout;
         for mut worker in self.signer_workers.drain(..).chain(self.sender_workers.drain(..)) {
-            match tokio::time::timeout(timeout, &mut worker).await {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                warn!("submission worker shutdown deadline elapsed, aborting");
+                worker.abort();
+                continue;
+            }
+            match tokio::time::timeout(remaining, &mut worker).await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) if e.is_cancelled() => {}
                 Ok(Err(e)) => warn!(error = %e, "submission worker panicked"),
@@ -1308,7 +1316,7 @@ mod tests {
 
     use alloy_primitives::{Address, Bytes, TxHash, U256};
     use alloy_signer_local::PrivateKeySigner;
-    use tokio::sync::mpsc;
+    use tokio::sync::{mpsc, oneshot};
     use tokio_util::sync::CancellationToken;
 
     use super::{
@@ -1573,6 +1581,64 @@ mod tests {
         assert_eq!(pipeline.pending_batches(), 0);
         assert!(matches!(submit_event_rx.try_recv(), Ok(SubmitEvent::Failed(_))));
         assert!(submit_event_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn close_and_fail_queued_cancels_workers_before_locking_receivers() {
+        let (_prepared_tx, prepared_rx) = mpsc::channel(1);
+        let (_signed_tx, signed_rx) = mpsc::channel(1);
+        let prepared_queue = Arc::new(PipelineQueue::new(prepared_rx));
+        let signed_queue = Arc::new(PipelineQueue::new(signed_rx));
+        let shutdown = CancellationToken::new();
+        let queue = Arc::clone(&signed_queue);
+        let worker_shutdown = shutdown.clone();
+        let (locked_tx, locked_rx) = oneshot::channel();
+        let holder = tokio::spawn(async move {
+            let _receiver = queue.receiver.lock().await;
+            let _ = locked_tx.send(());
+            worker_shutdown.cancelled().await;
+        });
+        locked_rx.await.expect("receiver holder must start");
+
+        let pipeline = SubmissionPipeline {
+            prepared_batch_tx: None,
+            signed_batch_tx: None,
+            prepared_queue,
+            signed_queue,
+            shutdown,
+            signer_workers: Vec::new(),
+            sender_workers: Vec::new(),
+        };
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            pipeline.close_and_fail_queued("submit queue abandoned"),
+        )
+        .await
+        .expect("queue close must release receiver holders before acquiring their locks");
+        holder.await.expect("receiver holder must stop cleanly");
+    }
+
+    #[tokio::test]
+    async fn shutdown_timeout_is_shared_across_all_workers() {
+        let (_prepared_tx, prepared_rx) = mpsc::channel(1);
+        let (_signed_tx, signed_rx) = mpsc::channel(1);
+        let blocked_worker = || tokio::spawn(std::future::pending::<()>());
+        let mut pipeline = SubmissionPipeline {
+            prepared_batch_tx: None,
+            signed_batch_tx: None,
+            prepared_queue: Arc::new(PipelineQueue::new(prepared_rx)),
+            signed_queue: Arc::new(PipelineQueue::new(signed_rx)),
+            shutdown: CancellationToken::new(),
+            signer_workers: vec![blocked_worker(), blocked_worker()],
+            sender_workers: vec![blocked_worker(), blocked_worker()],
+        };
+
+        tokio::time::timeout(
+            Duration::from_millis(250),
+            pipeline.shutdown_and_join(Duration::from_millis(100)),
+        )
+        .await
+        .expect("worker shutdown must use one shared timeout");
     }
 
     #[test]

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -12,6 +12,10 @@ repository.workspace = true
 name = "base-devnet"
 path = "src/bin/base_devnet.rs"
 
+[[bin]]
+name = "base-bench"
+path = "src/bin/base_bench.rs"
+
 [lints]
 workspace = true
 

--- a/etc/systems/src/benchmark_cli.rs
+++ b/etc/systems/src/benchmark_cli.rs
@@ -1,0 +1,488 @@
+//! Command-line orchestration for snapshot-backed benchmarks.
+
+use std::{
+    collections::BTreeMap,
+    io::Write as _,
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use alloy_provider::{Provider, RootProvider};
+use alloy_rpc_types_eth::BlockNumberOrTag;
+use alloy_signer_local::PrivateKeySigner;
+use base_common_network::Base;
+use base_load_tests::{
+    BaselineError, LoadTestDisplay, LoadTestExecutor, LoadTestRunHooks, LoadTestRunOptions,
+    MetricsSummary, TestConfig,
+};
+use chrono::{SecondsFormat, Utc};
+use clap::{Args, Parser, Subcommand};
+use eyre::{Result, WrapErr};
+
+use crate::{
+    DevnetBlockInterval, DevnetConfig, DevnetL2State, DevnetPrefund, PrometheusBlockCollector,
+    SnapshotBenchmarkReportConfig, SnapshotBenchmarkResult, SnapshotBlockMetrics,
+    SnapshotChainConfig, SnapshotL2Stack, SystemTestStackBuilder,
+};
+
+/// Base benchmark launcher.
+#[derive(Debug, Parser)]
+#[command(author, version, about = "Benchmark a Base development network")]
+pub struct BenchmarkCli {
+    /// Benchmark target.
+    #[command(subcommand)]
+    pub command: BenchmarkCommand,
+}
+
+/// Supported benchmark targets.
+#[derive(Debug, Subcommand)]
+pub enum BenchmarkCommand {
+    /// Run one load test against a Base snapshot continuation.
+    Snapshot(SnapshotBenchmarkArgs),
+}
+
+/// Arguments for one snapshot-backed benchmark case.
+#[derive(Debug, Args)]
+pub struct SnapshotBenchmarkArgs {
+    /// Built-in Base chain name or path to a Base genesis JSON file.
+    #[arg(long, default_value = "mainnet")]
+    pub chain: String,
+    /// Rollup config JSON for a custom chain JSON whose chain ID is not built in.
+    #[arg(long)]
+    pub rollup_config: Option<PathBuf>,
+    /// Writable builder snapshot datadir.
+    #[arg(long, env = "BASE_SNAPSHOT_BUILDER_DATADIR")]
+    pub builder_datadir: PathBuf,
+    /// Writable client snapshot datadir for the same chain.
+    #[arg(long, env = "BASE_SNAPSHOT_CLIENT_DATADIR")]
+    pub client_datadir: PathBuf,
+    /// Load-test YAML. RPC and Flashblocks URLs are replaced with launched endpoints.
+    #[arg(long)]
+    pub load_test_config: PathBuf,
+    /// Required benchmark artifact directory.
+    ///
+    /// Writes `<output-dir>/{benchmark-result.json,metadata.json,metrics-sequencer.json,metrics-validator.json,load-test-result.json}`.
+    #[arg(long)]
+    pub output_dir: PathBuf,
+    /// User-visible scenario identifier for the report series.
+    #[arg(long)]
+    pub scenario: String,
+    /// Cohort key shared by runs that should be compared in the report.
+    #[arg(long, default_value = "snapshot-throughput")]
+    pub benchmark_run: String,
+    /// Unique run identifier; defaults to `<benchmark-run>-<timestamp>`.
+    #[arg(long)]
+    pub run_id: Option<String>,
+    /// Stable build identifier for visualizer comparisons.
+    #[arg(long, env = "BASE_BENCH_CLIENT_VERSION")]
+    pub client_version: Option<String>,
+    /// Maximum time to wait for graceful in-process stack shutdown after result artifacts have
+    /// been written. Expiry terminates the process because snapshot datadirs are disposable.
+    #[arg(long, default_value_t = 10)]
+    pub shutdown_timeout_seconds: u64,
+}
+
+/// Wei minted to the benchmark's ephemeral funder in the first local descendant (1000 ETH).
+const PREFUND_AMOUNT_WEI: u128 = 1_000_000_000_000_000_000_000;
+const RESULT_FILE_NAME: &str = "benchmark-result.json";
+
+impl BenchmarkCli {
+    /// Runs the selected benchmark case.
+    pub async fn run(self) -> Result<()> {
+        let _progress = LoadTestDisplay::init_tracing();
+        match self.command {
+            BenchmarkCommand::Snapshot(args) => args.run().await,
+        }
+    }
+}
+
+impl SnapshotBenchmarkArgs {
+    /// Starts the devnet, runs the load test, writes results, and shuts down.
+    pub async fn run(self) -> Result<()> {
+        let test_config = TestConfig::load(&self.load_test_config)
+            .wrap_err("failed to load benchmark load-test configuration")?;
+        let block_interval = Self::block_interval_from_test_config(&test_config)?;
+        let funder_key = PrivateKeySigner::random();
+        let client_version = self.client_version.clone().ok_or_else(|| {
+            eyre::eyre!("--client-version or BASE_BENCH_CLIENT_VERSION is required")
+        })?;
+        let mut devnet = DevnetConfig::snapshot(
+            self.builder_datadir.clone(),
+            self.client_datadir.clone(),
+            SnapshotChainConfig {
+                chain: self.chain.clone(),
+                rollup_config: self.rollup_config.clone(),
+            },
+        )?;
+        let DevnetL2State::Snapshot(snapshot) = &mut devnet.l2_state else {
+            unreachable!("snapshot constructor must create snapshot state")
+        };
+        snapshot.block_interval = block_interval;
+        snapshot.prefund =
+            Some(DevnetPrefund { address: funder_key.address(), amount: PREFUND_AMOUNT_WEI });
+
+        Self::reset_output_dir(&self.output_dir)?;
+        let result_path = self.output_dir.join(RESULT_FILE_NAME);
+        let output_name = Self::output_directory_name(&self.output_dir);
+        let run_id =
+            self.run_id.clone().unwrap_or_else(|| Self::derived_run_id(&self.benchmark_run));
+        let report = SnapshotBenchmarkReportConfig::new(
+            self.output_dir.clone(),
+            output_name,
+            run_id,
+            self.benchmark_run.clone(),
+            self.scenario.clone(),
+            client_version,
+        );
+
+        eyre::ensure!(
+            self.shutdown_timeout_seconds > 0,
+            "shutdown timeout must be greater than zero"
+        );
+        let mut stack = SystemTestStackBuilder::new()
+            .with_devnet_config(devnet)
+            .build_snapshot_sequencer()
+            .await?;
+        let benchmark_result =
+            self.execute(&mut stack, test_config, block_interval, funder_key).await;
+
+        // Persist the report before teardown. Reth may have a non-cancellable serial state-root
+        // fallback still running after consensus shutdown, and dropping its runtime waits for
+        // blocking work to finish. The snapshot datadirs are disposable, so teardown is bounded
+        // separately after preserving the useful benchmark output.
+        let output_result = (|| -> Result<()> {
+            let (result, run_error) = benchmark_result?;
+            let encoded = serde_json::to_vec_pretty(&result)?;
+            std::fs::write(&result_path, encoded).wrap_err_with(|| {
+                format!("failed to write benchmark result {}", result_path.display())
+            })?;
+            if let Some(error) = run_error {
+                return Err(error.into());
+            }
+            if result.load_test.throughput.total_confirmed == 0 {
+                eyre::bail!("benchmark completed without confirmed transactions")
+            }
+            if result.load_test.gas.total_gas == 0 {
+                eyre::bail!("benchmark completed without measured gas")
+            }
+            if let Some(expected_blocks) =
+                result.load_test.config.as_ref().and_then(|config| config.measurement_blocks)
+            {
+                eyre::ensure!(
+                    result.load_test.measurement_block_count == expected_blocks,
+                    "benchmark observed {} of {expected_blocks} requested blocks",
+                    result.load_test.measurement_block_count
+                );
+                eyre::ensure!(
+                    result.blocks.len() as u64 == expected_blocks
+                        && result.validator_blocks.len() as u64 == expected_blocks,
+                    "benchmark block metrics do not contain exactly {expected_blocks} blocks"
+                );
+            }
+            report.write_visualizer_bundle(&result)?;
+            println!("benchmark result: {}", result_path.display());
+            std::io::stdout().flush().wrap_err("failed to flush benchmark result output")?;
+            Ok(())
+        })();
+
+        if let Err(error) = &output_result {
+            eprintln!("benchmark result processing failed before shutdown: {error:?}");
+            let _ = std::io::stderr().flush();
+        }
+        let shutdown_result =
+            Self::shutdown_with_deadline(stack, self.shutdown_timeout_seconds).await;
+        output_result?;
+        shutdown_result
+    }
+
+    /// Gracefully shuts down the stack, but terminates the process if runtime destruction remains
+    /// blocked after the deadline. A native thread is used because the Tokio runtime itself may be
+    /// the component waiting on a non-cancellable blocking state-root task.
+    async fn shutdown_with_deadline(stack: SnapshotL2Stack, timeout_seconds: u64) -> Result<()> {
+        let complete = Arc::new(AtomicBool::new(false));
+        let watchdog_complete = Arc::clone(&complete);
+        thread::spawn(move || {
+            thread::sleep(Duration::from_secs(timeout_seconds));
+            if !watchdog_complete.load(Ordering::Acquire) {
+                eprintln!(
+                    "snapshot stack shutdown exceeded {timeout_seconds}s after result output; forcing failed process exit"
+                );
+                let _ = std::io::stderr().flush();
+                // The result path was explicitly flushed before teardown. A graceful shutdown is
+                // already stuck, and the snapshot datadirs are disposable, so report the abnormal
+                // teardown to the caller instead of waiting indefinitely for runtime destructors.
+                std::process::exit(1);
+            }
+        });
+
+        let result = stack.shutdown().await;
+        complete.store(true, Ordering::Release);
+        result
+    }
+
+    /// Executes the load test against a running snapshot stack.
+    pub async fn execute(
+        &self,
+        stack: &mut SnapshotL2Stack,
+        mut test_config: TestConfig,
+        block_interval: DevnetBlockInterval,
+        funder_key: PrivateKeySigner,
+    ) -> Result<(SnapshotBenchmarkResult, Option<BaselineError>)> {
+        let builder_rpc = stack.builder_rpc_url()?;
+        test_config.transaction_submission_rpcs = vec![builder_rpc.clone()];
+        test_config.query_rpc = Some(builder_rpc.clone());
+        test_config.txpool_nodes.clear();
+        test_config.flashblocks_ws = (block_interval == DevnetBlockInterval::TwoSeconds)
+            .then(|| stack.builder_flashblocks_url())
+            .transpose()?;
+        test_config.chain_id = Some(stack.chain_id());
+        let load_config = test_config.to_load_config(None)?;
+        let funder_address = funder_key.address();
+        let sequencer_metrics =
+            PrometheusBlockCollector::start(builder_rpc.clone(), stack.builder_metrics_url()?)
+                .await?;
+        let load_result = LoadTestExecutor::run_prepared(
+            test_config,
+            load_config,
+            funder_key,
+            LoadTestRunOptions {
+                continuous: false,
+                install_signal_handler: true,
+                skip_drain: true,
+            },
+            LoadTestRunHooks {
+                display: None,
+                before_cleanup: (|_: &MetricsSummary| {}) as fn(&MetricsSummary),
+            },
+        )
+        .await;
+        let output = load_result?;
+        let summary = output.summary;
+        let measurement_end = summary
+            .measurement_end_block
+            .ok_or_else(|| eyre::eyre!("load test did not report a measurement end block"))?;
+        let sequencer_metrics = sequencer_metrics.finish(measurement_end).await?;
+        stack.stop_sequencer().await?;
+        let client_rpc = stack.client_rpc_url()?;
+        let validator_metrics =
+            PrometheusBlockCollector::start(client_rpc.clone(), stack.client_metrics_url()?)
+                .await?;
+        stack.start_validator().await?;
+        let validator_metrics = validator_metrics.finish(measurement_end).await?;
+        let (blocks, validator_blocks) = tokio::try_join!(
+            Self::collect_block_metrics(&builder_rpc, &summary, &sequencer_metrics),
+            Self::collect_block_metrics(&client_rpc, &summary, &validator_metrics),
+        )?;
+        eyre::ensure!(
+            blocks.len() == validator_blocks.len()
+                && blocks
+                    .iter()
+                    .zip(&validator_blocks)
+                    .all(|(builder, validator)| builder.number == validator.number
+                        && builder.hash == validator.hash),
+            "follow client does not match the builder over the measured block window"
+        );
+
+        let result = SnapshotBenchmarkResult {
+            chain_id: stack.chain_id(),
+            block_interval_ms: block_interval.duration().as_millis() as u64,
+            boundary_number: stack.boundary().head.number,
+            boundary_hash: stack.boundary().head.hash,
+            builder_rpc_url: builder_rpc.to_string(),
+            client_rpc_url: client_rpc.to_string(),
+            funder_address,
+            load_test: summary,
+            blocks,
+            validator_blocks,
+        };
+        Ok((result, output.run_error))
+    }
+
+    /// Fetches every canonical block in the measured window from the builder.
+    pub async fn collect_block_metrics(
+        rpc_url: &url::Url,
+        summary: &MetricsSummary,
+        prometheus_metrics: &BTreeMap<u64, BTreeMap<String, f64>>,
+    ) -> Result<Vec<SnapshotBlockMetrics>> {
+        let (Some(start), Some(end)) =
+            (summary.measurement_start_block, summary.measurement_end_block)
+        else {
+            return Ok(Vec::new());
+        };
+        eyre::ensure!(
+            end.checked_sub(start) == Some(summary.measurement_block_count),
+            "measured block bounds {start}..={end} do not match count {}",
+            summary.measurement_block_count
+        );
+        let provider = RootProvider::<Base>::new_http(rpc_url.clone());
+        tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                if provider.get_block_by_number(BlockNumberOrTag::Number(end)).await?.is_some() {
+                    return Ok::<_, eyre::Report>(());
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await
+        .wrap_err_with(|| format!("timed out waiting for measured block {end} at {rpc_url}"))??;
+        let mut blocks = Vec::with_capacity(summary.measurement_block_count as usize);
+        for number in start.saturating_add(1)..=end {
+            let block = provider
+                .get_block_by_number(BlockNumberOrTag::Number(number))
+                .full()
+                .await
+                .wrap_err_with(|| {
+                    format!("failed to fetch measured block {number} from {rpc_url}")
+                })?
+                .ok_or_else(|| {
+                    eyre::eyre!("measured block {number} is unavailable from {rpc_url}")
+                })?;
+            let prometheus_metrics = prometheus_metrics.get(&number).cloned().ok_or_else(|| {
+                eyre::eyre!("Prometheus sample for block {number} from {rpc_url} is missing")
+            })?;
+            blocks.push(SnapshotBlockMetrics {
+                number: block.header.number,
+                hash: block.header.hash,
+                timestamp: block.header.timestamp,
+                timestamp_ms: block
+                    .header
+                    .timestamp_ms
+                    .unwrap_or_else(|| block.header.timestamp.saturating_mul(1_000)),
+                gas_used: block.header.gas_used,
+                gas_limit: block.header.gas_limit,
+                transaction_count: block.transactions.len() as u64,
+                prometheus_metrics,
+            });
+        }
+        eyre::ensure!(
+            blocks.len() as u64 == summary.measurement_block_count,
+            "fetched {} of {} measured blocks",
+            blocks.len(),
+            summary.measurement_block_count
+        );
+        Ok(blocks)
+    }
+
+    /// Derives the snapshot cadence from the load-test configuration.
+    fn block_interval_from_test_config(test_config: &TestConfig) -> Result<DevnetBlockInterval> {
+        let block_time = test_config
+            .parse_block_time()
+            .map_err(eyre::Report::from)
+            .wrap_err("failed to parse block_time from load-test configuration")?;
+        if block_time == DevnetBlockInterval::TwoSeconds.duration() {
+            return Ok(DevnetBlockInterval::TwoSeconds);
+        }
+        if block_time == DevnetBlockInterval::TwoHundredMilliseconds.duration() {
+            return Ok(DevnetBlockInterval::TwoHundredMilliseconds);
+        }
+        eyre::bail!(
+            "unsupported block_time {:?}; expected 2s or 200ms for snapshot benchmarks",
+            block_time
+        )
+    }
+
+    fn output_directory_name(path: &Path) -> String {
+        path.file_name().and_then(|name| name.to_str()).unwrap_or("benchmark-output").to_string()
+    }
+
+    /// Removes stale artifacts so a failed rerun cannot be mistaken for an older completed run.
+    fn reset_output_dir(path: &Path) -> Result<()> {
+        if path.exists() {
+            std::fs::remove_dir_all(path).wrap_err_with(|| {
+                format!("failed to clear benchmark output directory {}", path.display())
+            })?;
+        }
+        std::fs::create_dir_all(path).wrap_err_with(|| {
+            format!("failed to create benchmark output directory {}", path.display())
+        })
+    }
+
+    fn derived_run_id(benchmark_run: &str) -> String {
+        let timestamp = Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+        format!("{benchmark_run}-{timestamp}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use clap::Parser;
+
+    use super::{BenchmarkCli, BenchmarkCommand, SnapshotBenchmarkArgs};
+
+    #[test]
+    fn parses_snapshot_benchmark_defaults() {
+        let cli = BenchmarkCli::parse_from([
+            "base-bench",
+            "snapshot",
+            "--chain",
+            "sepolia",
+            "--builder-datadir",
+            "/snapshot/builder",
+            "--client-datadir",
+            "/snapshot/client",
+            "--load-test-config",
+            "load.yaml",
+            "--output-dir",
+            "results/case-a",
+            "--scenario",
+            "example-scenario",
+        ]);
+
+        let BenchmarkCommand::Snapshot(args) = cli.command;
+        assert_eq!(args.chain, "sepolia");
+        assert_eq!(args.output_dir.to_string_lossy(), "results/case-a");
+        assert_eq!(args.scenario, "example-scenario");
+        assert_eq!(args.benchmark_run, "snapshot-throughput");
+        assert!(args.run_id.is_none());
+        assert!(args.client_version.is_none());
+        assert_eq!(args.shutdown_timeout_seconds, 10);
+    }
+
+    #[test]
+    fn parses_snapshot_benchmark_output_and_run_id() {
+        let cli = BenchmarkCli::parse_from([
+            "base-bench",
+            "snapshot",
+            "--chain",
+            "mainnet",
+            "--builder-datadir",
+            "/snapshot/builder",
+            "--client-datadir",
+            "/snapshot/client",
+            "--load-test-config",
+            "load.yaml",
+            "--output-dir",
+            "result-dir",
+            "--scenario",
+            "example-scenario",
+            "--run-id",
+            "manual-run-id",
+            "--shutdown-timeout-seconds",
+            "30",
+        ]);
+
+        let BenchmarkCommand::Snapshot(args) = cli.command;
+        assert_eq!(args.output_dir.to_string_lossy(), "result-dir");
+        assert_eq!(args.run_id.as_deref(), Some("manual-run-id"));
+        assert_eq!(args.shutdown_timeout_seconds, 30);
+    }
+
+    #[test]
+    fn reset_output_dir_removes_stale_artifacts() {
+        let output = tempfile::tempdir().unwrap();
+        let stale = output.path().join("metadata.json");
+        fs::write(&stale, "old completed run").unwrap();
+
+        SnapshotBenchmarkArgs::reset_output_dir(output.path()).unwrap();
+
+        assert!(output.path().is_dir());
+        assert!(!stale.exists());
+    }
+}

--- a/etc/systems/src/bin/base_bench.rs
+++ b/etc/systems/src/bin/base_bench.rs
@@ -1,0 +1,9 @@
+//! Base snapshot benchmark binary entrypoint.
+
+use base_system_tests::BenchmarkCli;
+use clap::Parser;
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    BenchmarkCli::parse().run().await
+}

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -15,6 +15,9 @@ pub use utils::unique_name;
 mod b20;
 pub use b20::{B20CreateConfig, B20PrecompileClient};
 
+mod benchmark_cli;
+pub use benchmark_cli::{BenchmarkCli, BenchmarkCommand, SnapshotBenchmarkArgs};
+
 mod benchmark_report;
 pub use benchmark_report::{
     SnapshotBenchmarkReportConfig, SnapshotBenchmarkResult, SnapshotBlockMetrics,


### PR DESCRIPTION
## Summary

Part 4 of 5. Adds `base-bench snapshot`, which launches a snapshot continuation, runs a load test, gathers per-block metrics, verifies validator replay, and emits the report artifacts from the preceding PR.

## Included

- Add the `base-bench` binary and snapshot benchmark CLI.
- Clear the output directory before each run so stale `metadata.json` cannot represent a failed rerun.
- Fail fast when a required client-version identifier is missing.
- Exit non-zero if bounded teardown expires, after flushing persisted result output.
- Stabilize 200ms load runs with cadence-aware refills and bounded submission shutdown.

## Validation

- `cargo clippy -p base-system-tests --no-default-features --lib -- -D warnings`
- `cargo test -p base-system-tests --no-default-features --lib benchmark_cli::tests`
- `cargo +nightly fmt --all -- --check`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>