### PR TITLE
Validate Cobalt schedules at consensus ingress

### DIFF
--- a/crates/consensus/engine/README.md
+++ b/crates/consensus/engine/README.md
@@ -37,6 +37,7 @@ The engine implements a task-driven architecture where operations are queued and
 ```
 
 - **Automatic Forkchoice Handling**: [`Engine::build`](crate::Engine::build) automatically performs forkchoice updates during block building, eliminating the need for explicit forkchoice management in user code.
+- **Rollup Schedule Validation**: [`InsertTask`](crate::InsertTask) validates Cobalt payload timestamps against the absolute rollup schedule before calling `engine_newPayload`.
 - **Internal Synchronization**: [`SynchronizeTask`](crate::SynchronizeTask) handles internal execution layer synchronization and is primarily used by other tasks rather than directly by users.
 - **Priority-Based Execution**: Tasks are executed in priority order to ensure optimal sequencer performance and block processing efficiency.
 

--- a/crates/consensus/engine/src/task_queue/tasks/insert/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/error.rs
@@ -5,7 +5,7 @@
 use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_transport::{RpcError, TransportErrorKind};
 use base_common_rpc_types_engine::BasePayloadError;
-use base_protocol::FromBlockError;
+use base_protocol::{BaseTimeScheduleError, FromBlockError};
 
 use crate::{
     EngineTaskError, SynchronizeTaskError, task_queue::tasks::task::EngineTaskErrorSeverity,
@@ -31,6 +31,9 @@ pub enum InsertTaskError {
     /// Error converting the payload + chain genesis into an L2 block info.
     #[error(transparent)]
     L2BlockInfoConstruction(#[from] FromBlockError),
+    /// The payload timestamp does not match the absolute rollup schedule.
+    #[error(transparent)]
+    InvalidBaseTimeSchedule(#[from] BaseTimeScheduleError),
     /// The forkchoice update call to consolidate the block into the engine state failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
@@ -44,7 +47,8 @@ impl EngineTaskError for InsertTaskError {
         match self {
             Self::EmptyAuthoritativePayloads
             | Self::FromBlockError(_)
-            | Self::L2BlockInfoConstruction(_) => EngineTaskErrorSeverity::Critical,
+            | Self::L2BlockInfoConstruction(_)
+            | Self::InvalidBaseTimeSchedule(_) => EngineTaskErrorSeverity::Critical,
             Self::InsertFailed(_)
             | Self::UnexpectedPayloadStatus(_)
             | Self::ForkchoiceUpdateDidNotApply => EngineTaskErrorSeverity::Temporary,

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -12,7 +12,7 @@ use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::{
     BaseExecutionPayload, BaseExecutionPayloadEnvelope, BaseExecutionPayloadSidecar,
 };
-use base_protocol::L2BlockInfo;
+use base_protocol::{BaseTimeUpdateTx, L2BlockInfo};
 use tokio::sync::mpsc;
 
 use crate::{
@@ -254,6 +254,13 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
             return Ok(state.sync_state.unsafe_head());
         }
 
+        BaseTimeUpdateTx::validate_block_timestamp(
+            &self.rollup_config,
+            &block.body.transactions,
+            block.header.number,
+            block.header.timestamp,
+        )?;
+
         // Insert the new payload.
         let insert_time_start = Instant::now();
         let response = match execution_payload {
@@ -381,12 +388,15 @@ mod tests {
     use alloy_primitives::{Address, B256, Bloom, FixedBytes, U256};
     use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
     use base_common_consensus::{BaseTxEnvelope, TxDeposit};
+    use base_common_genesis::{BaseUpgradeConfig, RollupConfig, UpgradeConfig};
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
-    use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
+    use base_protocol::{
+        BaseTimeScheduleError, BaseTimeUpdateTx, BlockInfo, L1BlockInfoBedrock, L2BlockInfo,
+    };
 
     use super::{InsertPayloadPolicy, InsertPayloadSafety, InsertTask};
     use crate::{
-        Engine, EngineTaskExt, InsertTaskError,
+        Engine, EngineTaskError, EngineTaskErrorSeverity, EngineTaskExt, InsertTaskError,
         test_utils::{TestEngineStateBuilder, test_engine_client_builder},
     };
 
@@ -443,6 +453,36 @@ mod tests {
 
     fn bedrock_payload(block_number: u64) -> BaseExecutionPayload {
         bedrock_payload_with_parent(block_number, B256::ZERO)
+    }
+
+    fn cobalt_config() -> Arc<RollupConfig> {
+        Arc::new(RollupConfig {
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { cobalt: Some(2), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+    }
+
+    fn cobalt_payload(
+        block_number: u64,
+        timestamp: u64,
+        timestamp_millis_part: u16,
+    ) -> BaseExecutionPayload {
+        let BaseExecutionPayload::V1(mut payload) = bedrock_payload(block_number) else {
+            unreachable!()
+        };
+        payload.timestamp = timestamp;
+        payload.transactions.push(
+            BaseTxEnvelope::from(
+                BaseTimeUpdateTx::new(timestamp_millis_part).unwrap().into_deposit_tx(block_number),
+            )
+            .encoded_2718()
+            .into(),
+        );
+        BaseExecutionPayload::V1(payload)
     }
 
     fn canyon_payload(block_number: u64) -> BaseExecutionPayload {
@@ -609,6 +649,62 @@ mod tests {
             "stale unsafe payload should not be sent to engine_newPayload"
         );
         assert_eq!(state.sync_state.unsafe_head(), current_unsafe);
+    }
+
+    #[tokio::test]
+    async fn cobalt_schedule_mismatch_is_rejected_before_new_payload() {
+        let client = test_client();
+        let mut state = TestEngineStateBuilder::new().build();
+
+        for (payload, expected_error) in [
+            (
+                cobalt_payload(2, 3, 200),
+                BaseTimeScheduleError::InvalidTimestamp { expected: 2, actual: 3 },
+            ),
+            (
+                cobalt_payload(2, 2, 400),
+                BaseTimeScheduleError::InvalidTimestampMillisPart { expected: 200, actual: 400 },
+            ),
+        ] {
+            let error = InsertTask::unsafe_payload(
+                Arc::clone(&client),
+                cobalt_config(),
+                BaseExecutionPayloadEnvelope {
+                    parent_beacon_block_root: None,
+                    execution_payload: payload,
+                },
+            )
+            .execute_with_result(&mut state)
+            .await
+            .unwrap_err();
+
+            assert_eq!(error.severity(), EngineTaskErrorSeverity::Critical);
+            assert!(matches!(
+                &error,
+                InsertTaskError::InvalidBaseTimeSchedule(actual) if *actual == expected_error
+            ));
+        }
+
+        assert!(client.last_new_payload_v2().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_unsafe_payload_is_dropped_before_schedule_validation() {
+        let client = test_client();
+        let current_unsafe = l2_block_info(4, B256::with_last_byte(4), B256::with_last_byte(3));
+        let mut state = TestEngineStateBuilder::new().with_unsafe_head(current_unsafe).build();
+        let envelope = BaseExecutionPayloadEnvelope {
+            parent_beacon_block_root: None,
+            execution_payload: cobalt_payload(2, 3, 200),
+        };
+
+        let result = InsertTask::unsafe_payload(Arc::clone(&client), cobalt_config(), envelope)
+            .execute_with_result(&mut state)
+            .await
+            .expect("stale payload should be dropped before validation");
+
+        assert_eq!(result, current_unsafe);
+        assert!(client.last_new_payload_v2().await.is_none());
     }
 
     #[tokio::test]

--- a/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
@@ -75,7 +75,8 @@ impl SealTaskError {
                 }
                 InsertTaskError::EmptyAuthoritativePayloads
                 | InsertTaskError::FromBlockError(_)
-                | InsertTaskError::L2BlockInfoConstruction(_) => true,
+                | InsertTaskError::L2BlockInfoConstruction(_)
+                | InsertTaskError::InvalidBaseTimeSchedule(_) => true,
                 InsertTaskError::InsertFailed(_)
                 | InsertTaskError::UnexpectedPayloadStatus(_)
                 | InsertTaskError::ForkchoiceUpdateDidNotApply => false,
@@ -115,7 +116,7 @@ impl EngineTaskError for SealTaskError {
 mod tests {
     use alloy_rpc_types_engine::PayloadStatusEnum;
     use alloy_transport::RpcError;
-    use base_protocol::FromBlockError;
+    use base_protocol::{BaseTimeScheduleError, FromBlockError};
     use rstest::rstest;
 
     use super::*;
@@ -173,6 +174,13 @@ mod tests {
     )]
     #[case::l2_block_info_construction(
         InsertTaskError::L2BlockInfoConstruction(FromBlockError::InvalidGenesisHash),
+        true
+    )]
+    #[case::invalid_base_time_schedule(
+        InsertTaskError::InvalidBaseTimeSchedule(BaseTimeScheduleError::InvalidTimestamp {
+            expected: 1,
+            actual: 2,
+        }),
         true
     )]
     fn test_insertion_non_forkchoice_error_is_fatal(

--- a/crates/consensus/protocol/src/base_time.rs
+++ b/crates/consensus/protocol/src/base_time.rs
@@ -106,6 +106,42 @@ impl BaseTimeUpdateTx {
         Ok(timestamp.wrapping_mul(1_000).wrapping_add(u64::from(base_time.timestamp_millis_part())))
     }
 
+    /// Validates a Cobalt block's timestamp against the absolute rollup schedule.
+    pub fn validate_block_timestamp<T: BaseTransaction>(
+        rollup_config: &RollupConfig,
+        transactions: &[T],
+        block_number: u64,
+        timestamp: u64,
+    ) -> Result<(), BaseTimeScheduleError> {
+        let Some(cobalt_activation_block) = rollup_config.cobalt_activation_block_number() else {
+            return Ok(());
+        };
+        let blocks_since_genesis = block_number.saturating_sub(rollup_config.genesis.l2.number);
+        if blocks_since_genesis < cobalt_activation_block {
+            return Ok(());
+        }
+
+        let (expected_timestamp, expected_millis_part) =
+            rollup_config.l2_block_timestamp_parts(block_number);
+        if timestamp != expected_timestamp {
+            return Err(BaseTimeScheduleError::InvalidTimestamp {
+                expected: expected_timestamp,
+                actual: timestamp,
+            });
+        }
+
+        let actual_millis_part =
+            Self::extract_from_transactions(transactions, block_number)?.timestamp_millis_part();
+        if actual_millis_part != expected_millis_part {
+            return Err(BaseTimeScheduleError::InvalidTimestampMillisPart {
+                expected: expected_millis_part,
+                actual: actual_millis_part,
+            });
+        }
+
+        Ok(())
+    }
+
     /// Validates and decodes a `BaseTime` metadata deposit.
     pub fn validate_deposit(
         deposit: &TxDeposit,
@@ -225,6 +261,30 @@ pub enum BaseTimeMetadataError {
     InvalidCalldata(BaseTimeUpdateDecodeError),
 }
 
+/// An error validating a Cobalt block timestamp against the rollup schedule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum BaseTimeScheduleError {
+    /// The whole-second timestamp does not match the scheduled timestamp.
+    #[error("invalid L2 block timestamp: expected {expected}, got {actual}")]
+    InvalidTimestamp {
+        /// The scheduled timestamp.
+        expected: u64,
+        /// The block's timestamp.
+        actual: u64,
+    },
+    /// The `BaseTime` metadata deposit is invalid.
+    #[error(transparent)]
+    InvalidMetadata(#[from] BaseTimeMetadataError),
+    /// The millisecond component does not match the scheduled timestamp.
+    #[error("invalid BaseTime timestamp millis part: expected {expected}, got {actual}")]
+    InvalidTimestampMillisPart {
+        /// The scheduled millisecond component.
+        expected: u16,
+        /// The block's millisecond component.
+        actual: u16,
+    },
+}
+
 #[cfg(test)]
 mod tests {
     use alloy_consensus::{Sealable, TxLegacy};
@@ -232,9 +292,11 @@ mod tests {
     use base_common_consensus::{
         BaseTransactionSigned, BaseTypedTransaction, Predeploys, SystemAddresses, TxDeposit,
     };
+    use base_common_genesis::{BaseUpgradeConfig, ChainGenesis, RollupConfig, UpgradeConfig};
 
     use super::{
-        BaseTimeMetadataError, BaseTimeUpdateDecodeError, BaseTimeUpdateError, BaseTimeUpdateTx,
+        BaseTimeMetadataError, BaseTimeScheduleError, BaseTimeUpdateDecodeError,
+        BaseTimeUpdateError, BaseTimeUpdateTx,
     };
     use crate::REGOLITH_SYSTEM_TX_GAS;
 
@@ -334,6 +396,73 @@ mod tests {
         ];
 
         assert_eq!(BaseTimeUpdateTx::extract_timestamp_ms(&transactions, 9, 42), Ok(42_600));
+    }
+
+    #[test]
+    fn validates_cobalt_block_timestamp_against_absolute_schedule() {
+        let config = RollupConfig {
+            genesis: ChainGenesis { l2_time: 10, ..Default::default() },
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { cobalt: Some(14), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let transactions = |block_number, millis_part| -> Vec<BaseTransactionSigned> {
+            vec![
+                TxDeposit::default().seal_slow().into(),
+                base_time_deposit(block_number, millis_part).seal_slow().into(),
+            ]
+        };
+
+        assert_eq!(
+            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(2, 0), 2, 14),
+            Ok(())
+        );
+        assert_eq!(
+            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(3, 200), 3, 14),
+            Ok(())
+        );
+        assert_eq!(
+            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(7, 0), 7, 15),
+            Ok(())
+        );
+        assert_eq!(
+            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(3, 200), 3, 15),
+            Err(BaseTimeScheduleError::InvalidTimestamp { expected: 14, actual: 15 })
+        );
+        assert_eq!(
+            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(3, 400), 3, 14),
+            Err(BaseTimeScheduleError::InvalidTimestampMillisPart { expected: 200, actual: 400 })
+        );
+        assert_eq!(
+            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(7, 800), 7, 15),
+            Err(BaseTimeScheduleError::InvalidTimestampMillisPart { expected: 0, actual: 800 })
+        );
+    }
+
+    #[test]
+    fn skips_schedule_validation_before_cobalt() {
+        let config = RollupConfig {
+            genesis: ChainGenesis { l2_time: 10, ..Default::default() },
+            block_time: 2,
+            upgrades: UpgradeConfig {
+                base: BaseUpgradeConfig { cobalt: Some(14), ..Default::default() },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert_eq!(
+            BaseTimeUpdateTx::validate_block_timestamp::<BaseTransactionSigned>(
+                &config,
+                &[],
+                1,
+                u64::MAX,
+            ),
+            Ok(())
+        );
     }
 
     #[test]

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -53,7 +53,8 @@ pub use deposits::{DepositDecodeError, Deposits};
 
 mod base_time;
 pub use base_time::{
-    BaseTimeMetadataError, BaseTimeUpdateDecodeError, BaseTimeUpdateError, BaseTimeUpdateTx,
+    BaseTimeMetadataError, BaseTimeScheduleError, BaseTimeUpdateDecodeError, BaseTimeUpdateError,
+    BaseTimeUpdateTx,
 };
 
 mod timing;


### PR DESCRIPTION
- Validate Cobalt payload timestamps and BaseTime metadata against the absolute rollup schedule.
- Reject schedule mismatches before calling the execution layer and classify them as non-retryable.