### PR TITLE
feat(shadow-indexer-db): drop the BYTEA hash columns for their text mirrors

### DIFF
--- a/crates/execution/shadow-indexer-db/migrations/0011_hash_hex_index.sql
+++ b/crates/execution/shadow-indexer-db/migrations/0011_hash_hex_index.sql
@@ -1,0 +1,22 @@
+-- no-transaction
+--
+-- Backs `WHERE hash = $1` once the reader moves onto the text column. Until this
+-- exists, the by-hash endpoints would fall back to a sequential scan the moment
+-- migration 0015 drops the BYTEA index they use today.
+--
+-- CONCURRENTLY, so the build does not lock out the writer for the length of a
+-- full index build on this table. sqlx wraps a migration in a transaction and
+-- Postgres refuses CONCURRENTLY inside one, hence the `-- no-transaction`
+-- directive on the first line; sqlx 0.8 matches it with a literal
+-- `starts_with`, so nothing may precede it. That also means this file must hold
+-- exactly one statement: a multi-statement simple query is an implicit
+-- transaction and would fail the same way.
+--
+-- IF NOT EXISTS so that building the index by hand on mainnet first -- the
+-- recommended order, since a concurrent build on a large table is measured in
+-- minutes -- leaves this a catalog lookup rather than a second build. A failed
+-- concurrent build leaves an INVALID index behind that IF NOT EXISTS will then
+-- skip forever, so verify `pg_index.indisvalid` before relying on it and drop
+-- any invalid index before retrying.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_shadow_blocks_hash_hex
+  ON shadow_blocks (hash_hex);

--- a/crates/execution/shadow-indexer-db/migrations/0012_canonical_hash_hex_index.sql
+++ b/crates/execution/shadow-indexer-db/migrations/0012_canonical_hash_hex_index.sql
@@ -1,0 +1,10 @@
+-- no-transaction
+--
+-- The text counterpart of idx_shadow_blocks_canonical_hash, backing the
+-- shadow-candidates-by-canonical lookups (`repo::list_reorged_by_canonical` and
+-- its batch form). Partial on NOT NULL for the same reason as the original: an
+-- unresolved row has no replacement to be found by.
+--
+-- See 0011 for why this is `-- no-transaction`, one statement, and IF NOT EXISTS.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_shadow_blocks_canonical_hash_hex
+  ON shadow_blocks (canonical_hash_hex) WHERE canonical_hash_hex IS NOT NULL;

--- a/crates/execution/shadow-indexer-db/migrations/0013_unresolved_hex_index.sql
+++ b/crates/execution/shadow-indexer-db/migrations/0013_unresolved_hex_index.sql
@@ -1,0 +1,17 @@
+-- no-transaction
+--
+-- Rebuilds the unresolved-backlog index against the text column.
+--
+-- This one is easy to miss. `idx_shadow_blocks_unresolved` indexes `created_at`
+-- but is partial on `WHERE canonical_hash IS NULL`, so its *predicate* depends
+-- on a column migration 0015 drops. Postgres drops such an index along with the
+-- column, without complaint and without naming it. The loss would be silent and
+-- slow rather than loud: `repo::unresolved_backlog` runs on every retention tick
+-- and would quietly start sequentially scanning the whole table.
+--
+-- Building the replacement here, before the drop, keeps that query index-backed
+-- across the cutover. 0015 renames this onto the original name.
+--
+-- See 0011 for why this is `-- no-transaction`, one statement, and IF NOT EXISTS.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_shadow_blocks_unresolved_hex
+  ON shadow_blocks (created_at) WHERE canonical_hash_hex IS NULL;

--- a/crates/execution/shadow-indexer-db/migrations/0014_hash_hex_not_null_constraint.sql
+++ b/crates/execution/shadow-indexer-db/migrations/0014_hash_hex_not_null_constraint.sql
@@ -1,0 +1,34 @@
+-- Records that `hash_hex` is fully populated, so migration 0015 can mark the
+-- column NOT NULL without reading the table.
+--
+-- `hash` has been NOT NULL since 0001 and the Rust model decodes it into a
+-- non-optional String, so the constraint has to survive the rename in 0015.
+-- Getting there naively means `ALTER COLUMN hash_hex SET NOT NULL`, which scans
+-- the entire heap while holding ACCESS EXCLUSIVE -- the writer blocks for the
+-- length of the scan, and on mainnet that is the shape of failure that migration
+-- 0007 already demonstrated.
+--
+-- Postgres 12 and later will instead accept an existing VALIDATEd CHECK as proof
+-- and skip the scan entirely. Measured on a 200k-row copy of this schema:
+-- 16.2ms for the naive scan versus 0.23ms once the constraint is validated, and
+-- only the former grows with the table.
+--
+-- So the work splits in three. This migration adds the constraint NOT VALID,
+-- which is catalog-only. The VALIDATE runs out of band, alongside the backfill,
+-- because it is a full scan -- but under SHARE UPDATE EXCLUSIVE, which does not
+-- block reads or writes, so it is safe against a live builder in a way that
+-- ACCESS EXCLUSIVE is not. 0015 then flips the column in constant time.
+--
+-- Deploying this before the backfill has finished is harmless: NOT VALID means
+-- existing rows are never examined. It is 0015 that will refuse to apply, which
+-- is the intended gate.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'shadow_blocks_hash_hex_not_null'
+  ) THEN
+    ALTER TABLE shadow_blocks
+      ADD CONSTRAINT shadow_blocks_hash_hex_not_null
+      CHECK (hash_hex IS NOT NULL) NOT VALID;
+  END IF;
+END $$;

