### PR TITLE
docs: document snapshot benchmarks

### DIFF
--- a/crates/infra/load-tests/examples/account-create-mainnet-snapshot.yaml
+++ b/crates/infra/load-tests/examples/account-create-mainnet-snapshot.yaml
@@ -1,0 +1,30 @@
+# Load Test Configuration - Local Mainnet Snapshot Account Creation
+#
+# This config is for `base-bench snapshot` against two writable Base mainnet
+# snapshot datadirs. The benchmark launcher replaces the placeholder RPC URLs,
+# generates and prefunds an ephemeral funder key, and skips account draining.
+
+transaction_submission_rpcs:
+  - "http://127.0.0.1:7545"
+query_rpc: "http://127.0.0.1:7545"
+txpool_nodes: []
+flashblocks_ws: "ws://127.0.0.1:7111"
+
+chain_id: 8453
+sender_count: 100
+block_time: "2s"
+in_flight_per_sender: 1024
+max_total_in_flight: 100000
+batch_size: 20
+duration: null
+measurement_blocks: 500
+target_gps: null
+seed: 12345
+
+funding_amount: "10000000000000000"
+fresh_recipient_ratio: 1.0
+skip_drain: true
+
+transactions:
+  - weight: 100
+    type: transfer

--- a/docs/guides/SNAPSHOT_BENCHMARKS.md
+++ b/docs/guides/SNAPSHOT_BENCHMARKS.md
@@ -1,0 +1,169 @@
+# Snapshot Benchmarking
+
+This guide covers repeatable performance measurements on an L1-free Base
+snapshot devnet. It explains how to run `base-bench snapshot`, publish its output
+to `base/benchmark`, and select the exact runs to compare.
+
+The snapshot benchmark is for local performance investigation. It mutates its
+builder and validator datadirs, so every attempt needs a fresh writable datadir pair.
+
+## Prerequisites
+
+- Build an optimized `base-bench` binary. Debug builds are not suitable for a
+  400M-gas performance measurement.
+- Start from an immutable, fully prepared Base datadir snapshot.
+- Restore that exact snapshot into separate writable builder and validator datadirs.
+- Keep the source snapshot immutable for benchmark purposes; only remove or reset
+  the disposable per-run datadirs.
+
+Materialize a pair for one run using the snapshot/restore system appropriate to the
+environment, then set the datadir paths:
+
+```sh
+RUN=blake2f-2s-run-1
+BUILDER_DATADIR=/path/to/restored/${RUN}-builder
+CLIENT_DATADIR=/path/to/restored/${RUN}-client
+
+test -f "$BUILDER_DATADIR/db/mdbx.dat"
+test -f "$CLIENT_DATADIR/db/mdbx.dat"
+```
+
+## Run One Benchmark
+
+Build and run the snapshot harness from this repository:
+
+```sh
+cargo build --release -p base-system-tests --bin base-bench
+
+export BASE_BENCH_CLIENT_VERSION="base/$(git rev-parse --short HEAD)"
+
+target/release/base-bench snapshot \
+  --chain sepolia \
+  --builder-datadir "$BUILDER_DATADIR" \
+  --client-datadir "$CLIENT_DATADIR" \
+  --load-test-config /path/to/blake2f-2s.yaml \
+  --benchmark-run snapshot-throughput \
+  --scenario blake2f-2s-run-1 \
+  --run-id blake2f-2s-<timestamp> \
+  --output-dir results/blake2f-2s-run-1
+```
+
+`--chain` selects the network rules used to continue the snapshot. It accepts the
+built-in Base aliases, including `mainnet` (the default) and `sepolia`. It also
+accepts a path to a Base genesis JSON file. A JSON chain whose L2 chain ID is not
+one of the built-in Base networks additionally requires its rollup configuration:
+
+```sh
+target/release/base-bench snapshot \
+  --chain /path/to/genesis.json \
+  --rollup-config /path/to/rollup.json \
+  --builder-datadir "$BUILDER_DATADIR" \
+  --client-datadir "$CLIENT_DATADIR" \
+  --load-test-config /path/to/load-test.yaml \
+  --benchmark-run custom-throughput \
+  --scenario custom-run-1 \
+  --output-dir results/custom-run-1
+```
+
+For a genesis JSON whose L2 chain ID matches a built-in Base network, the built-in
+rollup configuration is selected automatically and `--rollup-config` is optional.
+
+`base-bench snapshot` launches the snapshot builder and validator, funds an
+ephemeral load-test account, runs the workload, verifies that both roles have
+matching canonical blocks for the measured window, and then shuts down.
+
+Each `--output-dir` is a self-contained `base/benchmark` input directory:
+
+```text
+<output-dir>/
+  benchmark-result.json
+  load-test-result.json
+  metadata.json
+  metrics-sequencer.json
+  metrics-validator.json
+```
+
+`metadata.json` is the completion signal when publishing results. Write or upload
+the metrics and artifacts before it.
+
+## Choose Comparable Runs
+
+Use the fields below consistently. They have different purposes.
+
+| Field | Purpose | Comparison rule |
+|---|---|---|
+| `--benchmark-run` | Report cohort | Use the same value for every candidate in one comparison, such as `snapshot-throughput`. |
+| `--scenario` | User-visible experiment/repetition label | Use a descriptive value for each selected run, such as `blake2f-2s-run-1` or `blake2f-200ms-run-1`. |
+| `--run-id` | Immutable artifact identifier | Keep it unique. It does not group runs. |
+| `--output-dir` | Complete local artifact directory | Keep it unique. Never allow two runs to write to the same directory. |
+| `BASE_BENCH_CLIENT_VERSION` | Binary/build label | Keep it equal for cadence comparisons; deliberately vary it only for client-version comparisons. |
+
+For a fair 2-second versus 200-millisecond Blake2f comparison on any selected chain:
+
+1. Restore both roles from the same immutable snapshot for every repetition.
+2. Use the same release binary, host, load parameters, seed, and funding policy.
+3. Configure the 2-second YAML with 30 measured blocks.
+4. Configure the 200-millisecond YAML with 300 measured blocks.
+5. Give both cases the same `--benchmark-run`; use distinct scenarios and artifact IDs.
+6. Alternate cadence order across repetitions (`2s`, `200ms`, then `200ms`, `2s`) to reduce thermal and cache-order bias.
+
+For both YAMLs, use one fixed Blake2f precompile payload with 50,000 rounds and
+keep sender count, in-flight limits, batching, funding, and seed identical. The
+2-second case uses 30 blocks and the 200-millisecond case uses 300, giving both
+the same 60-second measurement window.
+
+Keep maximum-throughput tuning separate from fixed-offered-load comparisons. Record
+whether runs use a warm or cold page-cache policy; matching restored datadirs alone
+do not make page-cache state equal.
+
+Snapshot roles persist every block so the disposable datadirs remain inspectable. Reth's Engine
+persistence-backpressure threshold is cadence-scaled to preserve the default wall-clock headroom:
+16 blocks at 2 seconds and 160 blocks at 200 milliseconds. Without this scaling, a slow persistence
+flush can stop Engine API intake after only 3.2 seconds at 200 milliseconds, producing empty-block
+runs followed by catch-up bursts. The report artifacts retain the Engine backpressure and failed
+response metrics so this condition is visible rather than misclassified as workload capacity.
+
+## Compare In Base/benchmark
+
+Place each completed output directory beneath one parent directory, for example:
+
+```text
+results/
+  blake2f-2s-run-1/
+  blake2f-200ms-run-1/
+```
+
+From the paired `base/benchmark` repository, run the local report API against that
+parent directory and start the frontend in API mode:
+
+```sh
+make build-server
+./bin/report-server --local-dir /absolute/path/to/results --port 8080
+
+cd report
+yarn install
+VITE_DATA_SOURCE=api \
+  VITE_API_BASE_URL=http://127.0.0.1:8080/ \
+  VITE_ALLOWED_HOSTS=localhost \
+  yarn dev --host 127.0.0.1 --port 3000
+```
+
+Open `http://127.0.0.1:3000/#/run-comparison/snapshot-throughput`. Filter
+`Transaction Payload=blake2f`, choose the desired `Scenario` values and node role,
+then set **Show Line Per** to **Block Time Milliseconds**. This renders the 2-second
+and 200-millisecond series together while preserving their individual scenarios.
+The generated metric files record `BlockNumber` in two-second-equivalent units, so block 1 at
+200 milliseconds is `0.1`, block 10 is `1.0`, and a 6,000-block run ends at `600.0`, matching a
+600-block two-second run directly on the x-axis.
+
+The report server can synthesize additional comparison rows from the source runs.
+Use the original run IDs for raw artifacts; synthetic entries are comparison views,
+not additional benchmark executions.
+
+## Cleanup
+
+After the harness exits, retain the result directory and remove or reset only the
+disposable datadirs through the environment's snapshot/restore lifecycle.
+
+If a run was interrupted, check for lingering `base-bench` or `base-devnet` processes
+before removing its datadirs. Never remove or modify the immutable source snapshot.

