### PR TITLE
feat(snapshotter): stream generated archives directly to S3

### DIFF
--- a/bin/snapshotter/main.rs
+++ b/bin/snapshotter/main.rs
@@ -113,7 +113,6 @@ mod tests {
             "--consensus-container-name=consensus",
             "--el-rpc-url=http://execution:8545",
             "--source-datadir=/data",
-            "--output-dir=/snapshots",
             "--bucket=snapshots",
         ])
         .unwrap();

--- a/bin/snapshotter/main.rs
+++ b/bin/snapshotter/main.rs
@@ -56,7 +56,8 @@ async fn main() -> Result<()> {
         config.bucket.clone(),
         config.prefix.clone(),
         config.public_base_url.clone(),
-    );
+    )
+    .with_max_streaming_part_uploads(config.max_streaming_part_uploads.get());
 
     let snapshotter = Snapshotter::new(container_manager, tip_checker, uploader, config);
     snapshotter.run().await

--- a/crates/execution/cli/src/commands/snapshot_manifest.rs
+++ b/crates/execution/cli/src/commands/snapshot_manifest.rs
@@ -73,19 +73,17 @@ impl SnapshotManifestCommand {
             block,
             "packaging modular snapshot archives"
         );
-        SnapshotGenerator::generate_manifest(
-            &ManifestGenerationParams {
-                source_datadir: &self.source_datadir,
-                chain_id: self.chain_id,
-                base_url: self.base_url.as_deref(),
-                block: Some(block),
-                blocks_per_file: Some(blocks_per_file),
-                remote_static_files: &remote_static_files,
-                previous_manifest: previous_manifest.as_ref(),
-                upload_proofs: self.proofs,
-            },
-            &self.output_dir,
-        )
+        SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+            source_datadir: &self.source_datadir,
+            output_dir: Some(&self.output_dir),
+            chain_id: self.chain_id,
+            base_url: self.base_url.as_deref(),
+            block: Some(block),
+            blocks_per_file: Some(blocks_per_file),
+            remote_static_files: &remote_static_files,
+            previous_manifest: previous_manifest.as_ref(),
+            upload_proofs: self.proofs,
+        })
         .map_err(|error| eyre::eyre!("snapshot generation failed: {error:#}"))?;
         Ok(())
     }

--- a/crates/execution/cli/src/commands/snapshot_manifest.rs
+++ b/crates/execution/cli/src/commands/snapshot_manifest.rs
@@ -75,7 +75,7 @@ impl SnapshotManifestCommand {
         );
         SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
             source_datadir: &self.source_datadir,
-            output_dir: &self.output_dir,
+            output_dir: Some(&self.output_dir),
             chain_id: self.chain_id,
             base_url: self.base_url.as_deref(),
             block: Some(block),

--- a/crates/execution/cli/src/commands/snapshot_manifest.rs
+++ b/crates/execution/cli/src/commands/snapshot_manifest.rs
@@ -73,17 +73,19 @@ impl SnapshotManifestCommand {
             block,
             "packaging modular snapshot archives"
         );
-        SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
-            source_datadir: &self.source_datadir,
-            output_dir: Some(&self.output_dir),
-            chain_id: self.chain_id,
-            base_url: self.base_url.as_deref(),
-            block: Some(block),
-            blocks_per_file: Some(blocks_per_file),
-            remote_static_files: &remote_static_files,
-            previous_manifest: previous_manifest.as_ref(),
-            upload_proofs: self.proofs,
-        })
+        SnapshotGenerator::generate_manifest(
+            &ManifestGenerationParams {
+                source_datadir: &self.source_datadir,
+                chain_id: self.chain_id,
+                base_url: self.base_url.as_deref(),
+                block: Some(block),
+                blocks_per_file: Some(blocks_per_file),
+                remote_static_files: &remote_static_files,
+                previous_manifest: previous_manifest.as_ref(),
+                upload_proofs: self.proofs,
+            },
+            &self.output_dir,
+        )
         .map_err(|error| eyre::eyre!("snapshot generation failed: {error:#}"))?;
         Ok(())
     }

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -14,6 +14,9 @@ pub const DEFAULT_TIP_THRESHOLD_SECS: u64 = 10;
 /// This preserves parallel packaging of the state, RocksDB-index, and proofs databases while leaving capacity for another archive.
 pub const DEFAULT_MAX_STREAMING_ARCHIVES: usize = 4;
 
