### PR TITLE
fix(prefetch): bound queued request memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,6 +4598,7 @@ dependencies = [
  "alloy-primitives",
  "base-node-runner",
  "base-precompile-storage",
+ "criterion",
  "reth-provider",
  "tracing",
 ]

--- a/crates/common/precompile-storage/src/prefetch.rs
+++ b/crates/common/precompile-storage/src/prefetch.rs
@@ -9,7 +9,7 @@
 //! When no prefetcher is installed — tests, tools, and `no_std` proof
 //! environments — sending a hint is a no-op atomic load.
 
-use alloc::{sync::Arc, vec::Vec};
+use alloc::sync::Arc;
 
 use alloy_primitives::{Address, U256};
 use revm::primitives::OnceLock;
@@ -49,13 +49,27 @@ impl PrefetchHint {
     }
 
     /// Forwards storage-slot hints for one address if a prefetcher is installed.
-    pub fn send_slots(address: Address, slots: &[U256]) {
+    ///
+    /// The slot set is produced lazily, so dispatch pays neither its derivation
+    /// nor a heap allocation when prefetching is disabled. When enabled, slot
+    /// keys and requests stay in fixed stack buffers.
+    pub fn send_slots_with<const N: usize>(
+        address: Address,
+        slots: impl FnOnce() -> ([U256; N], usize),
+    ) {
+        const CHUNK: usize = 8;
+
         let Some(prefetcher) = PREFETCHER.get() else {
             return;
         };
-        let requests: Vec<_> =
-            slots.iter().map(|&slot| PrefetchRequest { address, slot }).collect();
-        prefetcher.prefetch(&requests);
+        let (slots, slot_count) = slots();
+        for chunk in slots[..slot_count.min(N)].chunks(CHUNK) {
+            let mut requests = [PrefetchRequest { address, slot: U256::ZERO }; CHUNK];
+            for (request, &slot) in requests.iter_mut().zip(chunk) {
+                request.slot = slot;
+            }
+            prefetcher.prefetch(&requests[..chunk.len()]);
+        }
     }
 }
 
@@ -67,6 +81,7 @@ mod tests {
     //! run. Recording into shared state and asserting from the test body
     //! sidesteps that.
 
+    use core::cell::Cell;
     use std::sync::Mutex;
 
     use super::*;
@@ -87,14 +102,19 @@ mod tests {
         let address = Address::repeat_byte(0xB2);
         let slots = [U256::from(11u64), U256::from(9u64)];
 
-        PrefetchHint::send_slots(address, &slots);
+        let evaluated = Cell::new(false);
+        PrefetchHint::send_slots_with(address, || {
+            evaluated.set(true);
+            (slots, slots.len())
+        });
+        assert!(!evaluated.get());
 
         let recorder = Arc::new(RecordingPrefetcher::default());
         let recorder_for_prefetcher = Arc::<RecordingPrefetcher>::clone(&recorder);
         let prefetcher: Arc<dyn StatePrefetcher> = recorder_for_prefetcher;
         assert!(PrefetchHint::install(prefetcher));
 
-        PrefetchHint::send_slots(address, &slots);
+        PrefetchHint::send_slots_with(address, || (slots, slots.len()));
         assert_eq!(
             *recorder.calls.lock().unwrap(),
             vec![vec![
@@ -104,7 +124,7 @@ mod tests {
         );
 
         assert!(!PrefetchHint::install(Arc::new(RecordingPrefetcher::default())));
-        PrefetchHint::send_slots(address, &slots[..1]);
+        PrefetchHint::send_slots_with(address, || (slots, 1));
         assert_eq!(recorder.calls.lock().unwrap().len(), 2);
     }
 }

--- a/crates/common/precompiles/benches/base_precompiles.rs
+++ b/crates/common/precompiles/benches/base_precompiles.rs
@@ -512,12 +512,13 @@ fn base_prefetch_hint_disabled(c: &mut Criterion) {
 
     c.bench_function("base_prefetch_hint_disabled", |b| {
         b.iter(|| {
-            let slots = B20CoreStorage::transfer_hint_slots(
-                black_box(from),
-                black_box(to),
-                Some(black_box(spender)),
-            );
-            PrefetchHint::send_slots(black_box(token), black_box(&slots));
+            let token = black_box(token);
+            let from = black_box(from);
+            let to = black_box(to);
+            let spender = black_box(spender);
+            PrefetchHint::send_slots_with(token, || {
+                B20CoreStorage::transfer_hint_slots(from, to, Some(spender))
+            });
         });
     });
 }

--- a/crates/common/precompiles/src/b20_asset/dispatch.rs
+++ b/crates/common/precompiles/src/b20_asset/dispatch.rs
@@ -217,18 +217,16 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
 
             // --- ERC-20 mutating ---
             C::transfer(c) => {
-                PrefetchHint::send_slots(
-                    self.token_address(),
-                    &B20CoreStorage::transfer_hint_slots(caller, c.to, None),
-                );
+                PrefetchHint::send_slots_with(self.token_address(), || {
+                    B20CoreStorage::transfer_hint_slots(caller, c.to, None)
+                });
                 logic.transfer(self, caller, c.to, c.amount, privileged)?;
                 true.abi_encode().into()
             }
             C::transferFrom(c) => {
-                PrefetchHint::send_slots(
-                    self.token_address(),
-                    &B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller)),
-                );
+                PrefetchHint::send_slots_with(self.token_address(), || {
+                    B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller))
+                });
                 logic.transfer_from(self, caller, c.from, c.to, c.amount, privileged)?;
                 true.abi_encode().into()
             }