--- a/etc/systems/README.md
+++ b/etc/systems/README.md
@@ -17,7 +17,7 @@ snapshot builder EL <-> standalone L1-free sequencer CL
 ```
 
 Both ELs start from separate writable copies of the same Base mainnet Reth datadir. The builder
-mines real descendants of the captured mainnet head and the follow client canonicalizes those
+mines real descendants of the captured snapshot head and the follow client canonicalizes those
 blocks. Transactions submitted to the builder use its real transaction pool and normal
 `eth_sendRawTransaction` path.
 
@@ -34,9 +34,9 @@ full-block results and do not compare Flashblock latency against the 2s case.
 Run commands from the `base/base` repository root. You need:
 
 - the normal Rust and native build dependencies for this repository;
-- an immutable Base mainnet Reth snapshot;
-- two fresh, writable clones of that snapshot for each run;
-- enough free space for both clones to diverge during the run; and
+- an immutable Base Reth snapshot;
+- two fresh, writable datadirs restored from that snapshot for each run;
+- enough free space for both datadirs to change during the run; and
 - Foundry's `cast` only when manually interacting with `base-devnet`.
 
 Each supplied datadir must already exist and contain `db/mdbx.dat`. Builder and client paths must
@@ -52,31 +52,21 @@ cast wallet address --private-key "$FUNDER_KEY"
 
 Never use a key that controls real funds.
 
-## Prepare local ZFS clones
+## Prepare writable snapshot restores
 
-Keep the source dataset immutable and clone the same snapshot once for each EL. Substitute your
-actual source snapshot and disposable dataset names:
+Keep the source snapshot immutable. Use the environment's snapshot/restore mechanism to
+materialize two writable datadirs from that same snapshot, then pass their paths to the launcher:
 
 ```bash
