### PR TITLE
feat(proposer): resolve proposal intervals per game for Denim

### DIFF
--- a/crates/infra/basectl/src/commands/proofs.rs
+++ b/crates/infra/basectl/src/commands/proofs.rs
@@ -165,10 +165,9 @@ pub struct ProofsProposeArgs {
     pub retry_failed: bool,
     /// Intermediate output root interval (checkpoint stride).
     ///
-    /// Only needed when the game type has no registered implementation to
-    /// read `INTERMEDIATE_BLOCK_INTERVAL` from; when it does, the flag must
-    /// match that canonical value because a proof with any other stride
-    /// would not verify on chain.
+    /// Only needed when the game does not expose its interval configuration;
+    /// otherwise the flag must match the canonical value because a proof with
+    /// any other stride would not verify on chain.
     #[arg(long = "intermediate-root-interval", value_name = "N")]
     pub intermediate_root_interval: Option<u64>,
     /// Poll the prover service until the proof succeeds or fails.
@@ -306,10 +305,9 @@ pub struct ProofsFinalizeArgs {
     pub retry_failed: bool,
     /// Intermediate output root interval (checkpoint stride).
     ///
-    /// Only needed when the game type has no registered implementation to
-    /// read `INTERMEDIATE_BLOCK_INTERVAL` from; when it does, the flag must
-    /// match that canonical value because a proof with any other stride
-    /// would not verify on chain.
+    /// Only needed when the game does not expose its interval configuration;
+    /// otherwise the flag must match the canonical value because a proof with
+    /// any other stride would not verify on chain.
     #[arg(long = "intermediate-root-interval", value_name = "N")]
     pub intermediate_root_interval: Option<u64>,
     /// Prover-service RPC URL (also `BASECTL_PROVER_RPC` or config `prover_rpc`).

--- a/crates/infra/basectl/src/rpc/games.rs
+++ b/crates/infra/basectl/src/rpc/games.rs
@@ -79,8 +79,8 @@ pub struct GameDetails {
     pub target_block: u64,
     /// Number of L2 blocks the game covers.
     pub block_interval: u64,
-    /// Canonical `INTERMEDIATE_BLOCK_INTERVAL` read from the game proxy's
-    /// fixed implementation; `None` when the game does not expose it.
+    /// Canonical intermediate checkpoint interval resolved by the game proxy;
+    /// `None` when the game does not expose its interval configuration.
     pub intermediate_root_interval: Option<u64>,
     /// Number of intermediate output roots committed with the game.
     pub intermediate_root_count: usize,
@@ -296,7 +296,7 @@ impl GamesClient {
         let is_aggregate = if implementation == Address::ZERO {
             false
         } else {
-            match self.verifier.read_intermediate_block_interval(implementation).await {
+            match self.verifier.read_intervals_for_starting_block(implementation, 0).await {
                 Ok(_) => true,
                 Err(error) if error.is_missing_method() => {
                     // Empty reverts are indistinguishable from missing selectors; log for diagnosis.
@@ -390,13 +390,13 @@ impl GamesClient {
             });
         }
 
-        // The game proxy delegate-calls the implementation it was cloned from
-        // at creation, so this reads the stride the game was committed with.
+        // The game proxy delegate-calls the implementation it was cloned from,
+        // so resolve the start-aware stride through that proxy.
         // The factory's current `gameImpls` entry can be swapped by an
         // implementation upgrade and must not be trusted for a live game.
         let intermediate_root_interval =
-            match self.verifier.read_intermediate_block_interval(address).await {
-                Ok(interval) => Some(interval),
+            match self.verifier.read_intervals_for_starting_block(address, starting_block).await {
+                Ok((_, interval)) => Some(interval),
                 Err(error) if error.is_missing_method() => None,
                 Err(error) => return Err(self.contract_error(error)),
             };
@@ -583,8 +583,9 @@ mod tests {
         push_abi(&asserter, &(1_u32, 1_u64, unsupported_game));
         push_abi(&asserter, &unsupported_impl);
         asserter.push_success(&Bytes::new());
+        asserter.push_success(&Bytes::new());
         push_abi(&asserter, &aggregate_impl);
-        push_abi(&asserter, &U256::from(100));
+        push_abi(&asserter, &(U256::from(100), U256::from(10)));
 
         let skipped = client
             .scan_index(0, GameListFilter { limit: 1, game_type: None, missing_zk: false })
@@ -656,7 +657,7 @@ mod tests {
 
         push_game_details_reads(&asserter);
         push_abi(&asserter, &(game, 0_u64));
-        push_abi(&asserter, &U256::from(100));
+        push_abi(&asserter, &(U256::from(1000), U256::from(100)));
 
         let details = client.game_details(game).await.unwrap();
 
@@ -677,6 +678,7 @@ mod tests {
 
         push_game_details_reads(&asserter);
         push_abi(&asserter, &(game, 0_u64));
+        asserter.push_success(&Bytes::new());
         asserter.push_success(&Bytes::new());
 
         let details = client.game_details(game).await.unwrap();

--- a/crates/infra/basectl/src/rpc/prover.rs
+++ b/crates/infra/basectl/src/rpc/prover.rs
@@ -64,9 +64,9 @@ impl ProofProposeRequest {
     /// Validates that the game can still accept a ZK proposal proof and takes
     /// the block range, L1 head, and checkpoint stride from the game so the
     /// proof journal matches what the contract reconstructs.
-    /// `intermediate_root_interval` supplies the stride when the game does
-    /// not expose `INTERMEDIATE_BLOCK_INTERVAL`; otherwise it must match the
-    /// game's committed value.
+    /// `intermediate_root_interval` supplies the stride when the game does not
+    /// expose its interval configuration; otherwise it must match the game's
+    /// committed value.
     pub fn for_game(
         details: &GameDetails,
         prover_address: Address,
@@ -147,14 +147,14 @@ impl ProofProposeRequest {
         {
             return Err(not_provable(&format!(
                 "intermediate root interval {explicit} does not match the game \
-                 implementation's INTERMEDIATE_BLOCK_INTERVAL {canonical}; a proof with a \
+                 implementation's canonical interval {canonical}; a proof with a \
                  different stride would not verify on chain"
             )));
         }
         let intermediate_root_interval =
             intermediate_root_interval.or(details.intermediate_root_interval).ok_or_else(|| {
                 not_provable(
-                    "the game does not expose INTERMEDIATE_BLOCK_INTERVAL; \
+                    "the game does not expose its intermediate root interval; \
                      pass --intermediate-root-interval",
                 )
             })?;

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -341,6 +341,15 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         Ok(5)
     }
 
+    async fn read_intervals_for_starting_block(
+        &self,
+        impl_address: Address,
+        _starting_block: u64,
+    ) -> Result<(u64, u64), ContractError> {
+        self.intermediate_block_interval_reads.lock().unwrap().push(impl_address);
+        Ok((10, 5))
+    }
+
     async fn intermediate_output_roots(
         &self,
         game_address: Address,

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -253,6 +253,7 @@ pub trait AggregateVerifierClient: Send + Sync {
     /// Cobalt switches the verifier to a shorter cadence at a fixed L2 block, so
     /// the pair is a function of the game's starting block. Callers must resolve
     /// it per game rather than reading `BLOCK_INTERVAL` once at startup.
+    /// Legacy implementations fall back to their fixed interval getters.
     async fn read_intervals_for_starting_block(
         &self,
         impl_address: Address,
@@ -488,10 +489,25 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
     ) -> Result<(u64, u64), ContractError> {
         let contract =
             IAggregateVerifier::IAggregateVerifierInstance::new(impl_address, &self.provider);
-        let result = contract_call!(
+        let result = match contract_call!(
             contract.intervalsForStartingBlock(U256::from(starting_block)).call(),
             "intervalsForStartingBlock failed"
-        )?;
+        ) {
+            Ok(result) => result,
+            Err(error) if error.is_missing_method() => {
+                let (block_interval, intermediate_block_interval) = futures::try_join!(
+                    self.read_block_interval(impl_address),
+                    self.read_intermediate_block_interval(impl_address),
+                )?;
+                if !block_interval.is_multiple_of(intermediate_block_interval) {
+                    return Err(ContractError::validation(format!(
+                        "BLOCK_INTERVAL ({block_interval}) is not divisible by INTERMEDIATE_BLOCK_INTERVAL ({intermediate_block_interval})"
+                    )));
+                }
+                return Ok((block_interval, intermediate_block_interval));
+            }
+            Err(error) => return Err(error),
+        };
 
         let block_interval: u64 = result
             ._0

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -250,7 +250,7 @@ pub trait AggregateVerifierClient: Send + Sync {
     /// `AggregateVerifier` implementation applies to a game whose range starts
     /// at `starting_block`.
     ///
-    /// Denim switches the verifier to a shorter cadence at a fixed L2 block, so
+    /// Cobalt switches the verifier to a shorter cadence at a fixed L2 block, so
     /// the pair is a function of the game's starting block. Callers must resolve
     /// it per game rather than reading `BLOCK_INTERVAL` once at startup.
     async fn read_intervals_for_starting_block(
@@ -512,7 +512,7 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         }
         if !block_interval.is_multiple_of(intermediate_block_interval) {
             return Err(ContractError::validation(format!(
-                "BLOCK_INTERVAL ({block_interval}) is not divisible by                  INTERMEDIATE_BLOCK_INTERVAL ({intermediate_block_interval})"
+                "BLOCK_INTERVAL ({block_interval}) is not divisible by INTERMEDIATE_BLOCK_INTERVAL ({intermediate_block_interval})"
             )));
         }
 

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -60,6 +60,13 @@ sol! {
         /// Returns the intermediate block interval for intermediate output root checkpoints.
         function INTERMEDIATE_BLOCK_INTERVAL() external view returns (uint256);
 
+        /// Returns the `(blockInterval, intermediateBlockInterval)` pair the verifier
+        /// applies to a game whose range starts at `startingBlock`.
+        function intervalsForStartingBlock(uint256 startingBlock)
+            external
+            view
+            returns (uint256, uint256);
+
         /// Returns the game type.
         function gameType() external view returns (uint32);
 
@@ -238,6 +245,19 @@ pub trait AggregateVerifierClient: Send + Sync {
         &self,
         impl_address: Address,
     ) -> Result<u64, ContractError>;
+
+    /// Reads the `(block_interval, intermediate_block_interval)` pair the
+    /// `AggregateVerifier` implementation applies to a game whose range starts
+    /// at `starting_block`.
+    ///
+    /// Denim switches the verifier to a shorter cadence at a fixed L2 block, so
+    /// the pair is a function of the game's starting block. Callers must resolve
+    /// it per game rather than reading `BLOCK_INTERVAL` once at startup.
+    async fn read_intervals_for_starting_block(
+        &self,
+        impl_address: Address,
+        starting_block: u64,
+    ) -> Result<(u64, u64), ContractError>;
 
     /// Returns the intermediate output roots for the given game.
     ///
@@ -459,6 +479,44 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
         }
 
         Ok(interval)
+    }
+
+    async fn read_intervals_for_starting_block(
+        &self,
+        impl_address: Address,
+        starting_block: u64,
+    ) -> Result<(u64, u64), ContractError> {
+        let contract =
+            IAggregateVerifier::IAggregateVerifierInstance::new(impl_address, &self.provider);
+        let result = contract_call!(
+            contract.intervalsForStartingBlock(U256::from(starting_block)).call(),
+            "intervalsForStartingBlock failed"
+        )?;
+
+        let block_interval: u64 = result
+            ._0
+            .try_into()
+            .map_err(|_| ContractError::validation("BLOCK_INTERVAL overflows u64"))?;
+        let intermediate_block_interval: u64 = result
+            ._1
+            .try_into()
+            .map_err(|_| ContractError::validation("INTERMEDIATE_BLOCK_INTERVAL overflows u64"))?;
+
+        if block_interval < 2 {
+            return Err(ContractError::validation(
+                "BLOCK_INTERVAL must be at least 2 (single-block proposals are not supported)",
+            ));
+        }
+        if intermediate_block_interval == 0 {
+            return Err(ContractError::validation("INTERMEDIATE_BLOCK_INTERVAL cannot be 0"));
+        }
+        if !block_interval.is_multiple_of(intermediate_block_interval) {
+            return Err(ContractError::validation(format!(
+                "BLOCK_INTERVAL ({block_interval}) is not divisible by                  INTERMEDIATE_BLOCK_INTERVAL ({intermediate_block_interval})"
+            )));
+        }
+
+        Ok((block_interval, intermediate_block_interval))
     }
 
     async fn intermediate_output_roots(

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -250,7 +250,7 @@ pub trait AggregateVerifierClient: Send + Sync {
     /// `AggregateVerifier` implementation applies to a game whose range starts
     /// at `starting_block`.
     ///
-    /// Cobalt switches the verifier to a shorter cadence at a fixed L2 block, so
+    /// Denim switches the verifier to a shorter cadence at a fixed L2 block, so
     /// the pair is a function of the game's starting block. Callers must resolve
     /// it per game rather than reading `BLOCK_INTERVAL` once at startup.
     /// Legacy implementations fall back to their fixed interval getters.

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -218,8 +218,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        ProofCollector, ProofDispatcher, ProofDispatcherConfig, ProofRecovery, ProofRecoveryConfig,
-        ProofSubmitter,
+        ProofCollector, ProofDispatcher, ProofRecovery, ProofRecoveryConfig, ProofSubmitter,
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockProofRequester, MockRollupClient, test_anchor_root,
@@ -262,7 +261,7 @@ mod tests {
             l2,
             Arc::<MockRollupClient>::clone(&rollup),
             Arc::clone(&intervals),
-            ProofDispatcherConfig::from(&config),
+            config.proposer_address,
         );
         let proof_submitter = ProofSubmitter::new(
             output_proposer,

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -39,7 +39,7 @@ pub struct DriverConfig {
     pub submit_timeout: Option<Duration>,
     /// Game type ID for `AggregateVerifier` dispute games.
     ///
-    /// The proposal intervals are deliberately absent: they change at the Denim
+    /// The proposal intervals are deliberately absent: they change at the Cobalt
     /// activation block and are resolved per game by
     /// [`crate::IntervalResolver`].
     pub game_type: u32,

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -37,11 +37,11 @@ pub struct DriverConfig {
     /// Optional maximum duration for a single inline submit (validation + L1
     /// transaction). `None` disables the outer pipeline timeout.
     pub submit_timeout: Option<Duration>,
-    /// Number of L2 blocks between proposals (read from `AggregateVerifier` at startup).
-    pub block_interval: u64,
-    /// Number of L2 blocks between intermediate output root checkpoints.
-    pub intermediate_block_interval: u64,
     /// Game type ID for `AggregateVerifier` dispute games.
+    ///
+    /// The proposal intervals are deliberately absent: they change at the Denim
+    /// activation block and are resolved per game by
+    /// [`crate::IntervalResolver`].
     pub game_type: u32,
     /// Address of the proposer that submits proof transactions onchain.
     /// Included in the proof journal so the enclave signs over the correct `msg.sender`.
@@ -57,8 +57,6 @@ impl Default for DriverConfig {
             poll_interval: Duration::from_secs(12),
             recovery_scan_concurrency: 8,
             submit_timeout: None,
-            block_interval: 512,
-            intermediate_block_interval: 512,
             game_type: 0,
             proposer_address: Address::ZERO,
             anchor_state_registry_address: Address::ZERO,
@@ -225,7 +223,7 @@ mod tests {
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockProofRequester, MockRollupClient, test_anchor_root,
-            test_sync_status,
+            test_fixed_interval_resolver, test_sync_status,
         },
     };
 
@@ -254,16 +252,16 @@ mod tests {
             poll_interval: Duration::from_secs(3600),
             submit_timeout: Some(std::time::Duration::from_secs(60)),
             recovery_scan_concurrency: 8,
-            block_interval: 512,
-            intermediate_block_interval: 512,
             ..Default::default()
         };
+        let intervals = test_fixed_interval_resolver(512, 512);
 
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
             Arc::<MockL1>::clone(&l1),
             l2,
             Arc::<MockRollupClient>::clone(&rollup),
+            Arc::clone(&intervals),
             ProofDispatcherConfig::from(&config),
         );
         let proof_submitter = ProofSubmitter::new(
@@ -271,12 +269,11 @@ mod tests {
             Arc::<MockRollupClient>::clone(&rollup),
             Arc::clone(&factory),
             verifier,
+            Arc::clone(&intervals),
             &config,
         );
         let proof_recovery = Arc::new(ProofRecovery::new(
             ProofRecoveryConfig {
-                block_interval: config.block_interval,
-                intermediate_block_interval: config.intermediate_block_interval,
                 game_type: config.game_type,
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
@@ -284,12 +281,13 @@ mod tests {
             Arc::<MockRollupClient>::clone(&rollup),
             anchor_registry,
             factory,
+            Arc::clone(&intervals),
         ));
         let proof_collector = ProofCollector::new(
             Arc::clone(&proof_requester),
             Arc::clone(&rollup),
             proof_submitter,
-            config.block_interval,
+            intervals,
             config.submit_timeout,
         );
         let pipeline =

--- a/crates/proof/proposer/src/driver.rs
+++ b/crates/proof/proposer/src/driver.rs
@@ -39,7 +39,7 @@ pub struct DriverConfig {
     pub submit_timeout: Option<Duration>,
     /// Game type ID for `AggregateVerifier` dispute games.
     ///
-    /// The proposal intervals are deliberately absent: they change at the Cobalt
+    /// The proposal intervals are deliberately absent: they change at the Denim
     /// activation block and are resolved per game by
     /// [`crate::IntervalResolver`].
     pub game_type: u32,

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -33,7 +33,7 @@ mod proof_collector;
 pub use proof_collector::ProofCollector;
 
 mod proof_dispatcher;
-pub use proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig};
+pub use proof_dispatcher::ProofDispatcher;
 
 mod proof_submitter;
 pub use proof_submitter::{ProofSubmitter, SubmitAction};

--- a/crates/proof/proposer/src/lib.rs
+++ b/crates/proof/proposer/src/lib.rs
@@ -21,7 +21,7 @@ mod proof_adapter;
 pub use proof_adapter::ProposerProofAdapter;
 
 mod proposal_intervals;
-pub use proposal_intervals::ProposalIntervals;
+pub use proposal_intervals::{IntervalResolver, Intervals};
 
 mod proof_target;
 pub use proof_target::ProofTarget;

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -216,7 +216,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        OutputProposer, ProofDispatcherConfig, ProofRecoveryConfig, ProofSubmitter,
+        OutputProposer, ProofRecoveryConfig, ProofSubmitter,
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
             MockOutputProposer, MockRollupClient, test_anchor_root, test_fixed_interval_resolver,
@@ -300,7 +300,7 @@ mod tests {
             l2,
             Arc::<MockRollupClient>::clone(&rollup),
             Arc::clone(&intervals),
-            ProofDispatcherConfig::from(&config),
+            config.proposer_address,
         );
         let proof_recovery = Arc::new(ProofRecovery::new(
             ProofRecoveryConfig {

--- a/crates/proof/proposer/src/pipeline.rs
+++ b/crates/proof/proposer/src/pipeline.rs
@@ -68,7 +68,6 @@ where
     /// recovery walk.
     pub async fn run(&self, cancel: CancellationToken) {
         info!(
-            block_interval = self.config.block_interval,
             poll_interval_secs = self.config.poll_interval.as_secs(),
             submit_timeout_secs = ?self.config.submit_timeout.map(|timeout| timeout.as_secs()),
             "Starting proving pipeline"
@@ -220,7 +219,8 @@ mod tests {
         OutputProposer, ProofDispatcherConfig, ProofRecoveryConfig, ProofSubmitter,
         test_utils::{
             MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL1, MockL2,
-            MockOutputProposer, MockRollupClient, test_anchor_root, test_sync_status,
+            MockOutputProposer, MockRollupClient, test_anchor_root, test_fixed_interval_resolver,
+            test_sync_status,
         },
     };
 
@@ -291,23 +291,19 @@ mod tests {
             Arc::new(MockDisputeGameFactory::default());
         let verifier = Arc::new(MockAggregateVerifier::default());
         let output_proposer: Arc<dyn OutputProposer> = Arc::new(MockOutputProposer::default());
-        let config = DriverConfig {
-            poll_interval: Duration::from_millis(10),
-            block_interval: 100,
-            intermediate_block_interval: 100,
-            ..Default::default()
-        };
+        let config =
+            DriverConfig { poll_interval: Duration::from_millis(10), ..Default::default() };
+        let intervals = test_fixed_interval_resolver(100, 100);
         let proof_dispatcher = ProofDispatcher::new(
             Arc::clone(&proof_requester),
             Arc::<MockL1>::clone(&l1),
             l2,
             Arc::<MockRollupClient>::clone(&rollup),
+            Arc::clone(&intervals),
             ProofDispatcherConfig::from(&config),
         );
         let proof_recovery = Arc::new(ProofRecovery::new(
             ProofRecoveryConfig {
-                block_interval: config.block_interval,
-                intermediate_block_interval: config.intermediate_block_interval,
                 game_type: config.game_type,
                 anchor_state_registry_address: config.anchor_state_registry_address,
                 scan_concurrency: config.recovery_scan_concurrency,
@@ -315,19 +311,21 @@ mod tests {
             Arc::<MockRollupClient>::clone(&rollup),
             anchor_registry,
             factory,
+            Arc::clone(&intervals),
         ));
         let proof_submitter = ProofSubmitter::new(
             output_proposer,
             Arc::<MockRollupClient>::clone(&rollup),
             Arc::new(MockDisputeGameFactory::default()),
             verifier,
+            Arc::clone(&intervals),
             &config,
         );
         let proof_collector = ProofCollector::new(
             Arc::clone(&proof_requester),
             Arc::clone(&rollup),
             proof_submitter,
-            config.block_interval,
+            intervals,
             config.submit_timeout,
         );
         ProvingPipeline::new(config, proof_dispatcher, proof_recovery, proof_collector)

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -86,7 +86,7 @@ where
                 return false;
             }
 
-            // Resolved per target: the interval changes at the Denim activation
+            // Resolved per target: the interval changes at the Cobalt activation
             // block, so the cursor's own starting block picks the cadence.
             let starting_block = current.l2_block_number;
             let block_interval = match self.intervals.for_starting_block(starting_block).await {

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -14,8 +14,8 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
 use crate::{
-    Metrics, ProofSubmitter, ProofTarget, ProposerError, ProposerProofAdapter, RecoveredState,
-    SubmitAction,
+    IntervalResolver, Metrics, ProofSubmitter, ProofTarget, ProposerError, ProposerProofAdapter,
+    RecoveredState, SubmitAction,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -33,7 +33,7 @@ where
     proof_requester: Arc<dyn ProofRequesterProvider>,
     rollup_client: Arc<R>,
     submitter: ProofSubmitter,
-    block_interval: u64,
+    intervals: Arc<IntervalResolver>,
     submit_timeout: Option<Duration>,
 }
 
@@ -43,7 +43,6 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProofCollector")
-            .field("block_interval", &self.block_interval)
             .field("submit_timeout", &self.submit_timeout)
             .finish_non_exhaustive()
     }
@@ -58,10 +57,10 @@ where
         proof_requester: Arc<dyn ProofRequesterProvider>,
         rollup_client: Arc<R>,
         submitter: ProofSubmitter,
-        block_interval: u64,
+        intervals: Arc<IntervalResolver>,
         submit_timeout: Option<Duration>,
     ) -> Self {
-        Self { proof_requester, rollup_client, submitter, block_interval, submit_timeout }
+        Self { proof_requester, rollup_client, submitter, intervals, submit_timeout }
     }
 
     /// Runs one collector tick.
@@ -87,9 +86,23 @@ where
                 return false;
             }
 
-            let Some(target_block) =
-                ProofTarget::next_block(current.l2_block_number, self.block_interval)
-            else {
+            // Resolved per target: the interval changes at the Denim activation
+            // block, so the cursor's own starting block picks the cadence.
+            let starting_block = current.l2_block_number;
+            let block_interval = match self.intervals.for_starting_block(starting_block).await {
+                Ok(intervals) => intervals.block_interval,
+                Err(error) => {
+                    Metrics::errors_total(error.metric_label()).increment(1);
+                    warn!(
+                        starting_block,
+                        error = %error,
+                        "Failed to resolve proposal intervals, retrying next tick"
+                    );
+                    return false;
+                }
+            };
+
+            let Some(target_block) = ProofTarget::next_block(starting_block, block_interval) else {
                 return false;
             };
 
@@ -132,7 +145,14 @@ where
             };
 
             match self
-                .submit_proof(target_block, &session_id, proof, current.parent_address, cancel)
+                .submit_proof(
+                    starting_block,
+                    target_block,
+                    &session_id,
+                    proof,
+                    current.parent_address,
+                    cancel,
+                )
                 .await
             {
                 SubmitOutcome::Advanced(next) => *current = next,
@@ -268,6 +288,7 @@ where
     )]
     async fn submit_proof(
         &self,
+        starting_block: u64,
         target_block: u64,
         session_id: &str,
         proof: TeeProofResult,
@@ -286,6 +307,7 @@ where
                 let submit = self.submitter.submit(
                     &proof.aggregate_proposal,
                     &proof.proposals,
+                    starting_block,
                     target_block,
                     parent_address,
                 );
@@ -448,7 +470,7 @@ mod tests {
         DriverConfig, OutputProposer,
         test_utils::{
             MockAggregateVerifier, MockDisputeGameFactory, MockOutputProposer, MockProofRequester,
-            MockRollupClient, test_proposal, test_sync_status,
+            MockRollupClient, test_fixed_interval_resolver, test_proposal, test_sync_status,
         },
     };
 
@@ -490,24 +512,21 @@ mod tests {
         factory_client: Arc<dyn DisputeGameFactoryClient>,
         verifier_client: Arc<dyn AggregateVerifierClient>,
     ) -> ProofCollector<MockRollupClient> {
+        let intervals = test_fixed_interval_resolver(BLOCK_INTERVAL, BLOCK_INTERVAL);
         let submitter = ProofSubmitter::new(
             output_proposer,
             Arc::<MockRollupClient>::clone(&rollup_client),
             factory_client,
             verifier_client,
-            &DriverConfig {
-                block_interval: BLOCK_INTERVAL,
-                intermediate_block_interval: BLOCK_INTERVAL,
-                recovery_scan_concurrency: 1,
-                ..Default::default()
-            },
+            Arc::clone(&intervals),
+            &DriverConfig { recovery_scan_concurrency: 1, ..Default::default() },
         );
 
         ProofCollector::new(
             proof_requester,
             rollup_client,
             submitter,
-            BLOCK_INTERVAL,
+            intervals,
             Some(std::time::Duration::from_secs(60)),
         )
     }
@@ -761,6 +780,7 @@ mod tests {
         aggregate_proposal.output_root = stale_root;
         let outcome = collector
             .submit_proof(
+                target_block - BLOCK_INTERVAL,
                 target_block,
                 &session_id,
                 TeeProofResult {

--- a/crates/proof/proposer/src/proof_collector.rs
+++ b/crates/proof/proposer/src/proof_collector.rs
@@ -86,7 +86,7 @@ where
                 return false;
             }
 
-            // Resolved per target: the interval changes at the Cobalt activation
+            // Resolved per target: the interval changes at the Denim activation
             // block, so the cursor's own starting block picks the cadence.
             let starting_block = current.l2_block_number;
             let block_interval = match self.intervals.for_starting_block(starting_block).await {

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -16,26 +16,19 @@ use crate::{
     error::ProposerError,
     proof_adapter::ProposerProofAdapter,
     proof_target::ProofTarget,
+    proposal_intervals::{IntervalResolver, Intervals},
 };
 
 /// Static parameters needed to build and dispatch proposer proof requests.
 #[derive(Debug, Clone, Copy)]
 pub struct ProofDispatcherConfig {
-    /// Number of L2 blocks between proof targets.
-    pub block_interval: u64,
     /// Address of the proposer that will submit the proof onchain.
     pub proposer_address: Address,
-    /// Number of L2 blocks between intermediate output root checkpoints.
-    pub intermediate_block_interval: u64,
 }
 
 impl From<&DriverConfig> for ProofDispatcherConfig {
     fn from(config: &DriverConfig) -> Self {
-        Self {
-            block_interval: config.block_interval,
-            proposer_address: config.proposer_address,
-            intermediate_block_interval: config.intermediate_block_interval,
-        }
+        Self { proposer_address: config.proposer_address }
     }
 }
 
@@ -45,6 +38,7 @@ pub struct ProofDispatcher {
     l1_client: Arc<dyn L1Provider>,
     l2_client: Arc<dyn L2Provider>,
     rollup_client: Arc<dyn RollupProvider>,
+    intervals: Arc<IntervalResolver>,
     config: ProofDispatcherConfig,
 }
 
@@ -61,9 +55,10 @@ impl ProofDispatcher {
         l1_client: Arc<dyn L1Provider>,
         l2_client: Arc<dyn L2Provider>,
         rollup_client: Arc<dyn RollupProvider>,
+        intervals: Arc<IntervalResolver>,
         config: ProofDispatcherConfig,
     ) -> Self {
-        Self { proof_requester, l1_client, l2_client, rollup_client, config }
+        Self { proof_requester, l1_client, l2_client, rollup_client, intervals, config }
     }
 
     /// Builds a proof request for `target_block` using `recovered` as the agreed parent.
@@ -72,6 +67,7 @@ impl ProofDispatcher {
         target_block: u64,
         recovered: &RecoveredState,
         claimed_l2_output_root: B256,
+        intervals: Intervals,
     ) -> Result<ProofRequest, ProposerError> {
         let (sync_status, agreed_l2_head) = tokio::try_join!(
             self.rollup_client.sync_status(),
@@ -106,7 +102,7 @@ impl ProofDispatcher {
             claimed_l2_output_root,
             claimed_l2_block_number: target_block,
             proposer: self.config.proposer_address,
-            intermediate_block_interval: self.config.intermediate_block_interval,
+            intermediate_block_interval: intervals.intermediate_block_interval,
             l1_head_number: l1_header.number,
             schedule_l2_block_number: None,
         })
@@ -159,9 +155,28 @@ impl ProofDispatcher {
 
     /// Dispatches every target from the current dispatcher cursor up to `finalized_head`.
     pub async fn tick(&self, current: &mut RecoveredState, finalized_head: u64) {
-        while let Some(target_block) =
-            ProofTarget::next_block(current.l2_block_number, self.config.block_interval)
-        {
+        loop {
+            // Resolved per target: the interval changes at the Denim activation
+            // block, so the cursor's own starting block picks the cadence.
+            let intervals = match self.intervals.for_starting_block(current.l2_block_number).await {
+                Ok(intervals) => intervals,
+                Err(error) => {
+                    Metrics::errors_total(error.metric_label()).increment(1);
+                    warn!(
+                        starting_block = current.l2_block_number,
+                        error = %error,
+                        "Failed to resolve proposal intervals, stopping tick at current cursor"
+                    );
+                    break;
+                }
+            };
+
+            let Some(target_block) =
+                ProofTarget::next_block(current.l2_block_number, intervals.block_interval)
+            else {
+                break;
+            };
+
             if target_block > finalized_head {
                 debug!(
                     current_block = current.l2_block_number,
@@ -178,20 +193,22 @@ impl ProofDispatcher {
                 break;
             };
 
-            let request =
-                match self.build_request(target_block, current, claimed_l2_output_root).await {
-                    Ok(request) => request,
-                    Err(error) => {
-                        Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED)
-                            .increment(1);
-                        warn!(
-                            target_block,
-                            error = %error,
-                            "Failed to build proof request, will retry next iteration"
-                        );
-                        break;
-                    }
-                };
+            let request = match self
+                .build_request(target_block, current, claimed_l2_output_root, intervals)
+                .await
+            {
+                Ok(request) => request,
+                Err(error) => {
+                    Metrics::proof_dispatch_total(Metrics::DISPATCH_OUTCOME_BUILD_FAILED)
+                        .increment(1);
+                    warn!(
+                        target_block,
+                        error = %error,
+                        "Failed to build proof request, will retry next iteration"
+                    );
+                    break;
+                }
+            };
 
             match self.dispatch_request(request).await {
                 Ok(session_id) => {
@@ -229,8 +246,8 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        MockL1, MockL2, MockProofRequester, MockRollupClient, test_l1_block_ref, test_l1_header,
-        test_l2_block_ref, test_sync_status,
+        MockL1, MockL2, MockProofRequester, MockRollupClient, test_fixed_interval_resolver,
+        test_l1_block_ref, test_l1_header, test_l2_block_ref, test_sync_status,
     };
 
     fn dispatcher(requester: Arc<MockProofRequester>) -> ProofDispatcher {
@@ -244,10 +261,8 @@ mod tests {
                 output_roots: Default::default(),
                 max_safe_block: None,
             }),
-            ProofDispatcherConfig::from(&DriverConfig {
-                block_interval: 100,
-                ..Default::default()
-            }),
+            test_fixed_interval_resolver(100, 100),
+            ProofDispatcherConfig::from(&DriverConfig::default()),
         )
     }
 
@@ -304,11 +319,8 @@ mod tests {
                 output_roots: Default::default(),
                 max_safe_block: None,
             }),
-            ProofDispatcherConfig {
-                block_interval: 100,
-                proposer_address: Address::repeat_byte(0x04),
-                intermediate_block_interval: 300,
-            },
+            test_fixed_interval_resolver(100, 100),
+            ProofDispatcherConfig { proposer_address: Address::repeat_byte(0x04) },
         );
         let recovered = RecoveredState {
             parent_address: Address::ZERO,
@@ -317,7 +329,12 @@ mod tests {
         };
 
         let err = dispatcher
-            .build_request(200, &recovered, B256::repeat_byte(0xaa))
+            .build_request(
+                200,
+                &recovered,
+                B256::repeat_byte(0xaa),
+                Intervals { block_interval: 100, intermediate_block_interval: 100 },
+            )
             .await
             .expect_err("L1 RPC header must match rollup-selected L1 head");
 

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -12,25 +12,12 @@ use tracing::{debug, info, instrument, warn};
 
 use crate::{
     Metrics,
-    driver::{DriverConfig, RecoveredState},
+    driver::RecoveredState,
     error::ProposerError,
     proof_adapter::ProposerProofAdapter,
     proof_target::ProofTarget,
     proposal_intervals::{IntervalResolver, Intervals},
 };
-
-/// Static parameters needed to build and dispatch proposer proof requests.
-#[derive(Debug, Clone, Copy)]
-pub struct ProofDispatcherConfig {
-    /// Address of the proposer that will submit the proof onchain.
-    pub proposer_address: Address,
-}
-
-impl From<&DriverConfig> for ProofDispatcherConfig {
-    fn from(config: &DriverConfig) -> Self {
-        Self { proposer_address: config.proposer_address }
-    }
-}
 
 /// Builds and dispatches proposer TEE proof requests.
 pub struct ProofDispatcher {
@@ -39,12 +26,14 @@ pub struct ProofDispatcher {
     l2_client: Arc<dyn L2Provider>,
     rollup_client: Arc<dyn RollupProvider>,
     intervals: Arc<IntervalResolver>,
-    config: ProofDispatcherConfig,
+    proposer_address: Address,
 }
 
 impl std::fmt::Debug for ProofDispatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ProofDispatcher").field("config", &self.config).finish_non_exhaustive()
+        f.debug_struct("ProofDispatcher")
+            .field("proposer_address", &self.proposer_address)
+            .finish_non_exhaustive()
     }
 }
 
@@ -56,9 +45,9 @@ impl ProofDispatcher {
         l2_client: Arc<dyn L2Provider>,
         rollup_client: Arc<dyn RollupProvider>,
         intervals: Arc<IntervalResolver>,
-        config: ProofDispatcherConfig,
+        proposer_address: Address,
     ) -> Self {
-        Self { proof_requester, l1_client, l2_client, rollup_client, intervals, config }
+        Self { proof_requester, l1_client, l2_client, rollup_client, intervals, proposer_address }
     }
 
     /// Builds a proof request for `target_block` using `recovered` as the agreed parent.
@@ -101,7 +90,7 @@ impl ProofDispatcher {
             agreed_l2_output_root: recovered.output_root,
             claimed_l2_output_root,
             claimed_l2_block_number: target_block,
-            proposer: self.config.proposer_address,
+            proposer: self.proposer_address,
             intermediate_block_interval: intervals.intermediate_block_interval,
             l1_head_number: l1_header.number,
             schedule_l2_block_number: None,
@@ -262,7 +251,7 @@ mod tests {
                 max_safe_block: None,
             }),
             test_fixed_interval_resolver(100, 100),
-            ProofDispatcherConfig::from(&DriverConfig::default()),
+            Address::ZERO,
         )
     }
 
@@ -320,7 +309,7 @@ mod tests {
                 max_safe_block: None,
             }),
             test_fixed_interval_resolver(100, 100),
-            ProofDispatcherConfig { proposer_address: Address::repeat_byte(0x04) },
+            Address::repeat_byte(0x04),
         );
         let recovered = RecoveredState {
             parent_address: Address::ZERO,

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -145,7 +145,7 @@ impl ProofDispatcher {
     /// Dispatches every target from the current dispatcher cursor up to `finalized_head`.
     pub async fn tick(&self, current: &mut RecoveredState, finalized_head: u64) {
         loop {
-            // Resolved per target: the interval changes at the Cobalt activation
+            // Resolved per target: the interval changes at the Denim activation
             // block, so the cursor's own starting block picks the cadence.
             let intervals = match self.intervals.for_starting_block(current.l2_block_number).await {
                 Ok(intervals) => intervals,

--- a/crates/proof/proposer/src/proof_dispatcher.rs
+++ b/crates/proof/proposer/src/proof_dispatcher.rs
@@ -156,7 +156,7 @@ impl ProofDispatcher {
     /// Dispatches every target from the current dispatcher cursor up to `finalized_head`.
     pub async fn tick(&self, current: &mut RecoveredState, finalized_head: u64) {
         loop {
-            // Resolved per target: the interval changes at the Denim activation
+            // Resolved per target: the interval changes at the Cobalt activation
             // block, so the cursor's own starting block picks the cadence.
             let intervals = match self.intervals.for_starting_block(current.l2_block_number).await {
                 Ok(intervals) => intervals,

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -207,7 +207,7 @@ impl ProofRecovery {
 
         loop {
             // Resolved per step so the walk keeps reconstructing games across the
-            // Denim activation block, where the verifier switches cadence.
+            // Cobalt activation block, where the verifier switches cadence.
             let intervals = self.intervals.for_starting_block(state.l2_block_number).await?;
 
             let Some(expected_block) =
@@ -513,35 +513,35 @@ mod tests {
         }
     }
 
-    /// The verifier switches to the Denim interval pair at
-    /// `DENIM_ACTIVATION_BLOCK`, so the walk has to reconstruct 100-block games
+    /// The verifier switches to the fast-cadence interval pair at
+    /// `FAST_ACTIVATION_BLOCK`, so the walk has to reconstruct 100-block games
     /// before it and 200-block games after it. A proposer that resolved the
     /// interval once at startup would look for a 100-block game at 400, find
     /// `Address::ZERO`, and re-propose over three games that already exist.
     #[tokio::test]
-    async fn test_recovery_forward_walk_crosses_denim_activation_block() {
-        const PRE_DENIM_INTERVAL: u64 = 100;
-        const PRE_DENIM_INTERMEDIATE: u64 = 50;
-        const DENIM_ACTIVATION_BLOCK: u64 = 300;
-        const DENIM_INTERVAL: u64 = 200;
-        const DENIM_INTERMEDIATE: u64 = 100;
+    async fn test_recovery_forward_walk_crosses_fast_activation_block() {
+        const SLOW_INTERVAL: u64 = 100;
+        const SLOW_INTERMEDIATE: u64 = 50;
+        const FAST_ACTIVATION_BLOCK: u64 = 300;
+        const FAST_INTERVAL: u64 = 200;
+        const FAST_INTERMEDIATE: u64 = 100;
 
-        // Starting blocks either side of the boundary: 0/100/200 are pre-Denim,
-        // 300/500 are Denim.
+        // Starting blocks either side of the boundary: 0/100/200 are slow-cadence,
+        // 300/500 are fast-cadence.
         let mut uuid_games = HashMap::new();
         let mut output_roots = HashMap::new();
         let mut parent = Address::ZERO;
         let mut starting_block = TEST_ANCHOR_BLOCK;
         for index in 0..5u64 {
-            let intervals = if starting_block < DENIM_ACTIVATION_BLOCK {
+            let intervals = if starting_block < FAST_ACTIVATION_BLOCK {
                 Intervals {
-                    block_interval: PRE_DENIM_INTERVAL,
-                    intermediate_block_interval: PRE_DENIM_INTERMEDIATE,
+                    block_interval: SLOW_INTERVAL,
+                    intermediate_block_interval: SLOW_INTERMEDIATE,
                 }
             } else {
                 Intervals {
-                    block_interval: DENIM_INTERVAL,
-                    intermediate_block_interval: DENIM_INTERMEDIATE,
+                    block_interval: FAST_INTERVAL,
+                    intermediate_block_interval: FAST_INTERMEDIATE,
                 }
             };
             let target_block = starting_block + intervals.block_interval;
@@ -594,24 +594,23 @@ mod tests {
             )
         };
 
-        let denim_aware = fixture(test_interval_resolver(MockAggregateVerifier {
-            block_interval: PRE_DENIM_INTERVAL,
-            intermediate_block_interval: PRE_DENIM_INTERMEDIATE,
-            denim_activation_block: DENIM_ACTIVATION_BLOCK,
-            denim_block_interval: DENIM_INTERVAL,
-            denim_intermediate_block_interval: DENIM_INTERMEDIATE,
+        let cobalt_aware = fixture(test_interval_resolver(MockAggregateVerifier {
+            block_interval: SLOW_INTERVAL,
+            intermediate_block_interval: SLOW_INTERMEDIATE,
+            fast_activation_block: FAST_ACTIVATION_BLOCK,
+            fast_block_interval: FAST_INTERVAL,
+            fast_intermediate_block_interval: FAST_INTERMEDIATE,
             ..Default::default()
         }));
-        let (state, _) = recover_uncached(&denim_aware).await;
-        assert_eq!(state.l2_block_number, 700, "walk must not stall at the Denim boundary");
+        let (state, _) = recover_uncached(&cobalt_aware).await;
+        assert_eq!(state.l2_block_number, 700, "walk must not stall at the cadence boundary");
         assert_eq!(state.parent_address, proxy_addr(4));
 
-        // The pre-Denim pair applied everywhere is the bug this guards against:
+        // The slow-cadence pair applied everywhere is the bug this guards against:
         // the walk looks for a 100-block game at 400 and stops at the boundary.
-        let stale =
-            fixture(test_fixed_interval_resolver(PRE_DENIM_INTERVAL, PRE_DENIM_INTERMEDIATE));
+        let stale = fixture(test_fixed_interval_resolver(SLOW_INTERVAL, SLOW_INTERMEDIATE));
         let (state, _) = recover_uncached(&stale).await;
-        assert_eq!(state.l2_block_number, DENIM_ACTIVATION_BLOCK);
+        assert_eq!(state.l2_block_number, FAST_ACTIVATION_BLOCK);
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -546,22 +546,15 @@ mod tests {
             };
             let target_block = starting_block + intervals.block_interval;
             let root_claim = B256::repeat_byte((index + 1) as u8);
-            let intermediate_roots = intervals
-                .intermediate_block_numbers(starting_block)
-                .unwrap()
-                .into_iter()
-                .map(|block| {
+            let intermediate_blocks = intervals.intermediate_block_numbers(starting_block).unwrap();
+            let intermediate_roots = intermediate_blocks
+                .iter()
+                .map(|&block| {
                     if block == target_block { root_claim } else { B256::repeat_byte(block as u8) }
                 })
                 .collect::<Vec<_>>();
-            for (block, root) in intervals
-                .intermediate_block_numbers(starting_block)
-                .unwrap()
-                .into_iter()
-                .zip(intermediate_roots.iter().copied())
-            {
-                output_roots.insert(block, root);
-            }
+            output_roots
+                .extend(intermediate_blocks.into_iter().zip(intermediate_roots.iter().copied()));
 
             let key = game_lookup_key(
                 starting_block,

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -10,16 +10,12 @@ use tracing::{debug, info, warn};
 
 use crate::{
     driver::RecoveredState, error::ProposerError, proof_target::ProofTarget,
-    proposal_intervals::ProposalIntervals,
+    proposal_intervals::IntervalResolver,
 };
 
 /// Runtime settings for proposer recovery.
 #[derive(Debug, Clone, Copy)]
 pub struct ProofRecoveryConfig {
-    /// Number of L2 blocks between output proposals.
-    pub block_interval: u64,
-    /// Number of L2 blocks between intermediate output roots.
-    pub intermediate_block_interval: u64,
     /// Dispute game type used for proposals.
     pub game_type: u32,
     /// Address used as the parent sentinel when the anchor has no game.
@@ -43,6 +39,7 @@ pub struct ProofRecovery {
     rollup_client: Arc<dyn RollupProvider>,
     anchor_registry: Arc<dyn AnchorStateRegistryClient>,
     factory_client: Arc<dyn DisputeGameFactoryClient>,
+    intervals: Arc<IntervalResolver>,
 }
 
 impl std::fmt::Debug for ProofRecovery {
@@ -58,8 +55,9 @@ impl ProofRecovery {
         rollup_client: Arc<dyn RollupProvider>,
         anchor_registry: Arc<dyn AnchorStateRegistryClient>,
         factory_client: Arc<dyn DisputeGameFactoryClient>,
+        intervals: Arc<IntervalResolver>,
     ) -> Self {
-        Self { config, rollup_client, anchor_registry, factory_client }
+        Self { config, rollup_client, anchor_registry, factory_client, intervals }
     }
 
     /// Attempts to recover onchain state and fetch the finalized head.
@@ -80,13 +78,23 @@ impl ProofRecovery {
         let finalized_head = sync_status.finalized_l2.number;
 
         if let Some(cached) = cache.as_ref() {
+            let block_interval = match self
+                .intervals
+                .for_starting_block(cached.state.l2_block_number)
+                .await
+            {
+                Ok(intervals) => intervals.block_interval,
+                Err(e) => {
+                    warn!(error = %e, "Failed to resolve proposal intervals, retrying next tick");
+                    return None;
+                }
+            };
             let Some(next_proposal_block) =
-                ProofTarget::next_block(cached.state.l2_block_number, self.config.block_interval)
+                ProofTarget::next_block(cached.state.l2_block_number, block_interval)
             else {
                 warn!(
                     cached_block = cached.state.l2_block_number,
-                    block_interval = self.config.block_interval,
-                    "Cannot compute next proposal block, skipping recovery"
+                    block_interval, "Cannot compute next proposal block, skipping recovery"
                 );
                 return None;
             };
@@ -143,8 +151,14 @@ impl ProofRecovery {
         // cursor over games that already existed (game_count unchanged).
         if let Some(cached) = usable_cache
             && cached.game_count == count
-            && ProofTarget::next_block(cached.state.l2_block_number, self.config.block_interval)
-                .is_none_or(|next_block| next_block > finalized_head)
+            && ProofTarget::next_block(
+                cached.state.l2_block_number,
+                self.intervals
+                    .for_starting_block(cached.state.l2_block_number)
+                    .await?
+                    .block_interval,
+            )
+            .is_none_or(|next_block| next_block > finalized_head)
         {
             debug!(game_count = count, "No changes since last recovery, returning cached state");
             return Ok(cached.state);
@@ -191,9 +205,17 @@ impl ProofRecovery {
     ) -> Result<RecoveredState, ProposerError> {
         let mut state = *start;
 
-        while let Some(expected_block) =
-            ProofTarget::next_block(state.l2_block_number, self.config.block_interval)
-        {
+        loop {
+            // Resolved per step so the walk keeps reconstructing games across the
+            // Denim activation block, where the verifier switches cadence.
+            let intervals = self.intervals.for_starting_block(state.l2_block_number).await?;
+
+            let Some(expected_block) =
+                ProofTarget::next_block(state.l2_block_number, intervals.block_interval)
+            else {
+                break;
+            };
+
             if expected_block > finalized_head {
                 debug!(expected_block, finalized_head, "Reached finalized head, ending walk");
                 break;
@@ -201,11 +223,8 @@ impl ProofRecovery {
 
             // Fetch all intermediate roots, including the canonical root for
             // `expected_block`, from the rollup node in one batch.
-            let intermediate_blocks = ProposalIntervals::intermediate_block_numbers(
-                self.config.block_interval,
-                self.config.intermediate_block_interval,
-                state.l2_block_number,
-            )?;
+            let intermediate_blocks =
+                intervals.intermediate_block_numbers(state.l2_block_number)?;
             let rollup = &self.rollup_client;
             let intermediate_roots = match stream::iter(intermediate_blocks.iter().copied())
                 .map(|block_number| async move {
@@ -241,8 +260,8 @@ impl ProofRecovery {
             let key = game_lookup_key(
                 state.l2_block_number,
                 state.parent_address,
-                self.config.block_interval,
-                self.config.intermediate_block_interval,
+                intervals.block_interval,
+                intervals.intermediate_block_interval,
                 &intermediate_roots,
             )
             .map_err(|e| ProposerError::Config(e.to_string()))?;
@@ -295,9 +314,13 @@ mod tests {
     use base_proof_contracts::AnchorRoot;
 
     use super::*;
-    use crate::test_utils::{
-        MockAnchorStateRegistry, MockDisputeGameFactory, MockRollupClient, test_anchor_root,
-        test_sync_status,
+    use crate::{
+        proposal_intervals::Intervals,
+        test_utils::{
+            MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory,
+            MockRollupClient, test_anchor_root, test_fixed_interval_resolver,
+            test_interval_resolver, test_sync_status,
+        },
     };
 
     const TEST_GAME_TYPE: u32 = 42;
@@ -325,18 +348,15 @@ mod tests {
             let block = anchor_block + block_interval * (i as u64 + 1);
             let root_claim = B256::repeat_byte((i as u8) + 1);
             let parent_block = block - block_interval;
-            let intermediate_roots = ProposalIntervals::intermediate_block_numbers(
-                block_interval,
-                intermediate_block_interval,
-                parent_block,
-            )
-            .unwrap()
-            .into_iter()
-            .map(|intermediate_block| match intermediate_block {
-                n if n == block => root_claim,
-                n => B256::repeat_byte(n as u8),
-            })
-            .collect::<Vec<_>>();
+            let intermediate_roots = Intervals { block_interval, intermediate_block_interval }
+                .intermediate_block_numbers(parent_block)
+                .unwrap()
+                .into_iter()
+                .map(|intermediate_block| match intermediate_block {
+                    n if n == block => root_claim,
+                    n => B256::repeat_byte(n as u8),
+                })
+                .collect::<Vec<_>>();
             output_roots.insert(block, root_claim);
             let key = game_lookup_key(
                 parent_block,
@@ -383,10 +403,26 @@ mod tests {
         intermediate_block_interval: u64,
         max_safe_block: Option<u64>,
     ) -> ProofRecovery {
+        recovery_with_intervals(
+            factory,
+            output_roots,
+            anchor_root,
+            anchor_game,
+            test_fixed_interval_resolver(block_interval, intermediate_block_interval),
+            max_safe_block,
+        )
+    }
+
+    fn recovery_with_intervals(
+        factory: MockDisputeGameFactory,
+        output_roots: HashMap<u64, B256>,
+        anchor_root: AnchorRoot,
+        anchor_game: Address,
+        intervals: Arc<IntervalResolver>,
+        max_safe_block: Option<u64>,
+    ) -> ProofRecovery {
         ProofRecovery::new(
             ProofRecoveryConfig {
-                block_interval,
-                intermediate_block_interval,
                 game_type: TEST_GAME_TYPE,
                 anchor_state_registry_address: Address::ZERO,
                 scan_concurrency: 8,
@@ -398,6 +434,7 @@ mod tests {
             }),
             Arc::new(MockAnchorStateRegistry { anchor_root, anchor_game }),
             Arc::new(factory),
+            intervals,
         )
     }
 
@@ -474,6 +511,107 @@ mod tests {
             assert_eq!(state.output_root, B256::repeat_byte((expected_proxy_index + 1) as u8));
             assert!(cache.is_some());
         }
+    }
+
+    /// The verifier switches to the Denim interval pair at
+    /// `DENIM_ACTIVATION_BLOCK`, so the walk has to reconstruct 100-block games
+    /// before it and 200-block games after it. A proposer that resolved the
+    /// interval once at startup would look for a 100-block game at 400, find
+    /// `Address::ZERO`, and re-propose over three games that already exist.
+    #[tokio::test]
+    async fn test_recovery_forward_walk_crosses_denim_activation_block() {
+        const PRE_DENIM_INTERVAL: u64 = 100;
+        const PRE_DENIM_INTERMEDIATE: u64 = 50;
+        const DENIM_ACTIVATION_BLOCK: u64 = 300;
+        const DENIM_INTERVAL: u64 = 200;
+        const DENIM_INTERMEDIATE: u64 = 100;
+
+        // Starting blocks either side of the boundary: 0/100/200 are pre-Denim,
+        // 300/500 are Denim.
+        let mut uuid_games = HashMap::new();
+        let mut output_roots = HashMap::new();
+        let mut parent = Address::ZERO;
+        let mut starting_block = TEST_ANCHOR_BLOCK;
+        for index in 0..5u64 {
+            let intervals = if starting_block < DENIM_ACTIVATION_BLOCK {
+                Intervals {
+                    block_interval: PRE_DENIM_INTERVAL,
+                    intermediate_block_interval: PRE_DENIM_INTERMEDIATE,
+                }
+            } else {
+                Intervals {
+                    block_interval: DENIM_INTERVAL,
+                    intermediate_block_interval: DENIM_INTERMEDIATE,
+                }
+            };
+            let target_block = starting_block + intervals.block_interval;
+            let root_claim = B256::repeat_byte((index + 1) as u8);
+            let intermediate_roots = intervals
+                .intermediate_block_numbers(starting_block)
+                .unwrap()
+                .into_iter()
+                .map(|block| {
+                    if block == target_block { root_claim } else { B256::repeat_byte(block as u8) }
+                })
+                .collect::<Vec<_>>();
+            for (block, root) in intervals
+                .intermediate_block_numbers(starting_block)
+                .unwrap()
+                .into_iter()
+                .zip(intermediate_roots.iter().copied())
+            {
+                output_roots.insert(block, root);
+            }
+
+            let key = game_lookup_key(
+                starting_block,
+                parent,
+                intervals.block_interval,
+                intervals.intermediate_block_interval,
+                &intermediate_roots,
+            )
+            .unwrap();
+            let proxy = proxy_addr(index);
+            uuid_games.insert((TEST_GAME_TYPE, key.root_claim, key.extra_data), proxy);
+
+            parent = proxy;
+            starting_block = target_block;
+        }
+        assert_eq!(starting_block, 700, "fixture should span both interval regimes");
+
+        let fixture = |intervals| {
+            recovery_with_intervals(
+                MockDisputeGameFactory {
+                    game_count: 5,
+                    uuid_games: uuid_games.clone(),
+                    ..Default::default()
+                },
+                output_roots.clone(),
+                test_anchor_root(TEST_ANCHOR_BLOCK),
+                Address::ZERO,
+                intervals,
+                None,
+            )
+        };
+
+        let denim_aware = fixture(test_interval_resolver(MockAggregateVerifier {
+            block_interval: PRE_DENIM_INTERVAL,
+            intermediate_block_interval: PRE_DENIM_INTERMEDIATE,
+            denim_activation_block: DENIM_ACTIVATION_BLOCK,
+            denim_block_interval: DENIM_INTERVAL,
+            denim_intermediate_block_interval: DENIM_INTERMEDIATE,
+            ..Default::default()
+        }));
+        let (state, _) = recover_uncached(&denim_aware).await;
+        assert_eq!(state.l2_block_number, 700, "walk must not stall at the Denim boundary");
+        assert_eq!(state.parent_address, proxy_addr(4));
+
+        // The pre-Denim pair applied everywhere is the bug this guards against:
+        // the walk looks for a 100-block game at 400 and stops at the boundary.
+        let stale =
+            fixture(test_fixed_interval_resolver(PRE_DENIM_INTERVAL, PRE_DENIM_INTERMEDIATE));
+        let (state, _) = recover_uncached(&stale).await;
+        assert_eq!(state.l2_block_number, DENIM_ACTIVATION_BLOCK);
     }
 
     #[tokio::test]

--- a/crates/proof/proposer/src/proof_recovery.rs
+++ b/crates/proof/proposer/src/proof_recovery.rs
@@ -207,7 +207,7 @@ impl ProofRecovery {
 
         loop {
             // Resolved per step so the walk keeps reconstructing games across the
-            // Cobalt activation block, where the verifier switches cadence.
+            // Denim activation block, where the verifier switches cadence.
             let intervals = self.intervals.for_starting_block(state.l2_block_number).await?;
 
             let Some(expected_block) =
@@ -587,7 +587,7 @@ mod tests {
             )
         };
 
-        let cobalt_aware = fixture(test_interval_resolver(MockAggregateVerifier {
+        let denim_aware = fixture(test_interval_resolver(MockAggregateVerifier {
             block_interval: SLOW_INTERVAL,
             intermediate_block_interval: SLOW_INTERMEDIATE,
             fast_activation_block: FAST_ACTIVATION_BLOCK,
@@ -595,7 +595,7 @@ mod tests {
             fast_intermediate_block_interval: FAST_INTERMEDIATE,
             ..Default::default()
         }));
-        let (state, _) = recover_uncached(&cobalt_aware).await;
+        let (state, _) = recover_uncached(&denim_aware).await;
         assert_eq!(state.l2_block_number, 700, "walk must not stall at the cadence boundary");
         assert_eq!(state.parent_address, proxy_addr(4));
 

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -124,7 +124,7 @@ impl ProofSubmitter {
         }
 
         // The intervals are a function of the starting block, not of process
-        // config: the verifier switches cadence at the Cobalt activation block.
+        // config: the verifier switches cadence at the Denim activation block.
         let intervals = self
             .intervals
             .for_starting_block(starting_block_number)

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -124,7 +124,7 @@ impl ProofSubmitter {
         }
 
         // The intervals are a function of the starting block, not of process
-        // config: the verifier switches cadence at the Denim activation block.
+        // config: the verifier switches cadence at the Cobalt activation block.
         let intervals = self
             .intervals
             .for_starting_block(starting_block_number)
@@ -610,7 +610,7 @@ mod tests {
     }
 
     /// The caller's target block must agree with the interval the verifier will
-    /// apply to the game's starting block. Across the Denim boundary a cursor
+    /// apply to the game's starting block. Across the cadence boundary a cursor
     /// built from a stale interval would otherwise commit an under-sized range.
     #[tokio::test]
     async fn submit_rejects_target_block_that_contradicts_resolved_interval() {

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info, instrument, warn};
 
 use crate::{
     Metrics, RecoveredState, driver::DriverConfig, error::ProposerError,
-    output_proposer::OutputProposer, proposal_intervals::ProposalIntervals,
+    output_proposer::OutputProposer, proposal_intervals::IntervalResolver,
 };
 
 const RECENT_GAME_LOOKUP_MAX_ATTEMPTS: usize = 3;
@@ -47,9 +47,8 @@ pub struct ProofSubmitter {
     rollup_client: Arc<dyn RollupProvider>,
     factory_client: Arc<dyn DisputeGameFactoryClient>,
     verifier_client: Arc<dyn AggregateVerifierClient>,
+    intervals: Arc<IntervalResolver>,
     game_type: u32,
-    block_interval: u64,
-    intermediate_block_interval: u64,
     output_fetch_concurrency: usize,
 }
 
@@ -57,8 +56,6 @@ impl std::fmt::Debug for ProofSubmitter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProofSubmitter")
             .field("game_type", &self.game_type)
-            .field("block_interval", &self.block_interval)
-            .field("intermediate_block_interval", &self.intermediate_block_interval)
             .field("output_fetch_concurrency", &self.output_fetch_concurrency)
             .finish_non_exhaustive()
     }
@@ -71,6 +68,7 @@ impl ProofSubmitter {
         rollup_client: Arc<dyn RollupProvider>,
         factory_client: Arc<dyn DisputeGameFactoryClient>,
         verifier_client: Arc<dyn AggregateVerifierClient>,
+        intervals: Arc<IntervalResolver>,
         config: &DriverConfig,
     ) -> Self {
         Self {
@@ -78,9 +76,8 @@ impl ProofSubmitter {
             rollup_client,
             factory_client,
             verifier_client,
+            intervals,
             game_type: config.game_type,
-            block_interval: config.block_interval,
-            intermediate_block_interval: config.intermediate_block_interval,
             output_fetch_concurrency: config.recovery_scan_concurrency,
         }
     }
@@ -95,12 +92,17 @@ impl ProofSubmitter {
     #[instrument(
         name = "proposer.submit_proof",
         skip_all,
-        fields(target_block = target_block, parent_address = %parent_address)
+        fields(
+            starting_block_number = starting_block_number,
+            target_block = target_block,
+            parent_address = %parent_address,
+        )
     )]
     pub async fn submit(
         &self,
         aggregate_proposal: &Proposal,
         proposals: &[Proposal],
+        starting_block_number: u64,
         target_block: u64,
         parent_address: Address,
     ) -> Result<RecoveredState, SubmitAction> {
@@ -121,20 +123,25 @@ impl ProofSubmitter {
             return Err(SubmitAction::RootMismatch);
         }
 
+        // The intervals are a function of the starting block, not of process
+        // config: the verifier switches cadence at the Denim activation block.
+        let intervals = self
+            .intervals
+            .for_starting_block(starting_block_number)
+            .await
+            .map_err(SubmitAction::Failed)?;
+        if starting_block_number.saturating_add(intervals.block_interval) != target_block {
+            return Err(SubmitAction::Failed(ProposerError::Internal(format!(
+                "target_block {target_block} is not {} blocks after starting block \
+                 {starting_block_number}",
+                intervals.block_interval
+            ))));
+        }
+
         // Extract intermediate roots.
-        let starting_block_number =
-            target_block.checked_sub(self.block_interval).ok_or_else(|| {
-                SubmitAction::Failed(ProposerError::Internal(format!(
-                    "target_block {target_block} < block_interval {}",
-                    self.block_interval
-                )))
-            })?;
-        let intermediate_blocks = ProposalIntervals::intermediate_block_numbers(
-            self.block_interval,
-            self.intermediate_block_interval,
-            starting_block_number,
-        )
-        .map_err(SubmitAction::Failed)?;
+        let intermediate_blocks = intervals
+            .intermediate_block_numbers(starting_block_number)
+            .map_err(SubmitAction::Failed)?;
         let intermediate_roots = Self::extract_intermediate_roots(
             starting_block_number,
             proposals,
@@ -186,8 +193,8 @@ impl ProofSubmitter {
         let key = game_lookup_key(
             starting_block_number,
             parent_address,
-            self.block_interval,
-            self.intermediate_block_interval,
+            intervals.block_interval,
+            intervals.intermediate_block_interval,
             &intermediate_roots,
         )
         .map_err(|e| SubmitAction::Failed(ProposerError::Config(e.to_string())))?;
@@ -438,7 +445,7 @@ mod tests {
     use super::*;
     use crate::test_utils::{
         MockAggregateVerifier, MockDisputeGameFactory, MockOutputProposer, MockRollupClient,
-        test_proposal, test_sync_status,
+        test_fixed_interval_resolver, test_proposal, test_sync_status,
     };
 
     const TEST_GAME_TYPE: u32 = 42;
@@ -465,12 +472,8 @@ mod tests {
             }),
             Arc::new(factory),
             Arc::new(verifier),
-            &DriverConfig {
-                game_type: TEST_GAME_TYPE,
-                block_interval: TEST_BLOCK_INTERVAL,
-                intermediate_block_interval: TEST_BLOCK_INTERVAL,
-                ..Default::default()
-            },
+            test_fixed_interval_resolver(TEST_BLOCK_INTERVAL, TEST_BLOCK_INTERVAL),
+            &DriverConfig { game_type: TEST_GAME_TYPE, ..Default::default() },
         )
     }
 
@@ -486,7 +489,7 @@ mod tests {
 
         let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
         let result = submitter
-            .submit(&aggregate_proposal, &proposals, TEST_BLOCK_INTERVAL, Address::ZERO)
+            .submit(&aggregate_proposal, &proposals, 0, TEST_BLOCK_INTERVAL, Address::ZERO)
             .await;
 
         assert!(result.is_ok());
@@ -515,7 +518,7 @@ mod tests {
 
                 let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
                 submitter
-                    .submit(&aggregate_proposal, &proposals, TEST_BLOCK_INTERVAL, Address::ZERO)
+                    .submit(&aggregate_proposal, &proposals, 0, TEST_BLOCK_INTERVAL, Address::ZERO)
                     .await
                     .unwrap();
             });
@@ -542,10 +545,9 @@ mod tests {
             }),
             Arc::new(MockDisputeGameFactory::with_uuid_game_responses([game_address])),
             Arc::new(MockAggregateVerifier::default()),
+            test_fixed_interval_resolver(TEST_BLOCK_INTERVAL, 25),
             &DriverConfig {
                 game_type: TEST_GAME_TYPE,
-                block_interval: TEST_BLOCK_INTERVAL,
-                intermediate_block_interval: 25,
                 recovery_scan_concurrency: 2,
                 ..Default::default()
             },
@@ -553,7 +555,7 @@ mod tests {
 
         let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
         let result = submitter
-            .submit(&aggregate_proposal, &proposals, TEST_BLOCK_INTERVAL, Address::ZERO)
+            .submit(&aggregate_proposal, &proposals, 0, TEST_BLOCK_INTERVAL, Address::ZERO)
             .await;
 
         assert!(result.is_ok());
@@ -573,7 +575,7 @@ mod tests {
 
         let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
         let result = submitter
-            .submit(&aggregate_proposal, &proposals, TEST_BLOCK_INTERVAL, Address::ZERO)
+            .submit(&aggregate_proposal, &proposals, 0, TEST_BLOCK_INTERVAL, Address::ZERO)
             .await;
 
         assert!(result.is_ok());
@@ -597,7 +599,7 @@ mod tests {
 
         let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
         let result = submitter
-            .submit(&aggregate_proposal, &proposals, TEST_BLOCK_INTERVAL, Address::ZERO)
+            .submit(&aggregate_proposal, &proposals, 0, TEST_BLOCK_INTERVAL, Address::ZERO)
             .await;
 
         let recovered = result.unwrap();
@@ -605,6 +607,31 @@ mod tests {
         assert_eq!(recovered.l2_block_number, TEST_BLOCK_INTERVAL);
         assert_eq!(*output.created.lock().unwrap(), 1);
         assert!(output.verified.lock().unwrap().is_empty());
+    }
+
+    /// The caller's target block must agree with the interval the verifier will
+    /// apply to the game's starting block. Across the Denim boundary a cursor
+    /// built from a stale interval would otherwise commit an under-sized range.
+    #[tokio::test]
+    async fn submit_rejects_target_block_that_contradicts_resolved_interval() {
+        let output = Arc::new(MockOutputProposer::default());
+        let submitter = submitter(
+            Arc::clone(&output),
+            MockDisputeGameFactory::default(),
+            MockAggregateVerifier::default(),
+        );
+
+        let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
+        let result = submitter
+            .submit(&aggregate_proposal, &proposals, 25, TEST_BLOCK_INTERVAL, Address::ZERO)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(SubmitAction::Failed(ref error))
+                if error.to_string().contains("is not 100 blocks after starting block 25")
+        ));
+        assert_eq!(*output.created.lock().unwrap(), 0);
     }
 
     #[tokio::test]
@@ -620,7 +647,7 @@ mod tests {
 
         let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
         let result = submitter
-            .submit(&aggregate_proposal, &proposals, TEST_BLOCK_INTERVAL, Address::ZERO)
+            .submit(&aggregate_proposal, &proposals, 0, TEST_BLOCK_INTERVAL, Address::ZERO)
             .await;
 
         assert!(matches!(
@@ -635,7 +662,8 @@ mod tests {
     #[tokio::test]
     async fn submit_recovers_when_existing_game_l1_head_mismatches() {
         let game_address = Address::repeat_byte(0xAA);
-        let verifier = MockAggregateVerifier { l1_head: B256::repeat_byte(0xCC) };
+        let verifier =
+            MockAggregateVerifier { l1_head: B256::repeat_byte(0xCC), ..Default::default() };
         let output = Arc::new(MockOutputProposer::default());
         let submitter = submitter(
             Arc::clone(&output),
@@ -645,7 +673,7 @@ mod tests {
 
         let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
         let result = submitter
-            .submit(&aggregate_proposal, &proposals, TEST_BLOCK_INTERVAL, Address::ZERO)
+            .submit(&aggregate_proposal, &proposals, 0, TEST_BLOCK_INTERVAL, Address::ZERO)
             .await;
 
         assert!(matches!(result, Err(SubmitAction::GameAlreadyExists)));
@@ -681,7 +709,7 @@ mod tests {
 
             let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
             let result = submitter
-                .submit(&aggregate_proposal, &proposals, TEST_BLOCK_INTERVAL, Address::ZERO)
+                .submit(&aggregate_proposal, &proposals, 0, TEST_BLOCK_INTERVAL, Address::ZERO)
                 .await;
 
             match expected_discard_label {
@@ -706,7 +734,7 @@ mod tests {
 
         let (aggregate_proposal, proposals) = proof_result(TEST_BLOCK_INTERVAL);
         let result = submitter
-            .submit(&aggregate_proposal, &proposals, TEST_BLOCK_INTERVAL, Address::ZERO)
+            .submit(&aggregate_proposal, &proposals, 0, TEST_BLOCK_INTERVAL, Address::ZERO)
             .await;
 
         assert!(matches!(result, Err(SubmitAction::GameAlreadyExists)));

--- a/crates/proof/proposer/src/proof_submitter.rs
+++ b/crates/proof/proposer/src/proof_submitter.rs
@@ -130,7 +130,7 @@ impl ProofSubmitter {
             .for_starting_block(starting_block_number)
             .await
             .map_err(SubmitAction::Failed)?;
-        if starting_block_number.saturating_add(intervals.block_interval) != target_block {
+        if starting_block_number.checked_add(intervals.block_interval) != Some(target_block) {
             return Err(SubmitAction::Failed(ProposerError::Internal(format!(
                 "target_block {target_block} is not {} blocks after starting block \
                  {starting_block_number}",

--- a/crates/proof/proposer/src/proposal_intervals.rs
+++ b/crates/proof/proposer/src/proposal_intervals.rs
@@ -1,6 +1,6 @@
 //! Per-game resolution of the proposal checkpoint intervals.
 //!
-//! The `AggregateVerifier` switches to a shorter cadence at the Denim
+//! The `AggregateVerifier` switches to a shorter cadence at the Cobalt
 //! activation block, so `BLOCK_INTERVAL` / `INTERMEDIATE_BLOCK_INTERVAL` are a
 //! function of the block a game's range starts at, not process-wide constants.
 //! Every consumer resolves them from the starting block of the game it is
@@ -41,7 +41,7 @@ impl Intervals {
 ///
 /// Both the implementation address and the interval pair are read per lookup:
 /// the factory's `gameImpls` entry can be swapped by an upgrade, and the pair
-/// changes at the Denim activation block. Caching either one at startup makes
+/// changes at the Cobalt activation block. Caching either one at startup makes
 /// the proposer stop finding — and stop creating — games on the far side of a
 /// boundary it never observes.
 pub struct IntervalResolver {

--- a/crates/proof/proposer/src/proposal_intervals.rs
+++ b/crates/proof/proposer/src/proposal_intervals.rs
@@ -1,36 +1,107 @@
-//! Computes proposal checkpoint block intervals shared by recovery and submission.
+//! Per-game resolution of the proposal checkpoint intervals.
+//!
+//! The `AggregateVerifier` switches to a shorter cadence at the Denim
+//! activation block, so `BLOCK_INTERVAL` / `INTERMEDIATE_BLOCK_INTERVAL` are a
+//! function of the block a game's range starts at, not process-wide constants.
+//! Every consumer resolves them from the starting block of the game it is
+//! about to create, reconstruct, or look up.
 
-use base_proof_contracts::game_lookup_blocks;
+use std::sync::Arc;
+
+use base_proof_contracts::{AggregateVerifierClient, DisputeGameFactoryClient, game_lookup_blocks};
 
 use crate::error::ProposerError;
 
-/// Shared proposal interval calculations.
-#[derive(Debug)]
-pub struct ProposalIntervals;
+/// The checkpoint intervals a game starting at a given block is created with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Intervals {
+    /// Number of L2 blocks covered by one proposal.
+    pub block_interval: u64,
+    /// Number of L2 blocks between intermediate output root checkpoints.
+    pub intermediate_block_interval: u64,
+}
 
-impl ProposalIntervals {
-    /// Returns intermediate block numbers between `starting_block_number` and
-    /// the next proposal target, stepping by `intermediate_block_interval`.
+impl Intervals {
+    /// Computes the intermediate checkpoint block numbers for a game starting
+    /// at `starting_block_number`, including the target block.
     pub fn intermediate_block_numbers(
-        block_interval: u64,
-        intermediate_block_interval: u64,
+        &self,
         starting_block_number: u64,
     ) -> Result<Vec<u64>, ProposerError> {
-        game_lookup_blocks(starting_block_number, block_interval, intermediate_block_interval)
-            .map_err(|e| ProposerError::Config(e.to_string()))
+        game_lookup_blocks(
+            starting_block_number,
+            self.block_interval,
+            self.intermediate_block_interval,
+        )
+        .map_err(|e| ProposerError::Config(e.to_string()))
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// Resolves [`Intervals`] from the onchain `AggregateVerifier`.
+///
+/// Both the implementation address and the interval pair are read per lookup:
+/// the factory's `gameImpls` entry can be swapped by an upgrade, and the pair
+/// changes at the Denim activation block. Caching either one at startup makes
+/// the proposer stop finding — and stop creating — games on the far side of a
+/// boundary it never observes.
+pub struct IntervalResolver {
+    verifier_client: Arc<dyn AggregateVerifierClient>,
+    factory_client: Arc<dyn DisputeGameFactoryClient>,
+    game_type: u32,
+}
 
-    #[test]
-    fn intermediate_block_numbers_rejects_zero_block_interval() {
-        let result = ProposalIntervals::intermediate_block_numbers(0, 1, 0);
+impl std::fmt::Debug for IntervalResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IntervalResolver")
+            .field("game_type", &self.game_type)
+            .finish_non_exhaustive()
+    }
+}
 
-        assert!(
-            matches!(result, Err(ProposerError::Config(message)) if message == "block_interval must not be zero")
-        );
+impl IntervalResolver {
+    /// Creates an interval resolver for `game_type`.
+    pub const fn new(
+        verifier_client: Arc<dyn AggregateVerifierClient>,
+        factory_client: Arc<dyn DisputeGameFactoryClient>,
+        game_type: u32,
+    ) -> Self {
+        Self { verifier_client, factory_client, game_type }
+    }
+
+    /// Returns the intervals the verifier applies to a game whose range starts
+    /// at `starting_block`.
+    ///
+    /// ponytail: one `gameImpls` call plus one `intervalsForStartingBlock` call
+    /// per lookup, no cache. At a 12s poll with at most a handful of targets per
+    /// tick this is noise next to the rollup output fetches on the same path;
+    /// add a short-TTL cache keyed on `(impl_address, starting_block)` if the L1
+    /// read budget ever becomes the constraint.
+    pub async fn for_starting_block(
+        &self,
+        starting_block: u64,
+    ) -> Result<Intervals, ProposerError> {
+        let impl_address = self
+            .factory_client
+            .game_impls(self.game_type)
+            .await
+            .map_err(|e| ProposerError::Contract(format!("gameImpls lookup failed: {e}")))?;
+        if impl_address.is_zero() {
+            return Err(ProposerError::Contract(format!(
+                "no AggregateVerifier implementation registered for game type {}",
+                self.game_type
+            )));
+        }
+
+        let (block_interval, intermediate_block_interval) = self
+            .verifier_client
+            .read_intervals_for_starting_block(impl_address, starting_block)
+            .await
+            .map_err(|e| {
+                ProposerError::Contract(format!(
+                    "intervalsForStartingBlock({starting_block}) failed: {e}"
+                ))
+            })?;
+
+        Ok(Intervals { block_interval, intermediate_block_interval })
     }
 }

--- a/crates/proof/proposer/src/proposal_intervals.rs
+++ b/crates/proof/proposer/src/proposal_intervals.rs
@@ -1,6 +1,6 @@
 //! Per-game resolution of the proposal checkpoint intervals.
 //!
-//! The `AggregateVerifier` switches to a shorter cadence at the Cobalt
+//! The `AggregateVerifier` switches to a shorter cadence at the Denim
 //! activation block, so `BLOCK_INTERVAL` / `INTERMEDIATE_BLOCK_INTERVAL` are a
 //! function of the block a game's range starts at, not process-wide constants.
 //! Every consumer resolves them from the starting block of the game it is
@@ -41,7 +41,7 @@ impl Intervals {
 ///
 /// Both the implementation address and the interval pair are read per lookup:
 /// the factory's `gameImpls` entry can be swapped by an upgrade, and the pair
-/// changes at the Cobalt activation block. Caching either one at startup makes
+/// changes at the Denim activation block. Caching either one at startup makes
 /// the proposer stop finding — and stop creating — games on the far side of a
 /// boundary it never observes.
 pub struct IntervalResolver {

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -145,6 +145,14 @@ impl ProposerService {
             Arc::clone(&factory_client),
             config.game_type,
         ));
+        let anchor_block = anchor_registry.anchor_snapshot().await?.anchor_root.l2_block_number;
+        let startup_intervals = intervals.for_starting_block(anchor_block).await?;
+        info!(
+            anchor_block,
+            block_interval = startup_intervals.block_interval,
+            intermediate_block_interval = startup_intervals.intermediate_block_interval,
+            "Validated proposal interval resolver"
+        );
         let submit_timeout =
             config.tx_manager.as_ref().map_or(Some(DEFAULT_SUBMIT_TIMEOUT), |tx| {
                 (!tx.tx_send_timeout.is_zero())

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -36,7 +36,7 @@ use crate::{
     output_proposer::{OutputProposer, ProposalSubmitter},
     pipeline::ProvingPipeline,
     proof_collector::ProofCollector,
-    proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig},
+    proof_dispatcher::ProofDispatcher,
     proof_recovery::{ProofRecovery, ProofRecoveryConfig},
     proof_submitter::ProofSubmitter,
     proposal_intervals::IntervalResolver,
@@ -222,7 +222,7 @@ impl ProposerService {
             Arc::<L2Client>::clone(&l2_client),
             Arc::<RollupClient>::clone(&rollup_client),
             Arc::clone(&intervals),
-            ProofDispatcherConfig::from(&driver_config),
+            driver_config.proposer_address,
         );
         let proof_submitter = ProofSubmitter::new(
             output_proposer,

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -138,7 +138,7 @@ impl ProposerService {
         let factory_client: Arc<dyn DisputeGameFactoryClient> = Arc::new(factory_client);
         let verifier_client: Arc<dyn AggregateVerifierClient> = Arc::new(verifier_client);
 
-        // The proposal intervals change at the Denim activation block, so they are
+        // The proposal intervals change at the Cobalt activation block, so they are
         // resolved from each game's starting block instead of being read once here.
         let intervals = Arc::new(IntervalResolver::new(
             Arc::clone(&verifier_client),

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -39,6 +39,7 @@ use crate::{
     proof_dispatcher::{ProofDispatcher, ProofDispatcherConfig},
     proof_recovery::{ProofRecovery, ProofRecoveryConfig},
     proof_submitter::ProofSubmitter,
+    proposal_intervals::IntervalResolver,
 };
 
 const SUBMIT_TIMEOUT_SLACK: Duration = Duration::from_mins(2);
@@ -126,25 +127,8 @@ impl ProposerService {
                 config.game_type
             ));
         }
-        let (block_interval, intermediate_block_interval, init_bond) = tokio::try_join!(
-            verifier_client.read_block_interval(impl_address),
-            verifier_client.read_intermediate_block_interval(impl_address),
-            factory_client.init_bonds(config.game_type),
-        )?;
-        if block_interval < 2 {
-            return Err(eyre::eyre!(
-                "BLOCK_INTERVAL ({block_interval}) must be at least 2; single-block proposals are not supported"
-            ));
-        }
-        if block_interval % intermediate_block_interval != 0 {
-            return Err(eyre::eyre!(
-                "BLOCK_INTERVAL ({block_interval}) is not divisible by INTERMEDIATE_BLOCK_INTERVAL ({intermediate_block_interval})"
-            ));
-        }
+        let init_bond = factory_client.init_bonds(config.game_type).await?;
         info!(
-            block_interval,
-            intermediate_block_interval,
-            intermediate_roots_count = block_interval / intermediate_block_interval,
             init_bond = %init_bond,
             impl_address = %impl_address,
             game_type = config.game_type,
@@ -153,6 +137,14 @@ impl ProposerService {
 
         let factory_client: Arc<dyn DisputeGameFactoryClient> = Arc::new(factory_client);
         let verifier_client: Arc<dyn AggregateVerifierClient> = Arc::new(verifier_client);
+
+        // The proposal intervals change at the Denim activation block, so they are
+        // resolved from each game's starting block instead of being read once here.
+        let intervals = Arc::new(IntervalResolver::new(
+            Arc::clone(&verifier_client),
+            Arc::clone(&factory_client),
+            config.game_type,
+        ));
         let submit_timeout =
             config.tx_manager.as_ref().map_or(Some(DEFAULT_SUBMIT_TIMEOUT), |tx| {
                 (!tx.tx_send_timeout.is_zero())
@@ -220,8 +212,6 @@ impl ProposerService {
             poll_interval: config.poll_interval,
             recovery_scan_concurrency: config.recovery_scan_concurrency,
             submit_timeout,
-            block_interval,
-            intermediate_block_interval,
             game_type: config.game_type,
             proposer_address: proposer_address.unwrap_or_default(),
             anchor_state_registry_address: config.anchor_state_registry_addr,
@@ -231,6 +221,7 @@ impl ProposerService {
             Arc::<L1Client>::clone(&l1_client),
             Arc::<L2Client>::clone(&l2_client),
             Arc::<RollupClient>::clone(&rollup_client),
+            Arc::clone(&intervals),
             ProofDispatcherConfig::from(&driver_config),
         );
         let proof_submitter = ProofSubmitter::new(
@@ -238,12 +229,11 @@ impl ProposerService {
             Arc::<RollupClient>::clone(&rollup_client),
             Arc::clone(&factory_client),
             Arc::clone(&verifier_client),
+            Arc::clone(&intervals),
             &driver_config,
         );
         let proof_recovery = Arc::new(ProofRecovery::new(
             ProofRecoveryConfig {
-                block_interval: driver_config.block_interval,
-                intermediate_block_interval: driver_config.intermediate_block_interval,
                 game_type: driver_config.game_type,
                 anchor_state_registry_address: driver_config.anchor_state_registry_address,
                 scan_concurrency: driver_config.recovery_scan_concurrency,
@@ -251,12 +241,13 @@ impl ProposerService {
             Arc::<RollupClient>::clone(&rollup_client),
             anchor_registry,
             factory_client,
+            Arc::clone(&intervals),
         ));
         let proof_collector = ProofCollector::new(
             Arc::clone(&proof_requester),
             Arc::clone(&rollup_client),
             proof_submitter,
-            driver_config.block_interval,
+            Arc::clone(&intervals),
             driver_config.submit_timeout,
         );
         let pipeline =
@@ -290,7 +281,6 @@ impl ProposerService {
         Metrics::record_startup();
         info!(
             poll_interval = ?config.poll_interval,
-            block_interval,
             game_type = config.game_type,
             "Service is ready"
         );

--- a/crates/proof/proposer/src/service.rs
+++ b/crates/proof/proposer/src/service.rs
@@ -138,7 +138,7 @@ impl ProposerService {
         let factory_client: Arc<dyn DisputeGameFactoryClient> = Arc::new(factory_client);
         let verifier_client: Arc<dyn AggregateVerifierClient> = Arc::new(verifier_client);
 
-        // The proposal intervals change at the Cobalt activation block, so they are
+        // The proposal intervals change at the Denim activation block, so they are
         // resolved from each game's starting block instead of being read once here.
         let intervals = Arc::new(IntervalResolver::new(
             Arc::clone(&verifier_client),

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -247,22 +247,22 @@ pub const TEST_IMPL_ADDRESS: Address = Address::repeat_byte(0xA1);
 ///
 /// `read_intervals_for_starting_block` mirrors the onchain
 /// `intervalsForStartingBlock`: games whose range starts at or after
-/// `denim_activation_block` are created with the Denim interval pair. The
-/// default is a chain with Denim unscheduled.
+/// `fast_activation_block` are created with the fast-cadence interval pair.
+/// The default is a chain on which the speedup is unscheduled.
 #[derive(Debug)]
 pub struct MockAggregateVerifier {
     /// L1 head returned by `l1_head()`.
     pub l1_head: B256,
-    /// Pre-Denim `BLOCK_INTERVAL`.
+    /// Slow-cadence `BLOCK_INTERVAL`.
     pub block_interval: u64,
-    /// Pre-Denim `INTERMEDIATE_BLOCK_INTERVAL`.
+    /// Slow-cadence `INTERMEDIATE_BLOCK_INTERVAL`.
     pub intermediate_block_interval: u64,
-    /// First starting block that uses the Denim interval pair.
-    pub denim_activation_block: u64,
-    /// Post-Denim `BLOCK_INTERVAL`.
-    pub denim_block_interval: u64,
-    /// Post-Denim `INTERMEDIATE_BLOCK_INTERVAL`.
-    pub denim_intermediate_block_interval: u64,
+    /// First starting block that uses the fast-cadence interval pair.
+    pub fast_activation_block: u64,
+    /// Fast-cadence `BLOCK_INTERVAL`.
+    pub fast_block_interval: u64,
+    /// Fast-cadence `INTERMEDIATE_BLOCK_INTERVAL`.
+    pub fast_intermediate_block_interval: u64,
 }
 
 impl Default for MockAggregateVerifier {
@@ -271,9 +271,9 @@ impl Default for MockAggregateVerifier {
             l1_head: B256::ZERO,
             block_interval: 100,
             intermediate_block_interval: 100,
-            denim_activation_block: u64::MAX,
-            denim_block_interval: 100,
-            denim_intermediate_block_interval: 100,
+            fast_activation_block: u64::MAX,
+            fast_block_interval: 100,
+            fast_intermediate_block_interval: 100,
         }
     }
 }
@@ -295,8 +295,8 @@ pub fn test_fixed_interval_resolver(
     test_interval_resolver(MockAggregateVerifier {
         block_interval,
         intermediate_block_interval,
-        denim_block_interval: block_interval,
-        denim_intermediate_block_interval: intermediate_block_interval,
+        fast_block_interval: block_interval,
+        fast_intermediate_block_interval: intermediate_block_interval,
         ..Default::default()
     })
 }
@@ -335,10 +335,10 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         _: Address,
         starting_block: u64,
     ) -> Result<(u64, u64), ContractError> {
-        if starting_block < self.denim_activation_block {
+        if starting_block < self.fast_activation_block {
             Ok((self.block_interval, self.intermediate_block_interval))
         } else {
-            Ok((self.denim_block_interval, self.denim_intermediate_block_interval))
+            Ok((self.fast_block_interval, self.fast_intermediate_block_interval))
         }
     }
     async fn intermediate_output_roots(&self, _: Address) -> Result<Vec<B256>, ContractError> {

--- a/crates/proof/proposer/src/test_utils.rs
+++ b/crates/proof/proposer/src/test_utils.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::{HashMap, VecDeque},
-    sync::Mutex,
+    sync::{Arc, Mutex},
 };
 
 use alloy_eips::BlockNumberOrTag;
@@ -30,7 +30,9 @@ use base_prover_service_protocol::{
 };
 use jsonrpsee::{core::client::Error as JsonRpcClientError, types::ErrorObjectOwned};
 
-use crate::{error::ProposerError, output_proposer::OutputProposer};
+use crate::{
+    error::ProposerError, output_proposer::OutputProposer, proposal_intervals::IntervalResolver,
+};
 
 const TEST_SIGNATURE: [u8; 65] = {
     let mut signature = [0xab; 65];
@@ -216,7 +218,7 @@ impl DisputeGameFactoryClient for MockDisputeGameFactory {
         Ok(U256::ZERO)
     }
     async fn game_impls(&self, _: u32) -> Result<Address, ContractError> {
-        Ok(Address::ZERO)
+        Ok(TEST_IMPL_ADDRESS)
     }
     async fn games(
         &self,
@@ -238,11 +240,65 @@ impl DisputeGameFactoryClient for MockDisputeGameFactory {
     }
 }
 
+/// Address returned by `MockDisputeGameFactory::game_impls`.
+pub const TEST_IMPL_ADDRESS: Address = Address::repeat_byte(0xA1);
+
 /// Mock aggregate verifier contract client for tests.
-#[derive(Debug, Default)]
+///
+/// `read_intervals_for_starting_block` mirrors the onchain
+/// `intervalsForStartingBlock`: games whose range starts at or after
+/// `denim_activation_block` are created with the Denim interval pair. The
+/// default is a chain with Denim unscheduled.
+#[derive(Debug)]
 pub struct MockAggregateVerifier {
     /// L1 head returned by `l1_head()`.
     pub l1_head: B256,
+    /// Pre-Denim `BLOCK_INTERVAL`.
+    pub block_interval: u64,
+    /// Pre-Denim `INTERMEDIATE_BLOCK_INTERVAL`.
+    pub intermediate_block_interval: u64,
+    /// First starting block that uses the Denim interval pair.
+    pub denim_activation_block: u64,
+    /// Post-Denim `BLOCK_INTERVAL`.
+    pub denim_block_interval: u64,
+    /// Post-Denim `INTERMEDIATE_BLOCK_INTERVAL`.
+    pub denim_intermediate_block_interval: u64,
+}
+
+impl Default for MockAggregateVerifier {
+    fn default() -> Self {
+        Self {
+            l1_head: B256::ZERO,
+            block_interval: 100,
+            intermediate_block_interval: 100,
+            denim_activation_block: u64::MAX,
+            denim_block_interval: 100,
+            denim_intermediate_block_interval: 100,
+        }
+    }
+}
+
+/// Builds an [`IntervalResolver`] backed by `verifier` and a default factory.
+pub fn test_interval_resolver(verifier: MockAggregateVerifier) -> Arc<IntervalResolver> {
+    Arc::new(IntervalResolver::new(
+        Arc::new(verifier),
+        Arc::new(MockDisputeGameFactory::default()),
+        0,
+    ))
+}
+
+/// Builds an [`IntervalResolver`] that reports a single interval pair everywhere.
+pub fn test_fixed_interval_resolver(
+    block_interval: u64,
+    intermediate_block_interval: u64,
+) -> Arc<IntervalResolver> {
+    test_interval_resolver(MockAggregateVerifier {
+        block_interval,
+        intermediate_block_interval,
+        denim_block_interval: block_interval,
+        denim_intermediate_block_interval: intermediate_block_interval,
+        ..Default::default()
+    })
 }
 
 #[async_trait]
@@ -273,6 +329,17 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
     async fn read_intermediate_block_interval(&self, _: Address) -> Result<u64, ContractError> {
         unimplemented!("unused in proposer tests")
+    }
+    async fn read_intervals_for_starting_block(
+        &self,
+        _: Address,
+        starting_block: u64,
+    ) -> Result<(u64, u64), ContractError> {
+        if starting_block < self.denim_activation_block {
+            Ok((self.block_interval, self.intermediate_block_interval))
+        } else {
+            Ok((self.denim_block_interval, self.denim_intermediate_block_interval))
+        }
     }
     async fn intermediate_output_roots(&self, _: Address) -> Result<Vec<B256>, ContractError> {
         unimplemented!("unused in proposer tests")


### PR DESCRIPTION
Section 2 of the [Denim proof config switchover](https://bdocs.cbhq.net/d/denim-proof-config-switchover/v/latest/) design.

Depends on base/contracts#431, which adds `intervalsForStartingBlock(uint256)` to `AggregateVerifier`. This PR adds the Rust binding for it, so it must land after the contract is deployed.

## What changed?

**`crates/proof/contracts`**
- Added `intervalsForStartingBlock(uint256)` to the `IAggregateVerifier` `sol!` interface and `AggregateVerifierClient::read_intervals_for_starting_block`, which validates the pair (`block_interval >= 2`, non-zero intermediate, divisible) on read.

**`crates/proof/proposer`**
- Replaced the `ProposalIntervals` helper with `Intervals` (the resolved pair, plus its `intermediate_block_numbers`) and `IntervalResolver`, which reads the factory's current `gameImpls` entry and then `intervalsForStartingBlock(starting_block)` on every lookup.
- Removed `block_interval` / `intermediate_block_interval` from `DriverConfig`, `ProofDispatcherConfig`, `ProofRecoveryConfig`, `ProofSubmitter` and `ProofCollector`. All five now hold an `Arc<IntervalResolver>` and resolve from the starting block of the game in hand.
- `service.rs` no longer reads the two intervals at startup; it builds the resolver instead. The `gameImpls != 0` fail-fast check and the `init_bonds` read are kept.
- `ProofSubmitter::submit` takes `starting_block_number` from the caller (the collector's cursor) instead of computing `target_block - block_interval`, and rejects a target block that does not sit exactly one resolved interval after that starting block.

## Why?

Denim changes `BLOCK_INTERVAL` 600 → 6,000 and `INTERMEDIATE_BLOCK_INTERVAL` 30 → 300 at a fixed L2 block. The proposer read both from the implementation exactly once at startup and copied them into four config structs that were never refreshed, so from the boundary onward:

- the recovery forward walk builds the next game's UUID with the pre-Denim interval, `games()` returns `Address::ZERO`, and it logs "No game found at expected block, will propose from here" — re-proposing over games that already exist;
- `ProofSubmitter` derives `starting_block = target_block - block_interval` from the same stale value, so the committed range and the `extraData` in the game UUID are both wrong;
- `ProofDispatcher` puts the stale `intermediate_block_interval` in every `ProofRequest`.

Resolving per game also means an implementation upgrade is picked up without a proposer restart, since `gameImpls` is re-read each lookup.

Note on the doc's guidance to follow `basectl` (`crates/infra/basectl/src/rpc/games.rs:393-409`) and read the interval from the **game proxy** rather than the factory's mutable `gameImpls` entry: that applies to inspecting a game that already exists. The proposer's reads are all *predictive* — it computes the UUID of a game that has not been created yet — so there is no proxy to read from. `intervalsForStartingBlock` on the implementation is the equivalent: it returns exactly the pair the constructor will apply to that starting block, and for pre-Denim starting blocks the new implementation returns the same values the old one had.

`IntervalResolver` deliberately has no cache — two `eth_call`s per resolved target, against a 12s poll and the rollup output fetches already on the same path. There is a `ponytail:` comment naming the upgrade path if the L1 read budget ever becomes the constraint.

## How to test?

```
cd crates/proof
cargo test -p base-proposer -p base-proof-contracts
cargo clippy -p base-proof-contracts -p base-proposer -p base-challenger --all-targets -- -D warnings
cargo +nightly fmt --all -- --check
```

The two new tests are the ones that matter:

1. `cargo test -p base-proposer test_recovery_forward_walk_crosses_fast_activation_block`

   Builds a five-game chain whose starting blocks straddle a Denim activation at block 300 — 100-block games at 0/100/200, 200-block games at 300/500 — and runs the same fixture through two resolvers. With the Denim-aware resolver the walk reaches block 700 and parent `proxy_addr(4)`. With a fixed pre-Denim resolver (the old behaviour) the same chain stalls at block 300, which is the bug.

2. `cargo test -p base-proposer submit_rejects_target_block_that_contradicts_resolved_interval`

   `submit(.., starting_block = 25, target_block = 100, ..)` against a 100-block resolver fails with "is not 100 blocks after starting block 25" and creates no game.

Manual check against a chain with the upgraded verifier deployed but Denim not yet scheduled — the proposer should behave identically to today, since `intervalsForStartingBlock` returns the pre-Denim pair for every starting block until the `ProtocolVersions` schedule has a Denim entry:

```
cargo run -p base-proposer -- --l1-eth-rpc <l1> --rollup-rpc <rollup> --prover-rpc <prover> \
  --dispute-game-factory-addr <factory> --anchor-state-registry-addr <asr> --game-type <type> --dry-run
```

Expect the startup log to no longer print `block_interval` / `intermediate_block_interval` (they are per game now), and the recovery walk to reach the same tip it does on `main`.

## Follow-ups (not in this PR)

- Challenger (`crates/proof/challenge`): `AnchorUpdater` builds the next game's UUID from the same startup-cached pair. Separate PR, based on this one — it reuses `read_intervals_for_starting_block`. `GameScanner::resolve_intermediate_block_interval` also needs work: the doc lists it as already correct, but it caches by *implementation address*, so once one implementation serves both sides of the boundary it returns a single value for every game.
- Nitro TEE / ZK gating, per sections 4-5 of the doc.

---

### Update — back to Denim

The 200ms cadence switch has moved back to **Denim**, `ProtocolVersions` index 13. base/contracts#434 reverts the index in `AggregateVerifier` (12 → 13, semver 0.3.0); this branch follows it in prose and fixture names.

Nothing functional moved in either direction. This service resolves the interval pair from the verifier per game and never names a fork itself, so the earlier Cobalt retarget and this one are both comment-and-identifier changes. The mock builders and test names introduced along the way are cadence-neutral (`fast_activation_block`, `with_fast_intervals`, `..._crosses_fast_activation_block`) and did not need renaming for either move.

Index 13 sits one past the end of the current Base mainnet schedule, where index 12 was in range but zero. `_firstFastBlock()` reports "unscheduled" for both, so the deploy-time requirement is unchanged: the activation has to be registered on `ProtocolVersions` before the fork or the verifier stays on the slow cadence silently.

The branch name still says `denim` — which is now correct again. It was never renamed, since that would close and reopen the PR.