@@ -237,19 +235,17 @@ impl<S: AssetAccounting, A: PolicyAccounting> B20AssetToken<S, A> {
                 true.abi_encode().into()
             }
             C::transferWithMemo(c) => {
-                PrefetchHint::send_slots(
-                    self.token_address(),
-                    &B20CoreStorage::transfer_hint_slots(caller, c.to, None),
-                );
+                PrefetchHint::send_slots_with(self.token_address(), || {
+                    B20CoreStorage::transfer_hint_slots(caller, c.to, None)
+                });
                 logic.transfer(self, caller, c.to, c.amount, privileged)?;
                 logic.emit_memo(self, caller, c.memo)?;
                 true.abi_encode().into()
             }
             C::transferFromWithMemo(c) => {
-                PrefetchHint::send_slots(
-                    self.token_address(),
-                    &B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller)),
-                );
+                PrefetchHint::send_slots_with(self.token_address(), || {
+                    B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller))
+                });
                 logic.transfer_from(self, caller, c.from, c.to, c.amount, privileged)?;
                 logic.emit_memo(self, caller, c.memo)?;
                 true.abi_encode().into()

--- a/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
+++ b/crates/common/precompiles/src/b20_stablecoin/dispatch.rs
@@ -197,19 +197,17 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                 // --- Mutating operations: routed to the active version's logic ---
                 C::transfer(c) => {
                     let caller = ctx.caller();
-                    PrefetchHint::send_slots(
-                        self.token_address(),
-                        &B20CoreStorage::transfer_hint_slots(caller, c.to, None),
-                    );
+                    PrefetchHint::send_slots_with(self.token_address(), || {
+                        B20CoreStorage::transfer_hint_slots(caller, c.to, None)
+                    });
                     logic.transfer(self, caller, c.to, c.amount, privileged)?;
                     true.abi_encode().into()
                 }
                 C::transferFrom(c) => {
                     let caller = ctx.caller();
-                    PrefetchHint::send_slots(
-                        self.token_address(),
-                        &B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller)),
-                    );
+                    PrefetchHint::send_slots_with(self.token_address(), || {
+                        B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller))
+                    });
                     logic.transfer_from(self, caller, c.from, c.to, c.amount, privileged)?;
                     true.abi_encode().into()
                 }
@@ -220,20 +218,18 @@ impl<S: StablecoinAccounting, A: PolicyAccounting> B20StablecoinToken<S, A> {
                 }
                 C::transferWithMemo(c) => {
                     let caller = ctx.caller();
-                    PrefetchHint::send_slots(
-                        self.token_address(),
-                        &B20CoreStorage::transfer_hint_slots(caller, c.to, None),
-                    );
+                    PrefetchHint::send_slots_with(self.token_address(), || {
+                        B20CoreStorage::transfer_hint_slots(caller, c.to, None)
+                    });
                     logic.transfer(self, caller, c.to, c.amount, privileged)?;
                     logic.emit_memo(self, caller, c.memo)?;
                     true.abi_encode().into()
                 }
                 C::transferFromWithMemo(c) => {
                     let caller = ctx.caller();
-                    PrefetchHint::send_slots(
-                        self.token_address(),
-                        &B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller)),
-                    );
+                    PrefetchHint::send_slots_with(self.token_address(), || {
+                        B20CoreStorage::transfer_hint_slots(c.from, c.to, Some(caller))
+                    });
                     logic.transfer_from(self, caller, c.from, c.to, c.amount, privileged)?;
                     logic.emit_memo(self, caller, c.memo)?;
                     true.abi_encode().into()