-export SNAPSHOT=zroot/data/snapshots/base-mainnet-06-09@latest
-export BUILDER_DATASET=zroot/data/snapshots/base-mainnet-bench-builder
-export CLIENT_DATASET=zroot/data/snapshots/base-mainnet-bench-client
-
-sudo zfs clone "$SNAPSHOT" "$BUILDER_DATASET"
-sudo zfs clone "$SNAPSHOT" "$CLIENT_DATASET"
-
-export BUILDER_DATADIR=/home/user/snapshots/base-mainnet-bench-builder
-export CLIENT_DATADIR=/home/user/snapshots/base-mainnet-bench-client
+export BUILDER_DATADIR=/path/to/restored/builder
+export CLIENT_DATADIR=/path/to/restored/client
 test -f "$BUILDER_DATADIR/db/mdbx.dat"
 test -f "$CLIENT_DATADIR/db/mdbx.dat"
 ```
 
-An AWS run has the same ownership contract: materialize two writable datadirs from the same
-immutable snapshot on instance-local `NVMe`, then pass their paths. Snapshot and volume lifecycle is
-intentionally outside `base-devnet` so the command cannot destroy caller-owned data. The simple
-workflow keeps one sequencer datadir and one validator datadir for the life of the
-instance and reuses them rather than rolling them back between runs; record the mutated starting
-heads when doing so. Use fresh equivalent copies when strict boundary equivalence matters.
+Snapshot and datadir lifecycle is intentionally outside `base-devnet` so the command cannot destroy
+caller-owned data. A long-lived environment may reuse mutated datadirs only when it records their
+starting heads. Use fresh equivalent restores when strict boundary equivalence matters.
 
 ## Run a snapshot-backed development network
 
@@ -87,6 +77,7 @@ that address in the first local descendant:
 export FUNDER_ADDRESS=$(cast wallet address --private-key "$FUNDER_KEY")
 
 cargo run -p base-system-tests --bin base-devnet -- snapshot \
+  --chain sepolia \
   --builder-datadir "$BUILDER_DATADIR" \
   --client-datadir "$CLIENT_DATADIR" \
   --block-interval 2s \
@@ -97,9 +88,11 @@ cargo run -p base-system-tests --bin base-devnet -- snapshot \
 Use `--block-interval 200ms` for the subsecond variant. The first descendant activates `BaseTime`
 metadata and subsequent blocks advance on a deterministic 200ms schedule.
 
-Startup validates chain ID 8453, the boundary L1-info transaction, `SystemConfig`, and sequence
-number. It waits for the builder to extend the snapshot and for the client to follow before writing
-the runtime file. The process then runs until Ctrl-C and shuts both EL runtimes down gracefully.
+Startup validates the selected chain ID, the boundary L1-info transaction, `SystemConfig`, and
+sequence number. It waits for the builder to extend the snapshot and for the client to follow before
+writing the runtime file. The process then runs until Ctrl-C and shuts both EL runtimes down
+gracefully. `--chain` accepts built-in aliases such as `mainnet` and `sepolia`, or a Base genesis
+JSON path. A custom genesis whose chain ID is not built in also needs `--rollup-config <rollup.json>`.
 
 In another terminal, inspect the machine-readable endpoints and compare the live heads:
 
@@ -124,33 +117,125 @@ To pin a run to a known snapshot boundary, pass all three of `--expected-head-nu
 `--expected-head-hash`, and `--expected-head-timestamp`. Startup fails before load generation if
 the captured boundary differs.
 