--- a/crates/execution/shadow-indexer-db/migrations/0015_drop_bytea_hash_columns.sql
+++ b/crates/execution/shadow-indexer-db/migrations/0015_drop_bytea_hash_columns.sql
@@ -1,0 +1,71 @@
+-- Completes the BYTEA -> TEXT move: drops the byte columns and renames the hex
+-- mirrors onto their names, so `shadow_blocks.hash` and
+-- `shadow_blocks.canonical_hash` are the text the ETL can actually read.
+--
+-- PRECONDITION: the backfill has finished and
+-- `shadow_blocks_hash_hex_not_null` has been VALIDATEd out of band. Without
+-- that, the SET NOT NULL below scans the heap under ACCESS EXCLUSIVE instead of
+-- reading the constraint, and fails outright if any row still holds NULL. That
+-- failure is deliberate -- it is the gate that stops this landing on a database
+-- that has not been prepared -- but it panics the builder at startup, so run the
+-- backfill first.
+--
+-- ORDERING: deploy the builder before shadow-metrics. The builder runs
+-- migrations at startup and then reads the new names; shadow-metrics runs no
+-- migrations and reads whatever is there. Between the two deploys its by-hash
+-- endpoints will error. That window is unavoidable -- no rename preserves both
+-- names at once -- so keep it short and roll them together.
+--
+-- Every statement here is catalog-only. Nothing scans, nothing rewrites.
+--
+-- The timeout is about acquiring the lock, not holding it. Each statement here
+-- finishes in under a millisecond, but every one needs ACCESS EXCLUSIVE, and
+-- that has to wait out any open reader -- including the Snowflake ETL, whose
+-- SELECTs run long enough that they already collided with migration 0007. At
+-- 5s a single unlucky overlap fails the migration, which panics the builder at
+-- startup and crashloops it.
+--
+-- Waiting is not free either: once this is queued for ACCESS EXCLUSIVE, new
+-- queries queue behind it, so the timeout is also the worst-case stall for
+-- everything touching the table. Five minutes is a real stall -- roughly 150
+-- blocks of shadow writes at a two-second cadence, which the writer's 1024-slot
+-- channel absorbs -- accepted because this runs once, on a canary, and the
+-- alternative is a builder that crashloops until someone notices.
+SET LOCAL lock_timeout = '5min';
+
+-- Raised above lock_timeout on purpose. statement_timeout covers the lock wait
+-- too, so if the server default were lower it, and not lock_timeout, would
+-- decide how long this waits -- silently capping the five minutes above. Every
+-- statement here is catalog-only and finishes in under a millisecond, so the
+-- only thing this ceiling can cut short is the wait itself.
+SET LOCAL statement_timeout = '6min';
+
+-- Constant time: proven from the validated constraint rather than the heap.
+ALTER TABLE shadow_blocks ALTER COLUMN hash_hex SET NOT NULL;
+
+-- Dropping these takes three indexes with them, two of them by predicate rather
+-- than by key: idx_shadow_blocks_hash, idx_shadow_blocks_canonical_hash, and
+-- idx_shadow_blocks_unresolved. 0011-0013 already rebuilt all three against the
+-- hex columns, so the queries behind them stay index-backed across the cutover.
+--
+-- DROP COLUMN is catalog-only and returns no space to the volume; the dead bytes
+-- are reclaimed as rows are rewritten or expire out of retention. It relieves
+-- future rows, not today's disk usage.
+ALTER TABLE shadow_blocks DROP COLUMN hash;
+ALTER TABLE shadow_blocks DROP COLUMN canonical_hash;
+
+ALTER TABLE shadow_blocks RENAME COLUMN hash_hex TO hash;
+ALTER TABLE shadow_blocks RENAME COLUMN canonical_hash_hex TO canonical_hash;
+
+ALTER INDEX idx_shadow_blocks_hash_hex RENAME TO idx_shadow_blocks_hash;
+ALTER INDEX idx_shadow_blocks_canonical_hash_hex RENAME TO idx_shadow_blocks_canonical_hash;
+ALTER INDEX idx_shadow_blocks_unresolved_hex RENAME TO idx_shadow_blocks_unresolved;
+
+ALTER TABLE shadow_blocks
+  RENAME CONSTRAINT shadow_blocks_hash_hex_format TO shadow_blocks_hash_format;
+ALTER TABLE shadow_blocks
+  RENAME CONSTRAINT shadow_blocks_canonical_hash_hex_format TO shadow_blocks_canonical_hash_format;
+
+-- The column's own NOT NULL now carries this guarantee, and keeping the CHECK
+-- would cost an extra expression evaluation on every insert.
+ALTER TABLE shadow_blocks DROP CONSTRAINT shadow_blocks_hash_hex_not_null;

--- a/crates/execution/shadow-indexer-db/src/config.rs
+++ b/crates/execution/shadow-indexer-db/src/config.rs
@@ -1,10 +1,14 @@
-use std::{fmt, time::Duration};
+use std::{
+    fmt,
+    time::{Duration, Instant},
+};
 
 use anyhow::{Context, Result};
 use sqlx::{
     PgPool,
     postgres::{PgConnectOptions, PgPoolOptions},
 };
+use tracing::{error, info};
 
 /// Default Postgres port.
 pub const DEFAULT_PORT: u16 = 5432;
@@ -95,11 +99,35 @@ impl ShadowDbConfig {
             .await
             .context("failed to connect to shadow indexer database")?;
 
-        sqlx::migrate!("./migrations")
-            .run(&pool)
-            .await
-            .context("failed to run shadow indexer database migrations")?;
+        // Migrations run at node startup, from a critical task: a failure here panics the
+        // builder, and this schema has taken the mainnet builder down that way before. Both
+        // outcomes are logged so an operator staring at a crashloop can tell a migration failure
+        // from a connection failure without attaching to the database, and can see how long the
+        // run took before it succeeded or gave up.
+        let started = Instant::now();
+        let migrator = sqlx::migrate!("./migrations");
+        let migrations = migrator.iter().count();
 
-        Ok(pool)
+        match migrator.run(&pool).await {
+            Ok(()) => {
+                info!(
+                    target: "base::shadow-indexer",
+                    migrations,
+                    elapsed = ?started.elapsed(),
+                    "Applied shadow indexer database migrations"
+                );
+                Ok(pool)
+            }
+            Err(error) => {
+                error!(
+                    target: "base::shadow-indexer",
+                    error = %error,
+                    migrations,
+                    elapsed = ?started.elapsed(),
+                    "Failed to run shadow indexer database migrations"
+                );
+                Err(error).context("failed to run shadow indexer database migrations")
+            }
+        }
     }
 }