--- a/crates/common/precompiles/src/common/core_storage.rs
+++ b/crates/common/precompiles/src/common/core_storage.rs
@@ -1,6 +1,6 @@
 //! Core B-20 EVM storage layout shared by all token variants.
 
-use alloc::{string::String, vec, vec::Vec};
+use alloc::string::String;
 
 use alloy_primitives::{Address, B256, FixedBytes, U256};
 use base_precompile_macros::Storable;
@@ -98,28 +98,40 @@ pub struct B20CoreStorage {
 }
 
 impl B20CoreStorage {
+    /// Maximum storage slots read by a `transferFrom` with distinct accounts.
+    pub const TRANSFER_HINT_SLOTS: usize = 5;
+
     /// Storage slots a `transfer` (`spender == None`) or `transferFrom` reads, derivable from
-    /// calldata alone: the paused bitmask, the packed transfer-policy-id word, both balances,
-    /// and the `allowances[from][spender]` entry for the `transferFrom` path.
+    /// calldata alone: the paused bitmask, the packed transfer-policy-id word, both balances
+    /// (deduplicated for self-transfers), and the `allowances[from][spender]` entry for the
+    /// `transferFrom` path.
     ///
-    /// Used to issue a [`base_precompile_storage::PrefetchHint`] before dispatching the
-    /// operation, so the slots can be paged in concurrently instead of faulting one at a time
-    /// during execution. Slot arithmetic mirrors the generated handlers: namespace root plus the
-    /// generated per-field offset, with mapping keys folded in via [`StorageKey::mapping_slot`].
-    pub fn transfer_hint_slots(from: Address, to: Address, spender: Option<Address>) -> Vec<U256> {
+    /// This returns a stack-backed buffer plus its initialized length so issuing an optional
+    /// prefetch hint never allocates. Slot arithmetic mirrors the generated handlers: namespace
+    /// root plus the generated per-field offset, with mapping keys folded in via
+    /// [`StorageKey::mapping_slot`].
+    pub fn transfer_hint_slots(
+        from: Address,
+        to: Address,
+        spender: Option<Address>,
+    ) -> ([U256; Self::TRANSFER_HINT_SLOTS], usize) {
         let root = <Self as StorableType>::STORAGE_NAMESPACE_ROOT;
         let balances = root.saturating_add(__packing_b20_core_storage::BALANCES);
-        let mut slots = vec![
-            root.saturating_add(__packing_b20_core_storage::PAUSED),
-            root.saturating_add(__packing_b20_core_storage::TRANSFER_SENDER_POLICY_ID),
-            from.mapping_slot(balances),
-        ];
-        slots.push(to.mapping_slot(balances));
+        let mut slots = [U256::ZERO; Self::TRANSFER_HINT_SLOTS];
+        slots[0] = root.saturating_add(__packing_b20_core_storage::PAUSED);
+        slots[1] = root.saturating_add(__packing_b20_core_storage::TRANSFER_SENDER_POLICY_ID);
+        slots[2] = from.mapping_slot(balances);
+        let mut slot_count = 3;
+        if to != from {
+            slots[slot_count] = to.mapping_slot(balances);
+            slot_count += 1;
+        }
         if let Some(spender) = spender {
             let allowances = root.saturating_add(__packing_b20_core_storage::ALLOWANCES);
-            slots.push(spender.mapping_slot(from.mapping_slot(allowances)));
+            slots[slot_count] = spender.mapping_slot(from.mapping_slot(allowances));
+            slot_count += 1;
         }
-        slots
+        (slots, slot_count)
     }
 }
 
@@ -155,7 +167,7 @@ impl B20CoreStorageHandler<'_> {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{U256, uint};
+    use alloy_primitives::{Address, U256, uint};
     use base_precompile_storage::StorableType;
 
     use super::__packing_b20_core_storage;
@@ -163,6 +175,14 @@ mod tests {
 
     const B20_ROOT: U256 =
         uint!(0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434000_U256);
+
+    #[test]
+    fn transfer_hint_slots_dedupe_self_transfer_balance() {
+        let account = Address::repeat_byte(0xaa);
+        let spender = Address::repeat_byte(0xbb);
+        assert_eq!(B20CoreStorage::transfer_hint_slots(account, account, None).1, 3);
+        assert_eq!(B20CoreStorage::transfer_hint_slots(account, account, Some(spender)).1, 4);
+    }
 
     #[test]
     fn b20_namespaces_match_base_std_roots() {

--- a/crates/execution/state-prefetch/Cargo.toml
+++ b/crates/execution/state-prefetch/Cargo.toml
@@ -28,4 +28,9 @@ alloy-primitives.workspace = true
 tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
+criterion.workspace = true
 reth-provider = { workspace = true, features = ["test-utils"] }
+
+[[bench]]
+name = "pool"
+harness = false

--- a/crates/execution/state-prefetch/benches/pool.rs
+++ b/crates/execution/state-prefetch/benches/pool.rs
@@ -1,0 +1,36 @@
+//! Benchmarks for state-prefetch worker throughput.
+
+use alloy_primitives::{Address, U256};
+use base_execution_state_prefetch::StatePrefetchPool;
+use base_precompile_storage::{PrefetchRequest, StatePrefetcher};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use reth_provider::test_utils::MockEthProvider;
+
+const REQUESTS: usize = 4_096;
+const WORKERS: usize = 4;
+
+fn state_prefetch_pool(c: &mut Criterion) {
+    let mut group = c.benchmark_group("state_prefetch_pool");
+    group.throughput(Throughput::Elements(REQUESTS as u64));
+    group.bench_function("read_slots", |b| {
+        b.iter_batched(
+            || {
+                let pool = StatePrefetchPool::spawn(MockEthProvider::default(), WORKERS);
+                let address = Address::repeat_byte(0x01);
+                let requests = (0..REQUESTS)
+                    .map(|slot| PrefetchRequest { address, slot: U256::from(slot) })
+                    .collect::<Vec<_>>();
+                (pool, requests)
+            },
+            |(pool, requests)| {
+                pool.prefetch(&requests);
+                pool.join();
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, state_prefetch_pool);
+criterion_main!(benches);

--- a/crates/execution/state-prefetch/src/pool.rs
+++ b/crates/execution/state-prefetch/src/pool.rs
@@ -2,6 +2,7 @@
 
 use std::{
     sync::{
+        Arc,
         atomic::{AtomicUsize, Ordering},
         mpsc,
     },
@@ -13,9 +14,9 @@ use base_precompile_storage::{PrefetchRequest, StatePrefetcher};
 use reth_provider::StateProviderFactory;
 use tracing::trace;
 
-/// Per-worker queue capacity. Overflow drops the hint rather than blocking the
-/// execution path that produced it.
-const WORKER_QUEUE_CAPACITY: usize = 1024;
+/// Global cap for queued requests across all workers. Increasing worker count
+/// does not increase the maximum retained queue memory.
+const MAX_QUEUED_REQUESTS: usize = 4_096;
 
 /// Maximum number of prefetch worker threads a pool will spawn.
 pub const MAX_PREFETCH_WORKERS: usize = 256;
@@ -30,6 +31,7 @@ pub struct StatePrefetchPool {
     senders: Vec<mpsc::SyncSender<PrefetchRequest>>,
     workers: Vec<thread::JoinHandle<()>>,
     next_worker: AtomicUsize,
+    queued_requests: Arc<AtomicUsize>,
 }
 
 impl StatePrefetchPool {
@@ -45,17 +47,20 @@ impl StatePrefetchPool {
         assert!(workers > 0, "prefetch pool requires at least one worker");
         let mut senders = Vec::with_capacity(workers);
         let mut handles = Vec::with_capacity(workers);
+        let queued_requests = Arc::new(AtomicUsize::new(0));
+        let worker_queue_capacity = MAX_QUEUED_REQUESTS.div_ceil(workers);
         for index in 0..workers {
-            let (sender, receiver) = mpsc::sync_channel(WORKER_QUEUE_CAPACITY);
+            let (sender, receiver) = mpsc::sync_channel(worker_queue_capacity);
             let provider = provider.clone();
+            let queued_requests = Arc::clone(&queued_requests);
             let handle = thread::Builder::new()
                 .name(format!("state-prefetch-{index}"))
-                .spawn(move || Self::worker_loop(provider, receiver))
+                .spawn(move || Self::worker_loop(provider, receiver, queued_requests))
                 .expect("failed to spawn state prefetch worker");
             senders.push(sender);
             handles.push(handle);
         }
-        Self { senders, workers: handles, next_worker: AtomicUsize::new(0) }
+        Self { senders, workers: handles, next_worker: AtomicUsize::new(0), queued_requests }
     }
 
     /// Drains all queued hints and waits for every worker to exit.
@@ -70,8 +75,10 @@ impl StatePrefetchPool {
     fn worker_loop<P: StateProviderFactory>(
         provider: P,
         receiver: mpsc::Receiver<PrefetchRequest>,
+        queued_requests: Arc<AtomicUsize>,
     ) {
         while let Ok(request) = receiver.recv() {
+            queued_requests.fetch_sub(1, Ordering::Relaxed);
             let result = provider.latest().and_then(|state| {
                 state.storage(request.address, B256::from(request.slot)).map(|_| ())
             });
@@ -85,13 +92,35 @@ impl StatePrefetchPool {
             }
         }
     }
+
+    /// Reserves one of the globally bounded queue entries without blocking a producer.
+    fn try_reserve_queue_slot(&self) -> bool {
+        let mut queued = self.queued_requests.load(Ordering::Relaxed);
+        while queued < MAX_QUEUED_REQUESTS {
+            match self.queued_requests.compare_exchange_weak(
+                queued,
+                queued + 1,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(current) => queued = current,
+            }
+        }
+        false
+    }
 }
 
 impl StatePrefetcher for StatePrefetchPool {
     fn prefetch(&self, requests: &[PrefetchRequest]) {
         for &request in requests {
+            if !self.try_reserve_queue_slot() {
+                continue;
+            }
             let index = self.next_worker.fetch_add(1, Ordering::Relaxed) % self.senders.len();
-            let _ = self.senders[index].try_send(request);
+            if self.senders[index].try_send(request).is_err() {
+                self.queued_requests.fetch_sub(1, Ordering::Relaxed);
+            }
         }
     }
 }
@@ -102,6 +131,21 @@ mod tests {
     use reth_provider::test_utils::MockEthProvider;
 
     use super::*;
+
+    #[test]
+    fn queue_admission_is_globally_bounded() {
+        let pool = StatePrefetchPool {
+            senders: Vec::new(),
+            workers: Vec::new(),
+            next_worker: AtomicUsize::new(0),
+            queued_requests: Arc::new(AtomicUsize::new(0)),
+        };
+
+        for _ in 0..MAX_QUEUED_REQUESTS {
+            assert!(pool.try_reserve_queue_slot());
+        }
+        assert!(!pool.try_reserve_queue_slot());
+    }
 
     #[test]
     fn drains_all_hinted_requests_and_exits_cleanly() {


### PR DESCRIPTION
## Summary

- cap queued prefetch requests globally so worker-count configuration cannot multiply retained queue memory
- move B20 slot derivation behind the installed-prefetcher check
- replace transfer hint `Vec` construction with fixed stack buffers
- deduplicate self-transfer balance hints
- add queue-admission, slot-count, and Criterion benchmark coverage

The queue cap is a resource-safety change. The lazy/fixed-buffer changes are retained because the disabled-path benchmark shows a material reduction in hot-path overhead.

## Benchmark

`cargo bench -p base-common-precompiles --features test-utils --bench base_precompiles -- base_prefetch_hint_disabled --noplot`

| Implementation | Median |
|---|---:|
| Parent: eager `send_slots` + `Vec` | 652.06 ns |
| This PR: lazy fixed-buffer hint | 3.12 ns |

Criterion reported a **99.53% reduction** (~209× faster) across 100 samples.

## Stack

1. #4877 — minimal B20 storage prefetch implementation
2. **#4914 — global queue bound and benchmarked hint-path optimizations**
3. #4974 — benchmarked state-provider batching
4. #4975 — pin hints to the real B20 SLOAD footprint
5. #4976 — add worker metrics

## Testing

- `cargo test -p base-precompile-storage prefetch`
- `cargo test -p base-execution-state-prefetch`
- `cargo test -p base-common-precompiles transfer_hint_slots`
- benchmark command above
- targeted Clippy with `-D warnings`

Generated with Toshi