-## Cleanup
+## Run a snapshot benchmark
 
-After Ctrl-C, verify that no process still has either mount open, then destroy only the disposable
-datasets:
+`base-bench snapshot` owns the process lifecycle around one load test: it generates an ephemeral
+funder, deposits funds to it in the first local descendant, replaces placeholder endpoints in the
+YAML with dynamically allocated builder endpoints, runs the load generator, writes JSON, and shuts
+the stack down. It does not own the caller-provided snapshot datadirs.
+
+For the end-to-end workflow, including disposable snapshot restores, report artifact conventions, and
+how `--benchmark-run`, `--scenario`, and `--run-id` select runs in `base/benchmark`, see
+[Snapshot Benchmarking](../../docs/guides/SNAPSHOT_BENCHMARKS.md).
+
+Always use an optimized build for performance measurements. Debug payload execution becomes
+CPU-bound far below the 400M block gas limit.
 
 ```bash
-sudo zfs destroy "$BUILDER_DATASET"
-sudo zfs destroy "$CLIENT_DATASET"
+mkdir -p results
+export BASE_BENCH_CLIENT_VERSION="base/v0.0.0-$(git rev-parse --short HEAD)"
+
+cargo run --release -p base-system-tests --bin base-bench -- snapshot \
+  --chain mainnet \
+  --builder-datadir "$BUILDER_DATADIR" \
+  --client-datadir "$CLIENT_DATADIR" \
+  --load-test-config \
+    crates/infra/load-tests/examples/account-create-mainnet-snapshot.yaml \
+  --benchmark-run snapshot-throughput \
+  --scenario account-create-2s \
+  --output-dir results/account-create-2s
 ```
 
