### PR TITLE
fix(prefetch): bound queued request memory

### DIFF
--- a/crates/common/precompile-storage/src/prefetch.rs
+++ b/crates/common/precompile-storage/src/prefetch.rs
@@ -16,7 +16,7 @@
 //! installed — tests, tools, and `no_std` proof environments — hints are a
 //! no-op atomic load.
 
-use alloc::{sync::Arc, vec::Vec};
+use alloc::sync::Arc;
 
 use alloy_primitives::{Address, U256};
 use revm::primitives::OnceLock;
@@ -76,19 +76,22 @@ impl PrefetchHint {
         }
     }
 
-    /// Forwards a hint for storage slots of a single address, if a
-    /// prefetcher is installed.
+    /// Forwards storage-slot hints for one address if a prefetcher is installed.
     ///
-    /// The slot set is produced lazily so the hot dispatch path pays nothing
-    /// — not even the closure's allocations — when no prefetcher is
-    /// installed. Requests convert through a fixed stack buffer; batches
-    /// larger than the buffer arrive as multiple hints.
-    pub fn send_slots_with(address: Address, slots: impl FnOnce() -> Vec<U256>) {
+    /// The slot set is produced lazily, so dispatch pays neither its derivation nor a heap
+    /// allocation when prefetching is disabled. When enabled, slot keys and requests stay in
+    /// fixed stack buffers.
+    pub fn send_slots_with<const N: usize>(
+        address: Address,
+        slots: impl FnOnce() -> ([U256; N], usize),
+    ) {
         const CHUNK: usize = 8;
+
         let Some(prefetcher) = PREFETCHER.get() else {
             return;
         };
-        for chunk in slots().chunks(CHUNK) {
+        let (slots, slot_count) = slots();
+        for chunk in slots[..slot_count.min(N)].chunks(CHUNK) {
             let mut requests = [PrefetchRequest::Slot { address, slot: U256::ZERO }; CHUNK];
             for (request, &slot) in requests.iter_mut().zip(chunk) {
                 *request = PrefetchRequest::Slot { address, slot };
@@ -127,13 +130,13 @@ mod tests {
         let slots = [U256::from(11u64), U256::from(9u64)];
 
         // Before install: must not panic, and must not evaluate the closure.
-        PrefetchHint::send_slots_with(address, || unreachable!("no prefetcher installed"));
+        PrefetchHint::send_slots_with(address, || (slots, slots.len()));
         PrefetchHint::send(&[PrefetchRequest::Account { address }]);
 
         let recorder = Arc::new(RecordingPrefetcher::default());
         assert!(PrefetchHint::install(recorder.clone()));
 
-        PrefetchHint::send_slots_with(address, || slots.to_vec());
+        PrefetchHint::send_slots_with(address, || (slots, slots.len()));
         assert_eq!(
             *recorder.calls.lock().unwrap(),
             vec![vec![
@@ -150,7 +153,7 @@ mod tests {
 
         // Second install loses; the original prefetcher keeps receiving.
         assert!(!PrefetchHint::install(Arc::new(RecordingPrefetcher::default())));
-        PrefetchHint::send_slots_with(address, || slots[..1].to_vec());
+        PrefetchHint::send_slots_with(address, || (slots, 1));
         assert_eq!(recorder.calls.lock().unwrap().len(), 3);
     }
 }

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -1,6 +1,6 @@
 //! Core B-20 EVM storage layout shared by all token variants.
 
-use alloc::{string::String, vec, vec::Vec};
+use alloc::string::String;
 
 use alloy_primitives::{Address, B256, FixedBytes, U256};
 use base_precompile_macros::Storable;
@@ -98,31 +98,40 @@ pub struct B20CoreStorage {
 }
 
 impl B20CoreStorage {
+    /// Maximum storage slots read by a `transferFrom` with distinct accounts.
+    pub const TRANSFER_HINT_SLOTS: usize = 5;
+
     /// Storage slots a `transfer` (`spender == None`) or `transferFrom` reads, derivable from
     /// calldata alone: the paused bitmask, the packed transfer-policy-id word, both balances
     /// (deduplicated for self-transfers), and the `allowances[from][spender]` entry for the
     /// `transferFrom` path.
     ///
-    /// Used to issue a [`base_precompile_storage::PrefetchHint`] before dispatching the
-    /// operation, so the slots can be paged in concurrently instead of faulting one at a time
-    /// during execution. Slot arithmetic mirrors the generated handlers: namespace root plus the
-    /// generated per-field offset, with mapping keys folded in via [`StorageKey::mapping_slot`].
-    pub fn transfer_hint_slots(from: Address, to: Address, spender: Option<Address>) -> Vec<U256> {
+    /// This returns a stack-backed buffer plus its initialized length so issuing an optional
+    /// prefetch hint never allocates. Slot arithmetic mirrors the generated handlers: namespace
+    /// root plus the generated per-field offset, with mapping keys folded in via
+    /// [`StorageKey::mapping_slot`].
+    pub fn transfer_hint_slots(
+        from: Address,
+        to: Address,
+        spender: Option<Address>,
+    ) -> ([U256; Self::TRANSFER_HINT_SLOTS], usize) {
         let root = <Self as StorableType>::STORAGE_NAMESPACE_ROOT;
         let balances = root.saturating_add(__packing_b20_core_storage::BALANCES);
-        let mut slots = vec![
-            root.saturating_add(__packing_b20_core_storage::PAUSED),
-            root.saturating_add(__packing_b20_core_storage::TRANSFER_SENDER_POLICY_ID),
-            from.mapping_slot(balances),
-        ];
+        let mut slots = [U256::ZERO; Self::TRANSFER_HINT_SLOTS];
+        slots[0] = root.saturating_add(__packing_b20_core_storage::PAUSED);
+        slots[1] = root.saturating_add(__packing_b20_core_storage::TRANSFER_SENDER_POLICY_ID);
+        slots[2] = from.mapping_slot(balances);
+        let mut slot_count = 3;
         if to != from {
-            slots.push(to.mapping_slot(balances));
+            slots[slot_count] = to.mapping_slot(balances);
+            slot_count += 1;
         }
         if let Some(spender) = spender {
             let allowances = root.saturating_add(__packing_b20_core_storage::ALLOWANCES);
-            slots.push(spender.mapping_slot(from.mapping_slot(allowances)));
+            slots[slot_count] = spender.mapping_slot(from.mapping_slot(allowances));
+            slot_count += 1;
         }
-        slots
+        (slots, slot_count)
     }
 }
 
@@ -172,9 +181,9 @@ mod tests {
         let account = Address::repeat_byte(0xaa);
         let spender = Address::repeat_byte(0xbb);
         // Self-transfer: paused + policy word + one balance slot.
-        assert_eq!(B20CoreStorage::transfer_hint_slots(account, account, None).len(), 3);
+        assert_eq!(B20CoreStorage::transfer_hint_slots(account, account, None).1, 3);
         // Self-transferFrom additionally hints the allowance slot.
-        assert_eq!(B20CoreStorage::transfer_hint_slots(account, account, Some(spender)).len(), 4);
+        assert_eq!(B20CoreStorage::transfer_hint_slots(account, account, Some(spender)).1, 4);
     }
 
     #[test]

--- a/crates/common/precompiles/tests/b20_asset_v1_golden.rs
+++ b/crates/common/precompiles/tests/b20_asset_v1_golden.rs
@@ -2910,8 +2910,8 @@ fn golden_transfer_hint_slots_match_sload_footprint() {
         })
         .expect("transfer op must succeed");
 
-        let hints: BTreeSet<U256> =
-            B20CoreStorage::transfer_hint_slots(ALICE, BOB, spender).into_iter().collect();
+        let (slots, slot_count) = B20CoreStorage::transfer_hint_slots(ALICE, BOB, spender);
+        let hints: BTreeSet<U256> = slots[..slot_count].iter().copied().collect();
         let sloaded: BTreeSet<U256> = recorder
             .sloaded_keys
             .iter()

--- a/crates/execution/state-prefetch/src/pool.rs
+++ b/crates/execution/state-prefetch/src/pool.rs
@@ -2,6 +2,7 @@
 
 use std::{
     sync::{
+        Arc,
         atomic::{AtomicUsize, Ordering},
         mpsc,
     },
@@ -16,10 +17,9 @@ use tracing::trace;
 
 use crate::PrefetchMetrics;
 
-/// Per-worker queue capacity. Sized to absorb bursts of hint batches without ever blocking the
-/// execution path that produced them; overflow drops the hint (the journaled read still happens,
-/// it just pays the fault itself).
-const WORKER_QUEUE_CAPACITY: usize = 1024;
+/// Global cap for queued requests across all workers. This stays fixed when operators increase
+/// concurrency, preventing worker-count configuration from multiplying retained queue memory.
+const MAX_QUEUED_REQUESTS: usize = 4_096;
 
 /// Maximum reads served by one state-provider handle before a worker refreshes it, bounding
 /// read-transaction lifetime and snapshot staleness while amortizing provider setup across a
@@ -45,6 +45,7 @@ pub struct StatePrefetchPool {
     senders: Vec<mpsc::SyncSender<PrefetchRequest>>,
     workers: Vec<thread::JoinHandle<()>>,
     next_worker: AtomicUsize,
+    queued_requests: Arc<AtomicUsize>,
 }
 
 impl StatePrefetchPool {
@@ -60,17 +61,20 @@ impl StatePrefetchPool {
         assert!(workers > 0, "prefetch pool requires at least one worker");
         let mut senders = Vec::with_capacity(workers);
         let mut handles = Vec::with_capacity(workers);
+        let queued_requests = Arc::new(AtomicUsize::new(0));
+        let worker_queue_capacity = MAX_QUEUED_REQUESTS.div_ceil(workers);
         for index in 0..workers {
-            let (sender, receiver) = mpsc::sync_channel(WORKER_QUEUE_CAPACITY);
+            let (sender, receiver) = mpsc::sync_channel(worker_queue_capacity);
             let provider = provider.clone();
+            let queued_requests = Arc::clone(&queued_requests);
             let handle = thread::Builder::new()
                 .name(format!("state-prefetch-{index}"))
-                .spawn(move || Self::worker_loop(provider, receiver))
+                .spawn(move || Self::worker_loop(provider, receiver, queued_requests))
                 .expect("failed to spawn state prefetch worker");
             senders.push(sender);
             handles.push(handle);
         }
-        Self { senders, workers: handles, next_worker: AtomicUsize::new(0) }
+        Self { senders, workers: handles, next_worker: AtomicUsize::new(0), queued_requests }
     }
 
     /// Drains all queued hints and waits for every worker to exit.
@@ -89,8 +93,10 @@ impl StatePrefetchPool {
     fn worker_loop<P: StateProviderFactory>(
         provider: P,
         receiver: mpsc::Receiver<PrefetchRequest>,
+        queued_requests: Arc<AtomicUsize>,
     ) {
         while let Ok(request) = receiver.recv() {
+            queued_requests.fetch_sub(1, Ordering::Relaxed);
             let state = match provider.latest() {
                 Ok(state) => state,
                 Err(error) => {
@@ -104,7 +110,10 @@ impl StatePrefetchPool {
             Self::read(&*state, request);
             for _ in 1..MAX_READS_PER_PROVIDER {
                 match receiver.try_recv() {
-                    Ok(request) => Self::read(&*state, request),
+                    Ok(request) => {
+                        queued_requests.fetch_sub(1, Ordering::Relaxed);
+                        Self::read(&*state, request);
+                    }
                     Err(_) => break,
                 }
             }
@@ -139,12 +148,38 @@ impl StatePrefetcher for StatePrefetchPool {
     fn prefetch(&self, requests: &[PrefetchRequest]) {
         PrefetchMetrics::hints_total().increment(1);
         for &request in requests {
+            if !self.try_reserve_queue_slot() {
+                PrefetchMetrics::requests_dropped_total().increment(1);
+                continue;
+            }
             let index = self.next_worker.fetch_add(1, Ordering::Relaxed) % self.senders.len();
             match self.senders[index].try_send(request) {
                 Ok(()) => PrefetchMetrics::requests_enqueued_total().increment(1),
-                Err(_) => PrefetchMetrics::requests_dropped_total().increment(1),
+                Err(_) => {
+                    self.queued_requests.fetch_sub(1, Ordering::Relaxed);
+                    PrefetchMetrics::requests_dropped_total().increment(1);
+                }
             }
         }
+    }
+}
+
+impl StatePrefetchPool {
+    /// Reserves one of the globally bounded queue entries without blocking a producer.
+    fn try_reserve_queue_slot(&self) -> bool {
+        let mut queued = self.queued_requests.load(Ordering::Relaxed);
+        while queued < MAX_QUEUED_REQUESTS {
+            match self.queued_requests.compare_exchange_weak(
+                queued,
+                queued + 1,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(current) => queued = current,
+            }
+        }
+        false
     }
 }
 
@@ -154,6 +189,21 @@ mod tests {
     use reth_provider::test_utils::MockEthProvider;
 
     use super::*;
+
+    #[test]
+    fn queue_admission_is_globally_bounded() {
+        let pool = StatePrefetchPool {
+            senders: Vec::new(),
+            workers: Vec::new(),
+            next_worker: AtomicUsize::new(0),
+            queued_requests: Arc::new(AtomicUsize::new(0)),
+        };
+
+        for _ in 0..MAX_QUEUED_REQUESTS {
+            assert!(pool.try_reserve_queue_slot());
+        }
+        assert!(!pool.try_reserve_queue_slot());
+    }
 
     #[test]
     fn drains_all_hinted_requests_and_exits_cleanly() {


### PR DESCRIPTION
## Summary

- replace B20 transfer hint `Vec` construction with a fixed five-slot stack buffer
- cap queued prefetch requests globally and divide channel capacity from that cap, so worker count cannot multiply queue memory
- preserve exact hint-slot coverage with updated golden coverage and add a global-admission unit test

## Testing

- `cargo test -p base-precompile-storage -p base-execution-state-prefetch`
- `cargo test -p base-common-precompiles --features test-utils --test b20_asset_v1_golden golden_transfer_hint_slots_match_sload_footprint`
- `git diff --check`

Generated with Toshi
