### PR TITLE
Activate native block timing at Cobalt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4402,6 +4402,7 @@ dependencies = [
  "base-execution-chainspec",
  "base-execution-eip8130-rpc",
  "base-node-runner",
+ "base-protocol",
  "base-test-utils",
  "eyre",
  "serde_json",

--- a/actions/harness/tests/batcher/upgrade_transitions.rs
+++ b/actions/harness/tests/batcher/upgrade_transitions.rs
@@ -203,8 +203,8 @@ async fn mixed_singular_and_span_batches_after_delta() {
 
 /// A historical Span fixture may derive its pre-Denim prefix, but the cached
 /// tail must be discarded before the first Denim block. Resubmitting that tail
-/// through the production `SingleBatch` batcher must derive across Denim's 200ms
-/// block cadence.
+/// through the production `SingleBatch` batcher must derive across Cobalt's 200ms
+/// block cadence when both upgrades activate together.
 #[tokio::test]
 async fn span_batch_stops_at_denim_and_recovers_with_single_batches() {
     let batcher_cfg = BatcherConfig {
@@ -224,7 +224,7 @@ async fn span_batch_stops_at_denim_and_recovers_with_single_batches() {
         base: BaseUpgradeConfig {
             azul: Some(0),
             beryl: Some(0),
-            cobalt: Some(0),
+            cobalt: Some(6),
             denim: Some(6),
             ..Default::default()
         },

--- a/actions/harness/tests/batcher/upgrade_transitions.rs
+++ b/actions/harness/tests/batcher/upgrade_transitions.rs
@@ -198,15 +198,15 @@ async fn mixed_singular_and_span_batches_after_delta() {
 }
 
 // ---------------------------------------------------------------------------
-// C. Span batches stop at Denim and recover through production SingleBatch
+// C. Span batches stop at Cobalt and recover through production SingleBatch
 // ---------------------------------------------------------------------------
 
-/// A historical Span fixture may derive its pre-Denim prefix, but the cached
-/// tail must be discarded before the first Denim block. Resubmitting that tail
+/// A historical Span fixture may derive its pre-Cobalt prefix, but the cached
+/// tail must be discarded before the first Cobalt block. Resubmitting that tail
 /// through the production `SingleBatch` batcher must derive across Cobalt's 200ms
-/// block cadence when both upgrades activate together.
+/// block cadence.
 #[tokio::test]
-async fn span_batch_stops_at_denim_and_recovers_with_single_batches() {
+async fn span_batch_stops_at_cobalt_and_recovers_with_single_batches() {
     let batcher_cfg = BatcherConfig {
         encoder: EncoderConfig { da_type: DaType::Calldata, ..EncoderConfig::default() },
         ..BatcherConfig::default()
@@ -225,7 +225,6 @@ async fn span_batch_stops_at_denim_and_recovers_with_single_batches() {
             azul: Some(0),
             beryl: Some(0),
             cobalt: Some(6),
-            denim: Some(6),
             ..Default::default()
         },
         ..Default::default()
@@ -259,7 +258,7 @@ async fn span_batch_stops_at_denim_and_recovers_with_single_batches() {
     assert_eq!(
         node.l2_safe_number(),
         2,
-        "only blocks before Denim activation at block 3 may derive from the span"
+        "only blocks before Cobalt activation at block 3 may derive from the span"
     );
 
     let mut source = ActionL2Source::new();
@@ -270,8 +269,8 @@ async fn span_batch_stops_at_denim_and_recovers_with_single_batches() {
     chain.push(h.l1.tip().clone());
 
     let recovered = node.run_until_idle().await;
-    assert_eq!(recovered, 6, "the SingleBatch path must recover all post-Denim blocks");
-    assert_eq!(node.l2_safe_number(), 8, "safe head must advance across Denim");
+    assert_eq!(recovered, 6, "the SingleBatch path must recover all post-Cobalt blocks");
+    assert_eq!(node.l2_safe_number(), 8, "safe head must advance across Cobalt");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -277,7 +277,7 @@ pub struct Args {
     #[command(flatten)]
     pub flashblocks: FlashblocksArgs,
 
-    /// Runs both payload builders and selects the basic builder when Denim activates.
+    /// Runs both payload builders and selects the basic builder when Cobalt activates.
     #[arg(
         long = "builder.payload-builder-cutover",
         default_value = "false",

--- a/crates/builder/multiplex/README.md
+++ b/crates/builder/multiplex/README.md
@@ -1,12 +1,12 @@
 # `base-builder-multiplex`
 
 Runs Base flashblocks and Base basic payload builders in parallel behind a single routing
-`PayloadBuilderHandle`, cutting the selected builder over when Denim activates.
+`PayloadBuilderHandle`, cutting the selected builder over when Cobalt activates.
 
 ## Overview
 
 - with cutover mode enabled, fans out every `BuildNewPayload` request to both builders,
-- selects flashblocks before Denim and basic at and after Denim,
+- selects flashblocks before Cobalt and basic at and after Cobalt,
 - routes reads (`BestPayload`, `PayloadTimestamp`, `Resolve`, `Subscribe`) to the builder
   selected for each payload,
 - with basic-only mode enabled, starts only the basic payload builder for operation after the

--- a/crates/builder/multiplex/src/config.rs
+++ b/crates/builder/multiplex/src/config.rs
@@ -1,7 +1,7 @@
 /// Runtime routing configuration.
 #[derive(Debug, Clone, Default)]
 pub struct RoutingConfig {
-    /// Enables the Denim payload-builder cutover while running both builders.
+    /// Enables the Cobalt payload-builder cutover while running both builders.
     pub cutover_enabled: bool,
 }
 

--- a/crates/builder/multiplex/src/router.rs
+++ b/crates/builder/multiplex/src/router.rs
@@ -73,7 +73,7 @@ pub type ResolveFuture = std::pin::Pin<
     >,
 >;
 
-/// Router that cuts payload selection from flashblocks to basic when Denim activates.
+/// Router that cuts payload selection from flashblocks to basic when Cobalt activates.
 #[derive(Debug)]
 pub struct MultiplexRouter {
     /// Flashblocks payload-builder handle.
@@ -84,7 +84,7 @@ pub struct MultiplexRouter {
     pub flashblocks_health: HealthState,
     /// Basic health state.
     pub basic_health: HealthState,
-    /// Chain spec that owns the Denim activation condition.
+    /// Chain spec that owns the Cobalt activation condition.
     pub chain_spec: Arc<BaseChainSpec>,
     /// Whether recent payload IDs are routed to the basic builder, ordered oldest first.
     pub payload_routes: VecDeque<(PayloadId, bool)>,
@@ -109,9 +109,9 @@ impl MultiplexRouter {
         }
     }
 
-    /// Returns whether Denim selects the basic builder at `timestamp`.
+    /// Returns whether Cobalt selects the basic builder at `timestamp`.
     pub fn basic_selected_at(&self, timestamp: u64) -> bool {
-        self.chain_spec.is_denim_active_at_timestamp(timestamp)
+        self.chain_spec.is_cobalt_active_at_timestamp(timestamp)
     }
 
     /// Returns the recorded route for a payload, defaulting unknown payloads to flashblocks.
@@ -415,7 +415,7 @@ impl MultiplexRouter {
                     _ = events_tx.closed() => break,
                     result = flashblocks_events.recv(), if !flashblocks_closed => match result {
                         Ok(event) => {
-                            if !chain_spec.is_denim_active_at_timestamp(Self::event_timestamp(&event)) {
+                            if !chain_spec.is_cobalt_active_at_timestamp(Self::event_timestamp(&event)) {
                                 let _ = events_tx.send(event);
                             }
                         }
@@ -439,7 +439,7 @@ impl MultiplexRouter {
                     },
                     result = basic_events.recv(), if !basic_closed => match result {
                         Ok(event) => {
-                            if chain_spec.is_denim_active_at_timestamp(Self::event_timestamp(&event)) {
+                            if chain_spec.is_cobalt_active_at_timestamp(Self::event_timestamp(&event)) {
                                 let _ = events_tx.send(event);
                             }
                         }
@@ -539,7 +539,7 @@ mod tests {
 
     use super::*;
 
-    const DENIM_TIMESTAMP: u64 = 10;
+    const COBALT_TIMESTAMP: u64 = 10;
 
     fn test_router() -> (
         MultiplexRouter,
@@ -555,7 +555,7 @@ mod tests {
             HealthState::new(),
             Arc::new(
                 BaseChainSpecBuilder::base_mainnet()
-                    .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(DENIM_TIMESTAMP))
+                    .with_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(COBALT_TIMESTAMP))
                     .build(),
             ),
         );
@@ -581,8 +581,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_fans_to_both_and_selects_by_denim_activation() {
-        for (timestamp, selected_basic) in [(DENIM_TIMESTAMP - 1, false), (DENIM_TIMESTAMP, true)] {
+    async fn build_fans_to_both_and_selects_by_cobalt_activation() {
+        for (timestamp, selected_basic) in [(COBALT_TIMESTAMP - 1, false), (COBALT_TIMESTAMP, true)]
+        {
             let (mut router, mut flash_rx, mut basic_rx) = test_router();
             let (tx, rx) = tokio::sync::oneshot::channel();
 
@@ -698,19 +699,19 @@ mod tests {
         let mut sub = sub_rx.await.expect("outer subscribe receiver");
 
         flash_events_tx
-            .send(Events::Attributes(sample_input(DENIM_TIMESTAMP - 1).attributes))
-            .expect("send pre-Denim flash event");
+            .send(Events::Attributes(sample_input(COBALT_TIMESTAMP - 1).attributes))
+            .expect("send pre-Cobalt flash event");
         assert_eq!(
             MultiplexRouter::event_timestamp(&sub.recv().await.expect("receive flash event")),
-            DENIM_TIMESTAMP - 1
+            COBALT_TIMESTAMP - 1
         );
 
         basic_events_tx
-            .send(Events::Attributes(sample_input(DENIM_TIMESTAMP).attributes))
-            .expect("send post-Denim basic event");
+            .send(Events::Attributes(sample_input(COBALT_TIMESTAMP).attributes))
+            .expect("send post-Cobalt basic event");
         assert_eq!(
             MultiplexRouter::event_timestamp(&sub.recv().await.expect("receive basic event")),
-            DENIM_TIMESTAMP
+            COBALT_TIMESTAMP
         );
 
         drop(sub);
@@ -726,7 +727,7 @@ mod tests {
         let (router_tx, router_rx) = mpsc::unbounded_channel();
         let handle = PayloadBuilderHandle::new(router_tx);
         let router_task = tokio::spawn(router.run(router_rx));
-        let input = sample_input(DENIM_TIMESTAMP);
+        let input = sample_input(COBALT_TIMESTAMP);
         let payload_id = input.payload_id();
 
         let build_rx = handle.send_new_payload(input);
@@ -767,7 +768,8 @@ mod tests {
 
     #[tokio::test]
     async fn stalled_shadow_does_not_block_selected_builder() {
-        for (timestamp, selected_basic) in [(DENIM_TIMESTAMP - 1, false), (DENIM_TIMESTAMP, true)] {
+        for (timestamp, selected_basic) in [(COBALT_TIMESTAMP - 1, false), (COBALT_TIMESTAMP, true)]
+        {
             let (router, mut flash_rx, mut basic_rx) = test_router();
             let (router_tx, router_rx) = mpsc::unbounded_channel();
             let handle = PayloadBuilderHandle::new(router_tx);

--- a/crates/builder/multiplex/src/service_builder.rs
+++ b/crates/builder/multiplex/src/service_builder.rs
@@ -44,7 +44,7 @@ impl MultiplexingServiceBuilder {
         self
     }
 
-    /// Enables or disables the Denim payload-builder cutover.
+    /// Enables or disables the Cobalt payload-builder cutover.
     pub const fn with_cutover_enabled(mut self, cutover_enabled: bool) -> Self {
         self.routing_config.cutover_enabled = cutover_enabled;
         self

--- a/crates/common/evm/src/base_time.rs
+++ b/crates/common/evm/src/base_time.rs
@@ -93,7 +93,7 @@ impl BaseTime {
     /// [`Predeploys::PROXY_ADMIN`] in its EIP-1967 admin slot. This transition validates that
     /// historical invariant; it does not install or repair proxy state.
     ///
-    /// The transition is staged behind the `Denim` activation condition. The implementation slot
+    /// The transition is staged behind the `Cobalt` activation condition. The implementation slot
     /// is the durable migration marker: any existing linkage is preserved so later execution cannot
     /// rewrite the initial deployment or undo a governance upgrade.
     pub fn ensure_predeploy<DB>(
@@ -104,7 +104,7 @@ impl BaseTime {
     where
         DB: Database + DatabaseCommit,
     {
-        if !chain_spec.is_denim_active_at_timestamp(timestamp) {
+        if !chain_spec.is_cobalt_active_at_timestamp(timestamp) {
             return Ok(());
         }
 
@@ -416,7 +416,7 @@ mod tests {
 
     impl Upgrades for TestUpgrades {
         fn fork_condition(&self, fork: BaseUpgrade) -> ForkCondition {
-            if fork == BaseUpgrade::Denim && self.0 {
+            if fork == BaseUpgrade::Cobalt && self.0 {
                 ForkCondition::Timestamp(100)
             } else {
                 ForkCondition::Never

--- a/crates/common/evm/src/executor/block_executor.rs
+++ b/crates/common/evm/src/executor/block_executor.rs
@@ -183,8 +183,8 @@ where
         )
         .map_err(BlockExecutionError::other)?;
 
-        // Install BaseTime before transactions so the activation block's metadata deposit can
-        // call it.
+        // Install BaseTime before the Cobalt system-account transition and transactions so the
+        // activation block's metadata deposit can call it.
         BaseTime::ensure_predeploy(
             &self.spec,
             self.evm.block().timestamp().saturating_to(),

--- a/crates/common/evm2/src/base_time.rs
+++ b/crates/common/evm2/src/base_time.rs
@@ -1,4 +1,4 @@
-//! Denim `BaseTime` predeploy install transition.
+//! Cobalt `BaseTime` predeploy install transition.
 
 use alloy_primitives::{Address, B256, Bytes, U256, address, b256, hex, uint};
 use base_common_consensus::Predeploys;
@@ -45,7 +45,7 @@ impl core::fmt::Display for BaseTimeTransitionError {
 
 impl core::error::Error for BaseTimeTransitionError {}
 
-/// The Denim `BaseTime` predeploy transition.
+/// The Cobalt `BaseTime` predeploy transition.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct BaseTime;
 
@@ -79,7 +79,7 @@ impl BaseTime {
     /// [`Predeploys::PROXY_ADMIN`] in its EIP-1967 admin slot. This transition validates that
     /// historical invariant; it does not install or repair proxy state.
     ///
-    /// The transition is staged behind the `Denim` activation. The implementation slot is the
+    /// The transition is staged behind the `Cobalt` activation. The implementation slot is the
     /// durable migration marker: any existing linkage is preserved so later execution cannot
     /// rewrite the initial deployment or undo a governance upgrade.
     pub fn ensure_predeploy(
@@ -88,7 +88,7 @@ impl BaseTime {
         evm: &mut Evm<'_, BaseEvmTypes>,
         block_state: &mut BlockStateAccumulator,
     ) -> HandlerResult<()> {
-        if !chain_spec.is_active_at_timestamp(BaseUpgrade::Denim, timestamp) {
+        if !chain_spec.is_active_at_timestamp(BaseUpgrade::Cobalt, timestamp) {
             return Ok(());
         }
 

--- a/crates/common/evm2/src/executor.rs
+++ b/crates/common/evm2/src/executor.rs
@@ -137,7 +137,7 @@ pub struct BlockExecutionResult {
 /// the block's state delta.
 ///
 /// The flow is [`apply_pre_execution`](Self::apply_pre_execution) (block-boundary system calls),
-/// then [`apply_transition_hooks`](Self::apply_transition_hooks) (the Canyon/Denim/Cobalt
+/// then [`apply_transition_hooks`](Self::apply_transition_hooks) (the Canyon/Cobalt
 /// irregular state transitions), then [`execute_transaction`](Self::execute_transaction) per
 /// transaction (running it through the registry, building its receipt with running cumulative gas,
 /// and committing its state into a [`BlockStateAccumulator`]), then [`finish`](Self::finish). The
@@ -210,7 +210,7 @@ impl<'a> BaseBlockExecutor<'a> {
     }
 
     /// Applies the Base transition-block irregular state changes, in the reference order: the
-    /// Canyon create2-deployer force-deploy, the Denim `BaseTime` predeploy install, then the
+    /// Canyon create2-deployer force-deploy, the Cobalt `BaseTime` predeploy install, then the
     /// Cobalt EIP-8130 system-account stub. Each is fork-gated on `chain_spec` at this block's
     /// timestamp and commits its state into the block state. Must run after
     /// [`apply_pre_execution`](Self::apply_pre_execution) and before any transactions.

--- a/crates/common/evm2/src/transition.rs
+++ b/crates/common/evm2/src/transition.rs
@@ -1,6 +1,6 @@
 //! Irregular (non-transaction) state transitions for Base block boundaries.
 //!
-//! The Canyon, Denim, and Cobalt block-boundary hooks apply *irregular* state changes — direct
+//! The Canyon and Cobalt block-boundary hooks apply *irregular* state changes — direct
 //! edits to account code and storage that are not the result of executing a transaction. This
 //! module provides the two pieces they share: [`BaseForkActivations`], the revm-free fork-schedule
 //! input used to detect activation blocks, and [`IrregularStateChange`], which persists an edit

--- a/crates/common/evm2/tests/transition_hooks.rs
+++ b/crates/common/evm2/tests/transition_hooks.rs
@@ -1,6 +1,6 @@
 //! Transition-block hook tests for `base-common-evm2`.
 //!
-//! Validates the Canyon create2-deployer, Denim `BaseTime`, and Cobalt EIP-8130 system-account
+//! Validates the Canyon create2-deployer and Cobalt `BaseTime`/EIP-8130 system-account
 //! irregular state transitions applied by [`BaseBlockExecutor::apply_transition_hooks`]: their
 //! fork gating, the state they install, and their idempotency. Each hook's parity with the revm
 //! reference (`base-common-evm`'s `canyon`/`cobalt`/`base_time` modules) is in the shape of the
@@ -89,21 +89,26 @@ fn canyon_is_skipped_after_the_activation_block() {
 }
 
 #[test]
-fn cobalt_plants_stub_on_codeless_nonce_manager() {
-    let mut executor = executor(BaseUpgrade::Cobalt, 1000, InMemoryDB::default());
+fn cobalt_installs_base_time_and_plants_stub_on_codeless_nonce_manager() {
+    let mut executor = executor(BaseUpgrade::Cobalt, 1000, db_with_valid_proxy());
     executor.apply_transition_hooks(&schedule(BaseUpgrade::Cobalt, 1000)).expect("hooks apply");
     let (mut evm, _, _) = executor.finish();
 
     let stub_hash = Bytecode::new_legacy(Bytes::from_static(&[0xEF])).hash_slow();
     assert_eq!(code_hash(&mut evm, NONCE_MANAGER), stub_hash, "the 0xEF stub is planted");
     assert_ne!(stub_hash, KECCAK256_EMPTY);
+    assert_eq!(
+        code_hash(&mut evm, BaseTime::IMPLEMENTATION_ADDRESS),
+        BaseTime::IMPLEMENTATION_CODE_HASH,
+        "BaseTime is installed before transactions at the same Cobalt boundary",
+    );
 }
 
 #[test]
 fn cobalt_does_not_overwrite_existing_code() {
     let real = Bytecode::new_raw(Bytes::from_static(&[0x60, 0x00]));
     let real_hash = real.hash_slow();
-    let mut db = InMemoryDB::default();
+    let mut db = db_with_valid_proxy();
     db.insert_account_info(&NONCE_MANAGER, evm2::AccountInfo::new(U256::ZERO, 0, real_hash, real));
     let mut executor = executor(BaseUpgrade::Cobalt, 1000, db);
     executor.apply_transition_hooks(&schedule(BaseUpgrade::Cobalt, 1000)).expect("hooks apply");
@@ -140,9 +145,9 @@ fn db_with_valid_proxy() -> InMemoryDB {
 }
 
 #[test]
-fn base_time_installs_and_links_implementation_on_denim() {
-    let mut executor = executor(BaseUpgrade::Denim, 1000, db_with_valid_proxy());
-    executor.apply_transition_hooks(&schedule(BaseUpgrade::Denim, 1000)).expect("hooks apply");
+fn base_time_installs_and_links_implementation_on_cobalt() {
+    let mut executor = executor(BaseUpgrade::Cobalt, 1000, db_with_valid_proxy());
+    executor.apply_transition_hooks(&schedule(BaseUpgrade::Cobalt, 1000)).expect("hooks apply");
     let (mut evm, _, _) = executor.finish();
 
     // The implementation runtime is installed at its code-namespace address.
@@ -159,9 +164,9 @@ fn base_time_installs_and_links_implementation_on_denim() {
 
 #[test]
 fn base_time_errors_on_missing_proxy() {
-    let mut executor = executor(BaseUpgrade::Denim, 1000, InMemoryDB::default());
+    let mut executor = executor(BaseUpgrade::Cobalt, 1000, InMemoryDB::default());
     let err = executor
-        .apply_transition_hooks(&schedule(BaseUpgrade::Denim, 1000))
+        .apply_transition_hooks(&schedule(BaseUpgrade::Cobalt, 1000))
         .expect_err("missing proxy is rejected");
     assert!(format!("{err}").contains("reserved proxy account"), "got: {err}");
 }
@@ -175,9 +180,9 @@ fn base_time_errors_on_codeless_proxy() {
         &Predeploys::BASE_TIME,
         evm2::AccountInfo { balance: U256::from(1), ..Default::default() },
     );
-    let mut executor = executor(BaseUpgrade::Denim, 1000, db);
+    let mut executor = executor(BaseUpgrade::Cobalt, 1000, db);
     let err = executor
-        .apply_transition_hooks(&schedule(BaseUpgrade::Denim, 1000))
+        .apply_transition_hooks(&schedule(BaseUpgrade::Cobalt, 1000))
         .expect_err("codeless proxy is rejected");
     assert!(format!("{err}").contains("existing proxy code"), "got: {err}");
 }
@@ -188,9 +193,9 @@ fn base_time_errors_on_unexpected_proxy_admin() {
     // must reject it rather than link an implementation behind an unexpected admin.
     let mut db = db_with_valid_proxy();
     db.insert_account_storage(&Predeploys::BASE_TIME, &ADMIN_SLOT, &U256::from(0xdead_u64));
-    let mut executor = executor(BaseUpgrade::Denim, 1000, db);
+    let mut executor = executor(BaseUpgrade::Cobalt, 1000, db);
     let err = executor
-        .apply_transition_hooks(&schedule(BaseUpgrade::Denim, 1000))
+        .apply_transition_hooks(&schedule(BaseUpgrade::Cobalt, 1000))
         .expect_err("unexpected proxy admin is rejected");
     assert!(format!("{err}").contains("canonical proxy admin"), "got: {err}");
 }
@@ -205,8 +210,8 @@ fn base_time_is_idempotent_when_already_linked() {
         &IMPLEMENTATION_SLOT,
         &U256::from_be_slice(existing.as_slice()),
     );
-    let mut executor = executor(BaseUpgrade::Denim, 1000, db);
-    executor.apply_transition_hooks(&schedule(BaseUpgrade::Denim, 1000)).expect("hooks apply");
+    let mut executor = executor(BaseUpgrade::Cobalt, 1000, db);
+    executor.apply_transition_hooks(&schedule(BaseUpgrade::Cobalt, 1000)).expect("hooks apply");
     let (mut evm, _, _) = executor.finish();
 
     assert_eq!(

--- a/crates/common/evm2/tests/transition_parity.rs
+++ b/crates/common/evm2/tests/transition_parity.rs
@@ -1,7 +1,7 @@
 //! Differential parity harness for the transition-block hooks.
 //!
 //! Runs each Base transition hook (Canyon create2-deployer, Cobalt EIP-8130 system-account stub,
-//! Denim `BaseTime` predeploy) through the `base-common-evm2` executor and, on an equivalent
+//! Cobalt `BaseTime` predeploy) through the `base-common-evm2` executor and, on an equivalent
 //! database, through the revm-based `base-common-evm` reference function, asserting the two engines
 //! install byte-identical state (the affected account code hashes and, for `BaseTime`, the linked
 //! EIP-1967 implementation slot).
@@ -73,6 +73,20 @@ fn evm2_code_hash(evm: &mut Evm<'static, BaseEvmTypes>, addr: Address) -> B256 {
         .unwrap_or(alloy_primitives::KECCAK256_EMPTY)
 }
 
+fn evm2_db_with_valid_base_time_proxy() -> InMemoryDB {
+    let mut db = InMemoryDB::default();
+    let proxy_code = Bytes::from_static(&[0x60, 0x00]);
+    let proxy_bytecode = evm2::bytecode::Bytecode::new_raw(proxy_code);
+    let proxy = evm2::AccountInfo::new(U256::ZERO, 0, proxy_bytecode.hash_slow(), proxy_bytecode);
+    db.insert_account_info(&Predeploys::BASE_TIME, proxy);
+    db.insert_account_storage(
+        &Predeploys::BASE_TIME,
+        &ADMIN_SLOT,
+        &U256::from_be_slice(Predeploys::PROXY_ADMIN.as_slice()),
+    );
+    db
+}
+
 fn revm_code_hash(db: &mut RevmDb, addr: Address) -> B256 {
     db.basic(addr).unwrap().map(|a| a.code_hash).unwrap_or(alloy_primitives::KECCAK256_EMPTY)
 }
@@ -97,10 +111,10 @@ fn canyon_create2_deployer_matches_revm() {
 
 #[test]
 fn cobalt_system_account_stub_matches_revm() {
-    // evm2 (Canyon active-at-0 so it does not re-fire; only Cobalt does).
+    // evm2 (Canyon active-at-0 so it does not re-fire; both Cobalt hooks do).
     let mut schedule = evm2_schedule(BaseUpgrade::Cobalt);
     schedule.set_activation_timestamp(BaseUpgrade::Canyon, 0);
-    let mut executor = evm2_executor(BaseUpgrade::Cobalt, InMemoryDB::default());
+    let mut executor = evm2_executor(BaseUpgrade::Cobalt, evm2_db_with_valid_base_time_proxy());
     executor.apply_transition_hooks(&schedule).expect("hooks apply");
     let (mut evm, _, _) = executor.finish();
     let evm2_hash = evm2_code_hash(&mut evm, NONCE_MANAGER);
@@ -118,22 +132,8 @@ fn cobalt_system_account_stub_matches_revm() {
 #[test]
 fn base_time_predeploy_matches_revm() {
     // evm2 side: seed a valid proxy, then run the hooks.
-    let mut evm2_db = InMemoryDB::default();
-    let proxy_code = Bytes::from_static(&[0x60, 0x00]);
-    let proxy = evm2::AccountInfo::new(
-        U256::ZERO,
-        0,
-        evm2::bytecode::Bytecode::new_raw(proxy_code.clone()).hash_slow(),
-        evm2::bytecode::Bytecode::new_raw(proxy_code.clone()),
-    );
-    evm2_db.insert_account_info(&Predeploys::BASE_TIME, proxy);
-    evm2_db.insert_account_storage(
-        &Predeploys::BASE_TIME,
-        &ADMIN_SLOT,
-        &U256::from_be_slice(Predeploys::PROXY_ADMIN.as_slice()),
-    );
-    let mut executor = evm2_executor(BaseUpgrade::Denim, evm2_db);
-    executor.apply_transition_hooks(&evm2_schedule(BaseUpgrade::Denim)).expect("hooks apply");
+    let mut executor = evm2_executor(BaseUpgrade::Cobalt, evm2_db_with_valid_base_time_proxy());
+    executor.apply_transition_hooks(&evm2_schedule(BaseUpgrade::Cobalt)).expect("hooks apply");
     let (mut evm, _, _) = executor.finish();
     let evm2_impl_hash = evm2_code_hash(&mut evm, BaseTime::IMPLEMENTATION_ADDRESS);
     let evm2_slot = evm
@@ -143,6 +143,7 @@ fn base_time_predeploy_matches_revm() {
 
     // revm side: seed the equivalent proxy, then run the reference.
     let mut db = RevmDb::default();
+    let proxy_code = Bytes::from_static(&[0x60, 0x00]);
     let revm_proxy = RevmBytecode::new_raw(proxy_code);
     db.insert_account_info(
         Predeploys::BASE_TIME,
@@ -158,7 +159,7 @@ fn base_time_predeploy_matches_revm() {
         U256::from_be_slice(Predeploys::PROXY_ADMIN.as_slice()),
     )
     .unwrap();
-    RevmBaseTime::ensure_predeploy(revm_schedule(BaseUpgrade::Denim), ACTIVATION_TS, &mut db)
+    RevmBaseTime::ensure_predeploy(revm_schedule(BaseUpgrade::Cobalt), ACTIVATION_TS, &mut db)
         .expect("reference applies");
     let revm_impl_hash = revm_code_hash(&mut db, RevmBaseTime::IMPLEMENTATION_ADDRESS);
     let revm_slot = db.storage(Predeploys::BASE_TIME, IMPLEMENTATION_SLOT).unwrap();

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -366,7 +366,7 @@ impl RollupConfig {
     /// Returns the L2 block offset from genesis at which Cobalt activates.
     ///
     /// If Cobalt is not configured, returns [`None`].
-    pub fn cobalt_activation_block_offset(&self) -> Option<u64> {
+    pub fn cobalt_activation_block_number(&self) -> Option<u64> {
         let cobalt_timestamp = self.upgrade_activation_timestamp(BaseUpgrade::Cobalt)?;
 
         if self.block_time == 0 {
@@ -374,19 +374,6 @@ impl RollupConfig {
         }
 
         Some(cobalt_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time))
-    }
-
-    /// Returns the L2 block offset from genesis at which Denim activates.
-    ///
-    /// If Denim is not configured, returns [`None`].
-    pub fn denim_activation_block_number(&self) -> Option<u64> {
-        let denim_timestamp = self.upgrade_activation_timestamp(BaseUpgrade::Denim)?;
-
-        if self.block_time == 0 {
-            panic!("rollup config: block time cannot be 0");
-        }
-
-        Some(denim_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time))
     }
 
     /// Returns the L2 block number at which the genesis-only Zenith testing gate activates.
@@ -419,7 +406,7 @@ impl RollupConfig {
             .saturating_add(blocks_since_genesis.saturating_mul(self.block_time));
         let legacy_millis = legacy_seconds.saturating_mul(1_000);
 
-        let Some(cobalt_activation_block) = self.cobalt_activation_block_offset() else {
+        let Some(cobalt_activation_block) = self.cobalt_activation_block_number() else {
             return legacy_millis;
         };
 
@@ -1154,7 +1141,7 @@ mod tests {
     #[test]
     fn l2_block_full_millis_matches_legacy_before_cobalt_activation() {
         let cfg = rollup_config_with_cobalt(10, 2, Some(15));
-        assert_eq!(cfg.cobalt_activation_block_offset(), Some(3));
+        assert_eq!(cfg.cobalt_activation_block_number(), Some(3));
 
         for block_number in 0..3 {
             let expected = (10 + block_number * 2) * 1_000;
@@ -1168,7 +1155,7 @@ mod tests {
     fn l2_block_full_millis_respects_cobalt_activation_boundary() {
         let cfg = rollup_config_with_cobalt(10, 2, Some(15));
 
-        assert_eq!(cfg.cobalt_activation_block_offset(), Some(3));
+        assert_eq!(cfg.cobalt_activation_block_number(), Some(3));
         assert_eq!(cfg.l2_block_timestamp_millis(3), 16_000);
         assert_eq!(cfg.l2_block_timestamp_parts(3), (16, 0));
     }
@@ -1207,7 +1194,7 @@ mod tests {
     fn l2_block_full_millis_without_cobalt_uses_legacy_formula() {
         let cfg = rollup_config_with_cobalt(11, 3, None);
 
-        assert_eq!(cfg.cobalt_activation_block_offset(), None);
+        assert_eq!(cfg.cobalt_activation_block_number(), None);
         for block_number in [0_u64, 1, 2, 10, 100] {
             let expected =
                 11u64.saturating_add(block_number.saturating_mul(3)).saturating_mul(1_000);
@@ -1219,8 +1206,8 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "rollup config: block time cannot be 0")]
-    fn cobalt_activation_block_offset_rejects_zero_block_time() {
-        rollup_config_with_cobalt(100, 0, Some(101)).cobalt_activation_block_offset();
+    fn cobalt_activation_block_number_rejects_zero_block_time() {
+        rollup_config_with_cobalt(100, 0, Some(101)).cobalt_activation_block_number();
     }
 
     #[test]
@@ -1228,7 +1215,7 @@ mod tests {
         let mut cfg = rollup_config_with_cobalt(10, 2, Some(15));
         cfg.genesis.l2.number = 50;
 
-        assert_eq!(cfg.cobalt_activation_block_offset(), Some(3));
+        assert_eq!(cfg.cobalt_activation_block_number(), Some(3));
         assert_eq!(cfg.l2_block_timestamp_millis(52), 14_000);
         assert_eq!(cfg.l2_block_timestamp_millis(53), 16_000);
         assert_eq!(cfg.l2_block_timestamp_millis(54), 16_200);
@@ -1257,7 +1244,7 @@ mod tests {
         };
         crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 15);
 
-        assert_eq!(cfg.cobalt_activation_block_offset(), Some(3));
+        assert_eq!(cfg.cobalt_activation_block_number(), Some(3));
         assert_eq!(cfg.l2_block_timestamp_millis(3), 16_000);
         assert_eq!(cfg.l2_block_timestamp_millis(4), 16_200);
 

--- a/crates/common/genesis/src/rollup.rs
+++ b/crates/common/genesis/src/rollup.rs
@@ -363,7 +363,20 @@ impl RollupConfig {
         }
     }
 
-    /// Returns the L2 block number at which Denim activates.
+    /// Returns the L2 block offset from genesis at which Cobalt activates.
+    ///
+    /// If Cobalt is not configured, returns [`None`].
+    pub fn cobalt_activation_block_offset(&self) -> Option<u64> {
+        let cobalt_timestamp = self.upgrade_activation_timestamp(BaseUpgrade::Cobalt)?;
+
+        if self.block_time == 0 {
+            panic!("rollup config: block time cannot be 0");
+        }
+
+        Some(cobalt_timestamp.saturating_sub(self.genesis.l2_time).div_ceil(self.block_time))
+    }
+
+    /// Returns the L2 block offset from genesis at which Denim activates.
     ///
     /// If Denim is not configured, returns [`None`].
     pub fn denim_activation_block_number(&self) -> Option<u64> {
@@ -391,8 +404,8 @@ impl RollupConfig {
 
     /// Returns the deterministic timestamp of an L2 block in milliseconds.
     ///
-    /// Before Denim activation, this matches the legacy whole-second schedule exactly.
-    /// After Denim activation, this advances by a fixed 200ms cadence from the activation block.
+    /// Before Cobalt activation, this matches the legacy whole-second schedule exactly.
+    /// After Cobalt activation, this advances by a fixed 200ms cadence from the activation block.
     ///
     /// `block_number` is an absolute L2 block number; it is measured relative to the L2 genesis
     /// block number (`self.genesis.l2.number`), which is non-zero for chains whose L2 genesis
@@ -406,22 +419,22 @@ impl RollupConfig {
             .saturating_add(blocks_since_genesis.saturating_mul(self.block_time));
         let legacy_millis = legacy_seconds.saturating_mul(1_000);
 
-        let Some(denim_activation_block) = self.denim_activation_block_number() else {
+        let Some(cobalt_activation_block) = self.cobalt_activation_block_offset() else {
             return legacy_millis;
         };
 
-        if blocks_since_genesis < denim_activation_block {
+        if blocks_since_genesis < cobalt_activation_block {
             return legacy_millis;
         }
 
-        let denim_activation_seconds = self
+        let cobalt_activation_seconds = self
             .genesis
             .l2_time
-            .saturating_add(denim_activation_block.saturating_mul(self.block_time));
-        let denim_activation_full_millis = denim_activation_seconds.saturating_mul(1_000);
-        denim_activation_full_millis.saturating_add(
+            .saturating_add(cobalt_activation_block.saturating_mul(self.block_time));
+        let cobalt_activation_full_millis = cobalt_activation_seconds.saturating_mul(1_000);
+        cobalt_activation_full_millis.saturating_add(
             blocks_since_genesis
-                .saturating_sub(denim_activation_block)
+                .saturating_sub(cobalt_activation_block)
                 .saturating_mul(Self::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS),
         )
     }
@@ -486,8 +499,8 @@ impl RollupConfig {
     /// The fixed cadence once subsecond blocks activates.
     pub const NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS: u64 = 200;
 
-    /// The number of Denim blocks produced in one legacy two-second block interval.
-    pub const DENIM_GAS_PARAMETER_SCALING_FACTOR: u32 = 10;
+    /// The number of Cobalt blocks produced in one legacy two-second block interval.
+    pub const COBALT_GAS_PARAMETER_SCALING_FACTOR: u32 = 10;
 
     /// Helper method for deserializing a default granite channel timeout.
     #[cfg(feature = "serde")]
@@ -1122,16 +1135,16 @@ mod tests {
         assert!(cfg.is_zenith_active(u64::MAX));
     }
 
-    fn rollup_config_with_denim(
+    fn rollup_config_with_cobalt(
         genesis_l2_time: u64,
         block_time: u64,
-        denim_time: Option<u64>,
+        cobalt_time: Option<u64>,
     ) -> RollupConfig {
         RollupConfig {
             genesis: ChainGenesis { l2_time: genesis_l2_time, ..Default::default() },
             block_time,
             upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { denim: denim_time, ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: cobalt_time, ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()
@@ -1139,9 +1152,9 @@ mod tests {
     }
 
     #[test]
-    fn l2_block_full_millis_matches_legacy_before_denim_activation() {
-        let cfg = rollup_config_with_denim(10, 2, Some(15));
-        assert_eq!(cfg.denim_activation_block_number(), Some(3));
+    fn l2_block_full_millis_matches_legacy_before_cobalt_activation() {
+        let cfg = rollup_config_with_cobalt(10, 2, Some(15));
+        assert_eq!(cfg.cobalt_activation_block_offset(), Some(3));
 
         for block_number in 0..3 {
             let expected = (10 + block_number * 2) * 1_000;
@@ -1152,17 +1165,17 @@ mod tests {
     }
 
     #[test]
-    fn l2_block_full_millis_respects_denim_activation_boundary() {
-        let cfg = rollup_config_with_denim(10, 2, Some(15));
+    fn l2_block_full_millis_respects_cobalt_activation_boundary() {
+        let cfg = rollup_config_with_cobalt(10, 2, Some(15));
 
-        assert_eq!(cfg.denim_activation_block_number(), Some(3));
+        assert_eq!(cfg.cobalt_activation_block_offset(), Some(3));
         assert_eq!(cfg.l2_block_timestamp_millis(3), 16_000);
         assert_eq!(cfg.l2_block_timestamp_parts(3), (16, 0));
     }
 
     #[test]
     fn l2_block_full_millis_advances_by_200ms_after_activation() {
-        let cfg = rollup_config_with_denim(10, 2, Some(15));
+        let cfg = rollup_config_with_cobalt(10, 2, Some(15));
 
         let activation = cfg.l2_block_timestamp_millis(3);
         let next = cfg.l2_block_timestamp_millis(4);
@@ -1175,8 +1188,8 @@ mod tests {
     }
 
     #[test]
-    fn l2_block_full_millis_keeps_fixed_200ms_cadence_in_denim_era() {
-        let cfg = rollup_config_with_denim(10, 2, Some(15));
+    fn l2_block_full_millis_keeps_fixed_200ms_cadence_in_cobalt_era() {
+        let cfg = rollup_config_with_cobalt(10, 2, Some(15));
 
         let start_block = 3;
         let mut previous = cfg.l2_block_timestamp_millis(start_block);
@@ -1191,10 +1204,10 @@ mod tests {
     }
 
     #[test]
-    fn l2_block_full_millis_without_denim_uses_legacy_formula() {
-        let cfg = rollup_config_with_denim(11, 3, None);
+    fn l2_block_full_millis_without_cobalt_uses_legacy_formula() {
+        let cfg = rollup_config_with_cobalt(11, 3, None);
 
-        assert_eq!(cfg.denim_activation_block_number(), None);
+        assert_eq!(cfg.cobalt_activation_block_offset(), None);
         for block_number in [0_u64, 1, 2, 10, 100] {
             let expected =
                 11u64.saturating_add(block_number.saturating_mul(3)).saturating_mul(1_000);
@@ -1206,8 +1219,49 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "rollup config: block time cannot be 0")]
-    fn denim_activation_block_number_rejects_zero_block_time() {
-        rollup_config_with_denim(100, 0, Some(101)).denim_activation_block_number();
+    fn cobalt_activation_block_offset_rejects_zero_block_time() {
+        rollup_config_with_cobalt(100, 0, Some(101)).cobalt_activation_block_offset();
+    }
+
+    #[test]
+    fn l2_block_full_millis_is_relative_to_nonzero_genesis_block() {
+        let mut cfg = rollup_config_with_cobalt(10, 2, Some(15));
+        cfg.genesis.l2.number = 50;
+
+        assert_eq!(cfg.cobalt_activation_block_offset(), Some(3));
+        assert_eq!(cfg.l2_block_timestamp_millis(52), 14_000);
+        assert_eq!(cfg.l2_block_timestamp_millis(53), 16_000);
+        assert_eq!(cfg.l2_block_timestamp_millis(54), 16_200);
+    }
+
+    #[test]
+    fn later_denim_activation_does_not_change_cobalt_cadence() {
+        let mut with_denim = rollup_config_with_cobalt(10, 2, Some(15));
+        with_denim.upgrades.base.denim = Some(20);
+        let without_denim = rollup_config_with_cobalt(10, 2, Some(15));
+
+        for block_number in 0..20 {
+            assert_eq!(
+                with_denim.l2_block_timestamp_millis(block_number),
+                without_denim.l2_block_timestamp_millis(block_number)
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_cobalt_reschedule_moves_native_cadence_boundary() {
+        let chain_id = 9_100_099;
+        let cfg = RollupConfig {
+            l2_chain_id: Chain::from_id(chain_id),
+            ..rollup_config_with_cobalt(10, 2, Some(20))
+        };
+        crate::RuntimeUpgradeRegistry::set_activation_timestamp(chain_id, BaseUpgrade::Cobalt, 15);
+
+        assert_eq!(cfg.cobalt_activation_block_offset(), Some(3));
+        assert_eq!(cfg.l2_block_timestamp_millis(3), 16_000);
+        assert_eq!(cfg.l2_block_timestamp_millis(4), 16_200);
+
+        crate::RuntimeUpgradeRegistry::clear_chain(chain_id);
     }
 
     fn rollup_config_with_zenith(
@@ -1243,7 +1297,7 @@ mod tests {
 
     #[test]
     fn l2_block_full_millis_saturates() {
-        let saturating = rollup_config_with_denim(u64::MAX, u64::MAX, None);
+        let saturating = rollup_config_with_cobalt(u64::MAX, u64::MAX, None);
         assert_eq!(saturating.l2_block_timestamp_millis(1), u64::MAX);
     }
 

--- a/crates/consensus/derive/src/attributes/stateful.rs
+++ b/crates/consensus/derive/src/attributes/stateful.rs
@@ -170,12 +170,12 @@ where
             ));
         }
 
-        if self.rollup_cfg.is_first_denim_block(target_l2_time, l2_parent.block_info.timestamp) {
+        if self.rollup_cfg.is_first_cobalt_block(target_l2_time, l2_parent.block_info.timestamp) {
             // Preserve gas throughput and base-fee responsiveness per unit of wall-clock time
-            // when Denim increases the number of blocks in each legacy block interval tenfold.
-            sys_config.gas_limit /= u64::from(RollupConfig::DENIM_GAS_PARAMETER_SCALING_FACTOR);
+            // when Cobalt increases the number of blocks in each legacy block interval tenfold.
+            sys_config.gas_limit /= u64::from(RollupConfig::COBALT_GAS_PARAMETER_SCALING_FACTOR);
             sys_config.eip1559_denominator = sys_config.eip1559_denominator.map(|denominator| {
-                denominator.saturating_mul(RollupConfig::DENIM_GAS_PARAMETER_SCALING_FACTOR)
+                denominator.saturating_mul(RollupConfig::COBALT_GAS_PARAMETER_SCALING_FACTOR)
             });
         }
 
@@ -217,7 +217,7 @@ where
         let mut encoded_l1_info_tx = Vec::with_capacity(l1_info_tx_envelope.length());
         l1_info_tx_envelope.encode_2718(&mut encoded_l1_info_tx);
 
-        let base_time_active = self.rollup_cfg.is_denim_active(target_l2_time);
+        let base_time_active = self.rollup_cfg.is_cobalt_active(target_l2_time);
         let mut txs = Vec::with_capacity(
             1 + usize::from(base_time_active)
                 + deposit_transactions.len()
@@ -756,7 +756,7 @@ mod tests {
             l2_chain_id: chain_id.into(),
             upgrades: UpgradeConfig {
                 ecotone_time: Some(102),
-                base: BaseUpgradeConfig { denim: Some(102), ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: Some(102), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()
@@ -804,7 +804,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_prepare_payload_uses_denim_formula_for_subsequent_block() {
+    async fn test_prepare_payload_uses_cobalt_formula_for_subsequent_block() {
         let block_time = 2_u64;
         let timestamp = 100_u64;
         let chain_id = 9_100_005;
@@ -818,7 +818,7 @@ mod tests {
             upgrades: UpgradeConfig {
                 ecotone_time: Some(102),
                 jovian_time: Some(0),
-                base: BaseUpgradeConfig { denim: Some(102), ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: Some(102), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()
@@ -875,7 +875,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_denim_gas_transition_applies_after_l1_system_config_updates() {
+    async fn test_cobalt_gas_transition_applies_after_l1_system_config_updates() {
         let timestamp = 100;
         let l2_number = 1;
         let system_config_address = address!("1111111111111111111111111111111111111111");
@@ -886,7 +886,7 @@ mod tests {
             upgrades: UpgradeConfig {
                 ecotone_time: Some(0),
                 jovian_time: Some(0),
-                base: BaseUpgradeConfig { denim: Some(102), ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: Some(102), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/consensus/derive/src/stages/batch/batch_provider.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_provider.rs
@@ -400,7 +400,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 0, ..Default::default() },
             ..Default::default()
         };
-        assert_eq!(cfg.cobalt_activation_block_offset(), Some(23));
+        assert_eq!(cfg.cobalt_activation_block_number(), Some(23));
         assert_eq!(cfg.l2_block_timestamp(298), cfg.l2_block_timestamp(301));
         let valid = SingleBatch {
             parent_hash: parent.block_info.hash,

--- a/crates/consensus/derive/src/stages/batch/batch_provider.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_provider.rs
@@ -379,13 +379,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_denim_validator_skips_same_second_stale_batch() {
+    async fn test_cobalt_validator_skips_same_second_stale_batch() {
         let origin = BlockInfo { number: 1, hash: B256::repeat_byte(0x11), ..Default::default() };
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             upgrades: UpgradeConfig {
                 holocene_time: Some(0),
-                base: BaseUpgradeConfig { denim: Some(46), ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: Some(46), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()
@@ -400,7 +400,7 @@ mod tests {
             l1_origin: BlockNumHash { number: 0, ..Default::default() },
             ..Default::default()
         };
-        assert_eq!(cfg.denim_activation_block_number(), Some(23));
+        assert_eq!(cfg.cobalt_activation_block_offset(), Some(23));
         assert_eq!(cfg.l2_block_timestamp(298), cfg.l2_block_timestamp(301));
         let valid = SingleBatch {
             parent_hash: parent.block_info.hash,

--- a/crates/consensus/derive/src/stages/batch/batch_queue.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_queue.rs
@@ -300,10 +300,10 @@ where
     /// Also returns the boolean that indicates if the batch is the last block in the batch.
     async fn next_batch(&mut self, parent: L2BlockInfo) -> PipelineResult<SingleBatch> {
         let next = parent.block_info.number + 1;
-        if self.cfg.is_denim_active(self.cfg.l2_block_timestamp(next))
+        if self.cfg.is_cobalt_active(self.cfg.l2_block_timestamp(next))
             && !self.next_spans.is_empty()
         {
-            warn!(target: "batch_queue", next_block_number = next, cached_batches = self.next_spans.len(), "Dropping cached span batches after Denim activation");
+            warn!(target: "batch_queue", next_block_number = next, cached_batches = self.next_spans.len(), "Dropping cached span batches after Cobalt activation");
             self.next_spans.clear();
         }
 
@@ -594,11 +594,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cached_span_is_not_emitted_at_denim() {
+    async fn test_cached_span_is_not_emitted_at_cobalt() {
         let cfg = Arc::new(RollupConfig {
             block_time: 2,
             upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { denim: Some(6), ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: Some(6), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/consensus/derive/src/stages/batch/batch_stream.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_stream.rs
@@ -136,10 +136,10 @@ where
         }
 
         let next = parent.block_info.number + 1;
-        if self.config.is_denim_active(self.config.l2_block_timestamp(next))
+        if self.config.is_cobalt_active(self.config.l2_block_timestamp(next))
             && (self.span.is_some() || !self.buffer.is_empty())
         {
-            warn!(target: "batch_span", next_block_number = next, "Dropping cached span state after Denim activation");
+            warn!(target: "batch_span", next_block_number = next, "Dropping cached span state after Cobalt activation");
             self.flush();
             return Err(PipelineError::NotEnoughData.temp());
         }
@@ -440,7 +440,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_crossing_span_stops_before_first_denim_block() {
+    async fn test_crossing_span_stops_before_first_cobalt_block() {
         let span = SpanBatch {
             batches: vec![
                 SpanBatchElement { epoch_num: 1, timestamp: 2, ..Default::default() },
@@ -456,7 +456,7 @@ mod tests {
             upgrades: UpgradeConfig {
                 delta_time: Some(0),
                 holocene_time: Some(0),
-                base: BaseUpgradeConfig { denim: Some(6), ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: Some(6), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()
@@ -474,12 +474,12 @@ mod tests {
         let second = stream.next_batch(second_parent, &origins).await.unwrap();
         assert_eq!(second.timestamp(), 4);
 
-        let denim_parent = L2BlockInfo {
+        let cobalt_parent = L2BlockInfo {
             block_info: BlockInfo { number: 2, timestamp: 4, ..Default::default() },
             ..Default::default()
         };
         assert_eq!(
-            stream.next_batch(denim_parent, &origins).await,
+            stream.next_batch(cobalt_parent, &origins).await,
             Err(PipelineError::NotEnoughData.temp())
         );
         assert!(stream.buffer.is_empty());

--- a/crates/consensus/derive/src/stages/batch/batch_validator.rs
+++ b/crates/consensus/derive/src/stages/batch/batch_validator.rs
@@ -246,7 +246,7 @@ where
 
         let next_timestamp =
             self.cfg.l2_block_timestamp(parent.block_info.number.saturating_add(1));
-        let needs_ancestry_check = self.cfg.is_denim_active(next_timestamp)
+        let needs_ancestry_check = self.cfg.is_cobalt_active(next_timestamp)
             && next_batch.timestamp == next_timestamp
             && next_batch.parent_hash != parent.block_info.hash;
         if needs_ancestry_check {
@@ -638,7 +638,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_pre_denim_validator_rejects_stale_parent_after_past_prefix() {
+    async fn test_pre_cobalt_validator_rejects_stale_parent_after_past_prefix() {
         let epoch = BlockInfo {
             number: 10,
             hash: B256::repeat_byte(0x10),
@@ -676,7 +676,7 @@ mod tests {
             upgrades: UpgradeConfig { holocene_time: Some(0), ..Default::default() },
             ..Default::default()
         });
-        assert!(!cfg.is_denim_active(601));
+        assert!(!cfg.is_cobalt_active(601));
         let mut bv = BatchValidator::new(cfg, prev, TestL2ChainProvider::default());
         bv.origin = Some(inclusion_block);
         bv.l1_blocks = vec![epoch, inclusion_block];
@@ -689,7 +689,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_denim_validator_retries_then_flushes_unknown_parent() {
+    async fn test_cobalt_validator_retries_then_flushes_unknown_parent() {
         let origin = BlockInfo { number: 1, hash: B256::repeat_byte(0x11), ..Default::default() };
         let parent = L2BlockInfo {
             block_info: BlockInfo {
@@ -712,7 +712,7 @@ mod tests {
             block_time: 2,
             upgrades: UpgradeConfig {
                 holocene_time: Some(0),
-                base: BaseUpgradeConfig { denim: Some(0), ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: Some(0), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -353,12 +353,12 @@ mod tests {
     }
 
     #[test]
-    fn test_check_batch_timestamp_accepts_same_second_in_denim_era() {
+    fn test_check_batch_timestamp_accepts_same_second_in_cobalt_era() {
         let cfg = RollupConfig {
             block_time: 2,
             genesis: ChainGenesis { l2_time: 98, ..Default::default() },
             upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { denim: Some(102), ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: Some(102), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()
@@ -376,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn test_check_batch_timestamp_non_denim_unchanged() {
+    fn test_check_batch_timestamp_pre_cobalt_unchanged() {
         let cfg = RollupConfig {
             block_time: 2,
             genesis: ChainGenesis { l2_time: 98, ..Default::default() },
@@ -648,7 +648,7 @@ mod tests {
             parent_hash: BlockHash::ZERO,
             epoch_num: 1,
             epoch_hash: BlockHash::ZERO,
-            timestamp: 1,
+            timestamp: 0,
             transactions,
         };
 

--- a/crates/consensus/protocol/src/batch/single.rs
+++ b/crates/consensus/protocol/src/batch/single.rs
@@ -640,7 +640,7 @@ mod tests {
     }
 
     #[test]
-    fn test_check_batch_accept_8130_post_cobalt() {
+    fn test_check_batch_accept_8130() {
         let mut transactions = example_transactions();
         transactions.push(eip_8130_tx_bytes());
 
@@ -652,7 +652,6 @@ mod tests {
             transactions,
         };
 
-        // Notice: Cobalt is active.
         let cfg = RollupConfig {
             max_sequencer_drift: 1,
             block_time: 1,

--- a/crates/consensus/protocol/src/batch/span.rs
+++ b/crates/consensus/protocol/src/batch/span.rs
@@ -597,9 +597,9 @@ impl SpanBatch {
             return (BatchValidity::Undecided, None);
         }
         let next = l2_safe_head.block_info.number + 1;
-        if cfg.is_denim_active(cfg.l2_block_timestamp(next)) {
-            warn!(target: "batch_span", next_block_number = next, "Dropping span batch after Denim activation");
-            return (BatchValidity::Drop(BatchDropReason::SpanBatchPostDenim), None);
+        if cfg.is_cobalt_active(cfg.l2_block_timestamp(next)) {
+            warn!(target: "batch_span", next_block_number = next, "Dropping span batch after Cobalt activation");
+            return (BatchValidity::Drop(BatchDropReason::SpanBatchPostCobalt), None);
         }
 
         let epoch = l1_origins[0];
@@ -1054,7 +1054,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_check_batch_prefix_rejects_first_denim_block_with_nonzero_genesis() {
+    async fn test_check_batch_prefix_rejects_first_cobalt_block_with_nonzero_genesis() {
         let cfg = RollupConfig {
             block_time: 2,
             genesis: ChainGenesis {
@@ -1063,7 +1063,7 @@ mod tests {
                 ..Default::default()
             },
             upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { denim: Some(104), ..Default::default() },
+                base: BaseUpgradeConfig { cobalt: Some(104), ..Default::default() },
                 ..Default::default()
             },
             ..Default::default()
@@ -1075,7 +1075,7 @@ mod tests {
         let mut fetcher = TestBatchValidator::default();
         let l1_origins = [BlockInfo::default()];
 
-        let pre_denim_parent = L2BlockInfo {
+        let pre_cobalt_parent = L2BlockInfo {
             block_info: BlockInfo { number: 40, timestamp: 100, ..Default::default() },
             ..Default::default()
         };
@@ -1084,16 +1084,16 @@ mod tests {
                 .check_batch_prefix(
                     &cfg,
                     &l1_origins,
-                    pre_denim_parent,
+                    pre_cobalt_parent,
                     &BlockInfo::default(),
                     &mut fetcher,
                 )
                 .await
                 .0,
-            BatchValidity::Drop(BatchDropReason::SpanBatchPostDenim)
+            BatchValidity::Drop(BatchDropReason::SpanBatchPostCobalt)
         );
 
-        let denim_parent = L2BlockInfo {
+        let cobalt_parent = L2BlockInfo {
             block_info: BlockInfo { number: 41, timestamp: 102, ..Default::default() },
             ..Default::default()
         };
@@ -1102,13 +1102,13 @@ mod tests {
                 .check_batch_prefix(
                     &cfg,
                     &l1_origins,
-                    denim_parent,
+                    cobalt_parent,
                     &BlockInfo::default(),
                     &mut fetcher,
                 )
                 .await
                 .0,
-            BatchValidity::Drop(BatchDropReason::SpanBatchPostDenim)
+            BatchValidity::Drop(BatchDropReason::SpanBatchPostCobalt)
         );
     }
 
@@ -2240,10 +2240,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_check_batch_accept_eip8130_post_cobalt() {
-        // Mirror of `test_check_batch_with_eip8130_tx` with Cobalt active: the same
-        // span batch carrying an EIP-8130 transaction is accepted once the fork gate
-        // opens, exercising the post-Cobalt side for symmetry with the single-batch tests.
+    async fn test_check_batch_rejects_eip8130_span_post_cobalt() {
+        // Cobalt enables EIP-8130 but simultaneously disables Span batches, so
+        // EIP-8130 transactions must use singular batches.
         let cfg = RollupConfig {
             seq_window_size: 100,
             max_sequencer_drift: 100,
@@ -2301,7 +2300,7 @@ mod tests {
         };
         assert_eq!(
             batch.check_batch(&cfg, &l1_blocks, l2_safe_head, &inclusion_block, &mut fetcher).await,
-            BatchValidity::Accept
+            BatchValidity::Drop(BatchDropReason::SpanBatchPostCobalt)
         );
     }
 

--- a/crates/consensus/protocol/src/batch/validity.rs
+++ b/crates/consensus/protocol/src/batch/validity.rs
@@ -50,8 +50,8 @@ pub enum BatchDropReason {
     // === Span batch specific drops ===
     /// Span batch received before Delta upgrade.
     SpanBatchPreDelta,
-    /// Span batch would produce a block after Denim activation.
-    SpanBatchPostDenim,
+    /// Span batch would produce a block after Cobalt activation.
+    SpanBatchPostCobalt,
     /// Span batch has no new blocks after safe head (Holocene inactive).
     SpanBatchNoNewBlocksPreHolocene,
     /// Span batch timestamp is misaligned with block time.
@@ -100,7 +100,7 @@ impl core::fmt::Display for BatchDropReason {
             Self::Eip8130PreCobalt => write!(f, "EIP-8130 transaction before Cobalt activation"),
             Self::NonEmptyTransitionBlock => write!(f, "non-empty batch in transition block"),
             Self::SpanBatchPreDelta => write!(f, "span batch received before Delta upgrade"),
-            Self::SpanBatchPostDenim => write!(f, "span batch received after Denim activation"),
+            Self::SpanBatchPostCobalt => write!(f, "span batch received after Cobalt activation"),
             Self::SpanBatchNoNewBlocksPreHolocene => {
                 write!(f, "span batch has no new blocks after safe head")
             }

--- a/crates/consensus/protocol/src/timing.rs
+++ b/crates/consensus/protocol/src/timing.rs
@@ -1,7 +1,7 @@
 //! Sequencer timing defaults for subsecond block production.
 
 /// The default fixed offset into a subsecond slot at which the sequencer requests the
-/// sealed payload (`engine_getPayload`) once Denim is active.
+/// sealed payload (`engine_getPayload`) once Cobalt is active.
 ///
 /// This is the single shared default for both timing knobs derived from it: the CL's block
 /// seal target and the builder's wall-clock transaction cutoff. The two run in separate

--- a/crates/consensus/service/src/actors/sequencer/actor.rs
+++ b/crates/consensus/service/src/actors/sequencer/actor.rs
@@ -80,7 +80,7 @@ pub struct SequencerActor<
     /// The rollup configuration.
     pub rollup_config: Arc<RollupConfig>,
     /// Fixed offset into each subsecond slot at which the sealed payload is requested from
-    /// the engine once Denim is active. See [`SequencerConfig::seal_offset`].
+    /// the engine once Cobalt is active. See [`SequencerConfig::seal_offset`].
     ///
     /// [`SequencerConfig::seal_offset`]: crate::SequencerConfig::seal_offset
     pub seal_offset: Duration,
@@ -327,12 +327,12 @@ where
 
     /// Wall-clock time at which `block_number` should be sealed.
     ///
-    /// Denim-active blocks seal at a fixed offset into their 200ms slot, computed as
-    /// `T_N − (interval − seal_offset)` so the first Denim block still seals relative to
+    /// Cobalt-active blocks seal at a fixed offset into their 200ms slot, computed as
+    /// `T_N − (interval − seal_offset)` so the first Cobalt block still seals relative to
     /// its own timestamp. The target ignores how long the previous seal took: lateness
     /// shrinks the current build window instead of shifting the schedule.
     ///
-    /// Pre-Denim blocks compensate for the previous seal duration, capped at half the
+    /// Pre-Cobalt blocks compensate for the previous seal duration, capped at half the
     /// block interval so one slow seal cannot collapse the next build window to zero and
     /// trigger a fat/thin block oscillation.
     pub(super) fn block_seal_target(
@@ -342,7 +342,8 @@ where
     ) -> SystemTime {
         let target = UNIX_EPOCH
             + Duration::from_millis(self.rollup_config.l2_block_timestamp_millis(block_number));
-        if self.rollup_config.is_denim_active(self.rollup_config.l2_block_timestamp(block_number)) {
+        if self.rollup_config.is_cobalt_active(self.rollup_config.l2_block_timestamp(block_number))
+        {
             let interval =
                 Duration::from_millis(RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS);
             return target - interval.saturating_sub(self.seal_offset);

--- a/crates/consensus/service/src/actors/sequencer/config.rs
+++ b/crates/consensus/service/src/actors/sequencer/config.rs
@@ -44,7 +44,7 @@ pub struct SequencerConfig {
     /// Request timeout for L1 RPC calls on the sequencer block-production hot path.
     pub l1_rpc_timeout: Duration,
     /// Fixed offset into each subsecond slot at which the sealed payload is requested from
-    /// the engine once Denim is active. Must agree with the builder-side transaction
+    /// the engine once Cobalt is active. Must agree with the builder-side transaction
     /// cutoff, which defaults from the same constant
     /// ([`base_protocol::DEFAULT_SEAL_OFFSET`]).
     pub seal_offset: Duration,

--- a/crates/consensus/service/src/actors/sequencer/pipeline_state.rs
+++ b/crates/consensus/service/src/actors/sequencer/pipeline_state.rs
@@ -17,7 +17,7 @@ pub struct BuildPipelineState {
     /// Acknowledged parent whose child build is gated on the parent's timestamp.
     pub pending_build_parent: Option<L2BlockInfo>,
     /// Duration of the most recently completed seal, used as the ticker's lead time for
-    /// pre-Denim blocks only. Denim-active blocks seal at a fixed offset into their slot
+    /// pre-Cobalt blocks only. Cobalt-active blocks seal at a fixed offset into their slot
     /// and ignore this value.
     pub last_seal_duration: Duration,
     /// Wall-clock instant the most recent block finished, used to record

--- a/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
+++ b/crates/consensus/service/src/actors/sequencer/tests/actor_test.rs
@@ -1058,15 +1058,15 @@ type TestSequencerActor = SequencerActor<
 >;
 
 /// Returns a test actor whose rollup config anchors L2 genesis at 100s with 2s blocks and
-/// activates Denim at 102s (block 1) via genesis config. Block timestamps:
-/// block 0 → `100_000ms`, block 1 → `102_000ms` (first Denim block), block 2 → `102_200ms`, …
-fn denim_seal_target_actor() -> TestSequencerActor {
+/// activates Cobalt at 102s (block 1) via genesis config. Block timestamps:
+/// block 0 → `100_000ms`, block 1 → `102_000ms` (first Cobalt block), block 2 → `102_200ms`, …
+fn cobalt_seal_target_actor() -> TestSequencerActor {
     let mut actor = test_actor();
     actor.rollup_config = Arc::new(RollupConfig {
         block_time: 2,
         genesis: ChainGenesis { l2_time: 100, ..Default::default() },
         upgrades: UpgradeConfig {
-            base: BaseUpgradeConfig { denim: Some(102), ..Default::default() },
+            base: BaseUpgradeConfig { cobalt: Some(102), ..Default::default() },
             ..Default::default()
         },
         ..Default::default()
@@ -1075,8 +1075,8 @@ fn denim_seal_target_actor() -> TestSequencerActor {
 }
 
 #[test]
-fn denim_seal_target_is_fixed_offset_into_slot() {
-    let actor = denim_seal_target_actor();
+fn cobalt_seal_target_is_fixed_offset_into_slot() {
+    let actor = cobalt_seal_target_actor();
 
     // Block 2's slot starts at T_1 = 102_000ms; the fixed target is T_1 + 150ms
     // (equivalently T_2 − 50ms).
@@ -1085,8 +1085,8 @@ fn denim_seal_target_is_fixed_offset_into_slot() {
 }
 
 #[test]
-fn denim_seal_target_ignores_last_seal_duration() {
-    let actor = denim_seal_target_actor();
+fn cobalt_seal_target_ignores_last_seal_duration() {
+    let actor = cobalt_seal_target_actor();
 
     // Never grant minimum build time when behind: a slow previous seal must not move the
     // target. A target already in the past makes the ticker fire immediately instead.
@@ -1096,10 +1096,10 @@ fn denim_seal_target_ignores_last_seal_duration() {
 }
 
 #[test]
-fn first_denim_block_seal_target_is_relative_to_own_timestamp() {
-    let actor = denim_seal_target_actor();
+fn first_cobalt_block_seal_target_is_relative_to_own_timestamp() {
+    let actor = cobalt_seal_target_actor();
 
-    // Block 1 is the first Denim-active block; its parent slot spans a full legacy block
+    // Block 1 is the first Cobalt-active block; its parent slot spans a full legacy block
     // time, so the target is T_1 − (interval − seal_offset) = 102_000 − 50, not
     // T_0 + 150 = 100_150.
     let expected = UNIX_EPOCH + Duration::from_millis(101_950);
@@ -1107,8 +1107,8 @@ fn first_denim_block_seal_target_is_relative_to_own_timestamp() {
 }
 
 #[test]
-fn denim_seal_target_uses_configured_offset() {
-    let mut actor = denim_seal_target_actor();
+fn cobalt_seal_target_uses_configured_offset() {
+    let mut actor = cobalt_seal_target_actor();
     actor.seal_offset = Duration::from_millis(100);
 
     let expected = UNIX_EPOCH + Duration::from_millis(102_100);
@@ -1116,7 +1116,7 @@ fn denim_seal_target_uses_configured_offset() {
 }
 
 #[test]
-fn pre_denim_seal_target_keeps_adaptive_compensation() {
+fn pre_cobalt_seal_target_keeps_adaptive_compensation() {
     let mut actor = test_actor();
     actor.rollup_config = Arc::new(RollupConfig {
         block_time: 2,

--- a/crates/consensus/service/src/standalone.rs
+++ b/crates/consensus/service/src/standalone.rs
@@ -89,10 +89,10 @@ impl AttributesBuilder for StandaloneAttributesBuilder {
 
         let mut transactions = vec![Bytes::from(encoded_l1_info)];
         // Sub-second progression is conveyed solely by a `BaseTimeUpdateTx` deposit in the
-        // transactions list (the payload attributes no longer carry a millis field). Denim is the
+        // transactions list (the payload attributes no longer carry a millis field). Cobalt is the
         // upgrade that activates the native sub-second block cadence, matching the production
         // stateful attributes builder.
-        if self.rollup_config.is_denim_active(next_l2_time) {
+        if self.rollup_config.is_cobalt_active(next_l2_time) {
             let base_time =
                 BaseTimeUpdateTx::new(next_l2_timestamp_millis_part).map_err(|error| {
                     PipelineError::AttributesBuilder(BuilderError::BaseTimeUpdate(error)).crit()
@@ -431,7 +431,7 @@ mod tests {
     async fn subsecond_descendants_include_base_time_progression() {
         let (l1_info, parent) = snapshot_boundary();
         let mut rollup = anchored_rollup(parent, 2_002);
-        rollup.set_upgrade_activation_timestamp(base_common_genesis::BaseUpgrade::Denim, 2_002);
+        rollup.set_upgrade_activation_timestamp(base_common_genesis::BaseUpgrade::Cobalt, 2_002);
         let mut builder = StandaloneAttributesBuilder::new(
             std::sync::Arc::new(rollup),
             l1_info,

--- a/crates/execution/consensus/src/error.rs
+++ b/crates/execution/consensus/src/error.rs
@@ -17,9 +17,9 @@ pub enum BaseConsensusError {
         /// The child's full-millisecond timestamp.
         child_timestamp_ms: u128,
     },
-    /// The first Denim-active block claimed a non-zero millisecond component.
+    /// The first Cobalt-active block claimed a non-zero millisecond component.
     #[error(
-        "invalid BaseTime activation claim: first Denim block must have millisecond part 0, got {timestamp_millis_part}"
+        "invalid BaseTime activation claim: first Cobalt block must have millisecond part 0, got {timestamp_millis_part}"
     )]
     BaseTimeActivationMillisNonZero {
         /// The claimed sub-second millisecond component.

--- a/crates/execution/consensus/src/lib.rs
+++ b/crates/execution/consensus/src/lib.rs
@@ -230,8 +230,8 @@ impl HeaderValidator<Header> for BaseBeaconConsensus {
         validate_against_parent_hash_number(header.header(), parent)?;
 
         let allows_same_timestamp =
-            self.chain_spec.is_denim_active_at_timestamp(header.timestamp())
-                && self.chain_spec.is_denim_active_at_timestamp(parent.timestamp());
+            self.chain_spec.is_cobalt_active_at_timestamp(header.timestamp())
+                && self.chain_spec.is_cobalt_active_at_timestamp(parent.timestamp());
         let timestamp_is_invalid = header.timestamp() < parent.timestamp()
             || (header.timestamp() == parent.timestamp() && !allows_same_timestamp);
         if self.chain_spec.is_bedrock_active_at_block(header.number()) && timestamp_is_invalid {
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn activated_parent_validation_allows_same_second_headers() {
         let mut chain_spec = BaseChainSpec::mainnet();
-        chain_spec.set_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(10));
+        chain_spec.set_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(10));
         let parent_header = Header {
             number: 8,
             timestamp: 10,
@@ -358,7 +358,7 @@ mod tests {
     #[test]
     fn activated_parent_validation_rejects_timestamp_in_past() {
         let mut chain_spec = BaseChainSpec::mainnet();
-        chain_spec.set_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(10));
+        chain_spec.set_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(10));
         let parent_header = Header {
             number: 8,
             timestamp: 11,

--- a/crates/execution/consensus/src/validation/mod.rs
+++ b/crates/execution/consensus/src/validation/mod.rs
@@ -30,7 +30,7 @@ pub fn validate_base_time_metadata(
     block_number: u64,
     transactions: &[BaseTxEnvelope],
 ) -> Result<(), BaseTimeMetadataError> {
-    if chain_spec.is_denim_active_at_timestamp(timestamp) {
+    if chain_spec.is_cobalt_active_at_timestamp(timestamp) {
         BaseTimeUpdateTx::extract_from_transactions(transactions, block_number)?;
     }
 
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn validates_base_time_metadata_only_after_activation() {
         let mut chain_spec = BaseChainSpec::sepolia();
-        chain_spec.set_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(10));
+        chain_spec.set_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(10));
 
         validate_base_time_metadata(&chain_spec, 10, 9, &base_time_transactions(9, 400)).unwrap();
         assert!(matches!(

--- a/crates/execution/eip8130-rpc-node/Cargo.toml
+++ b/crates/execution/eip8130-rpc-node/Cargo.toml
@@ -23,6 +23,7 @@ tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 # base
+base-protocol.workspace = true
 base-test-utils.workspace = true
 base-common-precompiles.workspace = true
 base-common-consensus.workspace = true

--- a/crates/execution/eip8130-rpc-node/tests/receipt.rs
+++ b/crates/execution/eip8130-rpc-node/tests/receipt.rs
@@ -14,10 +14,19 @@ use base_common_consensus::{Call, Eip8130Constants, Eip8130Signed, TxEip8130};
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_eip8130_rpc_node::{Eip8130RpcExtension, Eip8130RpcMode};
 use base_node_runner::test_utils::{L1_BLOCK_INFO_DEPOSIT_TX, TestHarness};
+use base_protocol::BaseTimeUpdateTx;
 use base_test_utils::{Account, DEVNET_CHAIN_ID, build_test_genesis_cobalt};
 
 /// EIP-8130 transaction type byte.
 const EIP8130_TX_TYPE: u8 = 0x79;
+
+fn base_time_deposit() -> Bytes {
+    BaseTimeUpdateTx::new(0)
+        .expect("zero millisecond component must be valid")
+        .into_deposit_tx(1)
+        .encoded_2718()
+        .into()
+}
 
 /// Mines a minimal EOA-path EIP-8130 transaction and asserts its receipt is a
 /// successful type `0x79` receipt.
@@ -60,7 +69,9 @@ async fn eip8130_transaction_is_mined_and_has_a_receipt() -> eyre::Result<()> {
     assert_eq!(raw[0], EIP8130_TX_TYPE, "encoded transaction must carry the 0x79 type byte");
 
     // The L1 block-info deposit must lead every block.
-    harness.build_block_from_transactions(vec![L1_BLOCK_INFO_DEPOSIT_TX, raw]).await?;
+    harness
+        .build_block_from_transactions(vec![L1_BLOCK_INFO_DEPOSIT_TX, base_time_deposit(), raw])
+        .await?;
 
     let receipt = provider
         .get_transaction_receipt(tx_hash)
@@ -130,7 +141,9 @@ async fn eip8130_receipt_reports_phase_statuses() -> eyre::Result<()> {
     let tx_hash = *signed.hash();
     let raw: Bytes = signed.encoded_2718().into();
 
-    harness.build_block_from_transactions(vec![L1_BLOCK_INFO_DEPOSIT_TX, raw]).await?;
+    harness
+        .build_block_from_transactions(vec![L1_BLOCK_INFO_DEPOSIT_TX, base_time_deposit(), raw])
+        .await?;
 
     let receipt = provider
         .get_transaction_receipt(tx_hash)
@@ -199,7 +212,9 @@ async fn eip8130_sponsored_receipt_reports_declared_payer() -> eyre::Result<()> 
     let tx_hash = *signed.hash();
     let raw: Bytes = signed.encoded_2718().into();
 
-    harness.build_block_from_transactions(vec![L1_BLOCK_INFO_DEPOSIT_TX, raw]).await?;
+    harness
+        .build_block_from_transactions(vec![L1_BLOCK_INFO_DEPOSIT_TX, base_time_deposit(), raw])
+        .await?;
 
     let receipt = provider
         .get_transaction_receipt(tx_hash)
@@ -298,8 +313,15 @@ async fn two_eip8130_transactions_in_one_block_attribute_phase_statuses() -> eyr
     let raw_2: Bytes = signed_2.encoded_2718().into();
 
     // Both EIP-8130 transactions ride in the same block, behind the mandatory
-    // L1 block-info deposit.
-    harness.build_block_from_transactions(vec![L1_BLOCK_INFO_DEPOSIT_TX, raw_1, raw_2]).await?;
+    // L1 block-info and BaseTime metadata deposits.
+    harness
+        .build_block_from_transactions(vec![
+            L1_BLOCK_INFO_DEPOSIT_TX,
+            base_time_deposit(),
+            raw_1,
+            raw_2,
+        ])
+        .await?;
 
     let receipt_1 = provider
         .get_transaction_receipt(tx1_hash)

--- a/crates/execution/evm/tests/block_execution.rs
+++ b/crates/execution/evm/tests/block_execution.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use alloy_consensus::{Block, BlockBody, Header, SignableTransaction, TxEip1559};
 use alloy_primitives::{Address, Signature, StorageKey, StorageValue, U256, address, b256, bytes};
-use base_common_chains::BaseUpgrade;
 use base_common_consensus::{
     BaseReceipt, BaseTransactionSigned, Predeploys, SystemAddresses, TxDeposit,
 };
@@ -12,7 +11,7 @@ use base_common_evm::BaseTime;
 use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
 use base_execution_evm::{BaseEvmConfig, BaseRethReceiptBuilder};
 use base_protocol::BaseTimeUpdateTx;
-use reth_chainspec::{ForkCondition, MIN_TRANSACTION_GAS};
+use reth_chainspec::MIN_TRANSACTION_GAS;
 use reth_evm::execute::{BasicBlockExecutor, Executor};
 use reth_primitives_traits::{Account, RecoveredBlock};
 use reth_revm::{database::StateProviderDatabase, test_utils::StateProviderTest};
@@ -86,12 +85,7 @@ fn execute_same_block_base_time_read(getter_selector: [u8; 4]) -> U256 {
         HashMap::default(),
     );
 
-    let chain_spec = Arc::new(
-        BaseChainSpecBuilder::base_mainnet()
-            .cobalt_activated()
-            .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(0))
-            .build(),
-    );
+    let chain_spec = Arc::new(BaseChainSpecBuilder::base_mainnet().cobalt_activated().build());
 
     let l1_info_tx: BaseTransactionSigned = TxDeposit {
         from: SystemAddresses::DEPOSITOR_ACCOUNT,

--- a/crates/execution/node/src/engine.rs
+++ b/crates/execution/node/src/engine.rs
@@ -169,7 +169,7 @@ where
         let state_updates = state_updates();
         self.validate_isthmus_post_execution(state_updates, parent_state.as_ref(), block.header())?;
 
-        if !self.chain_spec().is_denim_active_at_timestamp(timestamp) {
+        if !self.chain_spec().is_cobalt_active_at_timestamp(timestamp) {
             return Ok(());
         }
 
@@ -178,7 +178,7 @@ where
                 .map_err(ConsensusError::other)?
                 .timestamp_millis_part();
 
-        if !self.chain_spec().is_denim_active_at_timestamp(parent_header.timestamp()) {
+        if !self.chain_spec().is_cobalt_active_at_timestamp(parent_header.timestamp()) {
             // The legacy parent has no millisecond component to anchor the 200ms progression
             // check, so the activation block must claim exactly 0 instead.
             if child_millis != 0 {
@@ -227,7 +227,7 @@ where
         header: &<Self::Block as Block>::Header,
     ) -> Result<(), InvalidPayloadAttributesError> {
         let timestamp = attributes.timestamp();
-        if !self.chain_spec().is_denim_active_at_timestamp(timestamp) {
+        if !self.chain_spec().is_cobalt_active_at_timestamp(timestamp) {
             return (timestamp > header.timestamp())
                 .then_some(())
                 .ok_or(InvalidPayloadAttributesError::InvalidTimestamp);
@@ -415,7 +415,7 @@ mod tests {
     use super::*;
     use crate::engine;
 
-    const DENIM_TIMESTAMP: u64 = 1_800_000_001;
+    const COBALT_TIMESTAMP: u64 = 1_800_000_001;
 
     fn validator_with_chain_spec(
         chain_spec: BaseChainSpec,
@@ -429,10 +429,10 @@ mod tests {
         validator_with_chain_spec(BaseChainSpec::sepolia())
     }
 
-    fn denim_validator() -> BaseEngineValidator<BaseTxEnvelope, BaseChainSpec> {
+    fn cobalt_validator() -> BaseEngineValidator<BaseTxEnvelope, BaseChainSpec> {
         validator_with_chain_spec(
             BaseChainSpecBuilder::base_mainnet()
-                .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(DENIM_TIMESTAMP))
+                .with_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(COBALT_TIMESTAMP))
                 .build(),
         )
     }
@@ -477,7 +477,7 @@ mod tests {
         .expect("valid test payload attributes")
     }
 
-    fn denim_attributes(timestamp: u64) -> BasePayloadBuilderAttributes<BaseTxEnvelope> {
+    fn cobalt_attributes(timestamp: u64) -> BasePayloadBuilderAttributes<BaseTxEnvelope> {
         get_attributes(Some(b64!("0000000000000000")), Some(1), timestamp)
     }
 
@@ -639,7 +639,7 @@ mod tests {
         timestamp_millis_part: u16,
         parent_timestamp: u64,
     ) -> Result<(), InvalidPayloadAttributesError> {
-        let mut attributes = denim_attributes(timestamp);
+        let mut attributes = cobalt_attributes(timestamp);
         add_base_time_transaction(&mut attributes, timestamp_millis_part);
         let header = Header { number: 8, timestamp: parent_timestamp, ..Default::default() };
 
@@ -648,36 +648,38 @@ mod tests {
     }
 
     #[test]
-    fn test_payload_attributes_post_denim_accept_same_second() {
-        let validator = denim_validator();
-
-        assert!(validate_against_parent(&validator, DENIM_TIMESTAMP, 200, DENIM_TIMESTAMP).is_ok());
-    }
-
-    #[test]
-    fn test_payload_attributes_post_denim_accept_next_second() {
-        let validator = denim_validator();
+    fn test_payload_attributes_post_cobalt_accept_same_second() {
+        let validator = cobalt_validator();
 
         assert!(
-            validate_against_parent(&validator, DENIM_TIMESTAMP + 1, 0, DENIM_TIMESTAMP).is_ok()
+            validate_against_parent(&validator, COBALT_TIMESTAMP, 200, COBALT_TIMESTAMP).is_ok()
         );
     }
 
     #[test]
-    fn test_payload_attributes_post_denim_reject_backwards_seconds() {
-        let validator = denim_validator();
+    fn test_payload_attributes_post_cobalt_accept_next_second() {
+        let validator = cobalt_validator();
+
+        assert!(
+            validate_against_parent(&validator, COBALT_TIMESTAMP + 1, 0, COBALT_TIMESTAMP).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_payload_attributes_post_cobalt_reject_backwards_seconds() {
+        let validator = cobalt_validator();
 
         assert!(matches!(
-            validate_against_parent(&validator, DENIM_TIMESTAMP, 800, DENIM_TIMESTAMP + 1),
+            validate_against_parent(&validator, COBALT_TIMESTAMP, 800, COBALT_TIMESTAMP + 1),
             Err(InvalidPayloadAttributesError::InvalidTimestamp)
         ));
     }
 
     #[test]
-    fn test_payload_attributes_post_denim_require_base_time_transaction() {
-        let validator = denim_validator();
-        let attributes = denim_attributes(DENIM_TIMESTAMP);
-        let header = Header { number: 8, timestamp: DENIM_TIMESTAMP, ..Default::default() };
+    fn test_payload_attributes_post_cobalt_require_base_time_transaction() {
+        let validator = cobalt_validator();
+        let attributes = cobalt_attributes(COBALT_TIMESTAMP);
+        let header = Header { number: 8, timestamp: COBALT_TIMESTAMP, ..Default::default() };
 
         let result = <engine::BaseEngineValidator<_, _> as PayloadValidator<BaseEngineTypes>>::
             validate_payload_attributes_against_header(&validator, &attributes, &header);
@@ -689,14 +691,14 @@ mod tests {
     }
 
     #[test]
-    fn test_payload_attributes_post_denim_reject_invalid_base_time_transaction() {
-        let validator = denim_validator();
-        let mut attributes = denim_attributes(DENIM_TIMESTAMP);
+    fn test_payload_attributes_post_cobalt_reject_invalid_base_time_transaction() {
+        let validator = cobalt_validator();
+        let mut attributes = cobalt_attributes(COBALT_TIMESTAMP);
         attributes.transactions = vec![
             WithEncoded::from_2718_encodable(TxDeposit::default().seal_slow().into()),
             WithEncoded::from_2718_encodable(TxDeposit::default().seal_slow().into()),
         ];
-        let header = Header { number: 8, timestamp: DENIM_TIMESTAMP, ..Default::default() };
+        let header = Header { number: 8, timestamp: COBALT_TIMESTAMP, ..Default::default() };
 
         let result = <engine::BaseEngineValidator<_, _> as PayloadValidator<BaseEngineTypes>>::
             validate_payload_attributes_against_header(&validator, &attributes, &header);
@@ -710,7 +712,7 @@ mod tests {
     fn post_execution_block(withdrawals_root: B256) -> RecoveredBlock<BaseBlock> {
         let block = BaseBlock {
             header: Header {
-                timestamp: DENIM_TIMESTAMP,
+                timestamp: COBALT_TIMESTAMP,
                 withdrawals_root: Some(withdrawals_root),
                 ..Default::default()
             },
@@ -772,7 +774,7 @@ mod tests {
     ) -> Result<(), InsertBlockErrorKind> {
         let validator = validator_with_chain_spec(
             BaseChainSpecBuilder::base_mainnet()
-                .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(DENIM_TIMESTAMP))
+                .with_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(COBALT_TIMESTAMP))
                 .build(),
         );
         let block = base_time_block(child_timestamp, child_millis_part, withdrawals_root);
@@ -808,13 +810,13 @@ mod tests {
     fn post_execution_skips_base_time_at_activation_but_checks_isthmus() {
         let block = post_execution_block(EMPTY_ROOT_HASH);
         let parent = SealedHeader::seal_slow(Header {
-            timestamp: DENIM_TIMESTAMP - 1,
+            timestamp: COBALT_TIMESTAMP - 1,
             ..Default::default()
         });
         let state_updates = HashedPostState::default();
         let error =
             PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
-                &denim_validator(),
+                &cobalt_validator(),
                 || &state_updates,
                 &block,
                 &parent,
@@ -831,11 +833,11 @@ mod tests {
     #[test]
     fn post_execution_validates_exact_200ms_progression() {
         for (parent_seconds, parent_millis, child_seconds, child_millis) in [
-            (DENIM_TIMESTAMP, 0, DENIM_TIMESTAMP, 200),
-            (DENIM_TIMESTAMP, 200, DENIM_TIMESTAMP, 400),
-            (DENIM_TIMESTAMP, 400, DENIM_TIMESTAMP, 600),
-            (DENIM_TIMESTAMP, 600, DENIM_TIMESTAMP, 800),
-            (DENIM_TIMESTAMP, 800, DENIM_TIMESTAMP + 1, 0),
+            (COBALT_TIMESTAMP, 0, COBALT_TIMESTAMP, 200),
+            (COBALT_TIMESTAMP, 200, COBALT_TIMESTAMP, 400),
+            (COBALT_TIMESTAMP, 400, COBALT_TIMESTAMP, 600),
+            (COBALT_TIMESTAMP, 600, COBALT_TIMESTAMP, 800),
+            (COBALT_TIMESTAMP, 800, COBALT_TIMESTAMP + 1, 0),
         ] {
             validate_base_time_progression(
                 parent_seconds,
@@ -848,12 +850,12 @@ mod tests {
         }
 
         for (parent_seconds, parent_millis, child_seconds, child_millis) in [
-            (DENIM_TIMESTAMP, 200, DENIM_TIMESTAMP, 200),
-            (DENIM_TIMESTAMP, 400, DENIM_TIMESTAMP, 200),
-            (DENIM_TIMESTAMP, 200, DENIM_TIMESTAMP, 600),
-            (DENIM_TIMESTAMP, 800, DENIM_TIMESTAMP + 1, 200),
-            (DENIM_TIMESTAMP, 800, DENIM_TIMESTAMP, 800),
-            (DENIM_TIMESTAMP, 200, DENIM_TIMESTAMP + 1, 400),
+            (COBALT_TIMESTAMP, 200, COBALT_TIMESTAMP, 200),
+            (COBALT_TIMESTAMP, 400, COBALT_TIMESTAMP, 200),
+            (COBALT_TIMESTAMP, 200, COBALT_TIMESTAMP, 600),
+            (COBALT_TIMESTAMP, 800, COBALT_TIMESTAMP + 1, 200),
+            (COBALT_TIMESTAMP, 800, COBALT_TIMESTAMP, 800),
+            (COBALT_TIMESTAMP, 200, COBALT_TIMESTAMP + 1, 400),
         ] {
             let error = validate_base_time_progression(
                 parent_seconds,
@@ -873,9 +875,9 @@ mod tests {
     #[test]
     fn post_execution_progression_error_contains_full_timestamps() {
         for (parent_seconds, parent_millis, child_seconds, child_millis) in [
-            (DENIM_TIMESTAMP, 200, DENIM_TIMESTAMP, 600),
-            (DENIM_TIMESTAMP, 800, DENIM_TIMESTAMP + 1, 200),
-            (DENIM_TIMESTAMP, 400, DENIM_TIMESTAMP, 200),
+            (COBALT_TIMESTAMP, 200, COBALT_TIMESTAMP, 600),
+            (COBALT_TIMESTAMP, 800, COBALT_TIMESTAMP + 1, 200),
+            (COBALT_TIMESTAMP, 400, COBALT_TIMESTAMP, 200),
         ] {
             let error = validate_base_time_progression(
                 parent_seconds,
@@ -911,15 +913,15 @@ mod tests {
             ),
         ] {
             let block =
-                base_time_block_with_transactions(DENIM_TIMESTAMP, EMPTY_ROOT_HASH, transactions);
+                base_time_block_with_transactions(COBALT_TIMESTAMP, EMPTY_ROOT_HASH, transactions);
             let parent = SealedHeader::seal_slow(Header {
-                timestamp: DENIM_TIMESTAMP,
+                timestamp: COBALT_TIMESTAMP,
                 ..Default::default()
             });
             let state_updates = HashedPostState::default();
             let error = PayloadValidator::<BaseEngineTypes>::
                 validate_block_post_execution_with_hashed_state(
-                    &denim_validator(),
+                    &cobalt_validator(),
                     || &state_updates,
                     &block,
                     &parent,
@@ -933,15 +935,15 @@ mod tests {
 
     #[test]
     fn post_execution_accepts_zero_claim_on_first_active_block() {
-        let block = base_time_block(DENIM_TIMESTAMP, 0, EMPTY_ROOT_HASH);
+        let block = base_time_block(COBALT_TIMESTAMP, 0, EMPTY_ROOT_HASH);
         let parent = SealedHeader::seal_slow(Header {
-            timestamp: DENIM_TIMESTAMP - 1,
+            timestamp: COBALT_TIMESTAMP - 1,
             ..Default::default()
         });
         let state_updates = HashedPostState::default();
 
         PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
-            &denim_validator(),
+            &cobalt_validator(),
             || &state_updates,
             &block,
             &parent,
@@ -953,15 +955,15 @@ mod tests {
     #[test]
     fn post_execution_rejects_nonzero_claim_on_first_active_block() {
         for millis_part in [200, 400, 600, 800] {
-            let block = base_time_block(DENIM_TIMESTAMP, millis_part, EMPTY_ROOT_HASH);
+            let block = base_time_block(COBALT_TIMESTAMP, millis_part, EMPTY_ROOT_HASH);
             let parent = SealedHeader::seal_slow(Header {
-                timestamp: DENIM_TIMESTAMP - 1,
+                timestamp: COBALT_TIMESTAMP - 1,
                 ..Default::default()
             });
             let state_updates = HashedPostState::default();
             let error = PayloadValidator::<BaseEngineTypes>::
                 validate_block_post_execution_with_hashed_state(
-                    &denim_validator(),
+                    &cobalt_validator(),
                     || &state_updates,
                     &block,
                     &parent,
@@ -981,18 +983,18 @@ mod tests {
     #[test]
     fn post_execution_requires_claim_on_first_active_block() {
         let block = base_time_block_with_transactions(
-            DENIM_TIMESTAMP,
+            COBALT_TIMESTAMP,
             EMPTY_ROOT_HASH,
             vec![TxDeposit::default().seal_slow().into()],
         );
         let parent = SealedHeader::seal_slow(Header {
-            timestamp: DENIM_TIMESTAMP - 1,
+            timestamp: COBALT_TIMESTAMP - 1,
             ..Default::default()
         });
         let state_updates = HashedPostState::default();
         let error =
             PayloadValidator::<BaseEngineTypes>::validate_block_post_execution_with_hashed_state(
-                &denim_validator(),
+                &cobalt_validator(),
                 || &state_updates,
                 &block,
                 &parent,
@@ -1006,9 +1008,9 @@ mod tests {
     #[test]
     fn post_execution_validates_isthmus_before_base_time() {
         let error = validate_base_time_progression(
-            DENIM_TIMESTAMP,
+            COBALT_TIMESTAMP,
             200,
-            DENIM_TIMESTAMP + 1,
+            COBALT_TIMESTAMP + 1,
             400,
             B256::ZERO,
         )

--- a/crates/execution/payload/src/builder.rs
+++ b/crates/execution/payload/src/builder.rs
@@ -418,7 +418,7 @@ impl<Txs> Builder<'_, Txs> {
             }
 
             // check if the new payload is even more valuable
-            if !ctx.is_denim_active() && !ctx.is_better_payload(info.total_fees) {
+            if !ctx.is_cobalt_active() && !ctx.is_better_payload(info.total_fees) {
                 // can skip building the block
                 return Ok(BuildOutcomeKind::Aborted { fees: info.total_fees });
             }
@@ -484,11 +484,11 @@ impl<Txs> Builder<'_, Txs> {
         );
         BuilderMetrics::record_inclusion(&info.inclusion);
 
-        if no_tx_pool || ctx.is_denim_active() {
+        if no_tx_pool || ctx.is_cobalt_active() {
             // if `no_tx_pool` is set only transactions from the payload attributes will be included
             // in the payload. In other words, the payload is deterministic and we can
             // freeze it once we've successfully built it.
-            // Denim-active sequencer builds are one-shot, so this payload is also final.
+            // Cobalt-active sequencer builds are one-shot, so this payload is also final.
             Ok(BuildOutcomeKind::Freeze(payload))
         } else {
             Ok(BuildOutcomeKind::Better { payload })
@@ -708,9 +708,9 @@ where
         &self.config.attributes
     }
 
-    /// Returns `true` if Denim is active at this payload's timestamp.
-    pub fn is_denim_active(&self) -> bool {
-        self.chain_spec.is_denim_active_at_timestamp(self.attributes().timestamp())
+    /// Returns `true` if Cobalt is active at this payload's timestamp.
+    pub fn is_cobalt_active(&self) -> bool {
+        self.chain_spec.is_cobalt_active_at_timestamp(self.attributes().timestamp())
     }
 
     /// Returns the current fee settings for transactions from the mempool
@@ -852,7 +852,7 @@ where
         let mut predicate_eval_cutoff_hit = false;
 
         let block_timestamp = self.attributes().timestamp();
-        let can_finalize_early = self.is_denim_active();
+        let can_finalize_early = self.is_cobalt_active();
         while let Some(tx) = best_txs.next(()) {
             if self.cancel.is_cancelled() {
                 return Ok(Some(()));
@@ -1319,8 +1319,8 @@ where
         );
 
         // A cancellation that raced the finalization break (or an empty iterator) must still
-        // win, so re-check it before the finalized payload is assembled. Gated on Denim so
-        // pre-Denim control flow is unchanged.
+        // win, so re-check it before the finalized payload is assembled. Gated on Cobalt so
+        // pre-Cobalt control flow is unchanged.
         if can_finalize_early && self.cancel.is_cancelled() {
             return Ok(Some(()));
         }
@@ -1459,12 +1459,12 @@ mod tests {
         assert_eq!(build_empty_payload(state_root_handle()), B256::repeat_byte(0x42));
     }
 
-    const DENIM_TIMESTAMP: u64 = 1;
+    const COBALT_TIMESTAMP: u64 = 1;
 
     fn pool_payload_context(timestamp: u64) -> BasePayloadBuilderCtx<BaseEvmConfig, BaseChainSpec> {
         let chain_spec = Arc::new(
             BaseChainSpecBuilder::base_mainnet()
-                .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(DENIM_TIMESTAMP))
+                .with_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(COBALT_TIMESTAMP))
                 .build(),
         );
         let parent = Arc::new(SealedHeader::seal_slow(Header {
@@ -1649,8 +1649,8 @@ mod tests {
     }
 
     #[test]
-    fn pre_denim_ignores_finalization_requests() {
-        let ctx = pool_payload_context(DENIM_TIMESTAMP - 1);
+    fn pre_cobalt_ignores_finalization_requests() {
+        let ctx = pool_payload_context(COBALT_TIMESTAMP - 1);
         ctx.cancel.request_finalization();
         let transactions = FinalizeAfterFirstTransaction {
             transactions: vec![pool_transaction(0)].into_iter(),
@@ -1659,14 +1659,14 @@ mod tests {
         };
 
         let BuildOutcomeKind::Better { payload } = build_pool_payload(ctx, transactions) else {
-            panic!("pre-Denim payload must remain eligible for improvement")
+            panic!("pre-Cobalt payload must remain eligible for improvement")
         };
         assert_eq!(payload.block().body().transactions.len(), 1);
     }
 
     #[test]
-    fn denim_finalization_preserves_completed_pool_transactions() {
-        let ctx = pool_payload_context(DENIM_TIMESTAMP);
+    fn cobalt_finalization_preserves_completed_pool_transactions() {
+        let ctx = pool_payload_context(COBALT_TIMESTAMP);
         let transactions = FinalizeAfterFirstTransaction {
             transactions: vec![pool_transaction(0), pool_transaction(1)].into_iter(),
             calls: 0,
@@ -1674,7 +1674,7 @@ mod tests {
         };
 
         let BuildOutcomeKind::Freeze(payload) = build_pool_payload(ctx, transactions) else {
-            panic!("Denim payload must freeze")
+            panic!("Cobalt payload must freeze")
         };
         assert_eq!(payload.block().body().transactions.len(), 1);
     }
@@ -1691,11 +1691,11 @@ mod tests {
         let transaction_hash = *transaction.hash();
 
         let BuildOutcomeKind::Freeze(payload) = build_parkable_pool_payload(
-            pool_payload_context(DENIM_TIMESTAMP),
+            pool_payload_context(COBALT_TIMESTAMP),
             TestParkableTransactions::new(vec![transaction]),
             &[sender],
         ) else {
-            panic!("Denim payload must freeze")
+            panic!("Cobalt payload must freeze")
         };
 
         assert_eq!(payload.block().body().transactions.len(), 1);
@@ -1725,11 +1725,11 @@ mod tests {
         let sender = transaction.sender();
 
         let BuildOutcomeKind::Freeze(payload) = build_parkable_pool_payload(
-            pool_payload_context(DENIM_TIMESTAMP),
+            pool_payload_context(COBALT_TIMESTAMP),
             TestParkableTransactions::new(vec![transaction]),
             &[sender],
         ) else {
-            panic!("Denim payload must freeze")
+            panic!("Cobalt payload must freeze")
         };
 
         assert!(payload.block().body().transactions.is_empty());
@@ -1745,11 +1745,11 @@ mod tests {
         let sender = transaction.sender();
 
         let BuildOutcomeKind::Freeze(payload) = build_parkable_pool_payload(
-            pool_payload_context(DENIM_TIMESTAMP),
+            pool_payload_context(COBALT_TIMESTAMP),
             TestParkableTransactions::new(vec![transaction]),
             &[sender],
         ) else {
-            panic!("Denim payload must freeze")
+            panic!("Cobalt payload must freeze")
         };
 
         assert!(payload.block().body().transactions.is_empty());
@@ -1770,11 +1770,11 @@ mod tests {
         let trigger_hash = *trigger.hash();
 
         let BuildOutcomeKind::Freeze(payload) = build_parkable_pool_payload(
-            pool_payload_context(DENIM_TIMESTAMP),
+            pool_payload_context(COBALT_TIMESTAMP),
             TestParkableTransactions::new(vec![gated, trigger]),
             &funded_senders,
         ) else {
-            panic!("Denim payload must freeze")
+            panic!("Cobalt payload must freeze")
         };
 
         let included_hashes = payload
@@ -1804,7 +1804,7 @@ mod tests {
         let trigger = pool_transaction_to(0, watched_address, U256::ONE);
         let funded_senders = [gated.sender(), matching.sender(), trigger.sender()];
         let trigger_hash = *trigger.hash();
-        let mut ctx = pool_payload_context(DENIM_TIMESTAMP);
+        let mut ctx = pool_payload_context(COBALT_TIMESTAMP);
         ctx.builder_config.predicate_eval_hard_cutoff = Duration::from_nanos(1);
 
         let BuildOutcomeKind::Freeze(payload) = build_parkable_pool_payload(
@@ -1812,7 +1812,7 @@ mod tests {
             TestParkableTransactions::new(vec![gated, matching, trigger]),
             &funded_senders,
         ) else {
-            panic!("Denim payload must freeze")
+            panic!("Cobalt payload must freeze")
         };
 
         let included_hashes = payload
@@ -1827,7 +1827,7 @@ mod tests {
 
     #[test]
     fn cancellation_takes_precedence_over_finalization() {
-        let ctx = pool_payload_context(DENIM_TIMESTAMP);
+        let ctx = pool_payload_context(COBALT_TIMESTAMP);
         ctx.cancel.request_finalization();
         drop(ctx.cancel.clone());
 

--- a/crates/execution/runner/tests/rpc_timestamp_ms.rs
+++ b/crates/execution/runner/tests/rpc_timestamp_ms.rs
@@ -1,4 +1,4 @@
-//! End-to-end wire checks for canonical Denim RPC timestamps.
+//! End-to-end wire checks for canonical Cobalt RPC timestamps.
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -43,9 +43,9 @@ fn receipt_logs(receipts: &Value, transaction_hash: &str) -> Value {
 }
 
 #[tokio::test]
-async fn canonical_denim_rpc_responses_include_millisecond_timestamps() -> eyre::Result<()> {
+async fn canonical_cobalt_rpc_responses_include_millisecond_timestamps() -> eyre::Result<()> {
     let mut genesis = build_test_genesis();
-    genesis.config.extra_fields.insert("base".into(), json!({ "denim": 3 }));
+    genesis.config.extra_fields.insert("base".into(), json!({ "cobalt": 3 }));
     let harness = TestHarness::builder()
         .with_chain_spec(Arc::new(BaseChainSpec::from_genesis(genesis)))
         .build()

--- a/crates/proof/proof/src/boot.rs
+++ b/crates/proof/proof/src/boot.rs
@@ -966,7 +966,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pins_schedule_using_denim_block_timestamp() {
+    async fn pins_schedule_using_cobalt_block_timestamp() {
         const GENESIS_BLOCK: u64 = 1_000;
         const CLAIM_BLOCK: u64 = 1_003;
 
@@ -975,7 +975,7 @@ mod tests {
         rollup_config.genesis.l2_time = 1_000;
         rollup_config.block_time = 2;
         rollup_config.upgrades = UpgradeConfig {
-            base: BaseUpgradeConfig { denim: Some(1_004), ..Default::default() },
+            base: BaseUpgradeConfig { cobalt: Some(1_004), ..Default::default() },
             ..Default::default()
         };
 
@@ -1003,7 +1003,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn gates_zenith_using_denim_claim_timestamp() {
+    async fn gates_zenith_using_cobalt_claim_timestamp() {
         const GENESIS_BLOCK: u64 = 1_000;
 
         let mut rollup_config = BaseChainConfig::MAINNET.rollup_config();
@@ -1012,7 +1012,7 @@ mod tests {
         rollup_config.block_time = 2;
         rollup_config.upgrades = UpgradeConfig {
             base: BaseUpgradeConfig {
-                denim: Some(1_004),
+                cobalt: Some(1_004),
                 zenith: Some(1_005),
                 ..Default::default()
             },
@@ -1028,7 +1028,7 @@ mod tests {
         oracle.insert_rollup_config(ORACLE_CHAIN_ID, &rollup_config);
 
         let boot_info =
-            BootInfo::load(&oracle).await.expect("Zenith activates after the claimed Denim block");
+            BootInfo::load(&oracle).await.expect("Zenith activates after the claimed Cobalt block");
         assert_eq!(boot_info.rollup_config.upgrades.base.zenith, None);
 
         let mut oracle = MockOracle::new();
@@ -1038,8 +1038,9 @@ mod tests {
         oracle.insert(L2_CLAIM_BLOCK_NUMBER_KEY, 1_007u64.to_be_bytes().to_vec());
         oracle.insert_rollup_config(ORACLE_CHAIN_ID, &rollup_config);
 
-        let err =
-            BootInfo::load(&oracle).await.expect_err("Zenith is active at the claimed Denim block");
+        let err = BootInfo::load(&oracle)
+            .await
+            .expect_err("Zenith is active at the claimed Cobalt block");
         assert!(matches!(err, OracleProviderError::UncommittedZenithUpgrade));
     }
 


### PR DESCRIPTION
- Anchor the native 200ms cadence, BaseTime transition, and timestamp validation to Cobalt.
- Align sequencer sealing and payload finalization with the Cobalt schedule while preserving Denim span-batch behavior.