-Never destroy the immutable source snapshot. If shutdown was interrupted, check for a lingering
-`base-devnet` process before unmounting or destroying storage.
+The account-create workload uses the adaptive open-loop load generator. Every successful transfer
+targets a runtime-random fresh address, forcing an account-trie insertion. Its 100 senders and
+1,024 in-flight transactions per sender can hold more than five 400M-gas blocks of 21K-gas
+transfers. The cross-cadence example keeps 1M gas outstanding. Larger 20M and 80M fresh-account
+queues overran payload deadlines in local storage: the 2s Flashblocks builder missed subsequent FCUs
+and the 200ms standard builder could remain inside state-root construction without advancing the
+measurement. It measures exactly 500 newly observed canonical blocks. Setup, prefill, and post-run
+confirmation draining are outside the measured block count. Use `duration` instead of (or in
+addition to) `measurement_blocks` in a custom YAML when a time-bounded smoke test is preferable;
+when both are set, the first limit reached stops submissions.
+
+The result includes cadence, boundary number/hash, builder/client endpoints, the generated funder
+address (never its private key), explicit measurement boundaries, every measured block's
+hash/timestamp/gas/transaction count, phase-specific Prometheus diagnostics, and the native
+`MetricsSummary`. The complete sequencer range is measured first; sequencing then stops and the
+validator replays that range. A run fails if either role lacks a sample for a measured block or if
+their canonical hashes differ. When metrics are available for another load-test failure, they are
+written before the command returns the error.
+
+`--output-dir` is one self-contained `base/benchmark` run directory. It receives
+`benchmark-result.json`, `metadata.json`, `metrics-sequencer.json`, `metrics-validator.json`, and
+`load-test-result.json`. Set `BASE_BENCH_CLIENT_VERSION` to a stable
+build label when the report should compare commits or releases. The role metrics contain
+`gas/per_block`, `gas/per_second`, `transactions/per_block`, `transactions/per_second`, and selected
+Reth Prometheus diagnostics. `BlockNumber` uses two-second-equivalent measurement units: each 2s
+block advances by `1.0`, while each 200ms block advances by `0.1`. This aligns equal-duration
+cadence runs on report x-axes; canonical block numbers remain in `load-test-result.json`.
+`benchmark/prometheus_blocks_per_scrape = 1` identifies
+an exact per-block scrape. Values above one mean a fast sequencer advanced multiple blocks during a
+scrape: counter deltas are evenly attributed across those blocks, gauges are repeated, and
+histogram averages describe the whole scrape interval. Collection is intentionally limited to one
+scrape per second because continuously rendering Reth's full endpoint measurably perturbs 200ms
+production. Each output directory is one self-contained report run. Give comparable invocations the
+same `--benchmark-run` cohort, a descriptive `--scenario`, and a unique `--output-dir`. Report
+series are identified by scenario and node role; `--run-id` is only the unique artifact identity and
+defaults to `<benchmark-run>-<timestamp>` when omitted. Upload the metrics and artifact files before
+`metadata.json` when publishing to the report service because metadata is its completion signal.
+
+For a saturated Blake2f comparison with equal 60-second measured windows, provide separate 2s and
+200ms YAMLs with 30 and 300 measured blocks, respectively. Both should issue one fixed
+50,000-round Blake2f call per transaction with identical sender, in-flight, batching, funding, and
+seed settings. The report labels these runs with `TransactionPayload=blake2f`; use scenarios such
+as `blake2f-2s-run-1` and `blake2f-200ms-run-1` to distinguish repetitions. A
+5,000-transaction global in-flight cap is exactly one 400M-gas block of queue headroom at the
+configured 80,000 gas limit per transaction, which keeps the builder saturated without leaving an
+oversized submission backlog at cutoff.
+
+## Compare 2s and 200ms fairly
+
+One restored datadir pair is one run. A run mutates both datadirs and they are not restartable. For every
+repetition:
+
+1. Restore builder and client datadirs from the exact same immutable snapshot.
+2. Use the same optimized binary, machine, workload settings, measured duration, and funder
+   generation method. Scale the block count with cadence (for example, 30 blocks at 2s and 300 at
+   200ms for equal 60-second windows).
+3. Run one cadence and save its result plus host/build/storage metadata.
+4. Stop the stack and remove or reset only that run's disposable datadirs.
+5. Restore another fresh pair before running the other cadence.
+6. Repeat in alternating order (`2s`, `200ms`, then `200ms`, `2s`) to reduce thermal and cache-order
+   bias.
+
+Keep fixed-offered-load comparisons separate from maximum-throughput tuning. Also choose and record
+a warm-cache or cold-cache policy; equivalent restores alone do not make page-cache state equal.
+
+## Cleanup
+
+After Ctrl-C or benchmark completion, verify that no process still has either datadir open, then
+remove or reset only the disposable datadirs using the environment's snapshot/restore workflow.
+
+Never remove or modify the immutable source snapshot. If shutdown was interrupted, check for a
+lingering `base-devnet` or `base-bench` process before changing the datadir lifecycle.
 
 ## Troubleshooting
 
