### PR TITLE
test(precompiles): cover Beryl permit zero spender

### DIFF
--- a/crates/common/precompiles/src/b20_asset/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_asset/logic/v1.rs
@@ -1431,6 +1431,18 @@ mod tests {
         );
     }
 
+    #[test]
+    fn permit_reverts_on_zero_spender() {
+        let mut tok = token();
+        let owner = anvil_owner();
+        let args = signed_permit(&tok, owner, Address::ZERO, U256::from(1u64), U256::MAX);
+        let err = LOGIC.permit(&mut tok, CHAIN_ID, U256::ZERO, args).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::InvalidSpender { spender: Address::ZERO })
+        );
+    }
+
     // --- asset: multiplier ---
 
     #[test]

--- a/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/logic/v1.rs
@@ -1423,6 +1423,18 @@ mod tests {
     }
 
     #[test]
+    fn permit_reverts_on_zero_spender() {
+        let mut tok = token();
+        let owner = anvil_owner();
+        let args = signed_permit(&tok, owner, Address::ZERO, U256::from(1u64), U256::MAX);
+        let err = LOGIC.permit(&mut tok, CHAIN_ID, U256::ZERO, args).unwrap_err();
+        assert_eq!(
+            err,
+            BasePrecompileError::revert(IB20::InvalidSpender { spender: Address::ZERO })
+        );
+    }
+
+    #[test]
     fn permit_replay_is_rejected() {
         let mut tok = token();
         let owner = anvil_owner();


### PR DESCRIPTION
## Summary
- add Beryl V1 Asset permit coverage for a valid signature with a zero spender
- add equivalent Beryl V1 Stablecoin coverage
- pin the documented `IB20::InvalidSpender(address(0))` behavior without changing V1 logic

## Testing
- `cargo +nightly fmt --check`
- `cargo test -p base-common-precompiles --lib permit_reverts_on_zero_spender`
- `cargo test -p base-common-precompiles --features test-utils --test b20_asset_v1_golden golden_permit`
- `cargo test -p base-common-precompiles --features test-utils --test b20_stablecoin_v1_golden golden_permit`