### PR TITLE
feat(snapshotter): skip unchanged archive compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4262,6 +4262,7 @@ dependencies = [
  "base-node-runner",
  "base-observability-events",
  "base-proofs-extension",
+ "base-reth-cli",
  "base-shadow-indexer",
  "base-shadow-indexer-db",
  "base-tx-forwarding",
@@ -4281,6 +4282,7 @@ dependencies = [
  "reth-cli-runner",
  "reth-cli-util",
  "reth-db",
+ "reth-db-api",
  "reth-discv4",
  "reth-discv5",
  "reth-ethereum-forks",
@@ -4293,6 +4295,7 @@ dependencies = [
  "reth-node-metrics",
  "reth-provider",
  "reth-rpc-server-types",
+ "reth-stages-types",
  "reth-tasks",
  "reth-tracing",
  "rstest",
@@ -5977,9 +5980,17 @@ dependencies = [
 name = "base-reth-cli"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
+ "blake3",
+ "rayon",
  "reth-cli-commands",
  "reth-node-core",
  "reth-prune-types",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -6163,24 +6174,20 @@ dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
- "blake3",
+ "base-reth-cli",
  "bollard",
  "clap",
  "futures",
  "human_bytes",
  "humantime",
- "rayon",
- "reth-cli-commands",
  "serde_json",
  "serial_test",
- "tar",
  "tempfile",
  "testcontainers",
  "testcontainers-modules",
  "tokio",
  "tracing",
  "url",
- "zstd",
 ]
 
 [[package]]

--- a/bin/base/src/commands/snapshot.rs
+++ b/bin/base/src/commands/snapshot.rs
@@ -1,9 +1,11 @@
 //! `base snapshot` subcommand group: snapshot manifest generation and download.
 
-use base_execution_cli::{chainspec::BaseChainSpecParser, commands::download};
+use base_execution_cli::{
+    chainspec::BaseChainSpecParser,
+    commands::{SnapshotManifestCommand, download},
+};
 use base_node_core::BaseNode;
 use clap::{Parser, Subcommand};
-use reth_cli_commands::download::manifest_cmd::SnapshotManifestCommand;
 use reth_cli_runner::CliRunner;
 
 /// Snapshot manifest generation and download utilities.

--- a/crates/execution/cli/Cargo.toml
+++ b/crates/execution/cli/Cargo.toml
@@ -31,10 +31,13 @@ reth-network-peers.workspace = true
 reth-ethereum-forks.workspace = true
 reth-rpc-server-types.workspace = true
 reth-tasks.workspace = true
+reth-db-api.workspace = true
+reth-stages-types.workspace = true
 reth-db = { workspace = true, features = ["mdbx"] }
 
 # op-reth
 base-metering.workspace = true
+base-reth-cli.workspace = true
 base-cli-utils.workspace = true
 base-node-core.workspace = true
 base-txpool-rpc.workspace = true

--- a/crates/execution/cli/src/commands/mod.rs
+++ b/crates/execution/cli/src/commands/mod.rs
@@ -5,9 +5,7 @@ use std::{fmt, sync::Arc};
 use base_execution_chainspec::BaseChainSpec;
 use clap::Subcommand;
 use reth_cli_commands::{
-    config_cmd, db,
-    download::manifest_cmd::SnapshotManifestCommand,
-    dump_genesis, init_cmd,
+    config_cmd, db, dump_genesis, init_cmd,
     node::{self, NoArgs},
     prune, re_execute, stage,
 };
@@ -20,6 +18,8 @@ mod genesis_output_root;
 pub use genesis_output_root::GenesisOutputRootCommand;
 pub mod init_state;
 pub mod p2p;
+mod snapshot_manifest;
+pub use snapshot_manifest::SnapshotManifestCommand;
 
 #[cfg(feature = "dev")]
 pub mod test_vectors;

--- a/crates/execution/cli/src/commands/snapshot_manifest.rs
+++ b/crates/execution/cli/src/commands/snapshot_manifest.rs
@@ -1,0 +1,183 @@
+//! Base-owned snapshot manifest command.
+
+use std::{collections::HashMap, path::PathBuf};
+
+use base_reth_cli::{ManifestGenerationParams, SnapshotGenerator, SnapshotManifest};
+use clap::Parser;
+use eyre::{ContextCompat, Result, WrapErr};
+use reth_db::{Database, mdbx::DatabaseArguments, open_db_read_only, tables};
+use reth_db_api::transaction::DbTx;
+use reth_stages_types::StageId;
+use tracing::{info, warn};
+
+/// Generate modular chunk archives and a snapshot manifest from a source datadir.
+#[derive(Debug, Parser)]
+pub struct SnapshotManifestCommand {
+    /// Source datadir containing static files and databases.
+    #[arg(long, short = 'd')]
+    source_datadir: PathBuf,
+
+    /// Output directory where new chunk archives and manifest.json are written.
+    #[arg(long, short = 'o')]
+    output_dir: PathBuf,
+
+    /// Optional base URL where archives will be hosted.
+    #[arg(long)]
+    base_url: Option<String>,
+
+    /// Block number this snapshot was taken at.
+    ///
+    /// If omitted, this is inferred from the source datadir's Finish stage checkpoint.
+    #[arg(long)]
+    block: Option<u64>,
+
+    /// Chain ID.
+    #[arg(long, default_value = "1")]
+    chain_id: u64,
+
+    /// Blocks per archive file for chunked components.
+    ///
+    /// If omitted, this is inferred from header static-file ranges in the source datadir.
+    #[arg(long)]
+    blocks_per_file: Option<u64>,
+
+    /// Previous manifest whose uncompressed file hashes may be reused.
+    #[arg(long, requires = "existing_archives")]
+    previous_manifest: Option<PathBuf>,
+
+    /// JSON object mapping existing archive filenames to their compressed sizes.
+    #[arg(long, requires = "previous_manifest")]
+    existing_archives: Option<PathBuf>,
+
+    /// Include the proofs database in the snapshot.
+    #[arg(long)]
+    proofs: bool,
+}
+
+impl SnapshotManifestCommand {
+    /// Packages snapshot archives and writes the manifest file.
+    pub fn execute(self) -> Result<()> {
+        let block = match self.block {
+            Some(block) => block,
+            None => infer_snapshot_block(&self.source_datadir)?,
+        };
+        let blocks_per_file = match self.blocks_per_file {
+            Some(blocks_per_file) => blocks_per_file,
+            None => infer_blocks_per_file(&self.source_datadir)?,
+        };
+        let remote_static_files = read_existing_archives(self.existing_archives.as_ref())?;
+        let previous_manifest = read_previous_manifest(self.previous_manifest.as_ref())?;
+        info!(
+            source = %self.source_datadir.display(),
+            output = %self.output_dir.display(),
+            block,
+            "packaging modular snapshot archives"
+        );
+        SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+            source_datadir: &self.source_datadir,
+            output_dir: &self.output_dir,
+            chain_id: self.chain_id,
+            base_url: self.base_url.as_deref(),
+            block: Some(block),
+            blocks_per_file: Some(blocks_per_file),
+            remote_static_files: &remote_static_files,
+            previous_manifest: previous_manifest.as_ref(),
+            upload_proofs: self.proofs,
+        })
+        .map_err(|error| eyre::eyre!("snapshot generation failed: {error:#}"))?;
+        Ok(())
+    }
+}
+
+fn read_existing_archives(path: Option<&PathBuf>) -> Result<HashMap<String, u64>> {
+    let Some(path) = path else { return Ok(HashMap::new()) };
+    let bytes = std::fs::read(path)
+        .wrap_err_with(|| format!("failed to read existing archives from {}", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .wrap_err_with(|| format!("failed to parse existing archives from {}", path.display()))
+}
+
+fn read_previous_manifest(path: Option<&PathBuf>) -> Result<Option<SnapshotManifest>> {
+    let Some(path) = path else { return Ok(None) };
+    let bytes = std::fs::read(path)
+        .wrap_err_with(|| format!("failed to read previous manifest from {}", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .wrap_err_with(|| format!("failed to parse previous manifest from {}", path.display()))
+        .map(Some)
+}
+
+fn infer_snapshot_block(source_datadir: &std::path::Path) -> Result<u64> {
+    if let Ok(block) = infer_snapshot_block_from_db(source_datadir) {
+        return Ok(block);
+    }
+
+    warn!("could not read Finish stage checkpoint; using static-file tip");
+    infer_snapshot_block_from_headers(source_datadir)
+}
+
+fn infer_snapshot_block_from_db(source_datadir: &std::path::Path) -> Result<u64> {
+    for db_path in [source_datadir.join("db"), source_datadir.to_path_buf()] {
+        if !db_path.exists() {
+            continue;
+        }
+        let Ok(db) = open_db_read_only(&db_path, DatabaseArguments::default()) else { continue };
+        let tx = db.tx()?;
+        if let Some(checkpoint) = tx.get::<tables::StageCheckpoints>(StageId::Finish.to_string())? {
+            return Ok(checkpoint.block_number);
+        }
+    }
+    eyre::bail!("could not infer block from the Finish stage checkpoint")
+}
+
+fn infer_snapshot_block_from_headers(source_datadir: &std::path::Path) -> Result<u64> {
+    header_ranges(source_datadir)?
+        .into_iter()
+        .map(|(_, end)| end)
+        .max()
+        .context("no header static files found to infer block")
+}
+
+fn infer_blocks_per_file(source_datadir: &std::path::Path) -> Result<u64> {
+    let mut inferred = None;
+    for (start, end) in header_ranges(source_datadir)? {
+        let span = end.saturating_sub(start).saturating_add(1);
+        if let Some(existing) = inferred {
+            if existing != span {
+                eyre::bail!("inconsistent header static-file ranges; pass --blocks-per-file")
+            }
+        } else {
+            inferred = Some(span);
+        }
+    }
+    inferred.context("could not infer --blocks-per-file; pass it manually")
+}
+
+fn header_ranges(source_datadir: &std::path::Path) -> Result<Vec<(u64, u64)>> {
+    let static_files_dir = source_datadir.join("static_files");
+    let static_files_dir =
+        if static_files_dir.exists() { static_files_dir } else { source_datadir.to_path_buf() };
+    let ranges = std::fs::read_dir(&static_files_dir)
+        .wrap_err_with(|| format!("failed to read {}", static_files_dir.display()))?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| parse_headers_range(&entry.file_name().to_string_lossy()))
+        .collect();
+    Ok(ranges)
+}
+
+fn parse_headers_range(file_name: &str) -> Option<(u64, u64)> {
+    let remainder = file_name.strip_prefix("static_file_headers_")?;
+    let (start, end_with_suffix) = remainder.split_once('_')?;
+    let end = end_with_suffix.chars().take_while(char::is_ascii_digit).collect::<String>();
+    Some((start.parse().ok()?, end.parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_header_ranges_with_suffixes() {
+        assert_eq!(parse_headers_range("static_file_headers_0_499999.off"), Some((0, 499_999)));
+        assert_eq!(parse_headers_range("static_file_transactions_0_499999"), None);
+    }
+}

--- a/crates/infra/snapshotter/Cargo.toml
+++ b/crates/infra/snapshotter/Cargo.toml
@@ -11,12 +11,8 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-tar = { workspace = true }
 url = { workspace = true }
-zstd = { workspace = true }
 anyhow = { workspace = true }
-blake3 = { workspace = true }
-rayon = { workspace = true }
 bollard = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
@@ -25,7 +21,7 @@ alloy-eips = { workspace = true }
 async-trait = { workspace = true }
 human_bytes = { workspace = true }
 serde_json = { workspace = true }
-reth-cli-commands = { workspace = true }
+base-reth-cli = { workspace = true }
 alloy-provider = { workspace = true, features = ["reqwest"] }
 tokio = { workspace = true, features = ["rt", "fs", "time"] }
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/infra/snapshotter/README.md
+++ b/crates/infra/snapshotter/README.md
@@ -8,9 +8,10 @@ Runs alongside a Base execution layer node (base-node-reth) and orchestrates per
 creation. `Snapshotter` coordinates the full lifecycle: fetching the EL's latest block and verifying
 it is at chain tip (within a configurable freshness window, default 10s), stopping the CL and EL
 containers via the Docker socket, generating a snapshot manifest and chunk archives for the
-captured block height using reth's `SnapshotManifestCommand`, uploading all artifacts to an
+captured block height using Base's shared snapshot generator, uploading all artifacts to an
 S3-compatible store (e.g. Cloudflare R2), then restarting the EL followed by the CL so it reconnects
-to the EL.
+to the EL. Existing static-file archives are reused only after their compressed size and the BLAKE3
+hashes of every uncompressed source file match the previous manifest.
 
 If the EL is not at tip when a run begins, the snapshot is skipped and both containers are left
 running untouched.

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -11,10 +11,7 @@ mod config;
 pub use config::{DEFAULT_TIP_THRESHOLD_SECS, S3ConfigType, SnapshotterConfig};
 
 mod progress;
-pub use progress::{
-    ActiveArchiveState, ArchiveProgress, ComponentProgressLogger, ComponentProgressReporter,
-    ComponentProgressState, ProgressDisplay, UploadProgress,
-};
+pub use progress::{ProgressDisplay, UploadProgress};
 
 mod container;
 pub use container::{ContainerManager, DockerContainerManager};
@@ -22,8 +19,7 @@ pub use container::{ContainerManager, DockerContainerManager};
 mod tip;
 pub use tip::{RpcTipChecker, TipChecker, TipStatus};
 
-mod snapshot;
-pub use snapshot::{
+pub use base_reth_cli::{
     ChunkFilename, ChunkedArchive, ComponentManifest, ManifestGenerationParams, OutputFileChecksum,
     SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
 };

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -7,6 +7,11 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+pub use base_reth_cli::{
+    ChunkFilename, ChunkedArchive, ComponentManifest, ManifestGenerationParams, OutputFileChecksum,
+    SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
+};
+
 mod config;
 pub use config::{DEFAULT_TIP_THRESHOLD_SECS, S3ConfigType, SnapshotterConfig};
 
@@ -18,11 +23,6 @@ pub use container::{ContainerManager, DockerContainerManager};
 
 mod tip;
 pub use tip::{RpcTipChecker, TipChecker, TipStatus};
-
-pub use base_reth_cli::{
-    ChunkFilename, ChunkedArchive, ComponentManifest, ManifestGenerationParams, OutputFileChecksum,
-    SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
-};
 
 mod upload;
 pub use upload::{SnapshotRun, SnapshotUploadParams, SnapshotUploader, UploadStrategy};

--- a/crates/infra/snapshotter/src/orchestrator.rs
+++ b/crates/infra/snapshotter/src/orchestrator.rs
@@ -7,15 +7,12 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
+use base_reth_cli::{ManifestGenerationParams, SnapshotGenerator, SnapshotManifest};
 use tracing::{error, info, warn};
 
 use crate::{
     SnapshotterConfig,
     container::ContainerManager,
-    snapshot::{
-        ManifestGenerationParams, OutputFileChecksum, SnapshotGenerator, SnapshotManifest,
-        SnapshotManifestExt,
-    },
     tip::TipChecker,
     upload::{SnapshotUploadParams, SnapshotUploader},
 };
@@ -177,27 +174,13 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
             "fetched previous manifest for blake3 diff"
         );
 
-        let previous_chunk_output_files: HashMap<String, Vec<OutputFileChecksum>> = remote_manifest
-            .as_ref()
-            .map(|manifest| {
-                remote_static_files
-                    .keys()
-                    .filter_map(|filename| {
-                        manifest
-                            .chunk_output_files_for_file(filename)
-                            .map(|output_files| (filename.clone(), output_files))
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
         let source_datadir = self.config.source_datadir.clone();
         let output_dir_for_gen = run_output_dir.clone();
         let chain_id = self.config.chain_id;
         let block = Some(self.config.block.unwrap_or(latest_block));
         let blocks_per_file = self.config.blocks_per_file;
         let remote_for_gen = remote_static_files.clone();
-        let previous_chunk_output_files_for_gen = previous_chunk_output_files;
+        let previous_manifest_for_gen = remote_manifest.clone();
         let upload_proofs = self.config.upload_proofs;
 
         let files = tokio::task::spawn_blocking(move || {
@@ -205,10 +188,11 @@ impl<C: ContainerManager, T: TipChecker> Snapshotter<C, T> {
                 source_datadir: &source_datadir,
                 output_dir: &output_dir_for_gen,
                 chain_id,
+                base_url: None,
                 block,
                 blocks_per_file,
                 remote_static_files: &remote_for_gen,
-                previous_chunk_output_files: &previous_chunk_output_files_for_gen,
+                previous_manifest: previous_manifest_for_gen.as_ref(),
                 upload_proofs,
             };
             SnapshotGenerator::generate_manifest(&params)

--- a/crates/infra/snapshotter/src/progress.rs
+++ b/crates/infra/snapshotter/src/progress.rs
@@ -1,4 +1,4 @@
-//! Shared progress-reporting helpers used across snapshot generation and upload.
+//! Progress-reporting helpers for snapshot uploads.
 
 use std::{
     collections::HashMap,
@@ -17,14 +17,13 @@ use human_bytes::human_bytes as format_bytes;
 use humantime::{FormattedDuration, format_duration};
 use tracing::{info, warn};
 
-/// Interval between periodic progress logs during long-running snapshot operations
-/// (archive compression and artifact upload).
+/// Interval between periodic progress logs during snapshot artifact uploads.
 pub(crate) const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(3);
 
 const UPLOAD_STALL_WARNING_AFTER: Duration = Duration::from_secs(5 * 60);
 const MAX_STALLED_UPLOADS_IN_LOG: usize = 5;
 
-/// Formats snapshot compression and upload progress for structured logs.
+/// Formats snapshot upload progress for structured logs.
 #[derive(Debug)]
 pub struct ProgressDisplay;
 
@@ -43,217 +42,6 @@ impl ProgressDisplay {
     pub fn duration(duration: Duration) -> FormattedDuration {
         format_duration(Duration::from_secs(duration.as_secs()))
     }
-}
-
-/// Cumulative compression progress shared across every file in a single archive,
-/// emitting a throttled log so large single-file archives report progress mid-stream.
-#[derive(Debug)]
-pub struct ArchiveProgress {
-    archive_name: String,
-    total_bytes: u64,
-    started: Instant,
-    last_log: Instant,
-    bytes_done: u64,
-}
-
-impl ArchiveProgress {
-    /// Creates a new tracker for an archive of `total_bytes` total uncompressed bytes.
-    pub fn new(archive_name: String, total_bytes: u64) -> Self {
-        let now = Instant::now();
-        Self { archive_name, total_bytes, started: now, last_log: now, bytes_done: 0 }
-    }
-
-    /// Adds `n` newly-compressed bytes, emitting a progress log once per interval.
-    pub fn record(&mut self, n: u64) {
-        self.bytes_done += n;
-        if self.last_log.elapsed() >= PROGRESS_LOG_INTERVAL {
-            info!(
-                archive = %self.archive_name,
-                bytes = %ProgressDisplay::human_byte_progress(self.bytes_done, self.total_bytes),
-                progress = %format!("{}%", ProgressDisplay::percent(self.bytes_done, self.total_bytes)),
-                elapsed = %ProgressDisplay::duration(self.started.elapsed()),
-                "compressing archive"
-            );
-            self.last_log = Instant::now();
-        }
-    }
-}
-
-/// Shared compression progress for a whole chunked snapshot component such as
-/// `transactions`, aggregating bytes across every archive compressed in parallel.
-#[derive(Clone, Debug)]
-pub struct ComponentProgressReporter {
-    state: Arc<ComponentProgressState>,
-}
-
-impl ComponentProgressReporter {
-    /// Registers an active archive within the component and returns a reporter
-    /// that streams byte progress into that archive's row.
-    pub(crate) fn start_archive(
-        &self,
-        archive_name: impl Into<String>,
-        total_bytes: u64,
-    ) -> ArchiveProgressReporter {
-        let archive_name = archive_name.into();
-        if let Ok(mut active_archives) = self.state.active_archives.lock() {
-            active_archives
-                .insert(archive_name.clone(), ActiveArchiveState { total_bytes, bytes_done: 0 });
-        }
-        ArchiveProgressReporter { component: self.clone(), archive_name }
-    }
-
-    /// Adds `n` compressed source bytes to the component-wide total.
-    pub fn record(&self, n: u64) {
-        self.state.bytes_done.fetch_add(n, Ordering::Relaxed);
-    }
-
-    /// Adds `n` source bytes to one active archive and the component total.
-    pub(crate) fn record_archive_bytes(&self, archive_name: &str, n: u64) {
-        self.record(n);
-        if let Ok(mut active_archives) = self.state.active_archives.lock()
-            && let Some(state) = active_archives.get_mut(archive_name)
-        {
-            state.bytes_done = state.bytes_done.saturating_add(n).min(state.total_bytes);
-        }
-    }
-
-    /// Marks one archive within the component as fully packaged.
-    pub(crate) fn archive_completed(&self, archive_name: &str) {
-        if let Ok(mut active_archives) = self.state.active_archives.lock()
-            && let Some(state) = active_archives.remove(archive_name)
-        {
-            let remaining = state.total_bytes.saturating_sub(state.bytes_done);
-            if remaining > 0 {
-                self.record(remaining);
-            }
-        }
-        self.state.archives_done.fetch_add(1, Ordering::Relaxed);
-    }
-
-    /// Removes a failed archive from the active set without counting it complete.
-    pub(crate) fn archive_failed(&self, archive_name: &str) {
-        if let Ok(mut active_archives) = self.state.active_archives.lock() {
-            active_archives.remove(archive_name);
-        }
-    }
-}
-
-/// Per-archive reporter backed by a shared component progress state.
-#[derive(Clone, Debug)]
-pub(crate) struct ArchiveProgressReporter {
-    component: ComponentProgressReporter,
-    archive_name: String,
-}
-
-impl ArchiveProgressReporter {
-    /// Adds `n` source bytes to this archive and the parent component total.
-    pub(crate) fn record(&self, n: u64) {
-        self.component.record_archive_bytes(&self.archive_name, n);
-    }
-
-    /// Marks this archive as fully packaged and removes it from the active set.
-    pub(crate) fn finish(&self) {
-        self.component.archive_completed(&self.archive_name);
-    }
-
-    /// Removes this archive from the active set after a failure.
-    pub(crate) fn fail(&self) {
-        self.component.archive_failed(&self.archive_name);
-    }
-}
-
-/// Owns a background logger that periodically reports one progress line for an
-/// entire chunked component while its archives are being compressed.
-pub struct ComponentProgressLogger {
-    stop_tx: Option<mpsc::Sender<()>>,
-    join_handle: Option<StdJoinHandle<()>>,
-    reporter: ComponentProgressReporter,
-}
-
-impl std::fmt::Debug for ComponentProgressLogger {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ComponentProgressLogger")
-            .field("reporter", &self.reporter)
-            .finish_non_exhaustive()
-    }
-}
-
-impl ComponentProgressLogger {
-    /// Starts a periodic logger for one chunked component.
-    pub fn new(component_name: String, total_bytes: u64, total_archives: usize) -> Self {
-        let state = Arc::new(ComponentProgressState {
-            component_name,
-            total_bytes,
-            total_archives,
-            started: Instant::now(),
-            bytes_done: AtomicU64::new(0),
-            archives_done: AtomicU64::new(0),
-            active_archives: Mutex::new(HashMap::new()),
-        });
-        let reporter = ComponentProgressReporter { state: Arc::clone(&state) };
-        let (stop_tx, stop_rx) = mpsc::channel();
-        let join_handle = std::thread::spawn(move || {
-            while stop_rx.recv_timeout(PROGRESS_LOG_INTERVAL).is_err() {
-                let bytes_done = state.bytes_done.load(Ordering::Relaxed);
-                let archives_done = state.archives_done.load(Ordering::Relaxed);
-                let active_archives = state.active_archives.lock().map_or(0, |active| active.len());
-                info!(
-                    component = %state.component_name,
-                    archives = %format!("{archives_done}/{}", state.total_archives),
-                    progress = %format!("{}%", ProgressDisplay::percent(bytes_done, state.total_bytes)),
-                    bytes = %ProgressDisplay::human_byte_progress(bytes_done, state.total_bytes),
-                    elapsed = %ProgressDisplay::duration(state.started.elapsed()),
-                    active_archives,
-                    "compressing component"
-                );
-            }
-        });
-        Self { stop_tx: Some(stop_tx), join_handle: Some(join_handle), reporter }
-    }
-
-    /// Returns a cloneable reporter that worker threads can update concurrently.
-    pub fn reporter(&self) -> ComponentProgressReporter {
-        self.reporter.clone()
-    }
-}
-
-impl Drop for ComponentProgressLogger {
-    fn drop(&mut self) {
-        if let Some(stop_tx) = self.stop_tx.take() {
-            let _ = stop_tx.send(());
-        }
-        if let Some(join_handle) = self.join_handle.take() {
-            let _ = join_handle.join();
-        }
-    }
-}
-
-/// Shared immutable metadata and atomics backing one component-wide compression logger.
-#[derive(Debug)]
-pub struct ComponentProgressState {
-    /// Snapshot component name such as `headers` or `receipts`.
-    pub component_name: String,
-    /// Total uncompressed source bytes scheduled for this component.
-    pub total_bytes: u64,
-    /// Number of archives that will be produced for this component.
-    pub total_archives: usize,
-    /// Monotonic timestamp when component compression started.
-    pub started: Instant,
-    /// Aggregate uncompressed source bytes processed across all archives.
-    pub bytes_done: AtomicU64,
-    /// Number of archives that have fully completed compression.
-    pub archives_done: AtomicU64,
-    /// Currently active archives used for completion accounting and progress logs.
-    pub active_archives: Mutex<HashMap<String, ActiveArchiveState>>,
-}
-
-/// Live progress state for one in-flight archive within a component.
-#[derive(Debug)]
-pub struct ActiveArchiveState {
-    /// Total uncompressed source bytes for this archive.
-    pub total_bytes: u64,
-    /// Uncompressed source bytes processed so far for this archive.
-    pub bytes_done: u64,
 }
 
 /// Cumulative upload progress shared across concurrent artifact uploads. A spawned

--- a/crates/infra/snapshotter/src/upload.rs
+++ b/crates/infra/snapshotter/src/upload.rs
@@ -23,14 +23,12 @@ use aws_sdk_s3::{
     primitives::ByteStream,
     types::{CompletedMultipartUpload, CompletedPart, Delete, ObjectIdentifier},
 };
+use base_reth_cli::{ChunkFilename, ComponentManifest, SnapshotManifest, SnapshotManifestExt};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
-use crate::{
-    progress::{UploadProgress, UploadStage},
-    snapshot::{ChunkFilename, ComponentManifest, SnapshotManifest, SnapshotManifestExt},
-};
+use crate::progress::{UploadProgress, UploadStage};
 
 /// Maximum number of concurrent file uploads.
 const MAX_CONCURRENT_UPLOADS: usize = 10;
@@ -330,11 +328,13 @@ impl SnapshotUploader {
                     let local_hashes = params.local_manifest.chunk_hashes_for_file(&file_name);
                     let remote_hashes =
                         params.remote_manifest.and_then(|m| m.chunk_hashes_for_file(&file_name));
+                    let remote_size_matches = params
+                        .remote_manifest
+                        .and_then(|manifest| manifest.chunk_size_for_file(&file_name))
+                        .zip(params.remote_static_files.get(&file_name).copied())
+                        .is_some_and(|(manifest_size, object_size)| manifest_size == object_size);
                     match (&local_hashes, &remote_hashes) {
-                        (Some(local), Some(remote))
-                            if local == remote
-                                && params.remote_static_files.contains_key(&file_name) =>
-                        {
+                        (Some(local), Some(remote)) if local == remote && remote_size_matches => {
                             debug!(file = %file_name, "skipping finalized static file (blake3 matches shared object)");
                             skipped += 1;
                             continue;
@@ -1135,7 +1135,7 @@ mod tests {
     fn build_published_manifest_sets_chunk_files_and_leaves_proofs_as_sibling() {
         use std::collections::BTreeMap;
 
-        use crate::snapshot::{ChunkedArchive, SingleArchive};
+        use base_reth_cli::{ChunkedArchive, SingleArchive};
 
         let mut components = BTreeMap::new();
         components.insert(

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -925,7 +925,6 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         }
     }
 
-    // Simulate all chunked components existing remotely for every finalized range.
     let chunk_components = [
         "headers",
         "transactions",
@@ -934,12 +933,31 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         "account_changesets",
         "storage_changesets",
     ];
+    let baseline = tempfile::tempdir()?;
+    SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+        source_datadir: source.path(),
+        output_dir: baseline.path(),
+        chain_id: 8453,
+        base_url: None,
+        block: Some(2_000_000),
+        blocks_per_file: Some(500_000),
+        remote_static_files: &HashMap::new(),
+        previous_manifest: None,
+        upload_proofs: false,
+    })?;
+    let previous_manifest = parse_local_manifest(baseline.path())?;
+
+    // Simulate the first three chunks of every component existing remotely.
     let mut remote: HashMap<String, u64> = HashMap::new();
     for component in chunk_components {
+        let ComponentManifest::Chunked(metadata) = &previous_manifest.components[component] else {
+            unreachable!("test components are chunked")
+        };
         for chunk_idx in 0..3u64 {
             let start = chunk_idx * 500_000;
             let end = start + 499_999;
-            remote.insert(format!("{component}-{start}-{end}.tar.zst"), 0);
+            let archive = format!("{component}-{start}-{end}.tar.zst");
+            remote.insert(archive, metadata.chunk_sizes[chunk_idx as usize]);
         }
     }
 
@@ -948,10 +966,11 @@ async fn selective_compression_skips_finalized_chunks() -> Result<()> {
         source_datadir: source.path(),
         output_dir: output.path(),
         chain_id: 8453,
+        base_url: None,
         block: Some(2_000_000),
         blocks_per_file: Some(500_000),
         remote_static_files: &remote,
-        previous_chunk_output_files: &HashMap::new(),
+        previous_manifest: Some(&previous_manifest),
         upload_proofs: false,
     })?;
 
@@ -1023,10 +1042,11 @@ async fn generate_and_upload_proofs_to_minio() -> Result<()> {
         source_datadir: source.path(),
         output_dir: output.path(),
         chain_id: 8453,
+        base_url: None,
         block: Some(0),
         blocks_per_file: Some(500_000),
         remote_static_files: &empty_remote,
-        previous_chunk_output_files: &HashMap::new(),
+        previous_manifest: None,
         upload_proofs: true,
     })?;
 

--- a/crates/infra/snapshotter/tests/e2e_test.rs
+++ b/crates/infra/snapshotter/tests/e2e_test.rs
@@ -599,12 +599,13 @@ async fn diff_upload_skips_chunks_when_blake3_matches() -> Result<()> {
         .send()
         .await?;
 
+    let old_bytes = vec![b'o'; 100];
     for &component in DIFF_TEST_COMPONENTS {
         let key = format!("diff-match/static_files/{component}-0-499999.tar.zst");
         s3.put_object()
             .bucket(bucket)
             .key(&key)
-            .body(aws_sdk_s3::primitives::ByteStream::from(b"old-bytes".to_vec()))
+            .body(aws_sdk_s3::primitives::ByteStream::from(old_bytes.clone()))
             .send()
             .await?;
     }
@@ -639,7 +640,7 @@ async fn diff_upload_skips_chunks_when_blake3_matches() -> Result<()> {
         let finalized_body = get_object_bytes(s3, bucket, &finalized_key).await?;
         assert_eq!(
             finalized_body.as_slice(),
-            b"old-bytes",
+            old_bytes.as_slice(),
             "{component} finalized chunk should be skipped when blake3 matches"
         );
 

--- a/crates/utilities/reth-cli/Cargo.toml
+++ b/crates/utilities/reth-cli/Cargo.toml
@@ -12,6 +12,16 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
+tar.workspace = true
+zstd.workspace = true
+anyhow.workspace = true
+blake3.workspace = true
+rayon.workspace = true
+tracing.workspace = true
+serde_json.workspace = true
 reth-node-core.workspace = true
 reth-prune-types.workspace = true
 reth-cli-commands.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/utilities/reth-cli/README.md
+++ b/crates/utilities/reth-cli/README.md
@@ -5,6 +5,9 @@ Reth-specific CLI utilities for Base execution layer binaries.
 ## Overview
 
 - **`init_reth!`**: Initializes Reth's global version metadata for P2P identification and logging.
+- **Snapshot manifests**: Provides the Base-owned archive generator shared by the execution node's
+  `snapshot-manifest` command and the snapshotter sidecar. Existing archives can be reused without
+  recompression after verifying their uncompressed BLAKE3 hashes.
 
 ## Usage
 

--- a/crates/utilities/reth-cli/src/lib.rs
+++ b/crates/utilities/reth-cli/src/lib.rs
@@ -12,3 +12,9 @@ pub use version::Version;
 
 mod snapshots;
 pub use snapshots::Snapshots;
+
+mod snapshot_manifest;
+pub use snapshot_manifest::{
+    ChunkFilename, ChunkedArchive, ComponentManifest, ManifestGenerationParams, OutputFileChecksum,
+    SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
+};

--- a/crates/utilities/reth-cli/src/snapshot_manifest.rs
+++ b/crates/utilities/reth-cli/src/snapshot_manifest.rs
@@ -1,15 +1,13 @@
-//! Snapshot archive generation with selective compression.
+//! Snapshot manifest command and archive generation with selective compression.
 //!
 //! Archive creation, BLAKE3 hashing, and manifest structure are derived from
 //! [reth](https://github.com/paradigmxyz/reth) (`crates/cli/commands/src/download/manifest.rs`,
 //! commit `d58c6e3`, tag `v2.1.0`), licensed under Apache-2.0.
 //!
-//! Modified to support skipping compression of finalized static file chunks
-//! that already exist in remote storage. Only the tip chunk and a configurable
-//! buffer of recent chunks are compressed.
+//! Modified to reuse archives whose uncompressed source files match a previous manifest.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     io::Read,
     path::{Path, PathBuf},
 };
@@ -20,10 +18,6 @@ pub use reth_cli_commands::download::manifest::{
     ChunkedArchive, ComponentManifest, OutputFileChecksum, SingleArchive, SnapshotManifest,
 };
 use tracing::info;
-
-use crate::progress::{
-    ArchiveProgressReporter, ComponentProgressLogger, ComponentProgressReporter,
-};
 
 /// Default blocks per static file segment.
 const DEFAULT_BLOCKS_PER_FILE: u64 = 500_000;
@@ -61,6 +55,9 @@ pub trait SnapshotManifestExt {
     /// Returns the full per-file metadata for a static-file chunk archive.
     fn chunk_output_files_for_file(&self, filename: &str) -> Option<Vec<OutputFileChecksum>>;
 
+    /// Returns the compressed size recorded for a static-file chunk archive.
+    fn chunk_size_for_file(&self, filename: &str) -> Option<u64>;
+
     /// Returns whether `filename` is the latest chunk for its component.
     fn is_latest_chunk_file(&self, filename: &str) -> bool;
 }
@@ -94,6 +91,15 @@ impl SnapshotManifestExt for SnapshotManifest {
         Some(entries.clone())
     }
 
+    fn chunk_size_for_file(&self, filename: &str) -> Option<u64> {
+        let (component, start, _end) = ChunkFilename::parse(filename)?;
+        let ComponentManifest::Chunked(meta) = self.components.get(&component)? else {
+            return None;
+        };
+        let chunk_index = usize::try_from(start / meta.blocks_per_file).ok()?;
+        meta.chunk_sizes.get(chunk_index).copied()
+    }
+
     fn is_latest_chunk_file(&self, filename: &str) -> bool {
         let Some((component, start, end)) = ChunkFilename::parse(filename) else {
             return false;
@@ -118,22 +124,25 @@ pub struct ManifestGenerationParams<'a> {
     pub output_dir: &'a Path,
     /// Chain ID recorded in the manifest.
     pub chain_id: u64,
+    /// Optional base URL recorded in the manifest.
+    pub base_url: Option<&'a str>,
     /// Snapshot block height. Inferred from header static files when `None`.
     pub block: Option<u64>,
     /// Blocks per static-file chunk archive. Defaults to `500_000` when `None`.
     pub blocks_per_file: Option<u64>,
-    /// Remote static-file chunk filenames and sizes used for skip-range computation.
+    /// Remote static-file chunk filenames and sizes used to verify reusable archives.
     pub remote_static_files: &'a HashMap<String, u64>,
-    /// Prior per-file chunk metadata reused for skipped archives.
-    pub previous_chunk_output_files: &'a HashMap<String, Vec<OutputFileChecksum>>,
+    /// Previously published manifest used to verify reusable archives.
+    pub previous_manifest: Option<&'a SnapshotManifest>,
     /// Whether to package `{source_datadir}/proofs` into `proofs.tar.zst`.
     pub upload_proofs: bool,
 }
 
 /// Generates snapshot archives with selective compression.
 ///
-/// Static file chunks whose block ranges are in `skip_ranges` are not
-/// compressed or written to the output directory.
+/// Static-file chunks are not compressed or written locally when their current
+/// uncompressed file metadata matches a previous manifest and the corresponding
+/// remote archive has the expected compressed size.
 #[derive(Debug)]
 pub struct SnapshotGenerator;
 
@@ -155,17 +164,12 @@ impl SnapshotGenerator {
             None => infer_block_from_headers(params.source_datadir)?,
         };
 
-        let remote_filenames: HashSet<&str> =
-            params.remote_static_files.keys().map(String::as_str).collect();
-        let skip_ranges = Self::compute_skip_ranges(&remote_filenames, block, blocks_per_file)?;
-
         info!(
             source = %params.source_datadir.display(),
             output = %params.output_dir.display(),
             chain_id = params.chain_id,
             block,
             blocks_per_file,
-            skip_count = skip_ranges.len(),
             "generating snapshot archives"
         );
 
@@ -189,7 +193,7 @@ impl SnapshotGenerator {
 
         for &(key, segment_name) in CHUNKED_COMPONENTS {
             let mut planned = Vec::new();
-            let mut planned_hash_only = Vec::new();
+            let mut reuse_candidates = Vec::new();
             let mut found_any = false;
             let mut chunk_sizes = vec![0u64; num_chunks as usize];
             let mut chunk_decompressed = vec![0u64; num_chunks as usize];
@@ -209,35 +213,32 @@ impl SnapshotGenerator {
                 }
                 found_any = true;
 
-                if skip_ranges.contains(&(start, end)) {
-                    let archive_name = ChunkFilename::format(key, start, end);
-                    chunk_sizes[i as usize] =
-                        params.remote_static_files.get(&archive_name).copied().ok_or_else(
-                            || {
-                                anyhow::anyhow!(
-                                    "missing remote size for skipped archive {archive_name}"
-                                )
-                            },
-                        )?;
-
-                    if let Some(output_files) =
-                        params.previous_chunk_output_files.get(&archive_name)
+                let archive_name = ChunkFilename::format(key, start, end);
+                if let (Some(&remote_size), Some(previous_manifest)) =
+                    (params.remote_static_files.get(&archive_name), params.previous_manifest)
+                {
+                    let previous_size = previous_manifest.chunk_size_for_file(&archive_name);
+                    if previous_size == Some(remote_size)
+                        && let Some(previous_output_files) =
+                            previous_manifest.chunk_output_files_for_file(&archive_name)
                     {
-                        chunk_decompressed[i as usize] = output_files.iter().map(|f| f.size).sum();
-                        chunk_output_files[i as usize] = output_files.clone();
-                    } else {
-                        planned_hash_only.push(PlannedChunk {
-                            chunk_idx: i,
-                            archive_path: params.output_dir.join(&archive_name),
-                            source_files,
+                        reuse_candidates.push(ReuseCandidate {
+                            chunk: PlannedChunk {
+                                chunk_idx: i,
+                                archive_path: params.output_dir.join(&archive_name),
+                                source_files,
+                            },
+                            archive_name,
+                            remote_size,
+                            previous_output_files,
                         });
+                        continue;
                     }
-                    continue;
                 }
 
                 planned.push(PlannedChunk {
                     chunk_idx: i,
-                    archive_path: params.output_dir.join(ChunkFilename::format(key, start, end)),
+                    archive_path: params.output_dir.join(archive_name),
                     source_files,
                 });
             }
@@ -245,44 +246,34 @@ impl SnapshotGenerator {
             if !found_any {
                 info!(component = key, "no static files found, skipping component");
             } else {
-                let hashed_only: Vec<PackagedChunk> = planned_hash_only
+                let checked_candidates = reuse_candidates
                     .into_par_iter()
-                    .map(|p| {
-                        let output_files = chunk_output_files_for_source_files(&p.source_files)?;
-                        Ok(PackagedChunk { chunk_idx: p.chunk_idx, size: 0, output_files })
+                    .map(|candidate| {
+                        let output_files =
+                            chunk_output_files_for_source_files(&candidate.chunk.source_files)?;
+                        Ok((candidate, output_files))
                     })
                     .collect::<Result<Vec<_>>>()?;
-
-                for p in hashed_only {
-                    let idx = p.chunk_idx as usize;
-                    chunk_decompressed[idx] = p.output_files.iter().map(|f| f.size).sum();
-                    chunk_output_files[idx] = p.output_files;
+                for (candidate, output_files) in checked_candidates {
+                    if output_files == candidate.previous_output_files {
+                        let idx = candidate.chunk.chunk_idx as usize;
+                        chunk_sizes[idx] = candidate.remote_size;
+                        chunk_decompressed[idx] = output_files.iter().map(|file| file.size).sum();
+                        chunk_output_files[idx] = output_files;
+                        info!(archive = %candidate.archive_name, "reusing existing snapshot archive");
+                    } else {
+                        planned.push(candidate.chunk);
+                    }
                 }
 
-                let progress_logger = if planned.is_empty() {
-                    None
-                } else {
-                    Some(ComponentProgressLogger::new(
-                        key.to_string(),
-                        planned_chunks_total_bytes(&planned)?,
-                        planned.len(),
-                    ))
-                };
-                let progress_reporter =
-                    progress_logger.as_ref().map(ComponentProgressLogger::reporter);
                 let packaged: Vec<PackagedChunk> = planned
                     .into_par_iter()
                     .map(|p| {
-                        let output_files = write_chunk_archive(
-                            &p.archive_path,
-                            &p.source_files,
-                            progress_reporter.clone(),
-                        )?;
+                        let output_files = write_chunk_archive(&p.archive_path, &p.source_files)?;
                         let size = std::fs::metadata(&p.archive_path)?.len();
                         Ok(PackagedChunk { chunk_idx: p.chunk_idx, size, output_files })
                     })
                     .collect::<Result<Vec<_>>>()?;
-                drop(progress_logger);
 
                 for p in packaged {
                     let idx = p.chunk_idx as usize;
@@ -400,8 +391,10 @@ impl SnapshotGenerator {
             chain_id: params.chain_id,
             storage_version: 2,
             timestamp,
-            base_url: None,
-            reth_version: None,
+            base_url: params.base_url.map(str::to_owned),
+            reth_version: Some(
+                reth_node_core::version::version_metadata().short_version.to_string(),
+            ),
             components,
         };
 
@@ -427,39 +420,6 @@ impl SnapshotGenerator {
         }
         files.sort_unstable();
         Ok(files)
-    }
-
-    /// Determines which finalized chunk ranges can be skipped based on what already
-    /// exists remotely. Keeps only the latest chunk in the timestamped run directory.
-    pub fn compute_skip_ranges(
-        remote_filenames: &HashSet<&str>,
-        block: u64,
-        blocks_per_file: u64,
-    ) -> Result<HashSet<(u64, u64)>> {
-        let num_chunks = block.div_ceil(blocks_per_file);
-        let latest_chunk = num_chunks.saturating_sub(1);
-
-        let mut skip = HashSet::new();
-        for i in 0..num_chunks {
-            if i >= latest_chunk {
-                continue;
-            }
-            let start = i * blocks_per_file;
-            let end = start
-                .checked_add(blocks_per_file - 1)
-                .context("block range overflow in skip computation")?;
-
-            let dominated_by_remote = CHUNKED_COMPONENTS.iter().all(|&(key, _)| {
-                let filename = ChunkFilename::format(key, start, end);
-                remote_filenames.contains(filename.as_str())
-            });
-
-            if dominated_by_remote {
-                skip.insert((start, end));
-            }
-        }
-
-        Ok(skip)
     }
 }
 
@@ -533,6 +493,13 @@ struct PlannedChunk {
     chunk_idx: u64,
     archive_path: PathBuf,
     source_files: Vec<PathBuf>,
+}
+
+struct ReuseCandidate {
+    chunk: PlannedChunk,
+    archive_name: String,
+    remote_size: u64,
+    previous_output_files: Vec<OutputFileChecksum>,
 }
 
 struct PackagedChunk {
@@ -668,29 +635,12 @@ fn package_single_component(
         bail!("cannot package empty archive: {archive_name}");
     }
     let archive_path = output_dir.join(archive_name);
-    let output_files = write_archive_from_planned_files(&archive_path, files, None)?;
+    let output_files = write_archive_from_planned_files(&archive_path, files)?;
     let size = std::fs::metadata(&archive_path)?.len();
     Ok((size, output_files))
 }
 
-fn write_chunk_archive(
-    path: &Path,
-    source_files: &[PathBuf],
-    progress: Option<ComponentProgressReporter>,
-) -> Result<Vec<OutputFileChecksum>> {
-    let archive_progress = match progress.as_ref() {
-        Some(progress) => Some(
-            progress.start_archive(
-                path.file_name()
-                    .ok_or_else(|| anyhow::anyhow!("invalid archive path: {}", path.display()))?
-                    .to_string_lossy()
-                    .to_string(),
-                source_files_total_bytes(source_files)?,
-            ),
-        ),
-        None => None,
-    };
-
+fn write_chunk_archive(path: &Path, source_files: &[PathBuf]) -> Result<Vec<OutputFileChecksum>> {
     let planned: Vec<PlannedFile> = source_files
         .iter()
         .map(|p| {
@@ -703,21 +653,7 @@ fn write_chunk_archive(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    let result = write_archive_from_planned_files(path, &planned, archive_progress.clone());
-    match result {
-        Ok(output_files) => {
-            if let Some(archive_progress) = archive_progress.as_ref() {
-                archive_progress.finish();
-            }
-            Ok(output_files)
-        }
-        Err(error) => {
-            if let Some(archive_progress) = archive_progress.as_ref() {
-                archive_progress.fail();
-            }
-            Err(error)
-        }
-    }
+    write_archive_from_planned_files(path, &planned)
 }
 
 fn chunk_output_files_for_source_files(
@@ -741,15 +677,13 @@ fn chunk_output_files_for_source_files(
 fn write_archive_from_planned_files(
     path: &Path,
     files: &[PlannedFile],
-    progress: Option<ArchiveProgressReporter>,
 ) -> Result<Vec<OutputFileChecksum>> {
     let file = std::fs::File::create(path)?;
     let mut encoder = zstd::Encoder::new(file, 0)?;
     encoder.include_checksum(true)?;
     let mut builder = tar::Builder::new(encoder);
 
-    let output_files =
-        compute_output_files_and_archive(files, Some((&mut builder, path)), progress)?;
+    let output_files = compute_output_files_and_archive(files, Some((&mut builder, path)))?;
 
     let encoder = builder.into_inner()?;
     encoder.finish()?;
@@ -760,20 +694,19 @@ fn write_archive_from_planned_files(
 fn compute_output_files_for_planned_files(
     files: &[PlannedFile],
 ) -> Result<Vec<OutputFileChecksum>> {
-    compute_output_files_and_archive(files, None, None)
+    compute_output_files_and_archive(files, None)
 }
 
 fn compute_output_files_and_archive(
     files: &[PlannedFile],
     mut archive: Option<(&mut tar::Builder<zstd::Encoder<'_, std::fs::File>>, &Path)>,
-    progress: Option<ArchiveProgressReporter>,
 ) -> Result<Vec<OutputFileChecksum>> {
     let mut output_files = Vec::with_capacity(files.len());
     for planned in files {
         let expected_size = std::fs::metadata(&planned.source_path)?.len();
 
         let source_file = std::fs::File::open(&planned.source_path)?;
-        let mut reader = HashingReader::new(source_file, progress.clone());
+        let mut reader = HashingReader::new(source_file);
 
         if let Some((builder, archive_path)) = archive.as_mut() {
             let mut header = tar::Header::new_gnu();
@@ -815,12 +748,11 @@ struct HashingReader<R> {
     inner: R,
     hasher: blake3::Hasher,
     bytes_read: u64,
-    progress: Option<ArchiveProgressReporter>,
 }
 
 impl<R: Read> HashingReader<R> {
-    fn new(inner: R, progress: Option<ArchiveProgressReporter>) -> Self {
-        Self { inner, hasher: blake3::Hasher::new(), bytes_read: 0, progress }
+    fn new(inner: R) -> Self {
+        Self { inner, hasher: blake3::Hasher::new(), bytes_read: 0 }
     }
 
     fn finalize(self) -> String {
@@ -834,25 +766,9 @@ impl<R: Read> Read for HashingReader<R> {
         if n > 0 {
             self.bytes_read += n as u64;
             self.hasher.update(&buf[..n]);
-            if let Some(progress) = self.progress.as_ref() {
-                progress.record(n as u64);
-            }
         }
         Ok(n)
     }
-}
-
-fn planned_chunks_total_bytes(chunks: &[PlannedChunk]) -> Result<u64> {
-    chunks.iter().try_fold(0u64, |acc, chunk| {
-        let chunk_bytes = source_files_total_bytes(&chunk.source_files)?;
-        Ok(acc + chunk_bytes)
-    })
-}
-
-fn source_files_total_bytes(source_files: &[PathBuf]) -> Result<u64> {
-    source_files.iter().try_fold(0u64, |chunk_acc, path| {
-        std::fs::metadata(path).map(|m| chunk_acc + m.len()).map_err(Into::into)
-    })
 }
 
 #[cfg(test)]
@@ -863,7 +779,7 @@ mod tests {
         source_datadir: &'a Path,
         output_dir: &'a Path,
         remote_static_files: &'a HashMap<String, u64>,
-        previous_chunk_output_files: &'a HashMap<String, Vec<OutputFileChecksum>>,
+        previous_manifest: Option<&'a SnapshotManifest>,
         block: Option<u64>,
         upload_proofs: bool,
     ) -> ManifestGenerationParams<'a> {
@@ -871,11 +787,37 @@ mod tests {
             source_datadir,
             output_dir,
             chain_id: 8453,
+            base_url: None,
             block,
             blocks_per_file: Some(500_000),
             remote_static_files,
-            previous_chunk_output_files,
+            previous_manifest,
             upload_proofs,
+        }
+    }
+
+    fn previous_headers_manifest(
+        output_files: Vec<OutputFileChecksum>,
+        size: u64,
+    ) -> SnapshotManifest {
+        SnapshotManifest {
+            block: 2_000_000,
+            chain_id: 8453,
+            storage_version: 2,
+            timestamp: 0,
+            base_url: None,
+            reth_version: None,
+            components: BTreeMap::from([(
+                "headers".to_string(),
+                ComponentManifest::Chunked(ChunkedArchive {
+                    blocks_per_file: 500_000,
+                    total_blocks: 2_000_000,
+                    chunk_sizes: vec![size, 0, 0, 0],
+                    chunk_decompressed_sizes: vec![],
+                    chunk_output_files: vec![output_files, vec![], vec![], vec![]],
+                    chunk_files: vec![],
+                }),
+            )]),
         }
     }
 
@@ -920,63 +862,6 @@ mod tests {
         std::fs::create_dir_all(dir.path().join("static_files")).unwrap();
 
         assert!(infer_block_from_headers(dir.path()).is_err());
-    }
-
-    #[test]
-    fn compute_skip_ranges_skips_finalized_chunks() {
-        let mut remote = HashSet::new();
-        for &(key, _) in CHUNKED_COMPONENTS {
-            remote.insert(ChunkFilename::format(key, 0, 499_999));
-            remote.insert(ChunkFilename::format(key, 500_000, 999_999));
-            remote.insert(ChunkFilename::format(key, 1_000_000, 1_499_999));
-            remote.insert(ChunkFilename::format(key, 1_500_000, 1_999_999));
-        }
-
-        // block=2_000_000, blocks_per_file=500_000 → 4 chunks (indices 0-3).
-        // Only chunk 3 remains mutable; chunks 0, 1, and 2 are finalized.
-        let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
-        let skip = SnapshotGenerator::compute_skip_ranges(&refs, 2_000_000, 500_000).unwrap();
-
-        assert!(skip.contains(&(0, 499_999)), "chunk 0 should be skipped");
-        assert!(skip.contains(&(500_000, 999_999)), "chunk 1 should be skipped");
-        assert!(skip.contains(&(1_000_000, 1_499_999)), "chunk 2 should be skipped");
-        assert!(!skip.contains(&(1_500_000, 1_999_999)), "chunk 3 (tip) should not be skipped");
-    }
-
-    #[test]
-    fn compute_skip_ranges_keeps_only_latest_chunk_when_few_chunks() {
-        let mut remote = HashSet::new();
-        for &(key, _) in CHUNKED_COMPONENTS {
-            remote.insert(ChunkFilename::format(key, 0, 499_999));
-            remote.insert(ChunkFilename::format(key, 500_000, 999_999));
-        }
-
-        // block=1_000_000 → 2 chunks; only chunk 1 remains mutable.
-        let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
-        let skip = SnapshotGenerator::compute_skip_ranges(&refs, 1_000_000, 500_000).unwrap();
-        assert_eq!(skip, HashSet::from([(0, 499_999)]), "only the latest chunk should be kept");
-    }
-
-    #[test]
-    fn compute_skip_ranges_skips_nothing_when_remote_empty() {
-        let remote = HashSet::new();
-        let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
-        let skip = SnapshotGenerator::compute_skip_ranges(&refs, 5_000_000, 500_000).unwrap();
-        assert!(skip.is_empty(), "nothing to skip when remote is empty");
-    }
-
-    #[test]
-    fn compute_skip_ranges_requires_all_components_present() {
-        let mut remote = HashSet::new();
-        // Only add headers, not other components
-        remote.insert(ChunkFilename::format("headers", 0, 499_999));
-
-        let refs: HashSet<&str> = remote.iter().map(String::as_str).collect();
-        let skip = SnapshotGenerator::compute_skip_ranges(&refs, 5_000_000, 500_000).unwrap();
-        assert!(
-            !skip.contains(&(0, 499_999)),
-            "should not skip range if not all components are present remotely"
-        );
     }
 
     #[test]
@@ -1030,12 +915,11 @@ mod tests {
         std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
 
         let remote = HashMap::new();
-        let previous_chunk_output_files = HashMap::new();
         let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
             &remote,
-            &previous_chunk_output_files,
+            None,
             Some(0),
             false,
         ))
@@ -1070,12 +954,11 @@ mod tests {
         std::fs::write(proofs_dir.join("000801.log"), b"wal-data").unwrap();
 
         let remote = HashMap::new();
-        let previous_chunk_output_files = HashMap::new();
         let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
             &remote,
-            &previous_chunk_output_files,
+            None,
             Some(0),
             true,
         ))
@@ -1120,12 +1003,11 @@ mod tests {
         std::fs::write(db_dir.join("mdbx.dat"), b"state-data").unwrap();
 
         let remote = HashMap::new();
-        let previous_chunk_output_files = HashMap::new();
         let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
             &remote,
-            &previous_chunk_output_files,
+            None,
             Some(0),
             true,
         ))
@@ -1158,12 +1040,11 @@ mod tests {
         std::fs::write(proofs_dir.join("CURRENT"), b"MANIFEST-000014\n").unwrap();
 
         let remote = HashMap::new();
-        let previous_chunk_output_files = HashMap::new();
         let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
             &remote,
-            &previous_chunk_output_files,
+            None,
             Some(0),
             false,
         ))
@@ -1184,7 +1065,7 @@ mod tests {
     }
 
     #[test]
-    fn generate_manifest_skips_finalized_ranges_via_remote() {
+    fn generate_manifest_reuses_archive_when_source_hashes_match() {
         let source = tempfile::tempdir().unwrap();
         let output = tempfile::tempdir().unwrap();
 
@@ -1192,8 +1073,7 @@ mod tests {
         std::fs::create_dir_all(&db_dir).unwrap();
         std::fs::write(db_dir.join("mdbx.dat"), b"state").unwrap();
 
-        // 4 header chunks → block=2M, bpf=500k
-        // tip=chunk3, buffer=2 → keep 1,2,3 → skip chunk 0
+        // Four header chunks, with the first already present remotely.
         let sf = source.path().join("static_files");
         std::fs::create_dir_all(&sf).unwrap();
         for i in 0..4u64 {
@@ -1202,18 +1082,20 @@ mod tests {
             std::fs::write(sf.join(format!("static_file_headers_{start}_{end}")), b"data").unwrap();
         }
 
-        // Simulate all chunked components existing remotely for range 0-499999
-        let mut remote = HashMap::new();
-        for &(key, _) in CHUNKED_COMPONENTS {
-            remote.insert(ChunkFilename::format(key, 0, 499_999), 0u64);
-        }
-
-        let previous_chunk_output_files = HashMap::new();
+        let remote = HashMap::from([("headers-0-499999.tar.zst".to_string(), 123)]);
+        let previous_manifest = previous_headers_manifest(
+            vec![OutputFileChecksum {
+                path: "static_files/static_file_headers_0_499999".to_string(),
+                size: 4,
+                blake3: blake3::hash(b"data").to_hex().to_string(),
+            }],
+            123,
+        );
         let files = SnapshotGenerator::generate_manifest(&test_manifest_params(
             source.path(),
             output.path(),
             &remote,
-            &previous_chunk_output_files,
+            Some(&previous_manifest),
             Some(2_000_000),
             false,
         ))
@@ -1226,7 +1108,7 @@ mod tests {
 
         assert!(
             !filenames.contains(&"headers-0-499999.tar.zst".to_string()),
-            "finalized range 0 should be skipped (all components exist remotely)"
+            "matching remote archive should not be recreated"
         );
         assert!(
             filenames.contains(&"headers-500000-999999.tar.zst".to_string()),
@@ -1238,12 +1120,12 @@ mod tests {
         );
         assert!(
             filenames.contains(&"headers-1500000-1999999.tar.zst".to_string()),
-            "tip range should be compressed"
+            "range without a remote archive should be compressed"
         );
     }
 
     #[test]
-    fn manifest_includes_output_metadata_for_skipped_chunks() {
+    fn source_hash_mismatch_recreates_archive() {
         let source = tempfile::tempdir().unwrap();
         let output = tempfile::tempdir().unwrap();
 
@@ -1251,7 +1133,7 @@ mod tests {
         std::fs::create_dir_all(&db_dir).unwrap();
         std::fs::write(db_dir.join("mdbx.dat"), b"state").unwrap();
 
-        // 4 header chunks → skip chunk 0
+        // Four header chunks, with stale metadata for the first archive.
         let sf = source.path().join("static_files");
         std::fs::create_dir_all(&sf).unwrap();
         for i in 0..4u64 {
@@ -1260,31 +1142,36 @@ mod tests {
             std::fs::write(sf.join(format!("static_file_headers_{start}_{end}")), b"data").unwrap();
         }
 
-        let mut remote = HashMap::new();
-        for &(key, _) in CHUNKED_COMPONENTS {
-            remote.insert(ChunkFilename::format(key, 0, 499_999), 0u64);
-        }
+        let remote = HashMap::from([("headers-0-499999.tar.zst".to_string(), 123)]);
 
-        let previous_chunk_output_files = HashMap::from([(
-            "headers-0-499999.tar.zst".to_string(),
+        let previous_manifest = previous_headers_manifest(
             vec![OutputFileChecksum {
                 path: "static_files/static_file_headers_0_499999".to_string(),
-                size: 777,
-                blake3: "reused-from-previous-manifest".to_string(),
+                size: 4,
+                blake3: blake3::hash(b"different").to_hex().to_string(),
             }],
-        )]);
+            123,
+        );
 
-        SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
+        let files = SnapshotGenerator::generate_manifest(&ManifestGenerationParams {
             source_datadir: source.path(),
             output_dir: output.path(),
             chain_id: 8453,
+            base_url: None,
             block: Some(2_000_000),
             blocks_per_file: Some(500_000),
             remote_static_files: &remote,
-            previous_chunk_output_files: &previous_chunk_output_files,
+            previous_manifest: Some(&previous_manifest),
             upload_proofs: false,
         })
         .unwrap();
+
+        assert!(
+            files.iter().any(|path| path
+                .file_name()
+                .is_some_and(|name| name == "headers-0-499999.tar.zst")),
+            "hash mismatch must recreate the archive"
+        );
 
         let manifest_content =
             std::fs::read_to_string(output.path().join("manifest.json")).unwrap();
@@ -1298,11 +1185,12 @@ mod tests {
         assert_eq!(chunk_output_files.len(), 4, "should have 4 chunk entries");
         assert!(
             chunk_output_files[0].as_array().is_some_and(|files| !files.is_empty()),
-            "skipped chunk should still retain output-file metadata"
+            "generated chunk should include output-file metadata"
         );
         assert_eq!(
-            chunk_output_files[0][0]["blake3"], "reused-from-previous-manifest",
-            "skipped chunk should reuse previous manifest metadata when available"
+            chunk_output_files[0][0]["blake3"],
+            blake3::hash(b"data").to_hex().to_string(),
+            "manifest must describe the newly generated archive"
         );
         assert!(
             headers.get("chunk_skipped").is_none(),


### PR DESCRIPTION
## Summary

- move snapshot manifest generation into Base-owned shared reth CLI utilities
- verify uncompressed static-file BLAKE3 metadata and remote archive size before reusing an existing R2 archive
- compress and upload only changed static-file chunks while preserving optional proofs snapshots
- remove the snapshotter's duplicate generator and obsolete compression progress code

## Testing

- `cargo check -p base-reth-cli -p base-snapshotter -p base-execution-cli -p base`
- `cargo test -p base-reth-cli`
- `cargo test -p base-snapshotter --lib`
- `cargo test -p base-execution-cli snapshot_manifest --lib`
- `git diff --check`