-- **Missing `db/mdbx.dat`:** pass the Reth datadir root, not its `db` directory or a ZFS mount that
-  contains another nesting level.
-- **Same builder/client path:** create two clones. One database cannot safely serve both roles.
-- **Boundary mismatch:** recreate both clones from the intended immutable snapshot or correct all
+- **Missing `db/mdbx.dat`:** pass the Reth datadir root, not its `db` directory or a parent directory
+  that contains another nested datadir.
+- **Same builder/client path:** restore two datadirs. One database cannot safely serve both roles.
+- **Boundary mismatch:** restore both datadirs from the intended immutable snapshot or correct all
   three expected-head flags; do not partially relax boundary validation.
 - **Address delegation or funding errors:** prefund a newly generated throwaway address via
   `--prefund-address` instead of the standard Anvil development address, whose delegated-account
   state at the tested snapshot can trip Reth's delegated-account in-flight limit while funding
   senders.
+- **Low gas usage in a debug run:** rerun with `cargo run --release`; debug runs are functional
+  smoke tests, not performance evidence.
+- **Output write failure:** create the output's parent directory before starting the run.
 - **Port conflict:** omit `--stable-ports` and consume the allocated URLs from runtime JSON.
-- **Unexpected disk growth:** account creation changes state heavily. Monitor ZFS referenced space
-  or EBS free space throughout long runs.
+- **Unexpected disk growth:** account creation changes state heavily. Monitor available storage
+  throughout long runs.
 - **No 200ms Flashblock data:** expected. The 200ms snapshot stack uses Base/Reth's standard payload
   service and does not publish or subscribe to Flashblocks; the 2s path remains unchanged. Compare
   canonical blocks, confirmations, gas, and throughput instead.
@@ -159,4 +244,5 @@ See the exact supported options at any revision with:
 
 ```bash
 cargo run -p base-system-tests --bin base-devnet -- snapshot --help
+cargo run -p base-system-tests --bin base-bench -- snapshot --help
 ```


### PR DESCRIPTION
## Summary

Part 5 of 5. Documents snapshot benchmark setup, execution, output grouping, report comparison, and cleanup; adds the mainnet account-creation example configuration.

## Included

- Add the snapshot benchmarking guide.
- Consolidate snapshot restore and benchmark instructions in the systems README.
- Add `account-create-mainnet-snapshot.yaml`.

## Validation

- `cargo +nightly fmt --all -- --check`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>