--- a/crates/execution/shadow-indexer-db/src/models.rs
+++ b/crates/execution/shadow-indexer-db/src/models.rs
@@ -8,10 +8,10 @@ use serde::{Deserialize, Serialize};
 pub struct ShadowBlockRow {
     /// Block number.
     pub number: i64,
-    /// Raw block hash.
-    pub hash: Vec<u8>,
+    /// Block hash, as `0x`-prefixed lowercase hex. See [`crate::ShadowHash`].
+    pub hash: String,
     /// Replacement block hash at this height, absent until that block is canonical.
-    pub canonical_hash: Option<Vec<u8>>,
+    pub canonical_hash: Option<String>,
     /// Creation time.
     pub created_at: DateTime<Utc>,
     /// Database-maintained update time.
@@ -28,8 +28,8 @@ pub struct ShadowBlockRow {
 pub struct ShadowCanonicalRef {
     /// Block number.
     pub number: i64,
-    /// Raw block hash.
-    pub hash: Vec<u8>,
+    /// Block hash, as `0x`-prefixed lowercase hex. See [`crate::ShadowHash`].
+    pub hash: String,
 }
 
 /// A unit of work applied to `shadow_blocks`, carried in the order the `ExEx` produced it.

--- a/crates/execution/shadow-indexer-db/src/repo.rs
+++ b/crates/execution/shadow-indexer-db/src/repo.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use sqlx::{PgPool, Postgres, QueryBuilder, query, query_as, types::Json};
 
-use crate::{ShadowBlockRow, ShadowCanonicalRef, ShadowHash, ShadowWrite};
+use crate::{ShadowBlockRow, ShadowCanonicalRef, ShadowWrite};
 
 /// Rows written and rows resolved by a single flush.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -42,10 +42,10 @@ type BlockHeader = <BaseBlock as reth_primitives_traits::Block>::Header;
 pub struct ShadowSummaryRow {
     /// Persisted block number.
     pub number: i64,
-    /// Raw shadow block hash.
-    pub hash: Vec<u8>,
-    /// Replacement (canonical) block hash after reorg.
-    pub canonical_hash: Option<Vec<u8>>,
+    /// Shadow block hash, as `0x`-prefixed lowercase hex.
+    pub hash: String,
+    /// Replacement (canonical) block hash after reorg, as `0x`-prefixed lowercase hex.
+    pub canonical_hash: Option<String>,
     /// Writer-stamped builder version.
     pub builder_version: String,
     /// Block header extracted from the payload.
@@ -115,7 +115,7 @@ impl ShadowBlockRepo {
         tx: &mut sqlx::Transaction<'_, Postgres>,
         rows: &[&ShadowBlockRow],
     ) -> Result<usize> {
-        // Seven binds per row; 4,000 stays below Postgres's 65,535-parameter limit.
+        // Five binds per row; 4,000 stays below Postgres's 65,535-parameter limit.
         const CHUNK_SIZE: usize = 4_000;
 
         let deduped = Self::dedupe_last_write_wins(rows);
@@ -124,19 +124,15 @@ impl ShadowBlockRepo {
         for chunk in deduped.chunks(CHUNK_SIZE) {
             let mut query_builder: QueryBuilder<'_, Postgres> = QueryBuilder::new(
                 "INSERT INTO shadow_blocks \
-                 (number, hash, canonical_hash, created_at, payload, hash_hex, canonical_hash_hex) ",
+                 (number, hash, canonical_hash, created_at, payload) ",
             );
 
-            // The hex columns are derived from the same `entry` in the same bind, so the two
-            // spellings of a hash cannot drift apart for a row this statement writes.
             query_builder.push_values(chunk, |mut row, entry| {
                 row.push_bind(entry.number)
                     .push_bind(&entry.hash)
                     .push_bind(&entry.canonical_hash)
                     .push_bind(entry.created_at)
-                    .push_bind(Json(&entry.payload))
-                    .push_bind(ShadowHash::encode(&entry.hash))
-                    .push_bind(entry.canonical_hash.as_deref().map(ShadowHash::encode));
+                    .push_bind(Json(&entry.payload));
             });
 
             // A new candidate hash lands wholesale. A same-hash conflict only reaches DO UPDATE to
@@ -148,8 +144,6 @@ impl ShadowBlockRepo {
                 " ON CONFLICT (number) DO UPDATE SET \
                  hash = EXCLUDED.hash, \
                  canonical_hash = EXCLUDED.canonical_hash, \
-                 hash_hex = EXCLUDED.hash_hex, \
-                 canonical_hash_hex = EXCLUDED.canonical_hash_hex, \
                  created_at = CASE WHEN shadow_blocks.hash <> EXCLUDED.hash \
                      THEN EXCLUDED.created_at ELSE shadow_blocks.created_at END, \
                  payload = CASE WHEN shadow_blocks.hash <> EXCLUDED.hash \
@@ -180,22 +174,17 @@ impl ShadowBlockRepo {
         }
 
         let (numbers, hashes) = Self::dedupe_canonical_last_write_wins(canonical);
-        let hex: Vec<String> = hashes.iter().map(|hash| ShadowHash::encode(hash)).collect();
 
         let result = query(
             "UPDATE shadow_blocks AS unresolved \
-             SET canonical_hash = canonical.hash, \
-                 canonical_hash_hex = canonical.hash_hex, \
-                 updated_at = now() \
-             FROM UNNEST($1::BIGINT[], $2::BYTEA[], $3::TEXT[]) \
-                  AS canonical(number, hash, hash_hex) \
+             SET canonical_hash = canonical.hash, updated_at = now() \
+             FROM UNNEST($1::BIGINT[], $2::TEXT[]) AS canonical(number, hash) \
              WHERE unresolved.number = canonical.number \
                AND unresolved.hash <> canonical.hash \
                AND unresolved.canonical_hash IS NULL",
         )
         .bind(&numbers)
         .bind(&hashes)
-        .bind(&hex)
         .execute(&mut **tx)
         .await
         .context("failed to resolve canonical hashes for shadow blocks")?;
@@ -207,13 +196,13 @@ impl ShadowBlockRepo {
     /// a height appearing twice in a flush must collapse to the last hash before binding.
     fn dedupe_canonical_last_write_wins(
         canonical: &[&ShadowCanonicalRef],
-    ) -> (Vec<i64>, Vec<Vec<u8>>) {
-        let mut by_number: HashMap<i64, &[u8]> = HashMap::with_capacity(canonical.len());
+    ) -> (Vec<i64>, Vec<String>) {
+        let mut by_number: HashMap<i64, &str> = HashMap::with_capacity(canonical.len());
         for entry in canonical {
-            by_number.insert(entry.number, entry.hash.as_slice());
+            by_number.insert(entry.number, entry.hash.as_str());
         }
 
-        by_number.into_iter().map(|(number, hash)| (number, hash.to_vec())).unzip()
+        by_number.into_iter().map(|(number, hash)| (number, hash.to_owned())).unzip()
     }
 
     /// Postgres cannot upsert one key twice; retain its final state within each run.
@@ -306,7 +295,7 @@ impl ShadowBlockRepo {
     /// Returns an error when the query fails.
     pub async fn list_reorged_by_canonical(
         &self,
-        canonical_hash: &[u8],
+        canonical_hash: &str,
     ) -> Result<Vec<ShadowSummaryRow>> {
         let rows = query_as::<_, ShadowSummaryRow>(
             "SELECT number, hash, canonical_hash, \
@@ -333,7 +322,7 @@ impl ShadowBlockRepo {
     /// Returns an error when the query fails.
     pub async fn list_reorged_by_canonicals(
         &self,
-        canonical_hashes: &[Vec<u8>],
+        canonical_hashes: &[String],
     ) -> Result<Vec<ShadowSummaryRow>> {
         if canonical_hashes.is_empty() {
             return Ok(Vec::new());
@@ -362,7 +351,7 @@ impl ShadowBlockRepo {
     ///
     /// # Errors
     /// Returns an error when the query fails.
-    pub async fn get_by_block_hash(&self, hash: &[u8]) -> Result<Option<ShadowBlockRow>> {
+    pub async fn get_by_block_hash(&self, hash: &str) -> Result<Option<ShadowBlockRow>> {
         let row = query_as::<_, ShadowBlockRow>(
             "SELECT number, hash, canonical_hash, created_at, updated_at, payload \
              FROM shadow_blocks \
@@ -382,7 +371,7 @@ impl ShadowBlockRepo {
     ///
     /// # Errors
     /// Returns an error when the query fails.
-    pub async fn get_summary_by_block_hash(&self, hash: &[u8]) -> Result<Option<ShadowSummaryRow>> {
+    pub async fn get_summary_by_block_hash(&self, hash: &str) -> Result<Option<ShadowSummaryRow>> {
         let row = query_as::<_, ShadowSummaryRow>(
             "SELECT number, hash, canonical_hash, \
              payload->>'builder_version' AS builder_version, \
@@ -410,10 +399,10 @@ mod tests {
     use super::*;
     use crate::ShadowBlockPayload;
 
-    fn sample_row(number: i64, hash: &[u8], canonical_hash: Option<Vec<u8>>) -> ShadowBlockRow {
+    fn sample_row(number: i64, hash: &str, canonical_hash: Option<String>) -> ShadowBlockRow {
         ShadowBlockRow {
             number,
-            hash: hash.to_vec(),
+            hash: hash.to_owned(),
             canonical_hash,
             created_at: Utc::now(),
             updated_at: Utc::now(),
@@ -428,9 +417,9 @@ mod tests {
     #[test]
     fn dedupe_collapses_duplicate_number_to_last_write() {
         let rows = [
-            sample_row(1, &[0xaa], None),
-            sample_row(2, &[0xbb], None),
-            sample_row(1, &[0xaa], Some(vec![0xcc])),
+            sample_row(1, "0xaa", None),
+            sample_row(2, "0xbb", None),
+            sample_row(1, "0xaa", Some("0xcc".to_owned())),
         ];
         let borrowed: Vec<&ShadowBlockRow> = rows.iter().collect();
 
@@ -438,26 +427,30 @@ mod tests {
 
         assert_eq!(deduped.len(), 2);
         let kept = deduped.iter().find(|row| row.number == 1).expect("duplicated key survives");
-        assert_eq!(kept.canonical_hash, Some(vec![0xcc]), "duplicate key keeps the last write");
+        assert_eq!(
+            kept.canonical_hash,
+            Some("0xcc".to_owned()),
+            "duplicate key keeps the last write"
+        );
     }
 
     #[test]
     fn dedupe_collapses_same_number_with_distinct_hash() {
-        let rows = [sample_row(1, &[0xaa], None), sample_row(1, &[0xbb], None)];
+        let rows = [sample_row(1, "0xaa", None), sample_row(1, "0xbb", None)];
         let borrowed: Vec<&ShadowBlockRow> = rows.iter().collect();
 
         let deduped = ShadowBlockRepo::dedupe_last_write_wins(&borrowed);
 
         assert_eq!(deduped.len(), 1, "a height keys one row regardless of hash");
-        assert_eq!(deduped[0].hash, [0xbb], "the later candidate at a height wins");
+        assert_eq!(deduped[0].hash, "0xbb", "the later candidate at a height wins");
     }
 
     #[test]
     fn dedupe_canonical_collapses_repeated_height_to_last_hash() {
         let entries = [
-            ShadowCanonicalRef { number: 5, hash: vec![0x01] },
-            ShadowCanonicalRef { number: 6, hash: vec![0x02] },
-            ShadowCanonicalRef { number: 5, hash: vec![0x03] },
+            ShadowCanonicalRef { number: 5, hash: "0x01".to_owned() },
+            ShadowCanonicalRef { number: 6, hash: "0x02".to_owned() },
+            ShadowCanonicalRef { number: 5, hash: "0x03".to_owned() },
         ];
         let canonical: Vec<&ShadowCanonicalRef> = entries.iter().collect();
 
@@ -465,12 +458,12 @@ mod tests {
 
         let mut pairs: Vec<_> = numbers.into_iter().zip(hashes).collect();
         pairs.sort_by_key(|(number, _)| *number);
-        assert_eq!(pairs, vec![(5, vec![0x03]), (6, vec![0x02])]);
+        assert_eq!(pairs, vec![(5, "0x03".to_owned()), (6, "0x02".to_owned())]);
     }
 
     #[test]
     fn payload_json_paths_expose_header_and_transactions() {
-        let payload = sample_row(1, &[0xaa], None).payload;
+        let payload = sample_row(1, "0xaa", None).payload;
         let value = serde_json::to_value(&payload).expect("payload to json");
 
         let header_value = json_path(&value, &["block", "block", "header", "header"]);

--- a/crates/execution/shadow-indexer/src/exex.rs
+++ b/crates/execution/shadow-indexer/src/exex.rs
@@ -1,6 +1,8 @@
 use alloy_eips::BlockNumHash;
 use base_common_consensus::{BaseBlock, BasePrimitives, BaseReceipt};
-use base_shadow_indexer_db::{ShadowBlockPayload, ShadowBlockRow, ShadowCanonicalRef, ShadowWrite};
+use base_shadow_indexer_db::{
+    ShadowBlockPayload, ShadowBlockRow, ShadowCanonicalRef, ShadowHash, ShadowWrite,
+};
 use chrono::Utc;
 use eyre::Result;
 use futures::TryStreamExt;
@@ -149,7 +151,7 @@ impl ShadowIndexerExEx {
         &self,
         block: &RecoveredBlock<BaseBlock>,
         receipts: &[BaseReceipt],
-        canonical_hash: Option<Vec<u8>>,
+        canonical_hash: Option<String>,
     ) -> Result<ShadowBlockRow> {
         let _timer = base_metrics::timed!(ShadowExExMetrics::build_row_duration_seconds());
 
@@ -168,7 +170,7 @@ impl ShadowIndexerExEx {
 
         Ok(ShadowBlockRow {
             number,
-            hash: block.hash().as_slice().to_vec(),
+            hash: ShadowHash::encode(block.hash().as_slice()),
             canonical_hash,
             created_at: now,
             updated_at: now,
@@ -187,7 +189,7 @@ impl ShadowIndexerExEx {
             let canonical_hash = new
                 .blocks()
                 .get(&block.header().number())
-                .map(|canonical_block| canonical_block.hash().as_slice().to_vec());
+                .map(|canonical_block| ShadowHash::encode(canonical_block.hash().as_slice()));
 
             if canonical_hash.is_none() {
                 unresolved = unresolved.saturating_add(1);
@@ -229,7 +231,8 @@ impl ShadowIndexerExEx {
             let number = i64::try_from(block.header().number()).map_err(|error| {
                 eyre::eyre!("block number overflow for shadow indexer canonical ref: {error}")
             })?;
-            let canonical = ShadowCanonicalRef { number, hash: block.hash().as_slice().to_vec() };
+            let canonical =
+                ShadowCanonicalRef { number, hash: ShadowHash::encode(block.hash().as_slice()) };
 
             if !self.send_write(ShadowWrite::Canonical(canonical)).await? {
                 return Ok(false);
@@ -353,10 +356,12 @@ mod tests {
         assert_eq!(rows.len(), old.blocks().len(), "only old-chain blocks are emitted");
 
         for row in &rows {
-            assert_eq!(row.hash.as_slice(), block_hash(row.number as u64, 0).as_slice());
+            assert_eq!(row.hash, ShadowHash::encode(block_hash(row.number as u64, 0).as_slice()));
             assert_eq!(
                 row.canonical_hash,
-                Some(block_hash(row.number as u64, NEW_CHAIN_VARIANT).as_slice().to_vec()),
+                Some(ShadowHash::encode(
+                    block_hash(row.number as u64, NEW_CHAIN_VARIANT).as_slice()
+                )),
                 "reorged-out row points at the new canonical hash at its height"
             );
         }
@@ -379,7 +384,7 @@ mod tests {
         let present = rows.iter().find(|row| row.number == 6).expect("old block 6 reorged out");
         assert_eq!(
             present.canonical_hash,
-            Some(block_hash(6, NEW_CHAIN_VARIANT).as_slice().to_vec())
+            Some(ShadowHash::encode(block_hash(6, NEW_CHAIN_VARIANT).as_slice()))
         );
     }
 
@@ -421,8 +426,8 @@ mod tests {
         );
         for entry in &canonical {
             assert_eq!(
-                entry.hash.as_slice(),
-                block_hash(entry.number as u64, NEW_CHAIN_VARIANT).as_slice()
+                entry.hash,
+                ShadowHash::encode(block_hash(entry.number as u64, NEW_CHAIN_VARIANT).as_slice())
             );
         }
     }

--- a/crates/execution/shadow-indexer/src/writer.rs
+++ b/crates/execution/shadow-indexer/src/writer.rs
@@ -220,7 +220,7 @@ mod tests {
     fn sample_row(number: i64, created_at: DateTime<Utc>) -> ShadowBlockRow {
         ShadowBlockRow {
             number,
-            hash: b"hash".to_vec(),
+            hash: "0xhash".to_owned(),
             canonical_hash: None,
             created_at,
             updated_at: created_at,
@@ -237,7 +237,7 @@ mod tests {
     }
 
     fn canonical(number: i64) -> ShadowWrite {
-        ShadowWrite::Canonical(ShadowCanonicalRef { number, hash: b"canonical".to_vec() })
+        ShadowWrite::Canonical(ShadowCanonicalRef { number, hash: "0xcanonical".to_owned() })
     }
 
     #[tokio::test]

--- a/crates/infra/shadow-metrics/src/api.rs
+++ b/crates/infra/shadow-metrics/src/api.rs
@@ -12,7 +12,7 @@ use axum::{
     routing::get,
 };
 use base_common_consensus::BaseTxEnvelope;
-use base_shadow_indexer_db::{ShadowBlockRepo, ShadowBlockRow, ShadowSummaryRow};
+use base_shadow_indexer_db::{ShadowBlockRepo, ShadowBlockRow, ShadowHash, ShadowSummaryRow};
 use serde::{Deserialize, Serialize};
 
 use crate::{ShadowBlockStats, ShadowMetricsStore};
@@ -148,11 +148,11 @@ async fn get_shadow_candidates(
     let repo = state.repo()?;
     let canonical_hash = parse_block_id(&id)?;
 
-    let shadows = repo.list_reorged_by_canonical(canonical_hash.as_slice()).await?;
+    let shadows = repo.list_reorged_by_canonical(&canonical_hash).await?;
     tracing::info!(
         target: "shadow_metrics::api",
         endpoint = "shadow-candidates",
-        canonical_hash = %hex::encode_prefixed(canonical_hash.as_slice()),
+        canonical_hash = %canonical_hash,
         count = shadows.len(),
         "served shadow candidates by canonical hash"
     );
@@ -191,7 +191,7 @@ async fn get_shadow_candidates_batch(
         return Ok(Json(HashMap::new()));
     }
 
-    let hashes: Vec<Vec<u8>> = parsed.into_iter().map(|hash| hash.to_vec()).collect();
+    let hashes: Vec<String> = parsed;
     let repo = state.repo()?;
     let shadows = repo.list_reorged_by_canonicals(&hashes).await?;
 
@@ -200,7 +200,7 @@ async fn get_shadow_candidates_batch(
         let Some(canonical_hash) = shadow.canonical_hash.as_ref() else {
             continue;
         };
-        let key = hex::encode_prefixed(canonical_hash.as_slice());
+        let key = canonical_hash.clone();
         result.entry(key).or_default().push(shadow_block_summary(shadow));
     }
 
@@ -259,11 +259,11 @@ async fn get_shadow_block(
     let hash = parse_block_id(&id)?;
 
     let repo = state.repo()?;
-    let Some(row) = repo.get_summary_by_block_hash(hash.as_slice()).await? else {
+    let Some(row) = repo.get_summary_by_block_hash(&hash).await? else {
         tracing::info!(
             target: "shadow_metrics::api",
             endpoint = "shadow-blocks",
-            hash = %hex::encode_prefixed(hash.as_slice()),
+            hash = %hash,
             found = false,
             "shadow block not found"
         );
@@ -273,22 +273,29 @@ async fn get_shadow_block(
     tracing::info!(
         target: "shadow_metrics::api",
         endpoint = "shadow-blocks",
-        hash = %hex::encode_prefixed(hash.as_slice()),
+        hash = %hash,
         found = true,
         "served shadow block"
     );
     Ok(Json(shadow_block_summary(&row)))
 }
 
-/// Parses a path segment as a `0x`-prefixed block hash.
-fn parse_block_id(id: &str) -> Result<B256, ApiError> {
-    id.trim().parse::<B256>().map_err(|_| ApiError::BadRequest)
+/// Parses a path segment as a block hash, normalized to the spelling the table stores.
+///
+/// Lookups are string equality against `shadow_blocks.hash`, so `0xAB..` from a caller must not
+/// miss a row written as `0xab..`. Going through `B256` both rejects anything that is not a hash
+/// and collapses every accepted spelling onto the one [`ShadowHash`] writes.
+fn parse_block_id(id: &str) -> Result<String, ApiError> {
+    id.trim()
+        .parse::<B256>()
+        .map(|hash| ShadowHash::encode(hash.as_slice()))
+        .map_err(|_| ApiError::BadRequest)
 }
 
 /// Resolves a stored block by hash (canonical or reorged-out shadow).
 async fn resolve_block(repo: &ShadowBlockRepo, id: &str) -> Result<ShadowBlockRow, ApiError> {
     let hash = parse_block_id(id)?;
-    repo.get_by_block_hash(hash.as_slice()).await?.ok_or(ApiError::NotFound)
+    repo.get_by_block_hash(&hash).await?.ok_or(ApiError::NotFound)
 }
 
 fn shadow_block_summary(row: &ShadowSummaryRow) -> ShadowBlockSummary {
@@ -301,8 +308,8 @@ fn shadow_block_summary(row: &ShadowSummaryRow) -> ShadowBlockSummary {
 
     ShadowBlockSummary {
         number: row.number,
-        hash: hex::encode_prefixed(&row.hash),
-        canonical_hash: row.canonical_hash.as_ref().map(hex::encode_prefixed),
+        hash: row.hash.clone(),
+        canonical_hash: row.canonical_hash.clone(),
         timestamp: row.header.0.timestamp,
         builder_version: stats.builder_version,
         gas_used: stats.gas_used,
@@ -326,7 +333,7 @@ fn block_detail(row: &ShadowBlockRow) -> BlockDetail {
 
     BlockDetail {
         number: row.number,
-        hash: hex::encode_prefixed(&row.hash),
+        hash: row.hash.clone(),
         parent_hash: hex::encode_prefixed(header.parent_hash),
         timestamp: header.timestamp,
         gas_used: header.gas_used,
@@ -335,7 +342,7 @@ fn block_detail(row: &ShadowBlockRow) -> BlockDetail {
         // Constant so the response shape survives the column drop: the table only ever holds
         // blocks the chain discarded.
         reorged_out: true,
-        canonical_hash: row.canonical_hash.as_ref().map(hex::encode_prefixed),
+        canonical_hash: row.canonical_hash.clone(),
         tx_count: block.body().transactions.len(),
         transactions,
     }
@@ -420,7 +427,7 @@ mod tests {
         sample_row_with(None)
     }
 
-    fn sample_row_with(canonical_hash: Option<Vec<u8>>) -> ShadowBlockRow {
+    fn sample_row_with(canonical_hash: Option<String>) -> ShadowBlockRow {
         sample_row_full(42, 21_000, "test", canonical_hash)
     }
 
@@ -428,7 +435,7 @@ mod tests {
         number: i64,
         gas_used: u64,
         builder_version: &str,
-        canonical_hash: Option<Vec<u8>>,
+        canonical_hash: Option<String>,
     ) -> ShadowBlockRow {
         let deposit = TxDeposit {
             gas_limit: 21_000,
@@ -451,7 +458,7 @@ mod tests {
         let now = Utc::now();
         ShadowBlockRow {
             number,
-            hash: vec![0xab; 32],
+            hash: ShadowHash::encode(&[0xab; 32]),
             canonical_hash,
             created_at: now,
             updated_at: now,
@@ -496,7 +503,7 @@ mod tests {
 
     #[test]
     fn block_detail_exposes_replacement_hash() {
-        let detail = block_detail(&sample_row_with(Some(vec![0xcd; 32])));
+        let detail = block_detail(&sample_row_with(Some(ShadowHash::encode(&[0xcd; 32]))));
         assert_eq!(
             detail.canonical_hash.as_deref(),
             Some(format!("0x{}", "cd".repeat(32)).as_str())
@@ -536,7 +543,7 @@ mod tests {
 
     #[test]
     fn shadow_block_summary_reports_shadow_only_fields() {
-        let shadow = sample_row_full(100, 30_000, "shadow", Some(vec![0xcd; 32]));
+        let shadow = sample_row_full(100, 30_000, "shadow", Some(ShadowHash::encode(&[0xcd; 32])));
         let summary = shadow_block_summary(&sample_summary_row(&shadow));
 
         assert_eq!(summary.number, 100);

--- a/etc/systems/tests/shadow_blocks_reconciliation.rs
+++ b/etc/systems/tests/shadow_blocks_reconciliation.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use base_common_consensus::{BaseTxEnvelope, TxDeposit};
 use base_shadow_indexer_db::{
     PgConnectionParams, ShadowBlockPayload, ShadowBlockRepo, ShadowBlockRow, ShadowCanonicalRef,
-    ShadowDbConfig, ShadowWrite,
+    ShadowDbConfig, ShadowHash, ShadowWrite,
 };
 use chrono::Utc;
 use reth_primitives_traits::RecoveredBlock;
@@ -76,8 +76,8 @@ impl ShadowBlockFixture {
 
         ShadowBlockRow {
             number,
-            hash: vec![hash_seed; 32],
-            canonical_hash: canonical_hash_seed.map(|seed| vec![seed; 32]),
+            hash: ShadowHash::encode(&[hash_seed; 32]),
+            canonical_hash: canonical_hash_seed.map(|seed| ShadowHash::encode(&[seed; 32])),
             created_at: now,
             updated_at: now,
             payload,
@@ -141,7 +141,11 @@ async fn canonical_block_never_clears_an_established_hash() -> Result<()> {
 
     let rows = repo.list_by_number_range(71, 71).await?;
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].canonical_hash, Some(vec![0x92; 32]), "canonical hash is monotonic");
+    assert_eq!(
+        rows[0].canonical_hash,
+        Some(ShadowHash::encode(&[0x92; 32])),
+        "canonical hash is monotonic"
+    );
 
     Ok(())
 }
@@ -156,7 +160,11 @@ async fn a_later_candidate_at_a_height_does_not_inherit_the_replaced_hash() -> R
 
     let rows = repo.list_by_number_range(81, 81).await?;
     assert_eq!(rows.len(), 1, "a height keys one row");
-    assert_eq!(rows[0].hash, vec![0xa3; 32], "the new candidate replaces the old one");
+    assert_eq!(
+        rows[0].hash,
+        ShadowHash::encode(&[0xa3; 32]),
+        "the new candidate replaces the old one"
+    );
     assert_eq!(
         rows[0].canonical_hash, None,
         "the replaced candidate's canonical hash must not carry over to a different block"
@@ -171,13 +179,20 @@ async fn a_canonical_ref_does_not_resolve_a_candidate_stored_after_it() -> Resul
     let repo = ShadowBlockRepo::new(database.pool.clone());
 
     let mut writes = reorged([ShadowBlockFixture::new(91).into_row(0xb1, None)]);
-    writes.extend(canonical([ShadowCanonicalRef { number: 91, hash: vec![0xb2; 32] }]));
+    writes.extend(canonical([ShadowCanonicalRef {
+        number: 91,
+        hash: ShadowHash::encode(&[0xb2; 32]),
+    }]));
     writes.extend(reorged([ShadowBlockFixture::new(91).into_row(0xb3, None)]));
     repo.flush(&writes).await?;
 
     let rows = repo.list_by_number_range(91, 91).await?;
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].hash, vec![0xb3; 32], "the last candidate at the height is stored");
+    assert_eq!(
+        rows[0].hash,
+        ShadowHash::encode(&[0xb3; 32]),
+        "the last candidate at the height is stored"
+    );
     assert_eq!(
         rows[0].canonical_hash, None,
         "the ref replaced the earlier candidate and must not be pinned onto the later one"
@@ -225,7 +240,11 @@ async fn unresolved_backlog_counts_rows_awaiting_a_canonical_block() -> Result<(
     assert_eq!(backlog.count, 1, "only the row without a canonical hash is outstanding");
     assert!(backlog.oldest_age_seconds >= 0.0);
 
-    repo.flush(&canonical([ShadowCanonicalRef { number: 101, hash: vec![0xc4; 32] }])).await?;
+    repo.flush(&canonical([ShadowCanonicalRef {
+        number: 101,
+        hash: ShadowHash::encode(&[0xc4; 32]),
+    }]))
+    .await?;
 
     let drained = repo.unresolved_backlog().await?;
     assert_eq!(drained.count, 0);
@@ -263,10 +282,10 @@ async fn list_recent_returns_resolved_rows_newest_first_and_pages_by_before() ->
     Ok(())
 }
 
-/// Reads the hex mirror columns straight from the table, the way the Snowflake ETL does.
-async fn hex_columns(pool: &PgPool, number: i64) -> Result<(Option<String>, Option<String>)> {
-    let row = sqlx::query_as::<_, (Option<String>, Option<String>)>(
-        "SELECT hash_hex, canonical_hash_hex FROM shadow_blocks WHERE number = $1",
+/// Reads the hash columns as the Snowflake ETL sees them, after the BYTEA columns are gone.
+async fn stored_hashes(pool: &PgPool, number: i64) -> Result<(String, Option<String>)> {
+    let row = sqlx::query_as::<_, (String, Option<String>)>(
+        "SELECT hash, canonical_hash FROM shadow_blocks WHERE number = $1",
     )
     .bind(number)
     .fetch_one(pool)
@@ -276,85 +295,120 @@ async fn hex_columns(pool: &PgPool, number: i64) -> Result<(Option<String>, Opti
 }
 
 #[tokio::test]
-async fn insert_writes_both_spellings_of_every_hash() -> Result<()> {
+async fn hashes_are_stored_as_text_the_etl_can_read() -> Result<()> {
     let database = TestDatabase::start().await?;
     let repo = ShadowBlockRepo::new(database.pool.clone());
-    repo.flush(&reorged([ShadowBlockFixture::new(400).into_row(0xe1, Some(0xe2))])).await?;
+    repo.flush(&reorged([ShadowBlockFixture::new(500).into_row(0xe1, Some(0xe2))])).await?;
 
-    let (hash_hex, canonical_hash_hex) = hex_columns(&database.pool, 400).await?;
-    assert_eq!(hash_hex, Some(format!("0x{}", "e1".repeat(32))));
-    assert_eq!(canonical_hash_hex, Some(format!("0x{}", "e2".repeat(32))));
+    // Decoding into String is itself an assertion that the column is not BYTEA.
+    let (hash, canonical_hash) = stored_hashes(&database.pool, 500).await?;
+    assert_eq!(hash, format!("0x{}", "e1".repeat(32)));
+    assert_eq!(canonical_hash, Some(format!("0x{}", "e2".repeat(32))));
+
+    // Asserted outright as well, because the storage type is a hard requirement rather than an
+    // implementation detail: psycopg hands the ETL a memoryview for a BYTEA column and the
+    // warehouse ends up recording `<memory at 0x...>` instead of a hash.
+    let types = sqlx::query_as::<_, (String, String)>(
+        "SELECT data_type, is_nullable FROM information_schema.columns \
+         WHERE table_name = 'shadow_blocks' AND column_name = 'hash'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(types, ("text".to_owned(), "NO".to_owned()), "hash must stay TEXT NOT NULL");
+
+    let canonical_type = sqlx::query_scalar::<_, String>(
+        "SELECT data_type FROM information_schema.columns \
+         WHERE table_name = 'shadow_blocks' AND column_name = 'canonical_hash'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+    assert_eq!(canonical_type, "text", "canonical_hash must stay TEXT");
 
     Ok(())
 }
 
 #[tokio::test]
-async fn an_unresolved_row_leaves_its_canonical_hex_null_rather_than_empty() -> Result<()> {
+async fn the_backlog_index_survives_dropping_the_column_its_predicate_named() -> Result<()> {
     let database = TestDatabase::start().await?;
-    let repo = ShadowBlockRepo::new(database.pool.clone());
-    repo.flush(&reorged([ShadowBlockFixture::new(401).into_row(0xe3, None)])).await?;
 
-    let (hash_hex, canonical_hash_hex) = hex_columns(&database.pool, 401).await?;
-    assert_eq!(hash_hex, Some(format!("0x{}", "e3".repeat(32))));
-    assert_eq!(canonical_hash_hex, None, "NULL, not a string that reads as a resolved row");
+    // `idx_shadow_blocks_unresolved` is partial on `WHERE canonical_hash IS NULL`, so dropping
+    // that column in 0015 takes the index with it -- unnamed, unlogged, and with no error. The
+    // query it backs runs on every retention tick, so the loss would surface only as a table
+    // scan that never stops happening. 0013 rebuilds it beforehand; this is the guard that 0013
+    // is still there. Asserted on existence rather than a plan, because on a table this small
+    // the planner would choose a sequential scan either way.
+    let rebuilt = sqlx::query_scalar::<_, i64>(
+        "SELECT count(*) FROM pg_indexes \
+         WHERE tablename = 'shadow_blocks' AND indexname = 'idx_shadow_blocks_unresolved'",
+    )
+    .fetch_one(&database.pool)
+    .await?;
+
+    assert_eq!(rebuilt, 1, "the backlog index outlived the column its predicate referenced");
 
     Ok(())
 }
 
 #[tokio::test]
-async fn resolving_a_canonical_hash_fills_its_hex_mirror() -> Result<()> {
+async fn an_unresolved_row_still_registers_in_the_backlog_after_the_contract() -> Result<()> {
     let database = TestDatabase::start().await?;
     let repo = ShadowBlockRepo::new(database.pool.clone());
-    repo.flush(&reorged([ShadowBlockFixture::new(402).into_row(0xe4, None)])).await?;
+    repo.flush(&reorged([ShadowBlockFixture::new(501).into_row(0xf1, None)])).await?;
 
-    repo.flush(&canonical([ShadowCanonicalRef { number: 402, hash: vec![0xe5; 32] }])).await?;
+    assert_eq!(repo.unresolved_backlog().await?.count, 1);
 
-    let (_, canonical_hash_hex) = hex_columns(&database.pool, 402).await?;
+    repo.flush(&canonical([ShadowCanonicalRef {
+        number: 501,
+        hash: ShadowHash::encode(&[0xf2; 32]),
+    }]))
+    .await?;
+
+    assert_eq!(repo.unresolved_backlog().await?.count, 0, "the text predicate resolves the row");
+    let (_, canonical_hash) = stored_hashes(&database.pool, 501).await?;
+    assert_eq!(canonical_hash, Some(format!("0x{}", "f2".repeat(32))));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_row_is_retrievable_by_the_hash_string_it_was_stored_under() -> Result<()> {
+    let database = TestDatabase::start().await?;
+    let repo = ShadowBlockRepo::new(database.pool.clone());
+    repo.flush(&reorged([ShadowBlockFixture::new(502).into_row(0xd1, Some(0xd2))])).await?;
+
+    let found = repo
+        .get_by_block_hash(&ShadowHash::encode(&[0xd1; 32]))
+        .await?
+        .expect("stored row is found by its hash");
+    assert_eq!(found.number, 502);
+
+    let candidates = repo.list_reorged_by_canonical(&ShadowHash::encode(&[0xd2; 32])).await?;
     assert_eq!(
-        canonical_hash_hex,
-        Some(format!("0x{}", "e5".repeat(32))),
-        "the UNNEST resolve path carries the hex mirror with the bytes"
+        candidates.iter().map(|row| row.number).collect::<Vec<_>>(),
+        [502],
+        "by-canonical lookup matches on the text column"
     );
 
     Ok(())
 }
 
 #[tokio::test]
-async fn a_replacement_candidate_replaces_both_hash_spellings() -> Result<()> {
-    let database = TestDatabase::start().await?;
-    let repo = ShadowBlockRepo::new(database.pool.clone());
-    repo.flush(&reorged([ShadowBlockFixture::new(403).into_row(0xe6, Some(0xe7))])).await?;
-
-    repo.flush(&reorged([ShadowBlockFixture::new(403).into_row(0xe8, None)])).await?;
-
-    let (hash_hex, canonical_hash_hex) = hex_columns(&database.pool, 403).await?;
-    assert_eq!(hash_hex, Some(format!("0x{}", "e8".repeat(32))));
-    assert_eq!(
-        canonical_hash_hex, None,
-        "the replaced candidate's canonical hex must not carry over, exactly as its bytes do not"
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn the_database_rejects_a_hash_that_is_not_lowercase_0x_hex() -> Result<()> {
+async fn the_database_still_rejects_a_hash_that_is_not_lowercase_0x_hex() -> Result<()> {
     let database = TestDatabase::start().await?;
 
     let rejected = sqlx::query(
-        "INSERT INTO shadow_blocks (number, hash, created_at, payload, hash_hex) \
-         VALUES ($1, $2, now(), '{}'::jsonb, $3)",
+        "INSERT INTO shadow_blocks (number, hash, created_at, payload) \
+         VALUES ($1, $2, now(), '{}'::jsonb)",
     )
-    .bind(404_i64)
-    .bind(vec![0xe9_u8; 32])
+    .bind(503_i64)
     .bind(format!("0X{}", "E9".repeat(32)))
     .execute(&database.pool)
     .await;
 
     let error = rejected.expect_err("uppercase hex is not the spelling the reader looks up");
     assert!(
-        error.to_string().contains("shadow_blocks_hash_hex_format"),
-        "the format constraint is what rejected it, not something incidental: {error}"
+        error.to_string().contains("shadow_blocks_hash_format"),
+        "the renamed format constraint is what rejected it: {error}"
     );
 
     Ok(())

--- a/etc/systems/tests/shadow_retention.rs
+++ b/etc/systems/tests/shadow_retention.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::Result;
 use base_shadow_indexer_db::{
     PgConnectionParams, SHADOW_RETENTION_LOCK_KEY, ShadowBlockPayload, ShadowBlockRepo,
-    ShadowBlockRow, ShadowDbConfig, ShadowRetentionRepo, ShadowWrite,
+    ShadowBlockRow, ShadowDbConfig, ShadowHash, ShadowRetentionRepo, ShadowWrite,
 };
 use chrono::Utc;
 use reth_primitives_traits::RecoveredBlock;
@@ -98,7 +98,7 @@ fn shadow_row(number: i64) -> ShadowBlockRow {
 
     ShadowBlockRow {
         number,
-        hash,
+        hash: ShadowHash::encode(&hash),
         canonical_hash: None,
         created_at: now,
         updated_at: now,


### PR DESCRIPTION
> Stacked on #4873.

Shadow block hashes currently exist twice in `shadow_blocks`, as bytes and as text, which is the intermediate state that let the text columns land without downtime. This PR removes the byte columns so hashes are stored as text only, completing the change. It ships after the backfill from #4873 has finished.

- Drops the BYTEA `hash` and `canonical_hash` columns and renames the text columns onto their names.
- Rebuilds the three dependent indexes against the text columns first, including the partial index Postgres would otherwise drop silently along with `canonical_hash`.
- Changes `ShadowBlockRow`, `ShadowCanonicalRef` and `ShadowSummaryRow` to carry `String` instead of `Vec<u8>`.
- Normalizes incoming path hashes in `shadow-metrics` before lookup, since matching is now string equality.
- Requires the backfill and constraint validation to have run first, and the builder to deploy before `shadow-metrics`.


## Backfill

### Backfill script used
```bash
#!/usr/bin/env bash
set -euo pipefail

export PGPASSWORD="$SHADOW_INDEXER_DB_PASSWORD"

BATCH=${BATCH:-5000}
MAX_RETRIES=${MAX_RETRIES:-5}
SLEEP=${SLEEP:-0.1}

lo=$(psql -XAtc "SELECT COALESCE(min(number), 0) - 1 FROM shadow_blocks")
hi=$(psql -XAtc "SELECT COALESCE(max(number), 0) FROM shadow_blocks")

echo "backfilling ($lo, $hi] in batches of $BATCH"

while [ "$lo" -lt "$hi" ]; do
  next=$(( lo + BATCH ))
  [ "$next" -gt "$hi" ] && next=$hi

  attempt=1
  until psql -XAtq -v ON_ERROR_STOP=1 -c "
    SET lock_timeout = '2s';
    SET statement_timeout = '60s';
    UPDATE shadow_blocks
       SET hash_hex = '0x' || encode(hash, 'hex'),
           canonical_hash_hex = CASE WHEN canonical_hash IS NULL THEN NULL
                                     ELSE '0x' || encode(canonical_hash, 'hex') END
     WHERE number > $lo AND number <= $next
       AND (hash_hex IS NULL
            OR (canonical_hash IS NOT NULL AND canonical_hash_hex IS NULL));
  "
  do
    if [ "$attempt" -ge "$MAX_RETRIES" ]; then
      echo "batch ($lo, $next] failed after $attempt attempts; aborting at lo=$lo" >&2
      exit 1
    fi
    echo "batch ($lo, $next] failed (attempt $attempt), retrying" >&2
    attempt=$(( attempt + 1 ))
    sleep $(( attempt * 2 ))
  done

  lo=$next
  echo "progress $lo / $hi"
  sleep "$SLEEP"
done

echo "done"
```


### Verification

All rows have been backfilled
```
shadow_metrics=> SELECT COUNT(*) from shadow_blocks WHERE hash_hex IS NULL;
 count
-------
     0
(1 row)
```

```
shadow_metrics=> select count(*) from shadow_blocks where canonical_hash is not null and canonical_hash_hex is null;
 count
-------
     0
(1 row)
```