+/// Default global number of streamed S3 multipart parts allowed to upload concurrently.
+pub const DEFAULT_MAX_STREAMING_PART_UPLOADS: usize = 64;
+
 /// How the S3/R2 client is configured.
 #[derive(Debug, Clone, ValueEnum)]
 pub enum S3ConfigType {
@@ -97,6 +100,13 @@ pub struct SnapshotterConfig {
     /// while an S3 multipart part is uploaded and retried; lower this on memory-constrained nodes.
     #[arg(long, env = "SNAPSHOTTER_MAX_STREAMING_ARCHIVES", default_value = "4")]
     pub max_streaming_archives: NonZeroUsize,
+
+    /// Maximum number of concurrently uploading S3 parts across all streamed archives.
+    ///
+    /// This is intentionally environment-only (`SNAPSHOTTER_MAX_STREAMING_PART_UPLOADS`). With
+    /// 128 MiB parts, the default of 64 bounds queued/in-flight compressed parts to roughly 8 GiB.
+    #[arg(env = "SNAPSHOTTER_MAX_STREAMING_PART_UPLOADS", default_value = "64")]
+    pub max_streaming_part_uploads: NonZeroUsize,
 
     /// Number of completed timestamped snapshot run directories to retain remotely.
     ///

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -9,6 +9,11 @@ use url::Url;
 /// EL to be considered "at tip".
 pub const DEFAULT_TIP_THRESHOLD_SECS: u64 = 10;
 
+/// Default number of archive streams compressed and uploaded concurrently.
+///
+/// This preserves parallel packaging of the state, RocksDB-index, and proofs databases.
+pub const DEFAULT_MAX_STREAMING_ARCHIVES: usize = 3;
+
 /// How the S3/R2 client is configured.
 #[derive(Debug, Clone, ValueEnum)]
 pub enum S3ConfigType {
@@ -97,6 +102,14 @@ pub struct SnapshotterConfig {
     /// Defaults to Rayon's global thread count, normally the available CPU count.
     #[arg(long)]
     pub snapshot_threads: Option<usize>,
+
+    /// Maximum number of archive streams compressed and uploaded concurrently.
+    ///
+    /// The default of three preserves parallel compression of the state, RocksDB-index, and
+    /// proofs databases. Each active stream can retain roughly 1.25 `GiB` of compressed data
+    /// while an S3 multipart part is uploaded and retried; lower this on memory-constrained nodes.
+    #[arg(long, env = "SNAPSHOTTER_MAX_STREAMING_ARCHIVES", default_value = "3")]
+    pub max_streaming_archives: NonZeroUsize,
 
     /// Number of completed timestamped snapshot run directories to retain remotely.
     ///

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -11,8 +11,8 @@ pub const DEFAULT_TIP_THRESHOLD_SECS: u64 = 10;
 
 /// Default number of archive streams compressed and uploaded concurrently.
 ///
-/// This preserves parallel packaging of the state, RocksDB-index, and proofs databases.
-pub const DEFAULT_MAX_STREAMING_ARCHIVES: usize = 3;
+/// This preserves parallel packaging of the state, RocksDB-index, and proofs databases while leaving capacity for another archive.
+pub const DEFAULT_MAX_STREAMING_ARCHIVES: usize = 4;
 
 /// How the S3/R2 client is configured.
 #[derive(Debug, Clone, ValueEnum)]
@@ -105,10 +105,10 @@ pub struct SnapshotterConfig {
 
     /// Maximum number of archive streams compressed and uploaded concurrently.
     ///
-    /// The default of three preserves parallel compression of the state, RocksDB-index, and
-    /// proofs databases. Each active stream can retain roughly 1.25 `GiB` of compressed data
+    /// The default of four preserves parallel compression of the state, RocksDB-index, and
+    /// proofs databases while leaving capacity for another archive. Each active stream can retain roughly 1.25 `GiB` of compressed data
     /// while an S3 multipart part is uploaded and retried; lower this on memory-constrained nodes.
-    #[arg(long, env = "SNAPSHOTTER_MAX_STREAMING_ARCHIVES", default_value = "3")]
+    #[arg(long, env = "SNAPSHOTTER_MAX_STREAMING_ARCHIVES", default_value = "4")]
     pub max_streaming_archives: NonZeroUsize,
 
     /// Number of completed timestamped snapshot run directories to retain remotely.
@@ -116,7 +116,7 @@ pub struct SnapshotterConfig {
     /// Older `{prefix}/{timestamp}/` directories, including their latest static-file
     /// chunks, are deleted after a successful upload. The append-only
     /// `{prefix}/static_files/` directory containing finalized chunks is never pruned.
-    #[arg(long, env = "SNAPSHOTTER_RETAIN_RUNS", default_value = "3")]
+    #[arg(long, env = "SNAPSHOTTER_RETAIN_RUNS", default_value = "4")]
     pub retain_runs: NonZeroUsize,
 
     /// Docker socket path.

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -104,7 +104,7 @@ pub struct SnapshotterConfig {
     /// Maximum number of concurrently uploading S3 parts across all streamed archives.
     ///
     /// This is intentionally environment-only (`SNAPSHOTTER_MAX_STREAMING_PART_UPLOADS`). With
-    /// 128 MiB parts, the default of 64 bounds queued/in-flight compressed parts to roughly 8 GiB.
+    /// 128 `MiB` parts, the default of 64 bounds queued/in-flight compressed parts to roughly 8 `GiB`.
     #[arg(env = "SNAPSHOTTER_MAX_STREAMING_PART_UPLOADS", default_value = "64")]
     pub max_streaming_part_uploads: NonZeroUsize,
 

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -103,7 +103,7 @@ pub struct SnapshotterConfig {
     /// Older `{prefix}/{timestamp}/` directories, including their latest static-file
     /// chunks, are deleted after a successful upload. The append-only
     /// `{prefix}/static_files/` directory containing finalized chunks is never pruned.
-    #[arg(long, env = "SNAPSHOTTER_RETAIN_RUNS", default_value = "4")]
+    #[arg(long, env = "SNAPSHOTTER_RETAIN_RUNS", default_value = "3")]
     pub retain_runs: NonZeroUsize,
 
     /// Docker socket path.

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -54,19 +54,6 @@ pub struct SnapshotterConfig {
     #[arg(long, short = 'd')]
     pub source_datadir: PathBuf,
 
-    /// Directory containing legacy staged snapshot runs for upload-only recovery.
-    ///
-    /// Normal snapshot runs stream compressed archives directly to object storage and do not
-    /// create a run directory here. A unique `run-<timestamp>` subdirectory is only expected
-    /// when using [`Self::upload_existing_run_timestamp`].
-    #[arg(long, short = 'o')]
-    pub output_dir: PathBuf,
-
-    /// Upload an already-generated `run-<timestamp>` directory from `output_dir`
-    /// instead of stopping the EL and regenerating snapshot artifacts.
-    #[arg(long)]
-    pub upload_existing_run_timestamp: Option<u64>,
-
     /// S3-compatible bucket name.
     #[arg(long)]
     pub bucket: String,

--- a/crates/infra/snapshotter/src/config.rs
+++ b/crates/infra/snapshotter/src/config.rs
@@ -49,9 +49,11 @@ pub struct SnapshotterConfig {
     #[arg(long, short = 'd')]
     pub source_datadir: PathBuf,
 
-    /// Output directory for snapshot archives and manifest.
+    /// Directory containing legacy staged snapshot runs for upload-only recovery.
     ///
-    /// A unique subdirectory is created per run.
+    /// Normal snapshot runs stream compressed archives directly to object storage and do not
+    /// create a run directory here. A unique `run-<timestamp>` subdirectory is only expected
+    /// when using [`Self::upload_existing_run_timestamp`].
     #[arg(long, short = 'o')]
     pub output_dir: PathBuf,
 

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -14,7 +14,9 @@ pub use base_reth_cli::{
 };
 
 mod config;
-pub use config::{DEFAULT_TIP_THRESHOLD_SECS, S3ConfigType, SnapshotterConfig};
+pub use config::{
+    DEFAULT_MAX_STREAMING_ARCHIVES, DEFAULT_TIP_THRESHOLD_SECS, S3ConfigType, SnapshotterConfig,
+};
 
 mod progress;
 pub use progress::UploadProgress;

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -15,7 +15,8 @@ pub use base_reth_cli::{
 
 mod config;
 pub use config::{
-    DEFAULT_MAX_STREAMING_ARCHIVES, DEFAULT_TIP_THRESHOLD_SECS, S3ConfigType, SnapshotterConfig,
+    DEFAULT_MAX_STREAMING_ARCHIVES, DEFAULT_MAX_STREAMING_PART_UPLOADS, DEFAULT_TIP_THRESHOLD_SECS,
+    S3ConfigType, SnapshotterConfig,
 };
 
 mod progress;

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -9,7 +9,8 @@
 
 pub use base_reth_cli::{
     ChunkFilename, ChunkedArchive, ComponentManifest, ManifestGenerationParams, OutputFileChecksum,
-    ProgressDisplay, SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
+    ProgressDisplay, SingleArchive, SnapshotArchiveSink, SnapshotArchiveWriter, SnapshotGenerator,
+    SnapshotManifest, SnapshotManifestExt,
 };
 
 mod config;
@@ -26,7 +27,8 @@ pub use tip::{RpcTipChecker, TipChecker, TipStatus};
 
 mod upload;
 pub use upload::{
-    SnapshotRun, SnapshotUploadParams, SnapshotUploader, StreamingMultipartUpload, UploadStrategy,
+    SnapshotRun, SnapshotUploadParams, SnapshotUploader, StreamingMultipartUpload,
+    StreamingS3ArchiveSink, UploadStrategy,
 };
 
 mod orchestrator;

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -177,16 +177,15 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         // upload-existing recovery, but the streaming sink never materializes this run directory.
         let output_dir_for_gen = self.config.output_dir.join(format!("run-{run_timestamp}"));
         let chain_id = self.config.chain_id;
-        let block = Some(self.config.block.unwrap_or(latest_block));
+        let block = self.config.block.unwrap_or(latest_block);
         let blocks_per_file = self.config.blocks_per_file;
         let remote_for_gen = remote_static_files.clone();
         let previous_manifest_for_gen = remote_manifest.clone();
         let upload_proofs = self.config.upload_proofs;
-        let effective_block = block.expect("snapshot block is always set above");
+        let effective_block = block;
         let effective_blocks_per_file = blocks_per_file.unwrap_or(500_000);
         let latest_chunk_start = effective_block
-            .checked_sub(1)
-            .unwrap_or(0)
+            .saturating_sub(1)
             .checked_div(effective_blocks_per_file)
             .and_then(|index| index.checked_mul(effective_blocks_per_file))
             .context("latest static-file chunk range overflow")?;
@@ -212,7 +211,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
                 output_dir: &output_dir_for_gen,
                 chain_id,
                 base_url: None,
-                block,
+                block: Some(block),
                 blocks_per_file,
                 remote_static_files: &remote_for_gen,
                 previous_manifest: previous_manifest_for_gen.as_ref(),

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -7,14 +7,14 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use base_reth_cli::{ManifestGenerationParams, SnapshotGenerator, SnapshotManifest};
+use base_reth_cli::{ChunkFilename, ManifestGenerationParams, SnapshotGenerator, SnapshotManifest};
 use tracing::{error, info, warn};
 
 use crate::{
     SnapshotterConfig,
     container::ContainerManager,
     tip::TipChecker,
-    upload::{SnapshotUploadParams, SnapshotUploader},
+    upload::{SnapshotUploadParams, SnapshotUploader, StreamingS3ArchiveSink},
 };
 
 /// Orchestrates the full snapshot flow: stop CL and EL → generate → upload → restart EL and CL.
@@ -162,8 +162,6 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
     async fn generate_and_upload(&self, latest_block: u64) -> Result<()> {
         let run_timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
 
-        let run_output_dir = create_run_output_dir(&self.config.output_dir, run_timestamp)?;
-
         let remote_static_files = self.uploader.list_remote_static_files().await?;
 
         info!(remote_files = remote_static_files.len(), "fetched remote static file listing");
@@ -175,15 +173,40 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         );
 
         let source_datadir = self.config.source_datadir.clone();
-        let output_dir_for_gen = run_output_dir.clone();
+        // `output_dir` remains part of the generator parameters for directory-backed callers and
+        // upload-existing recovery, but the streaming sink never materializes this run directory.
+        let output_dir_for_gen = self.config.output_dir.join(format!("run-{run_timestamp}"));
         let chain_id = self.config.chain_id;
         let block = Some(self.config.block.unwrap_or(latest_block));
         let blocks_per_file = self.config.blocks_per_file;
         let remote_for_gen = remote_static_files.clone();
         let previous_manifest_for_gen = remote_manifest.clone();
         let upload_proofs = self.config.upload_proofs;
+        let effective_block = block.expect("snapshot block is always set above");
+        let effective_blocks_per_file = blocks_per_file.unwrap_or(500_000);
+        let latest_chunk_start = effective_block
+            .checked_sub(1)
+            .unwrap_or(0)
+            .checked_div(effective_blocks_per_file)
+            .and_then(|index| index.checked_mul(effective_blocks_per_file))
+            .context("latest static-file chunk range overflow")?;
+        let key_uploader = self.uploader.clone();
+        let sink = StreamingS3ArchiveSink::new(
+            self.uploader.clone(),
+            tokio::runtime::Handle::current(),
+            1,
+            move |archive_name| {
+                let key = match ChunkFilename::parse(archive_name) {
+                    Some((_component, start, _end)) if start != latest_chunk_start => {
+                        key_uploader.static_file_object_key(archive_name)
+                    }
+                    _ => key_uploader.run_object_key(run_timestamp, archive_name),
+                };
+                Ok(key)
+            },
+        )?;
 
-        let files = tokio::task::spawn_blocking(move || {
+        let manifest = tokio::task::spawn_blocking(move || {
             let params = ManifestGenerationParams {
                 source_datadir: &source_datadir,
                 output_dir: &output_dir_for_gen,
@@ -195,29 +218,18 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
                 previous_manifest: previous_manifest_for_gen.as_ref(),
                 upload_proofs,
             };
-            SnapshotGenerator::generate_manifest(&params)
+            SnapshotGenerator::generate_manifest_with_sink(&params, &sink)
         })
         .await
         .context("snapshot generation task panicked")?
         .context("snapshot generation failed")?;
 
-        if files.is_empty() {
-            bail!("snapshot generation produced no files");
-        }
-
-        self.upload_run_directory(
-            &run_output_dir,
-            run_timestamp,
-            files,
-            remote_manifest.as_ref(),
-            &remote_static_files,
-        )
-        .await?;
-
-        info!(output_dir = %run_output_dir.display(), "cleaning up local artifacts");
-        if let Err(e) = tokio::fs::remove_dir_all(&run_output_dir).await {
-            error!(error = %e, "failed to clean up output directory");
-        }
+        self.uploader
+            .publish_streamed_manifest(&manifest, run_timestamp, self.config.retain_runs.get())
+            .await
+            .with_context(|| {
+                format!("failed to publish streamed snapshot manifest for {run_timestamp}")
+            })?;
 
         Ok(())
     }
@@ -305,14 +317,6 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             }
         }
     }
-}
-
-/// Creates a unique run output directory using the provided timestamp.
-fn create_run_output_dir(base: &std::path::Path, timestamp: u64) -> Result<PathBuf> {
-    let run_dir = base.join(format!("run-{timestamp}"));
-    std::fs::create_dir_all(&run_dir)
-        .with_context(|| format!("failed to create run dir {}", run_dir.display()))?;
-    Ok(run_dir)
 }
 
 /// Resolves an existing `run-<timestamp>` directory for upload-only mode.

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -193,7 +193,6 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         let manifest = tokio::task::spawn_blocking(move || {
             let params = ManifestGenerationParams {
                 source_datadir: &source_datadir,
-                output_dir: None,
                 chain_id,
                 base_url: None,
                 block: Some(block),

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -193,6 +193,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         let manifest = tokio::task::spawn_blocking(move || {
             let params = ManifestGenerationParams {
                 source_datadir: &source_datadir,
+                output_dir: None,
                 chain_id,
                 base_url: None,
                 block: Some(block),

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -1,20 +1,16 @@
 //! Orchestrates the full snapshot lifecycle with a restart safety guard.
 
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, bail};
-use base_reth_cli::{ChunkFilename, ManifestGenerationParams, SnapshotGenerator, SnapshotManifest};
+use base_reth_cli::{ChunkFilename, ManifestGenerationParams, SnapshotGenerator};
 use tracing::{error, info, warn};
 
 use crate::{
     SnapshotterConfig,
     container::ContainerManager,
     tip::TipChecker,
-    upload::{SnapshotUploadParams, SnapshotUploader, StreamingS3ArchiveSink},
+    upload::{SnapshotUploader, StreamingS3ArchiveSink},
 };
 
 /// Orchestrates the full snapshot flow: stop CL and EL → generate → upload → restart EL and CL.
@@ -56,15 +52,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
     /// 4. Uploads to S3/R2
     /// 5. Clears reth's persisted peer list (best effort)
     /// 6. Restarts the EL and then the CL (always, even on failure)
-    ///
-    /// When `upload_existing_run_timestamp` is set, the snapshotter skips the
-    /// container lifecycle entirely and uploads the existing `run-<timestamp>`
-    /// directory from `output_dir`.
     pub async fn run(&self) -> Result<()> {
-        if let Some(run_timestamp) = self.config.upload_existing_run_timestamp {
-            return self.upload_existing_run(run_timestamp).await;
-        }
-
         // Only snapshot when the EL is caught up to tip. Snapshotting a lagging
         // node would publish stale data and pause a node that is still syncing.
         //
@@ -173,9 +161,6 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         );
 
         let source_datadir = self.config.source_datadir.clone();
-        // `output_dir` remains part of the generator parameters for directory-backed callers and
-        // upload-existing recovery, but the streaming sink never materializes this run directory.
-        let output_dir_for_gen = self.config.output_dir.join(format!("run-{run_timestamp}"));
         let chain_id = self.config.chain_id;
         let block = self.config.block.unwrap_or(latest_block);
         let blocks_per_file = self.config.blocks_per_file;
@@ -208,7 +193,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         let manifest = tokio::task::spawn_blocking(move || {
             let params = ManifestGenerationParams {
                 source_datadir: &source_datadir,
-                output_dir: &output_dir_for_gen,
+                output_dir: None,
                 chain_id,
                 base_url: None,
                 block: Some(block),
@@ -233,73 +218,6 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         Ok(())
     }
 
-    /// Uploads an existing `run-<timestamp>` directory without regenerating artifacts
-    /// or touching the EL container lifecycle.
-    async fn upload_existing_run(&self, run_timestamp: u64) -> Result<()> {
-        let run_output_dir = existing_run_output_dir(&self.config.output_dir, run_timestamp)?;
-        info!(
-            run_timestamp,
-            output_dir = %run_output_dir.display(),
-            "uploading existing snapshot run"
-        );
-
-        let files = SnapshotGenerator::collect_output_files(&run_output_dir)?;
-        let remote_static_files = self.uploader.list_remote_static_files().await?;
-        let remote_manifest = self.uploader.fetch_previous_manifest().await?;
-        info!(
-            has_remote_manifest = remote_manifest.is_some(),
-            "fetched previous manifest for blake3 diff"
-        );
-        self.upload_run_directory(
-            &run_output_dir,
-            run_timestamp,
-            files,
-            remote_manifest.as_ref(),
-            &remote_static_files,
-        )
-        .await
-    }
-
-    /// Uploads one prepared run directory after generation or from upload-only mode.
-    async fn upload_run_directory(
-        &self,
-        run_output_dir: &Path,
-        run_timestamp: u64,
-        files: Vec<PathBuf>,
-        remote_manifest: Option<&SnapshotManifest>,
-        remote_static_files: &HashMap<String, u64>,
-    ) -> Result<()> {
-        if files.is_empty() {
-            bail!("snapshot run directory produced no files")
-        }
-
-        let manifest_bytes = tokio::fs::read(run_output_dir.join("manifest.json"))
-            .await
-            .context("failed to read run manifest.json")?;
-        let local_manifest: SnapshotManifest =
-            serde_json::from_slice(&manifest_bytes).context("failed to parse run manifest.json")?;
-
-        self.uploader
-            .upload(SnapshotUploadParams {
-                output_dir: run_output_dir,
-                files: &files,
-                timestamp: run_timestamp,
-                retain_runs: self.config.retain_runs.get(),
-                local_manifest: &local_manifest,
-                remote_manifest,
-                remote_static_files,
-            })
-            .await
-            .with_context(|| {
-                format!(
-                    "snapshot upload failed for run_timestamp={} output_dir={}",
-                    run_timestamp,
-                    run_output_dir.display()
-                )
-            })?;
-        Ok(())
-    }
-
     /// Removes reth's persisted peer list (`known-peers.json`) from the datadir.
     ///
     /// Best effort: a missing file or removal error is logged and swallowed so
@@ -316,15 +234,4 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             }
         }
     }
-}
-
-/// Resolves an existing `run-<timestamp>` directory for upload-only mode.
-fn existing_run_output_dir(base: &Path, timestamp: u64) -> Result<PathBuf> {
-    let run_dir = base.join(format!("run-{timestamp}"));
-    let metadata = std::fs::metadata(&run_dir)
-        .with_context(|| format!("failed to stat existing run dir {}", run_dir.display()))?;
-    if !metadata.is_dir() {
-        bail!("existing run path is not a directory: {}", run_dir.display());
-    }
-    Ok(run_dir)
 }

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -193,7 +193,7 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
         let sink = StreamingS3ArchiveSink::new(
             self.uploader.clone(),
             tokio::runtime::Handle::current(),
-            1,
+            self.config.max_streaming_archives.get(),
             move |archive_name| {
                 let key = match ChunkFilename::parse(archive_name) {
                     Some((_component, start, _end)) if start != latest_chunk_start => {

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -306,11 +306,15 @@ impl io::Write for StreamingMultipartUpload {
 ///
 /// Reth archive generation invokes the sink from Rayon workers. The supplied Tokio runtime handle
 /// starts and awaits S3 work from those synchronous workers; the limiter prevents Rayon from
-/// creating unbounded 640 MiB streaming buffers in parallel.
+/// creating unbounded 640 `MiB` streaming buffers in parallel.
+/// Maps a generated archive filename to its S3 object key.
+type StreamingArchiveDestination = dyn Fn(&str) -> Result<String> + Send + Sync;
+
+/// Bridges Base's synchronous snapshot archive sink to direct S3 multipart uploads.
 pub struct StreamingS3ArchiveSink {
     uploader: SnapshotUploader,
     runtime: Handle,
-    destination: Arc<dyn Fn(&str) -> Result<String> + Send + Sync>,
+    destination: Arc<StreamingArchiveDestination>,
     limiter: Arc<StreamingUploadLimiter>,
 }
 
@@ -324,7 +328,7 @@ impl StreamingS3ArchiveSink {
     /// Creates a streaming sink whose `destination` maps relative archive names to S3 keys.
     ///
     /// `max_active_archives` bounds concurrent archive generation and streaming-memory use. Use
-    /// one for state snapshots unless the deployment has memory for multiple ~1.25 GiB streams.
+    /// one for state snapshots unless the deployment has memory for multiple ~1.25 `GiB` streams.
     pub fn new<F>(
         uploader: SnapshotUploader,
         runtime: Handle,

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -39,16 +39,16 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 
-use crate::progress::{UploadProgress, UploadStage};
+use crate::{
+    config::DEFAULT_MAX_STREAMING_PART_UPLOADS,
+    progress::{UploadProgress, UploadStage},
+};
 
 /// Maximum number of concurrent file uploads.
 const MAX_CONCURRENT_FILE_UPLOADS: usize = 10;
 
 /// Maximum number of multipart upload parts in flight across all uploads.
 const MAX_CONCURRENT_MULTIPART_PARTS: usize = 100;
-
-/// Default global concurrency for streamed S3 multipart parts.
-const DEFAULT_MAX_STREAMING_PART_UPLOADS: usize = 64;
 
 /// Files larger than this threshold use multipart upload.
 /// S3 `put_object` has a 5 `GiB` limit; we switch well below that.
@@ -59,18 +59,16 @@ const MULTIPART_PART_SIZE: u64 = 100 * 1024 * 1024;
 
 /// Part size used for unknown-length streamed archives.
 ///
-/// S3 limits a multipart object to 10,000 parts and 5 `TiB`. 640 `MiB` permits an archive as large
-/// as the S3 object limit while leaving headroom below the part-count limit. This is deliberately
-/// separate from the smaller file-backed upload part size: a file's total size is known before
-/// upload, while a zstd stream's final compressed size is not.
+/// A `128 MiB` part keeps enough parts in flight to saturate R2 without excessive memory use.
+/// It supports streamed archives up to roughly `1.22 TiB` before S3's 10,000-part limit. This is
+/// deliberately separate from the smaller file-backed upload part size: a file's total size is
+/// known before upload, while a zstd stream's final compressed size is not.
 const STREAMING_MULTIPART_PART_SIZE: usize = 128 * 1024 * 1024;
 
-/// Number of complete multipart parts allowed to wait for upload per archive stream.
+/// Per-archive queue capacity for completed streamed parts.
 ///
-/// A stream producer also holds its current part while it is being filled. With the part size
-/// above, a value of one bounds a single archive stream to roughly 1.25 `GiB` of compressed output
-/// in memory (plus SDK request overhead), while still allowing the producer and uploader to run
-/// concurrently.
+/// A global semaphore bounds queued plus in-flight part memory across every archive; this queue
+/// only prevents one archive from monopolizing the multipart scheduler.
 const STREAMING_MULTIPART_CHANNEL_CAPACITY: usize = 16;
 
 /// Base delay between upload retries. Backoff is linear to keep behavior simple and predictable.
@@ -198,7 +196,7 @@ impl StreamingMultipartUpload {
     }
 
     /// Flushes the final (possibly smaller than 5 `MiB`) multipart part and marks the archive input
-    /// complete. The final part is legal because all preceding parts are exactly 640 `MiB`.
+    /// complete. The final part is legal because all preceding parts are exactly `128 MiB`.
     ///
     /// This does not wait for the remote object to become visible; use [`Self::complete`] for
     /// that. It is idempotent so cleanup paths can safely call it after a successful finish.
@@ -315,8 +313,8 @@ impl io::Write for StreamingMultipartUpload {
 /// Bridges Base's synchronous snapshot archive sink to direct S3 multipart uploads.
 ///
 /// Reth archive generation invokes the sink from Rayon workers. The supplied Tokio runtime handle
-/// starts and awaits S3 work from those synchronous workers; the limiter prevents Rayon from
-/// creating unbounded 640 `MiB` streaming buffers in parallel.
+/// starts and awaits S3 work from those synchronous workers; the limiter bounds concurrent archive
+/// writers while the uploader's global part permits bound compressed-buffer memory.
 /// Maps a generated archive filename to its S3 object key.
 type StreamingArchiveDestination = dyn Fn(&str) -> Result<String> + Send + Sync;
 
@@ -337,8 +335,8 @@ impl std::fmt::Debug for StreamingS3ArchiveSink {
 impl StreamingS3ArchiveSink {
     /// Creates a streaming sink whose `destination` maps relative archive names to S3 keys.
     ///
-    /// `max_active_archives` bounds concurrent archive generation and streaming-memory use. Use
-    /// one for state snapshots unless the deployment has memory for multiple ~1.25 `GiB` streams.
+    /// `max_active_archives` bounds concurrent archive generation. The uploader separately bounds
+    /// total queued and in-flight multipart buffers across all active streams.
     pub fn new<F>(
         uploader: SnapshotUploader,
         runtime: Handle,

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -352,6 +352,12 @@ impl StreamingS3ArchiveSink {
 
 impl SnapshotArchiveSink for StreamingS3ArchiveSink {
     fn create_archive(&self, archive_name: &str) -> Result<Box<dyn SnapshotArchiveWriter>> {
+        // Reth invokes archive sinks from synchronous Rayon workers. Calling Handle::block_on
+        // from a Tokio worker would panic, so catch an upstream threading-model regression early.
+        debug_assert!(
+            Handle::try_current().is_err(),
+            "streaming archive creation must not run from within a Tokio runtime"
+        );
         let permit = self.limiter.acquire();
         let key = (self.destination)(archive_name)?;
         let upload = self.runtime.block_on(self.uploader.start_streaming_multipart_upload(key))?;

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -1745,6 +1745,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn streaming_upload_limiter_allows_configured_parallelism() {
+        use std::{
+            sync::{Arc, mpsc as std_mpsc},
+            time::Duration,
+        };
+
+        let limiter = Arc::new(StreamingUploadLimiter::new(3));
+        let permits: Vec<_> = (0..3).map(|_| limiter.acquire()).collect();
+        let (started_tx, started_rx) = std_mpsc::channel();
+        let blocked_limiter = Arc::clone(&limiter);
+        let blocked = std::thread::spawn(move || {
+            let permit = blocked_limiter.acquire();
+            started_tx.send(()).expect("receiver should remain available");
+            drop(permit);
+        });
+
+        assert!(
+            started_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "a fourth archive must wait while all three streaming slots are occupied"
+        );
+
+        drop(permits);
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("releasing a slot should unblock another archive");
+        blocked.join().expect("blocking archive thread should finish");
+    }
+
+    #[test]
     fn static_file_chunks_are_diff_eligible() {
         assert_eq!(
             UploadStrategy::classify("headers-0-499999.tar.zst"),

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -15,7 +15,7 @@ use std::{
     future::Future,
     io,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Condvar, Mutex},
     time::Duration,
 };
 
@@ -25,10 +25,14 @@ use aws_sdk_s3::{
     primitives::ByteStream,
     types::{CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier},
 };
-use base_reth_cli::{ChunkFilename, ComponentManifest, SnapshotManifest, SnapshotManifestExt};
+use base_reth_cli::{
+    ChunkFilename, ComponentManifest, SnapshotArchiveSink, SnapshotArchiveWriter, SnapshotManifest,
+    SnapshotManifestExt,
+};
 use bytes::Bytes;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use tokio::{
+    runtime::Handle,
     sync::{Semaphore, mpsc},
     task::JoinHandle,
     time::sleep,
@@ -295,6 +299,129 @@ impl io::Write for StreamingMultipartUpload {
         // zstd may call flush while it is still writing its frame. A multipart part smaller than
         // 5 MiB is only valid as the final part, so only `finish` may flush `buffered`.
         Ok(())
+    }
+}
+
+/// Bridges Base's synchronous snapshot archive sink to direct S3 multipart uploads.
+///
+/// Reth archive generation invokes the sink from Rayon workers. The supplied Tokio runtime handle
+/// starts and awaits S3 work from those synchronous workers; the limiter prevents Rayon from
+/// creating unbounded 640 MiB streaming buffers in parallel.
+pub struct StreamingS3ArchiveSink {
+    uploader: SnapshotUploader,
+    runtime: Handle,
+    destination: Arc<dyn Fn(&str) -> Result<String> + Send + Sync>,
+    limiter: Arc<StreamingUploadLimiter>,
+}
+
+impl std::fmt::Debug for StreamingS3ArchiveSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamingS3ArchiveSink").finish_non_exhaustive()
+    }
+}
+
+impl StreamingS3ArchiveSink {
+    /// Creates a streaming sink whose `destination` maps relative archive names to S3 keys.
+    ///
+    /// `max_active_archives` bounds concurrent archive generation and streaming-memory use. Use
+    /// one for state snapshots unless the deployment has memory for multiple ~1.25 GiB streams.
+    pub fn new<F>(
+        uploader: SnapshotUploader,
+        runtime: Handle,
+        max_active_archives: usize,
+        destination: F,
+    ) -> Result<Self>
+    where
+        F: Fn(&str) -> Result<String> + Send + Sync + 'static,
+    {
+        if max_active_archives == 0 {
+            bail!("max_active_archives must be greater than zero");
+        }
+        Ok(Self {
+            uploader,
+            runtime,
+            destination: Arc::new(destination),
+            limiter: Arc::new(StreamingUploadLimiter::new(max_active_archives)),
+        })
+    }
+}
+
+impl SnapshotArchiveSink for StreamingS3ArchiveSink {
+    fn create_archive(&self, archive_name: &str) -> Result<Box<dyn SnapshotArchiveWriter>> {
+        let permit = self.limiter.acquire();
+        let key = (self.destination)(archive_name)?;
+        let upload = self.runtime.block_on(self.uploader.start_streaming_multipart_upload(key))?;
+        Ok(Box::new(StreamingS3ArchiveWriter {
+            runtime: self.runtime.clone(),
+            upload: Some(upload),
+            _permit: permit,
+        }))
+    }
+}
+
+struct StreamingS3ArchiveWriter {
+    runtime: Handle,
+    upload: Option<StreamingMultipartUpload>,
+    _permit: StreamingUploadPermit,
+}
+
+impl io::Write for StreamingS3ArchiveWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.upload
+            .as_mut()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "archive writer is finished"))?
+            .write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.upload
+            .as_mut()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "archive writer is finished"))?
+            .flush()
+    }
+}
+
+impl SnapshotArchiveWriter for StreamingS3ArchiveWriter {
+    fn finish(mut self: Box<Self>) -> Result<()> {
+        let mut upload = self.upload.take().expect("archive writer can only finish once");
+        upload.finish()?;
+        self.runtime.block_on(upload.complete())?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct StreamingUploadLimiter {
+    max_active: usize,
+    active: Mutex<usize>,
+    available: Condvar,
+}
+
+impl StreamingUploadLimiter {
+    const fn new(max_active: usize) -> Self {
+        Self { max_active, active: Mutex::new(0), available: Condvar::new() }
+    }
+
+    fn acquire(self: &Arc<Self>) -> StreamingUploadPermit {
+        let mut active = self.active.lock().expect("streaming upload limiter mutex poisoned");
+        while *active >= self.max_active {
+            active = self.available.wait(active).expect("streaming upload limiter mutex poisoned");
+        }
+        *active += 1;
+        StreamingUploadPermit { limiter: Arc::clone(self) }
+    }
+}
+
+struct StreamingUploadPermit {
+    limiter: Arc<StreamingUploadLimiter>,
+}
+
+impl Drop for StreamingUploadPermit {
+    fn drop(&mut self) {
+        let mut active =
+            self.limiter.active.lock().expect("streaming upload limiter mutex poisoned");
+        *active = active.checked_sub(1).expect("streaming upload limiter released without acquire");
+        self.limiter.available.notify_one();
     }
 }
 
@@ -878,6 +1005,69 @@ impl SnapshotUploader {
             "upload complete"
         );
         Ok(run_prefix)
+    }
+
+    /// Publishes a manifest after every archive has already been streamed to its final S3 key.
+    ///
+    /// The manifest is deliberately the last object written for a run: downloaders use its
+    /// presence as the snapshot-complete signal. This is the streaming counterpart to
+    /// [`Self::upload`], which uploads file-backed artifacts before publishing a manifest.
+    pub async fn publish_streamed_manifest(
+        &self,
+        local_manifest: &SnapshotManifest,
+        timestamp: u64,
+        retain_runs: usize,
+    ) -> Result<String> {
+        let run_prefix = self.run_prefix(timestamp);
+        let manifest_key = format!("{run_prefix}/manifest.json");
+        let published_manifest = build_published_manifest(
+            local_manifest,
+            self.public_snapshot_base_url().as_deref(),
+            timestamp,
+        )?;
+
+        retry_upload(
+            || async {
+                self.client
+                    .put_object()
+                    .bucket(&self.bucket)
+                    .key(&manifest_key)
+                    .body(ByteStream::from(published_manifest.clone()))
+                    .send()
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| UploadAttemptError::retry(error.into()))
+            },
+            |attempt, error| {
+                warn!(
+                    key = %manifest_key,
+                    attempt,
+                    error = %error,
+                    error_debug = ?error,
+                    next_retry_delay_secs = retry_delay_secs(attempt),
+                    "streamed manifest upload failed, retrying"
+                );
+            },
+            |attempt| {
+                info!(key = %manifest_key, attempt, "streamed manifest upload succeeded after retrying");
+            },
+        )
+        .await?;
+
+        if let Err(error) = self.prune_old_runs(retain_runs).await {
+            warn!(error = %error, retain_runs, "failed to prune old snapshot runs");
+        }
+        Ok(run_prefix)
+    }
+
+    /// Returns the complete timestamped-run key for a generated archive.
+    pub fn run_object_key(&self, timestamp: u64, archive_name: &str) -> String {
+        format!("{}/{archive_name}", self.run_prefix(timestamp))
+    }
+
+    /// Returns the complete shared static-files key for a generated finalized chunk archive.
+    pub fn static_file_object_key(&self, archive_name: &str) -> String {
+        format!("{}/{}", self.static_files_prefix(), archive_name)
     }
 
     /// Returns the `{prefix}/static_files` key prefix.

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -352,12 +352,8 @@ impl StreamingS3ArchiveSink {
 
 impl SnapshotArchiveSink for StreamingS3ArchiveSink {
     fn create_archive(&self, archive_name: &str) -> Result<Box<dyn SnapshotArchiveWriter>> {
-        // Reth invokes archive sinks from synchronous Rayon workers. Calling Handle::block_on
-        // from a Tokio worker would panic, so catch an upstream threading-model regression early.
-        debug_assert!(
-            Handle::try_current().is_err(),
-            "streaming archive creation must not run from within a Tokio runtime"
-        );
+        // Archive generation runs in Snapshotter's blocking task. `Handle::block_on` bridges
+        // this synchronous sink callback to the async multipart-upload setup.
         let permit = self.limiter.acquire();
         let key = (self.destination)(archive_name)?;
         let upload = self.runtime.block_on(self.uploader.start_streaming_multipart_upload(key))?;

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -1751,8 +1751,8 @@ mod tests {
             time::Duration,
         };
 
-        let limiter = Arc::new(StreamingUploadLimiter::new(3));
-        let permits: Vec<_> = (0..3).map(|_| limiter.acquire()).collect();
+        let limiter = Arc::new(StreamingUploadLimiter::new(4));
+        let permits: Vec<_> = (0..4).map(|_| limiter.acquire()).collect();
         let (started_tx, started_rx) = std_mpsc::channel();
         let blocked_limiter = Arc::clone(&limiter);
         let blocked = std::thread::spawn(move || {
@@ -1763,7 +1763,7 @@ mod tests {
 
         assert!(
             started_rx.recv_timeout(Duration::from_millis(50)).is_err(),
-            "a fourth archive must wait while all three streaming slots are occupied"
+            "a fifth archive must wait while all four streaming slots are occupied"
         );
 
         drop(permits);

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -33,7 +33,7 @@ use bytes::Bytes;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use tokio::{
     runtime::Handle,
-    sync::{Semaphore, mpsc},
+    sync::{OwnedSemaphorePermit, Semaphore, mpsc},
     task::JoinHandle,
     time::sleep,
 };
@@ -46,6 +46,9 @@ const MAX_CONCURRENT_FILE_UPLOADS: usize = 10;
 
 /// Maximum number of multipart upload parts in flight across all uploads.
 const MAX_CONCURRENT_MULTIPART_PARTS: usize = 100;
+
+/// Default global concurrency for streamed S3 multipart parts.
+const DEFAULT_MAX_STREAMING_PART_UPLOADS: usize = 64;
 
 /// Files larger than this threshold use multipart upload.
 /// S3 `put_object` has a 5 `GiB` limit; we switch well below that.
@@ -60,7 +63,7 @@ const MULTIPART_PART_SIZE: u64 = 100 * 1024 * 1024;
 /// as the S3 object limit while leaving headroom below the part-count limit. This is deliberately
 /// separate from the smaller file-backed upload part size: a file's total size is known before
 /// upload, while a zstd stream's final compressed size is not.
-const STREAMING_MULTIPART_PART_SIZE: usize = 640 * 1024 * 1024;
+const STREAMING_MULTIPART_PART_SIZE: usize = 128 * 1024 * 1024;
 
 /// Number of complete multipart parts allowed to wait for upload per archive stream.
 ///
@@ -68,7 +71,7 @@ const STREAMING_MULTIPART_PART_SIZE: usize = 640 * 1024 * 1024;
 /// above, a value of one bounds a single archive stream to roughly 1.25 `GiB` of compressed output
 /// in memory (plus SDK request overhead), while still allowing the producer and uploader to run
 /// concurrently.
-const STREAMING_MULTIPART_CHANNEL_CAPACITY: usize = 1;
+const STREAMING_MULTIPART_CHANNEL_CAPACITY: usize = 16;
 
 /// Base delay between upload retries. Backoff is linear to keep behavior simple and predictable.
 const UPLOAD_RETRY_DELAY: Duration = Duration::from_secs(5);
@@ -150,6 +153,7 @@ pub struct SnapshotUploader {
     prefix: String,
     public_base_url: Option<String>,
     multipart_part_permits: Arc<Semaphore>,
+    streaming_part_permits: Arc<Semaphore>,
 }
 
 /// A synchronous [`io::Write`] sink backed by an asynchronous S3 multipart upload.
@@ -172,11 +176,13 @@ pub struct StreamingMultipartUpload {
     bytes_written: u64,
     finished: bool,
     task: Option<JoinHandle<Result<u64>>>,
+    part_permits: Arc<Semaphore>,
+    runtime: Handle,
 }
 
 #[derive(Debug)]
 enum StreamingUploadMessage {
-    Part(Vec<u8>),
+    Part { bytes: Vec<u8>, permit: OwnedSemaphorePermit },
     Finish,
 }
 
@@ -239,12 +245,16 @@ impl StreamingMultipartUpload {
             .context("streaming multipart upload task panicked")?
     }
 
-    fn send_part(&self, part: Vec<u8>) -> io::Result<()> {
-        debug_assert!(!part.is_empty());
+    fn send_part(&self, bytes: Vec<u8>) -> io::Result<()> {
+        debug_assert!(!bytes.is_empty());
+        let permit =
+            self.runtime.block_on(self.part_permits.clone().acquire_owned()).map_err(|_| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "streaming part limiter closed")
+            })?;
         self.sender
             .as_ref()
             .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "streaming upload is closed"))?
-            .blocking_send(StreamingUploadMessage::Part(part))
+            .blocking_send(StreamingUploadMessage::Part { bytes, permit })
             .map_err(|_| {
                 io::Error::new(
                     io::ErrorKind::BrokenPipe,
@@ -445,7 +455,14 @@ impl SnapshotUploader {
             prefix,
             public_base_url,
             multipart_part_permits: Arc::new(Semaphore::new(MAX_CONCURRENT_MULTIPART_PARTS)),
+            streaming_part_permits: Arc::new(Semaphore::new(DEFAULT_MAX_STREAMING_PART_UPLOADS)),
         }
+    }
+
+    /// Sets the global number of queued or in-flight streamed multipart parts.
+    pub fn with_max_streaming_part_uploads(mut self, max_parts: usize) -> Self {
+        self.streaming_part_permits = Arc::new(Semaphore::new(max_parts));
+        self
     }
 
     /// Starts a multipart upload that accepts archive bytes through a synchronous
@@ -468,6 +485,7 @@ impl SnapshotUploader {
         let (sender, receiver) = mpsc::channel(STREAMING_MULTIPART_CHANNEL_CAPACITY);
         let task_uploader = self.clone();
         let task_key = key.clone();
+        let runtime = Handle::current();
         let task = tokio::spawn(async move {
             task_uploader.consume_streaming_multipart_upload(task_key, upload_id, receiver).await
         });
@@ -480,6 +498,8 @@ impl SnapshotUploader {
             bytes_written: 0,
             finished: false,
             task: Some(task),
+            part_permits: Arc::clone(&self.streaming_part_permits),
+            runtime,
         })
     }
 
@@ -528,27 +548,37 @@ impl SnapshotUploader {
     ) -> Result<u64> {
         let result = async {
             let mut completed_parts = Vec::new();
+            let mut uploads = futures::stream::FuturesUnordered::new();
             let mut bytes_uploaded = 0u64;
             let mut part_number = 1i32;
             let mut received_finish = false;
 
-            while let Some(message) = receiver.recv().await {
-                match message {
-                    StreamingUploadMessage::Part(part) => {
+            while !received_finish || !uploads.is_empty() {
+                tokio::select! {
+                    message = receiver.recv(), if !received_finish => match message {
+                    Some(StreamingUploadMessage::Part { bytes, permit }) => {
                         if part_number > 10_000 {
                             bail!("streaming multipart upload for {key} exceeds S3's 10,000-part limit");
                         }
-                        let part_len = u64::try_from(part.len())?;
-                        let completed = self
-                            .upload_streaming_part(&key, &upload_id, part_number, part)
-                            .await?;
-                        completed_parts.push(completed);
-                        bytes_uploaded = bytes_uploaded.saturating_add(part_len);
+                        let part_len = u64::try_from(bytes.len())?;
+                        let number = part_number;
+                        let part_key = key.clone();
+                        let part_upload_id = upload_id.clone();
+                        uploads.push(async move {
+                            let completed = self.upload_streaming_part(&part_key, &part_upload_id, number, bytes, permit).await?;
+                            Ok::<_, anyhow::Error>((number, part_len, completed))
+                        });
                         part_number += 1;
                     }
-                    StreamingUploadMessage::Finish => {
+                    Some(StreamingUploadMessage::Finish) => {
                         received_finish = true;
-                        break;
+                    }
+                    None => bail!("streaming archive writer for {key} was dropped before it finalized the zstd stream"),
+                    },
+                    Some(result) = uploads.next(), if !uploads.is_empty() => {
+                        let (_number, part_len, completed) = result?;
+                        completed_parts.push(completed);
+                        bytes_uploaded = bytes_uploaded.saturating_add(part_len);
                     }
                 }
             }
@@ -559,6 +589,8 @@ impl SnapshotUploader {
             if completed_parts.is_empty() {
                 bail!("streaming multipart upload for {key} contained no archive bytes");
             }
+
+            completed_parts.sort_unstable_by_key(|part| part.part_number);
 
             self.complete_streaming_multipart_upload(
                 &key,
@@ -586,16 +618,12 @@ impl SnapshotUploader {
         upload_id: &str,
         part_number: i32,
         bytes: Vec<u8>,
+        _permit: OwnedSemaphorePermit,
     ) -> Result<CompletedPart> {
         let bytes = Bytes::from(bytes);
         let length = bytes.len();
         retry_upload(
             || async {
-                let _permit = self
-                    .multipart_part_permits
-                    .acquire()
-                    .await
-                    .map_err(|error| UploadAttemptError::fatal(error.into()))?;
                 let upload_resp = self
                     .client
                     .upload_part()

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -248,9 +248,9 @@ impl StreamingMultipartUpload {
     fn send_part(&self, bytes: Vec<u8>) -> io::Result<()> {
         debug_assert!(!bytes.is_empty());
         let permit =
-            self.runtime.block_on(self.part_permits.clone().acquire_owned()).map_err(|_| {
-                io::Error::new(io::ErrorKind::BrokenPipe, "streaming part limiter closed")
-            })?;
+            self.runtime.block_on(Arc::clone(&self.part_permits).acquire_owned()).map_err(
+                |_| io::Error::new(io::ErrorKind::BrokenPipe, "streaming part limiter closed"),
+            )?;
         self.sender
             .as_ref()
             .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "streaming upload is closed"))?

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use base_snapshotter::{
     ChunkedArchive, ComponentManifest, ContainerManager, DockerContainerManager,
     ManifestGenerationParams, OutputFileChecksum, SnapshotGenerator, SnapshotManifest,
-    SnapshotUploadParams, SnapshotUploader, TipChecker, TipStatus,
+    SnapshotUploadParams, SnapshotUploader, StreamingS3ArchiveSink, TipChecker, TipStatus,
 };
 use bollard::{
     Docker,
@@ -686,6 +686,71 @@ async fn unfinished_stream_aborts_multipart_upload() -> Result<()> {
             .is_err(),
         "unfinalized stream must not publish an object"
     );
+
+    Ok(())
+}
+
+/// Exercises Base's selective snapshot generator through the streaming sink. This verifies the
+/// generator finalizes tar/zstd before the sink publishes the object and does not require a local
+/// archive output directory.
+#[tokio::test]
+#[serial]
+async fn snapshot_generator_streams_archives_to_minio() -> Result<()> {
+    let harness = TestHarness::new().await?;
+    let uploader = SnapshotUploader::new(
+        harness.storage_client.clone(),
+        harness.bucket_name.clone(),
+        "generator-streaming".to_string(),
+        None,
+    );
+    let sink = StreamingS3ArchiveSink::new(
+        uploader,
+        tokio::runtime::Handle::current(),
+        1,
+        |archive_name| Ok(format!("generator-streaming/{archive_name}")),
+    )?;
+
+    let source = tempfile::tempdir()?;
+    std::fs::create_dir_all(source.path().join("db"))?;
+    std::fs::write(source.path().join("db/mdbx.dat"), b"generated-state")?;
+    let output_dir = source.path().join("not-created");
+    let output_dir_for_generation = output_dir.clone();
+    let source_path = source.path().to_owned();
+    let remote_static_files = HashMap::new();
+    let manifest = tokio::task::spawn_blocking(move || {
+        SnapshotGenerator::generate_manifest_with_sink(
+            &ManifestGenerationParams {
+                source_datadir: &source_path,
+                output_dir: &output_dir_for_generation,
+                chain_id: 8453,
+                base_url: None,
+                block: Some(0),
+                blocks_per_file: Some(500_000),
+                remote_static_files: &remote_static_files,
+                previous_manifest: None,
+                upload_proofs: false,
+            },
+            &sink,
+        )
+    })
+    .await??;
+    assert!(manifest.components.contains_key("state"));
+    assert!(!output_dir.exists(), "streaming generation must not create the output directory");
+
+    let bytes = get_object_bytes(
+        &harness.storage_client,
+        &harness.bucket_name,
+        "generator-streaming/state.tar.zst",
+    )
+    .await?;
+    let decoder = zstd::Decoder::new(bytes.as_slice())?;
+    let mut archive = tar::Archive::new(decoder);
+    let mut entries = archive.entries()?;
+    let mut entry = entries.next().expect("state archive should contain mdbx.dat")?;
+    assert_eq!(entry.path()?.as_ref(), Path::new("db/mdbx.dat"));
+    let mut contents = Vec::new();
+    entry.read_to_end(&mut contents)?;
+    assert_eq!(contents, b"generated-state");
 
     Ok(())
 }

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -161,6 +161,10 @@ fn test_config(bucket: &str, tmp: &Path) -> base_snapshotter::SnapshotterConfig 
             base_snapshotter::DEFAULT_MAX_STREAMING_ARCHIVES,
         )
         .expect("default streaming archive count should be non-zero"),
+        max_streaming_part_uploads: std::num::NonZeroUsize::new(
+            base_snapshotter::DEFAULT_MAX_STREAMING_PART_UPLOADS,
+        )
+        .expect("default streaming part upload count should be non-zero"),
         retain_runs: NonZeroUsize::new(3).expect("retain runs should be non-zero"),
         docker_socket: "/var/run/docker.sock".to_string(),
         s3_config_type: base_snapshotter::S3ConfigType::Aws,

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -721,6 +721,7 @@ async fn snapshot_generator_streams_archives_to_minio() -> Result<()> {
         SnapshotGenerator::generate_manifest_with_sink(
             &ManifestGenerationParams {
                 source_datadir: &source_path,
+                output_dir: None,
                 chain_id: 8453,
                 base_url: None,
                 block: Some(0),
@@ -1113,19 +1114,17 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         "storage_changesets",
     ];
     let baseline = tempfile::tempdir()?;
-    SnapshotGenerator::generate_manifest(
-        &ManifestGenerationParams {
-            source_datadir: source.path(),
-            chain_id: 8453,
-            base_url: None,
-            block: Some(1_999_999),
-            blocks_per_file: Some(500_000),
-            remote_static_files: &HashMap::new(),
-            previous_manifest: None,
-            upload_proofs: false,
-        },
-        baseline.path(),
-    )?;
+    SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+        source_datadir: source.path(),
+        output_dir: Some(baseline.path()),
+        chain_id: 8453,
+        base_url: None,
+        block: Some(1_999_999),
+        blocks_per_file: Some(500_000),
+        remote_static_files: &HashMap::new(),
+        previous_manifest: None,
+        upload_proofs: false,
+    })?;
     let previous_manifest = parse_local_manifest(baseline.path())?;
 
     // Simulate the first three chunks of every component existing remotely.
@@ -1143,19 +1142,17 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
     }
 
     let output = tempfile::tempdir()?;
-    let files = SnapshotGenerator::generate_manifest(
-        &ManifestGenerationParams {
-            source_datadir: source.path(),
-            chain_id: 8453,
-            base_url: None,
-            block: Some(1_999_999),
-            blocks_per_file: Some(500_000),
-            remote_static_files: &remote,
-            previous_manifest: Some(&previous_manifest),
-            upload_proofs: false,
-        },
-        output.path(),
-    )?;
+    let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+        source_datadir: source.path(),
+        output_dir: Some(output.path()),
+        chain_id: 8453,
+        base_url: None,
+        block: Some(1_999_999),
+        blocks_per_file: Some(500_000),
+        remote_static_files: &remote,
+        previous_manifest: Some(&previous_manifest),
+        upload_proofs: false,
+    })?;
 
     let filenames: Vec<String> = files
         .iter()
@@ -1221,19 +1218,17 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
 
     let output = tempfile::tempdir()?;
     let empty_remote = HashMap::new();
-    let files = SnapshotGenerator::generate_manifest(
-        &ManifestGenerationParams {
-            source_datadir: source.path(),
-            chain_id: 8453,
-            base_url: None,
-            block: Some(0),
-            blocks_per_file: Some(500_000),
-            remote_static_files: &empty_remote,
-            previous_manifest: None,
-            upload_proofs: true,
-        },
-        output.path(),
-    )?;
+    let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+        source_datadir: source.path(),
+        output_dir: Some(output.path()),
+        chain_id: 8453,
+        base_url: None,
+        block: Some(0),
+        blocks_per_file: Some(500_000),
+        remote_static_files: &empty_remote,
+        previous_manifest: None,
+        upload_proofs: true,
+    })?;
 
     assert!(
         files.iter().any(|f| f.file_name().is_some_and(|n| n == "proofs.tar.zst")),

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -721,7 +721,6 @@ async fn snapshot_generator_streams_archives_to_minio() -> Result<()> {
         SnapshotGenerator::generate_manifest_with_sink(
             &ManifestGenerationParams {
                 source_datadir: &source_path,
-                output_dir: None,
                 chain_id: 8453,
                 base_url: None,
                 block: Some(0),
@@ -1114,17 +1113,19 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         "storage_changesets",
     ];
     let baseline = tempfile::tempdir()?;
-    SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
-        source_datadir: source.path(),
-        output_dir: Some(baseline.path()),
-        chain_id: 8453,
-        base_url: None,
-        block: Some(1_999_999),
-        blocks_per_file: Some(500_000),
-        remote_static_files: &HashMap::new(),
-        previous_manifest: None,
-        upload_proofs: false,
-    })?;
+    SnapshotGenerator::generate_manifest(
+        &ManifestGenerationParams {
+            source_datadir: source.path(),
+            chain_id: 8453,
+            base_url: None,
+            block: Some(1_999_999),
+            blocks_per_file: Some(500_000),
+            remote_static_files: &HashMap::new(),
+            previous_manifest: None,
+            upload_proofs: false,
+        },
+        baseline.path(),
+    )?;
     let previous_manifest = parse_local_manifest(baseline.path())?;
 
     // Simulate the first three chunks of every component existing remotely.
@@ -1142,17 +1143,19 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
     }
 
     let output = tempfile::tempdir()?;
-    let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
-        source_datadir: source.path(),
-        output_dir: Some(output.path()),
-        chain_id: 8453,
-        base_url: None,
-        block: Some(1_999_999),
-        blocks_per_file: Some(500_000),
-        remote_static_files: &remote,
-        previous_manifest: Some(&previous_manifest),
-        upload_proofs: false,
-    })?;
+    let files = SnapshotGenerator::generate_manifest(
+        &ManifestGenerationParams {
+            source_datadir: source.path(),
+            chain_id: 8453,
+            base_url: None,
+            block: Some(1_999_999),
+            blocks_per_file: Some(500_000),
+            remote_static_files: &remote,
+            previous_manifest: Some(&previous_manifest),
+            upload_proofs: false,
+        },
+        output.path(),
+    )?;
 
     let filenames: Vec<String> = files
         .iter()
@@ -1218,17 +1221,19 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
 
     let output = tempfile::tempdir()?;
     let empty_remote = HashMap::new();
-    let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
-        source_datadir: source.path(),
-        output_dir: Some(output.path()),
-        chain_id: 8453,
-        base_url: None,
-        block: Some(0),
-        blocks_per_file: Some(500_000),
-        remote_static_files: &empty_remote,
-        previous_manifest: None,
-        upload_proofs: true,
-    })?;
+    let files = SnapshotGenerator::generate_manifest(
+        &ManifestGenerationParams {
+            source_datadir: source.path(),
+            chain_id: 8453,
+            base_url: None,
+            block: Some(0),
+            blocks_per_file: Some(500_000),
+            remote_static_files: &empty_remote,
+            previous_manifest: None,
+            upload_proofs: true,
+        },
+        output.path(),
+    )?;
 
     assert!(
         files.iter().any(|f| f.file_name().is_some_and(|n| n == "proofs.tar.zst")),

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -151,8 +151,6 @@ fn test_config(bucket: &str, tmp: &Path) -> base_snapshotter::SnapshotterConfig 
         el_rpc_url: "http://127.0.0.1:8545".parse().expect("valid test URL"),
         tip_threshold_secs: base_snapshotter::DEFAULT_TIP_THRESHOLD_SECS,
         source_datadir: tmp.join("nonexistent-datadir"),
-        output_dir: tmp.join("output"),
-        upload_existing_run_timestamp: None,
         bucket: bucket.to_string(),
         prefix: "test".to_string(),
         chain_id: 8453,
@@ -717,15 +715,13 @@ async fn snapshot_generator_streams_archives_to_minio() -> Result<()> {
     let source = tempfile::tempdir()?;
     std::fs::create_dir_all(source.path().join("db"))?;
     std::fs::write(source.path().join("db/mdbx.dat"), b"generated-state")?;
-    let output_dir = source.path().join("not-created");
-    let output_dir_for_generation = output_dir.clone();
     let source_path = source.path().to_owned();
     let remote_static_files = HashMap::new();
     let manifest = tokio::task::spawn_blocking(move || {
         SnapshotGenerator::generate_manifest_with_sink(
             &ManifestGenerationParams {
                 source_datadir: &source_path,
-                output_dir: &output_dir_for_generation,
+                output_dir: None,
                 chain_id: 8453,
                 base_url: None,
                 block: Some(0),
@@ -739,7 +735,6 @@ async fn snapshot_generator_streams_archives_to_minio() -> Result<()> {
     })
     .await??;
     assert!(manifest.components.contains_key("state"));
-    assert!(!output_dir.exists(), "streaming generation must not create the output directory");
 
     let bytes = get_object_bytes(
         &harness.storage_client,
@@ -1121,7 +1116,7 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
     let baseline = tempfile::tempdir()?;
     SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
         source_datadir: source.path(),
-        output_dir: baseline.path(),
+        output_dir: Some(baseline.path()),
         chain_id: 8453,
         base_url: None,
         block: Some(1_999_999),
@@ -1149,7 +1144,7 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
     let output = tempfile::tempdir()?;
     let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
         source_datadir: source.path(),
-        output_dir: output.path(),
+        output_dir: Some(output.path()),
         chain_id: 8453,
         base_url: None,
         block: Some(1_999_999),
@@ -1225,7 +1220,7 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
     let empty_remote = HashMap::new();
     let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
         source_datadir: source.path(),
-        output_dir: output.path(),
+        output_dir: Some(output.path()),
         chain_id: 8453,
         base_url: None,
         block: Some(0),
@@ -1459,42 +1454,6 @@ async fn orchestrator_skips_when_not_at_tip() -> Result<()> {
     assert!(result.is_ok(), "run should return Ok when skipping a not-at-tip node");
     assert!(!manager.was_stopped(), "container must not be stopped when EL is not at tip");
     assert!(!manager.was_started(), "container must not be started when EL is not at tip");
-
-    Ok(())
-}
-
-#[tokio::test]
-#[serial]
-async fn upload_existing_run_skips_container_lifecycle() -> Result<()> {
-    let harness = TestHarness::new().await?;
-    let manager = std::sync::Arc::new(MockContainerManager::new());
-    let uploader = SnapshotUploader::new(
-        harness.storage_client.clone(),
-        harness.bucket_name.clone(),
-        "test".to_string(),
-        None,
-    );
-
-    let tmp = tempfile::tempdir()?;
-    let output_dir = tmp.path().join("output");
-    let run_timestamp = 1_700_000_123u64;
-    let run_dir = output_dir.join(format!("run-{run_timestamp}"));
-    create_fake_snapshot(&run_dir, 1_000_000)?;
-
-    let mut config = test_config(&harness.bucket_name, tmp.path());
-    config.output_dir = output_dir;
-    config.upload_existing_run_timestamp = Some(run_timestamp);
-
-    let snapshotter = base_snapshotter::Snapshotter::new(
-        std::sync::Arc::clone(&manager),
-        MockTipChecker::new(true),
-        uploader,
-        config,
-    );
-
-    snapshotter.run().await?;
-    assert!(!manager.was_stopped(), "upload-only mode should not stop the container");
-    assert!(!manager.was_started(), "upload-only mode should not restart the container");
 
     Ok(())
 }

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -159,6 +159,10 @@ fn test_config(bucket: &str, tmp: &Path) -> base_snapshotter::SnapshotterConfig 
         block: None,
         blocks_per_file: Some(500_000),
         snapshot_threads: None,
+        max_streaming_archives: std::num::NonZeroUsize::new(
+            base_snapshotter::DEFAULT_MAX_STREAMING_ARCHIVES,
+        )
+        .expect("default streaming archive count should be non-zero"),
         retain_runs: NonZeroUsize::new(3).expect("retain runs should be non-zero"),
         docker_socket: "/var/run/docker.sock".to_string(),
         s3_config_type: base_snapshotter::S3ConfigType::Aws,

--- a/crates/utilities/reth-cli/src/lib.rs
+++ b/crates/utilities/reth-cli/src/lib.rs
@@ -15,6 +15,8 @@ pub use snapshots::Snapshots;
 
 mod snapshot_manifest;
 pub use snapshot_manifest::{
-    ChunkFilename, ChunkedArchive, ComponentManifest, ManifestGenerationParams, OutputFileChecksum,
-    ProgressDisplay, SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
+    ChunkFilename, ChunkedArchive, ComponentManifest, DirectoryArchiveSink,
+    ManifestGenerationParams, OutputFileChecksum, ProgressDisplay, SingleArchive,
+    SnapshotArchiveSink, SnapshotArchiveWriter, SnapshotGenerator, SnapshotManifest,
+    SnapshotManifestExt,
 };

--- a/crates/utilities/reth-cli/src/snapshot_manifest.rs
+++ b/crates/utilities/reth-cli/src/snapshot_manifest.rs
@@ -185,8 +185,11 @@ impl SnapshotManifestExt for SnapshotManifest {
 pub struct ManifestGenerationParams<'a> {
     /// Reth node datadir containing static files, state DB, and optional proofs DB.
     pub source_datadir: &'a Path,
-    /// Directory where snapshot archives and `manifest.json` are written.
-    pub output_dir: &'a Path,
+    /// Optional directory where the directory-backed generator writes archives and `manifest.json`.
+    ///
+    /// This is required by [`SnapshotGenerator::generate_manifest`] and unused by
+    /// [`SnapshotGenerator::generate_manifest_with_sink`].
+    pub output_dir: Option<&'a Path>,
     /// Chain ID recorded in the manifest.
     pub chain_id: u64,
     /// Optional base URL recorded in the manifest.
@@ -272,24 +275,23 @@ impl SnapshotGenerator {
     ///
     /// From <https://github.com/paradigmxyz/reth/blob/420693521fccd1437071a15a4a54a3a98b5492cf/crates/cli/commands/src/download/manifest.rs>
     pub fn generate_manifest(params: &ManifestGenerationParams<'_>) -> Result<Vec<PathBuf>> {
-        std::fs::create_dir_all(params.output_dir).with_context(|| {
-            format!("failed to create output dir {}", params.output_dir.display())
-        })?;
+        let output_dir = params
+            .output_dir
+            .context("output_dir is required for directory-backed snapshot generation")?;
+        std::fs::create_dir_all(output_dir)
+            .with_context(|| format!("failed to create output dir {}", output_dir.display()))?;
 
-        let sink = DirectoryArchiveSink::new(params.output_dir);
+        let sink = DirectoryArchiveSink::new(output_dir);
         let manifest = Self::generate_manifest_with_sink(params, &sink)?;
-        std::fs::write(
-            params.output_dir.join("manifest.json"),
-            serde_json::to_string_pretty(&manifest)?,
-        )?;
-        let files = Self::collect_output_files(params.output_dir)?;
+        std::fs::write(output_dir.join("manifest.json"), serde_json::to_string_pretty(&manifest)?)?;
+        let files = Self::collect_output_files(output_dir)?;
         info!(file_count = files.len(), "snapshot generation complete");
         Ok(files)
     }
 
     /// Generates archives using an arbitrary synchronous output sink.
     ///
-    /// Unlike [`Self::generate_manifest`], this neither creates `output_dir` nor writes a
+    /// Unlike [`Self::generate_manifest`], this neither creates an output directory nor writes a
     /// manifest. Callers that stream archives can publish the returned manifest after every sink
     /// writer has completed successfully.
     pub fn generate_manifest_with_sink(
@@ -304,7 +306,6 @@ impl SnapshotGenerator {
 
         info!(
             source = %params.source_datadir.display(),
-            output = %params.output_dir.display(),
             chain_id = params.chain_id,
             block,
             blocks_per_file,
@@ -1021,7 +1022,7 @@ mod tests {
     ) -> ManifestGenerationParams<'a> {
         ManifestGenerationParams {
             source_datadir,
-            output_dir,
+            output_dir: Some(output_dir),
             chain_id: 8453,
             base_url: None,
             block,
@@ -1391,7 +1392,7 @@ mod tests {
 
         let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
             source_datadir: source.path(),
-            output_dir: output.path(),
+            output_dir: Some(output.path()),
             chain_id: 8453,
             base_url: None,
             block: Some(2_000_000),

--- a/crates/utilities/reth-cli/src/snapshot_manifest.rs
+++ b/crates/utilities/reth-cli/src/snapshot_manifest.rs
@@ -185,6 +185,11 @@ impl SnapshotManifestExt for SnapshotManifest {
 pub struct ManifestGenerationParams<'a> {
     /// Reth node datadir containing static files, state DB, and optional proofs DB.
     pub source_datadir: &'a Path,
+    /// Optional directory where the directory-backed generator writes archives and `manifest.json`.
+    ///
+    /// This is required by [`SnapshotGenerator::generate_manifest`] and unused by
+    /// [`SnapshotGenerator::generate_manifest_with_sink`].
+    pub output_dir: Option<&'a Path>,
     /// Chain ID recorded in the manifest.
     pub chain_id: u64,
     /// Optional base URL recorded in the manifest.
@@ -269,10 +274,10 @@ impl SnapshotGenerator {
     /// Returns the list of files created in the output directory.
     ///
     /// From <https://github.com/paradigmxyz/reth/blob/420693521fccd1437071a15a4a54a3a98b5492cf/crates/cli/commands/src/download/manifest.rs>
-    pub fn generate_manifest(
-        params: &ManifestGenerationParams<'_>,
-        output_dir: &Path,
-    ) -> Result<Vec<PathBuf>> {
+    pub fn generate_manifest(params: &ManifestGenerationParams<'_>) -> Result<Vec<PathBuf>> {
+        let output_dir = params
+            .output_dir
+            .context("output_dir is required for directory-backed snapshot generation")?;
         std::fs::create_dir_all(output_dir)
             .with_context(|| format!("failed to create output dir {}", output_dir.display()))?;
 
@@ -1009,6 +1014,7 @@ mod tests {
 
     fn test_manifest_params<'a>(
         source_datadir: &'a Path,
+        output_dir: &'a Path,
         remote_static_files: &'a HashMap<String, u64>,
         previous_manifest: Option<&'a SnapshotManifest>,
         block: Option<u64>,
@@ -1016,6 +1022,7 @@ mod tests {
     ) -> ManifestGenerationParams<'a> {
         ManifestGenerationParams {
             source_datadir,
+            output_dir: Some(output_dir),
             chain_id: 8453,
             base_url: None,
             block,
@@ -1145,10 +1152,14 @@ mod tests {
         std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(
-            &test_manifest_params(source.path(), &remote, None, Some(0), false),
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
+            source.path(),
             output.path(),
-        )
+            &remote,
+            None,
+            Some(0),
+            false,
+        ))
         .unwrap();
 
         assert!(
@@ -1180,10 +1191,14 @@ mod tests {
         std::fs::write(proofs_dir.join("000801.log"), b"wal-data").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(
-            &test_manifest_params(source.path(), &remote, None, Some(0), true),
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
+            source.path(),
             output.path(),
-        )
+            &remote,
+            None,
+            Some(0),
+            true,
+        ))
         .unwrap();
 
         assert!(
@@ -1225,10 +1240,14 @@ mod tests {
         std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(
-            &test_manifest_params(source.path(), &remote, None, Some(0), true),
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
+            source.path(),
             output.path(),
-        )
+            &remote,
+            None,
+            Some(0),
+            true,
+        ))
         .unwrap();
 
         assert!(
@@ -1258,10 +1277,14 @@ mod tests {
         std::fs::write(proofs_dir.join("CURRENT"), b"MANIFEST-000014\n").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(
-            &test_manifest_params(source.path(), &remote, None, Some(0), false),
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
+            source.path(),
             output.path(),
-        )
+            &remote,
+            None,
+            Some(0),
+            false,
+        ))
         .unwrap();
 
         assert!(
@@ -1305,16 +1328,14 @@ mod tests {
             }],
             123,
         );
-        let files = SnapshotGenerator::generate_manifest(
-            &test_manifest_params(
-                source.path(),
-                &remote,
-                Some(&previous_manifest),
-                Some(2_000_000),
-                false,
-            ),
+        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
+            source.path(),
             output.path(),
-        )
+            &remote,
+            Some(&previous_manifest),
+            Some(2_000_000),
+            false,
+        ))
         .unwrap();
 
         let filenames: Vec<String> = files
@@ -1369,19 +1390,17 @@ mod tests {
             123,
         );
 
-        let files = SnapshotGenerator::generate_manifest(
-            &ManifestGenerationParams {
-                source_datadir: source.path(),
-                chain_id: 8453,
-                base_url: None,
-                block: Some(2_000_000),
-                blocks_per_file: Some(500_000),
-                remote_static_files: &remote,
-                previous_manifest: Some(&previous_manifest),
-                upload_proofs: false,
-            },
-            output.path(),
-        )
+        let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+            source_datadir: source.path(),
+            output_dir: Some(output.path()),
+            chain_id: 8453,
+            base_url: None,
+            block: Some(2_000_000),
+            blocks_per_file: Some(500_000),
+            remote_static_files: &remote,
+            previous_manifest: Some(&previous_manifest),
+            upload_proofs: false,
+        })
         .unwrap();
 
         assert!(

--- a/crates/utilities/reth-cli/src/snapshot_manifest.rs
+++ b/crates/utilities/reth-cli/src/snapshot_manifest.rs
@@ -846,7 +846,7 @@ type SnapshotArchiveBuilder<'a> =
     tar::Builder<zstd::Encoder<'a, CountingWriter<Box<dyn SnapshotArchiveWriter>>>>;
 
 impl<W> CountingWriter<W> {
-    fn new(inner: W, compressed_bytes: Arc<AtomicU64>) -> Self {
+    const fn new(inner: W, compressed_bytes: Arc<AtomicU64>) -> Self {
         Self { inner, bytes_written: 0, compressed_bytes }
     }
 

--- a/crates/utilities/reth-cli/src/snapshot_manifest.rs
+++ b/crates/utilities/reth-cli/src/snapshot_manifest.rs
@@ -8,8 +8,12 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
-    io::Read,
+    io::{Read, Write},
     path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -41,7 +45,7 @@ const CHUNKED_COMPONENTS: &[(&str, &str)] = &[
     ("storage_changesets", "storage-change-sets"),
 ];
 
-/// Formats snapshot compression and upload progress for structured logs.
+/// Formats snapshot compression progress for structured logs.
 #[derive(Debug)]
 pub struct ProgressDisplay;
 
@@ -62,7 +66,6 @@ impl ProgressDisplay {
     /// Formats a byte count with two decimal places and human-readable binary units.
     pub fn bytes(bytes: f64) -> String {
         const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
-
         let bytes = bytes.max(0.0);
         let unit = if bytes == 0.0 {
             0
@@ -82,16 +85,17 @@ impl ProgressDisplay {
         format!("{}/s", Self::bytes(bytes_per_second))
     }
 
-    /// Calculates the ETA from average throughput since an operation started.
+    /// Calculates ETA from average throughput since start.
     pub fn eta(done: u64, total: u64, elapsed: Duration) -> Option<FormattedDuration> {
         if done == 0 || done >= total {
             return None;
         }
-        let seconds = total.saturating_sub(done) as f64 / (done as f64 / elapsed.as_secs_f64());
-        Some(Self::duration(Duration::from_secs_f64(seconds)))
+        Some(Self::duration(Duration::from_secs_f64(
+            total.saturating_sub(done) as f64 / (done as f64 / elapsed.as_secs_f64()),
+        )))
     }
 
-    /// Formats a duration at whole-second precision for periodic progress logs.
+    /// Formats a duration at whole-second precision.
     pub fn duration(duration: Duration) -> FormattedDuration {
         format_duration(Duration::from_secs(duration.as_secs()))
     }
@@ -199,6 +203,59 @@ pub struct ManifestGenerationParams<'a> {
     pub upload_proofs: bool,
 }
 
+/// Destination for generated snapshot archive streams.
+///
+/// Generation can package archives in parallel, so implementations must be thread-safe. The
+/// supplied archive name is the relative filename recorded in the manifest.
+pub trait SnapshotArchiveSink: Send + Sync {
+    /// Creates the destination writer for one archive.
+    fn create_archive(&self, archive_name: &str) -> Result<Box<dyn SnapshotArchiveWriter>>;
+}
+
+/// A destination writer for one generated archive.
+pub trait SnapshotArchiveWriter: Write + Send {
+    /// Publishes a complete archive after tar and zstd have finalized successfully.
+    fn finish(self: Box<Self>) -> Result<()>;
+}
+
+/// Filesystem-backed archive sink used by the legacy directory generator.
+#[derive(Debug)]
+pub struct DirectoryArchiveSink {
+    output_dir: PathBuf,
+}
+
+impl DirectoryArchiveSink {
+    /// Creates a filesystem archive sink rooted at `output_dir`.
+    pub fn new(output_dir: impl Into<PathBuf>) -> Self {
+        Self { output_dir: output_dir.into() }
+    }
+}
+
+impl SnapshotArchiveSink for DirectoryArchiveSink {
+    fn create_archive(&self, archive_name: &str) -> Result<Box<dyn SnapshotArchiveWriter>> {
+        Ok(Box::new(FileArchiveWriter(std::fs::File::create(self.output_dir.join(archive_name))?)))
+    }
+}
+
+struct FileArchiveWriter(std::fs::File);
+
+impl Write for FileArchiveWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl SnapshotArchiveWriter for FileArchiveWriter {
+    fn finish(mut self: Box<Self>) -> Result<()> {
+        self.flush()?;
+        Ok(())
+    }
+}
+
 /// Generates snapshot archives with selective compression.
 ///
 /// Static-file chunks are not compressed or written locally when their current
@@ -219,12 +276,31 @@ impl SnapshotGenerator {
             format!("failed to create output dir {}", params.output_dir.display())
         })?;
 
+        let sink = DirectoryArchiveSink::new(params.output_dir);
+        let manifest = Self::generate_manifest_with_sink(params, &sink)?;
+        std::fs::write(
+            params.output_dir.join("manifest.json"),
+            serde_json::to_string_pretty(&manifest)?,
+        )?;
+        let files = Self::collect_output_files(params.output_dir)?;
+        info!(file_count = files.len(), "snapshot generation complete");
+        Ok(files)
+    }
+
+    /// Generates archives using an arbitrary synchronous output sink.
+    ///
+    /// Unlike [`Self::generate_manifest`], this neither creates `output_dir` nor writes a
+    /// manifest. Callers that stream archives can publish the returned manifest after every sink
+    /// writer has completed successfully.
+    pub fn generate_manifest_with_sink(
+        params: &ManifestGenerationParams<'_>,
+        archive_sink: &dyn SnapshotArchiveSink,
+    ) -> Result<SnapshotManifest> {
         let blocks_per_file = params.blocks_per_file.unwrap_or(DEFAULT_BLOCKS_PER_FILE);
         let block = match params.block {
             Some(block) => block,
             None => infer_block_from_headers(params.source_datadir)?,
         };
-        let total_blocks = block.checked_add(1).context("snapshot block height exceeds u64")?;
 
         info!(
             source = %params.source_datadir.display(),
@@ -245,7 +321,7 @@ impl SnapshotGenerator {
 
         let mut components = BTreeMap::new();
 
-        let num_chunks = total_blocks.div_ceil(blocks_per_file);
+        let num_chunks = block.div_ceil(blocks_per_file);
         if num_chunks > MAX_CHUNKS {
             bail!(
                 "too many chunks ({num_chunks}) for block {block} with blocks_per_file \
@@ -287,7 +363,7 @@ impl SnapshotGenerator {
                         reuse_candidates.push(ReuseCandidate {
                             chunk: PlannedChunk {
                                 chunk_idx: i,
-                                archive_path: params.output_dir.join(&archive_name),
+                                archive_name: archive_name.clone(),
                                 source_files,
                             },
                             archive_name,
@@ -298,11 +374,7 @@ impl SnapshotGenerator {
                     }
                 }
 
-                planned.push(PlannedChunk {
-                    chunk_idx: i,
-                    archive_path: params.output_dir.join(archive_name),
-                    source_files,
-                });
+                planned.push(PlannedChunk { chunk_idx: i, archive_name, source_files });
             }
 
             if !found_any {
@@ -331,9 +403,13 @@ impl SnapshotGenerator {
                 let packaged: Vec<PackagedChunk> = planned
                     .into_par_iter()
                     .map(|p| {
-                        let output_files = write_chunk_archive(&p.archive_path, &p.source_files)?;
-                        let size = std::fs::metadata(&p.archive_path)?.len();
-                        Ok(PackagedChunk { chunk_idx: p.chunk_idx, size, output_files })
+                        let packaged =
+                            write_chunk_archive(archive_sink, &p.archive_name, &p.source_files)?;
+                        Ok(PackagedChunk {
+                            chunk_idx: p.chunk_idx,
+                            size: packaged.size,
+                            output_files: packaged.output_files,
+                        })
                     })
                     .collect::<Result<Vec<_>>>()?;
 
@@ -348,7 +424,7 @@ impl SnapshotGenerator {
                 info!(
                     component = key,
                     compressed_size = total_size,
-                    total_blocks,
+                    total_blocks = block,
                     "packaged chunked component"
                 );
 
@@ -356,7 +432,7 @@ impl SnapshotGenerator {
                     key.to_string(),
                     ComponentManifest::Chunked(ChunkedArchive {
                         blocks_per_file,
-                        total_blocks,
+                        total_blocks: block,
                         chunk_sizes,
                         chunk_decompressed_sizes: chunk_decompressed,
                         chunk_output_files,
@@ -388,7 +464,7 @@ impl SnapshotGenerator {
             .into_par_iter()
             .map(|(component, archive_name, files)| {
                 let (size, output_files) =
-                    package_single_component(params.output_dir, component, archive_name, &files)?;
+                    package_single_component(archive_sink, component, archive_name, &files)?;
                 let decompressed_size = output_files.iter().map(|file| file.size).sum();
                 info!(
                     component = %component,
@@ -433,13 +509,8 @@ impl SnapshotGenerator {
             components,
         };
 
-        let manifest_path = params.output_dir.join("manifest.json");
-        std::fs::write(&manifest_path, serde_json::to_string_pretty(&manifest)?)?;
-        info!(block, components = manifest.components.len(), "manifest written");
-
-        let files = Self::collect_output_files(params.output_dir)?;
-        info!(file_count = files.len(), "snapshot generation complete");
-        Ok(files)
+        info!(block, components = manifest.components.len(), "snapshot manifest generated");
+        Ok(manifest)
     }
 
     /// Collects all files in a snapshot output directory (non-recursive).
@@ -526,7 +597,7 @@ fn parse_headers_range(file_name: &str) -> Option<(u64, u64)> {
 
 struct PlannedChunk {
     chunk_idx: u64,
-    archive_path: PathBuf,
+    archive_name: String,
     source_files: Vec<PathBuf>,
 }
 
@@ -662,7 +733,7 @@ fn collect_files_inner(
 }
 
 fn package_single_component(
-    output_dir: &Path,
+    archive_sink: &dyn SnapshotArchiveSink,
     component: &str,
     archive_name: &str,
     files: &[PlannedFile],
@@ -670,7 +741,6 @@ fn package_single_component(
     if files.is_empty() {
         bail!("cannot package empty archive: {archive_name}");
     }
-    let archive_path = output_dir.join(archive_name);
     let raw_size = files.iter().try_fold(0u64, |total, file| {
         std::fs::metadata(&file.source_path).map(|metadata| total.saturating_add(metadata.len()))
     })?;
@@ -680,13 +750,24 @@ fn package_single_component(
         file_count = files.len(),
         "packaging database component"
     );
-    let mut progress = CompressionProgress::new(component, &archive_path, raw_size);
-    let output_files = write_archive_from_planned_files(&archive_path, files, Some(&mut progress))?;
-    let size = std::fs::metadata(&archive_path)?.len();
-    Ok((size, output_files))
+    let compressed_bytes = Arc::new(AtomicU64::new(0));
+    let mut progress =
+        CompressionProgress::new(component, archive_name, raw_size, Arc::clone(&compressed_bytes));
+    let packaged = write_archive_from_planned_files(
+        archive_sink,
+        archive_name,
+        files,
+        Some(&mut progress),
+        compressed_bytes,
+    )?;
+    Ok((packaged.size, packaged.output_files))
 }
 
-fn write_chunk_archive(path: &Path, source_files: &[PathBuf]) -> Result<Vec<OutputFileChecksum>> {
+fn write_chunk_archive(
+    archive_sink: &dyn SnapshotArchiveSink,
+    archive_name: &str,
+    source_files: &[PathBuf],
+) -> Result<PackagedArchive> {
     let planned: Vec<PlannedFile> = source_files
         .iter()
         .map(|p| {
@@ -699,7 +780,13 @@ fn write_chunk_archive(path: &Path, source_files: &[PathBuf]) -> Result<Vec<Outp
         })
         .collect::<Result<Vec<_>>>()?;
 
-    write_archive_from_planned_files(path, &planned, None)
+    write_archive_from_planned_files(
+        archive_sink,
+        archive_name,
+        &planned,
+        None,
+        Arc::new(AtomicU64::new(0)),
+    )
 }
 
 fn chunk_output_files_for_source_files(
@@ -721,22 +808,60 @@ fn chunk_output_files_for_source_files(
 }
 
 fn write_archive_from_planned_files(
-    path: &Path,
+    archive_sink: &dyn SnapshotArchiveSink,
+    archive_name: &str,
     files: &[PlannedFile],
     progress: Option<&mut CompressionProgress>,
-) -> Result<Vec<OutputFileChecksum>> {
-    let file = std::fs::File::create(path)?;
-    let mut encoder = zstd::Encoder::new(file, 0)?;
+    compressed_bytes: Arc<AtomicU64>,
+) -> Result<PackagedArchive> {
+    let writer = CountingWriter::new(archive_sink.create_archive(archive_name)?, compressed_bytes);
+    let mut encoder = zstd::Encoder::new(writer, 0)?;
     encoder.include_checksum(true)?;
     let mut builder = tar::Builder::new(encoder);
 
     let output_files =
-        compute_output_files_and_archive(files, Some((&mut builder, path)), progress)?;
+        compute_output_files_and_archive(files, Some((&mut builder, archive_name)), progress)?;
 
     let encoder = builder.into_inner()?;
-    encoder.finish()?;
+    let writer = encoder.finish()?;
+    let (writer, size) = writer.into_inner();
+    writer.finish()?;
 
-    Ok(output_files)
+    Ok(PackagedArchive { size, output_files })
+}
+
+struct PackagedArchive {
+    size: u64,
+    output_files: Vec<OutputFileChecksum>,
+}
+
+struct CountingWriter<W> {
+    inner: W,
+    bytes_written: u64,
+    compressed_bytes: Arc<AtomicU64>,
+}
+
+impl<W> CountingWriter<W> {
+    fn new(inner: W, compressed_bytes: Arc<AtomicU64>) -> Self {
+        Self { inner, bytes_written: 0, compressed_bytes }
+    }
+
+    fn into_inner(self) -> (W, u64) {
+        (self.inner, self.bytes_written)
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let bytes = self.inner.write(buf)?;
+        self.bytes_written += bytes as u64;
+        self.compressed_bytes.fetch_add(bytes as u64, Ordering::Relaxed);
+        Ok(bytes)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
 }
 
 fn compute_output_files_for_planned_files(
@@ -747,7 +872,10 @@ fn compute_output_files_for_planned_files(
 
 fn compute_output_files_and_archive(
     files: &[PlannedFile],
-    mut archive: Option<(&mut tar::Builder<zstd::Encoder<'_, std::fs::File>>, &Path)>,
+    mut archive: Option<(
+        &mut tar::Builder<zstd::Encoder<'_, CountingWriter<Box<dyn SnapshotArchiveWriter>>>>,
+        &str,
+    )>,
     mut progress: Option<&mut CompressionProgress>,
 ) -> Result<Vec<OutputFileChecksum>> {
     let mut output_files = Vec::with_capacity(files.len());
@@ -757,7 +885,7 @@ fn compute_output_files_and_archive(
         let source_file = std::fs::File::open(&planned.source_path)?;
         let mut reader = HashingReader::new(source_file, progress.as_deref_mut());
 
-        if let Some((builder, archive_path)) = archive.as_mut() {
+        if let Some((builder, archive_name)) = archive.as_mut() {
             let mut header = tar::Header::new_gnu();
             header.set_size(expected_size);
             header.set_mode(0o644);
@@ -767,7 +895,7 @@ fn compute_output_files_and_archive(
                     format!(
                         "failed to append {} to {}",
                         planned.source_path.display(),
-                        archive_path.display()
+                        archive_name
                     )
                 },
             )?;
@@ -795,21 +923,28 @@ fn compute_output_files_and_archive(
 
 struct CompressionProgress {
     component: String,
-    archive_path: PathBuf,
+    archive_name: String,
     raw_size: u64,
     raw_processed: u64,
+    compressed_bytes: Arc<AtomicU64>,
     started: Instant,
     last_log: Instant,
 }
 
 impl CompressionProgress {
-    fn new(component: &str, archive_path: &Path, raw_size: u64) -> Self {
+    fn new(
+        component: &str,
+        archive_name: &str,
+        raw_size: u64,
+        compressed_bytes: Arc<AtomicU64>,
+    ) -> Self {
         let now = Instant::now();
         Self {
             component: component.to_string(),
-            archive_path: archive_path.to_path_buf(),
+            archive_name: archive_name.to_string(),
             raw_size,
             raw_processed: 0,
+            compressed_bytes,
             started: now,
             last_log: now,
         }
@@ -820,18 +955,16 @@ impl CompressionProgress {
         if self.last_log.elapsed() < COMPRESSION_LOG_INTERVAL {
             return;
         }
-
         let elapsed = self.started.elapsed();
-        let compressed_size =
-            std::fs::metadata(&self.archive_path).map_or(0, |metadata| metadata.len());
         let speed = self.raw_processed as f64 / elapsed.as_secs_f64();
         let eta = ProgressDisplay::eta(self.raw_processed, self.raw_size, elapsed)
             .map_or_else(|| "unknown".to_string(), |eta| eta.to_string());
         info!(
             component = %self.component,
+            archive = %self.archive_name,
             raw_size = %ProgressDisplay::bytes(self.raw_size as f64),
             raw_processed = %ProgressDisplay::bytes(self.raw_processed as f64),
-            compressed_size = %ProgressDisplay::bytes(compressed_size as f64),
+            compressed_size = %ProgressDisplay::bytes(self.compressed_bytes.load(Ordering::Relaxed) as f64),
             progress = %ProgressDisplay::precise_percent(self.raw_processed, self.raw_size),
             speed = %ProgressDisplay::speed(speed),
             eta = %eta,
@@ -1038,48 +1171,6 @@ mod tests {
     }
 
     #[test]
-    fn generate_manifest_includes_chunk_containing_exact_block_height() {
-        let source = tempfile::tempdir().unwrap();
-        let output = tempfile::tempdir().unwrap();
-        let db_dir = source.path().join("db");
-        std::fs::create_dir_all(&db_dir).unwrap();
-        std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
-
-        let static_files_dir = source.path().join("static_files");
-        std::fs::create_dir_all(&static_files_dir).unwrap();
-        std::fs::write(static_files_dir.join("static_file_headers_0_499999"), b"first").unwrap();
-        std::fs::write(static_files_dir.join("static_file_headers_500000_999999"), b"second")
-            .unwrap();
-
-        let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
-            source.path(),
-            output.path(),
-            &remote,
-            None,
-            Some(500_000),
-            false,
-        ))
-        .unwrap();
-
-        assert!(files.iter().any(|path| {
-            path.file_name().is_some_and(|name| name == "headers-500000-999999.tar.zst")
-        }));
-
-        let manifest: SnapshotManifest =
-            serde_json::from_slice(&std::fs::read(output.path().join("manifest.json")).unwrap())
-                .unwrap();
-        assert_eq!(manifest.block, 500_000);
-        let ComponentManifest::Chunked(headers) = &manifest.components["headers"] else {
-            panic!("headers component should be chunked");
-        };
-        assert_eq!(headers.total_blocks, 500_001);
-        assert_eq!(headers.chunk_sizes.len(), 2);
-        assert_eq!(headers.chunk_output_files.len(), 2);
-        assert!(!headers.chunk_output_files[1].is_empty());
-    }
-
-    #[test]
     fn generate_manifest_creates_proofs_archive() {
         let source = tempfile::tempdir().unwrap();
         let output = tempfile::tempdir().unwrap();
@@ -1240,7 +1331,7 @@ mod tests {
             output.path(),
             &remote,
             Some(&previous_manifest),
-            Some(1_999_999),
+            Some(2_000_000),
             false,
         ))
         .unwrap();
@@ -1302,7 +1393,7 @@ mod tests {
             output_dir: output.path(),
             chain_id: 8453,
             base_url: None,
-            block: Some(1_999_999),
+            block: Some(2_000_000),
             blocks_per_file: Some(500_000),
             remote_static_files: &remote,
             previous_manifest: Some(&previous_manifest),

--- a/crates/utilities/reth-cli/src/snapshot_manifest.rs
+++ b/crates/utilities/reth-cli/src/snapshot_manifest.rs
@@ -185,11 +185,6 @@ impl SnapshotManifestExt for SnapshotManifest {
 pub struct ManifestGenerationParams<'a> {
     /// Reth node datadir containing static files, state DB, and optional proofs DB.
     pub source_datadir: &'a Path,
-    /// Optional directory where the directory-backed generator writes archives and `manifest.json`.
-    ///
-    /// This is required by [`SnapshotGenerator::generate_manifest`] and unused by
-    /// [`SnapshotGenerator::generate_manifest_with_sink`].
-    pub output_dir: Option<&'a Path>,
     /// Chain ID recorded in the manifest.
     pub chain_id: u64,
     /// Optional base URL recorded in the manifest.
@@ -274,10 +269,10 @@ impl SnapshotGenerator {
     /// Returns the list of files created in the output directory.
     ///
     /// From <https://github.com/paradigmxyz/reth/blob/420693521fccd1437071a15a4a54a3a98b5492cf/crates/cli/commands/src/download/manifest.rs>
-    pub fn generate_manifest(params: &ManifestGenerationParams<'_>) -> Result<Vec<PathBuf>> {
-        let output_dir = params
-            .output_dir
-            .context("output_dir is required for directory-backed snapshot generation")?;
+    pub fn generate_manifest(
+        params: &ManifestGenerationParams<'_>,
+        output_dir: &Path,
+    ) -> Result<Vec<PathBuf>> {
         std::fs::create_dir_all(output_dir)
             .with_context(|| format!("failed to create output dir {}", output_dir.display()))?;
 
@@ -1014,7 +1009,6 @@ mod tests {
 
     fn test_manifest_params<'a>(
         source_datadir: &'a Path,
-        output_dir: &'a Path,
         remote_static_files: &'a HashMap<String, u64>,
         previous_manifest: Option<&'a SnapshotManifest>,
         block: Option<u64>,
@@ -1022,7 +1016,6 @@ mod tests {
     ) -> ManifestGenerationParams<'a> {
         ManifestGenerationParams {
             source_datadir,
-            output_dir: Some(output_dir),
             chain_id: 8453,
             base_url: None,
             block,
@@ -1152,14 +1145,10 @@ mod tests {
         std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
-            source.path(),
+        let files = SnapshotGenerator::generate_manifest(
+            &test_manifest_params(source.path(), &remote, None, Some(0), false),
             output.path(),
-            &remote,
-            None,
-            Some(0),
-            false,
-        ))
+        )
         .unwrap();
 
         assert!(
@@ -1191,14 +1180,10 @@ mod tests {
         std::fs::write(proofs_dir.join("000801.log"), b"wal-data").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
-            source.path(),
+        let files = SnapshotGenerator::generate_manifest(
+            &test_manifest_params(source.path(), &remote, None, Some(0), true),
             output.path(),
-            &remote,
-            None,
-            Some(0),
-            true,
-        ))
+        )
         .unwrap();
 
         assert!(
@@ -1240,14 +1225,10 @@ mod tests {
         std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
-            source.path(),
+        let files = SnapshotGenerator::generate_manifest(
+            &test_manifest_params(source.path(), &remote, None, Some(0), true),
             output.path(),
-            &remote,
-            None,
-            Some(0),
-            true,
-        ))
+        )
         .unwrap();
 
         assert!(
@@ -1277,14 +1258,10 @@ mod tests {
         std::fs::write(proofs_dir.join("CURRENT"), b"MANIFEST-000014\n").unwrap();
 
         let remote = HashMap::new();
-        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
-            source.path(),
+        let files = SnapshotGenerator::generate_manifest(
+            &test_manifest_params(source.path(), &remote, None, Some(0), false),
             output.path(),
-            &remote,
-            None,
-            Some(0),
-            false,
-        ))
+        )
         .unwrap();
 
         assert!(
@@ -1328,14 +1305,16 @@ mod tests {
             }],
             123,
         );
-        let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
-            source.path(),
+        let files = SnapshotGenerator::generate_manifest(
+            &test_manifest_params(
+                source.path(),
+                &remote,
+                Some(&previous_manifest),
+                Some(2_000_000),
+                false,
+            ),
             output.path(),
-            &remote,
-            Some(&previous_manifest),
-            Some(2_000_000),
-            false,
-        ))
+        )
         .unwrap();
 
         let filenames: Vec<String> = files
@@ -1390,17 +1369,19 @@ mod tests {
             123,
         );
 
-        let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
-            source_datadir: source.path(),
-            output_dir: Some(output.path()),
-            chain_id: 8453,
-            base_url: None,
-            block: Some(2_000_000),
-            blocks_per_file: Some(500_000),
-            remote_static_files: &remote,
-            previous_manifest: Some(&previous_manifest),
-            upload_proofs: false,
-        })
+        let files = SnapshotGenerator::generate_manifest(
+            &ManifestGenerationParams {
+                source_datadir: source.path(),
+                chain_id: 8453,
+                base_url: None,
+                block: Some(2_000_000),
+                blocks_per_file: Some(500_000),
+                remote_static_files: &remote,
+                previous_manifest: Some(&previous_manifest),
+                upload_proofs: false,
+            },
+            output.path(),
+        )
         .unwrap();
 
         assert!(

--- a/crates/utilities/reth-cli/src/snapshot_manifest.rs
+++ b/crates/utilities/reth-cli/src/snapshot_manifest.rs
@@ -841,6 +841,10 @@ struct CountingWriter<W> {
     compressed_bytes: Arc<AtomicU64>,
 }
 
+/// Tar builder that writes Zstandard-compressed bytes to a snapshot archive sink.
+type SnapshotArchiveBuilder<'a> =
+    tar::Builder<zstd::Encoder<'a, CountingWriter<Box<dyn SnapshotArchiveWriter>>>>;
+
 impl<W> CountingWriter<W> {
     fn new(inner: W, compressed_bytes: Arc<AtomicU64>) -> Self {
         Self { inner, bytes_written: 0, compressed_bytes }
@@ -872,10 +876,7 @@ fn compute_output_files_for_planned_files(
 
 fn compute_output_files_and_archive(
     files: &[PlannedFile],
-    mut archive: Option<(
-        &mut tar::Builder<zstd::Encoder<'_, CountingWriter<Box<dyn SnapshotArchiveWriter>>>>,
-        &str,
-    )>,
+    mut archive: Option<(&mut SnapshotArchiveBuilder<'_>, &str)>,
     mut progress: Option<&mut CompressionProgress>,
 ) -> Result<Vec<OutputFileChecksum>> {
     let mut output_files = Vec::with_capacity(files.len());


### PR DESCRIPTION
## Summary

- refactor the Base-owned snapshot generator to write archives to a generic synchronous sink
- stream normal Snapshotter tar plus Zstd output directly into bounded S3 multipart uploads, without staging compressed archive files on disk
- pipeline streamed multipart uploads with a rolling window instead of serially awaiting each part
- remove Snapshotter output-directory configuration and the obsolete upload-existing-run recovery mode
- retain finalized static-chunk reuse, BLAKE3 validation, and state, RocksDB, and proofs archive support

## Streaming throughput and memory

Streamed archive parts are 128 MiB. Each part is uploaded as soon as it is produced; completed multipart parts are sorted by part number before completion.

SNAPSHOTTER_MAX_STREAMING_ARCHIVES defaults to 4 and controls compression/archive writers. SNAPSHOTTER_MAX_STREAMING_PART_UPLOADS is environment-only and defaults to 64. It caps queued plus in-flight streamed multipart parts globally, bounding compressed-part memory to roughly 8 GiB; the four active writers can add up to roughly 512 MiB of partial parts. Lower either environment value on memory-constrained nodes.

## Streaming behavior

Normal Snapshotter runs have no archive output directory. Newly generated non-tip static chunks stream to static_files; the tip chunk and state, RocksDB, and proofs archives stream to the timestamped run prefix. Snapshotter publishes manifest.json only after every archive stream and multipart upload completes.

## Testing

- cargo clippy -p base-snapshotter --all-targets -- -D warnings
- cargo test -p base-snapshotter --test e2e_test stream -- --nocapture