### PR TITLE
feat(challenger): resolve proposal intervals per game for Denim

### DIFF
--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -6,7 +6,7 @@ use alloy_primitives::Address;
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorRoot, AnchorSnapshot, AnchorStateRegistryClient,
     DisputeGameFactoryClient, GameStatus, encode_set_anchor_state_calldata, game_lookup_blocks,
-    game_lookup_key,
+    game_lookup_key, resolve_intervals,
 };
 use base_proof_rpc::L2Provider;
 use base_tx_manager::TxManager;
@@ -23,8 +23,6 @@ pub struct AnchorUpdater {
     cached_next_game: Option<(AnchorSnapshot, Address)>,
     anchor_state_registry_address: Address,
     game_type: u32,
-    block_interval: u64,
-    intermediate_block_interval: u64,
 }
 
 impl std::fmt::Debug for AnchorUpdater {
@@ -32,8 +30,6 @@ impl std::fmt::Debug for AnchorUpdater {
         f.debug_struct("AnchorUpdater")
             .field("anchor_state_registry_address", &self.anchor_state_registry_address)
             .field("game_type", &self.game_type)
-            .field("block_interval", &self.block_interval)
-            .field("intermediate_block_interval", &self.intermediate_block_interval)
             .finish_non_exhaustive()
     }
 }
@@ -46,8 +42,6 @@ impl AnchorUpdater {
         l2_provider: Arc<dyn L2Provider>,
         anchor_state_registry_address: Address,
         game_type: u32,
-        block_interval: u64,
-        intermediate_block_interval: u64,
     ) -> Self {
         Self {
             factory_client,
@@ -56,8 +50,6 @@ impl AnchorUpdater {
             cached_next_game: None,
             anchor_state_registry_address,
             game_type,
-            block_interval,
-            intermediate_block_interval,
         }
     }
 
@@ -79,7 +71,8 @@ impl AnchorUpdater {
             Some((cached_anchor, address)) if cached_anchor == anchor => address,
             _ => {
                 self.cached_next_game = None;
-                let Some(address) = self.next_game(anchor.anchor_root, anchor.anchor_game).await
+                let Some(address) =
+                    self.next_game(verifier_client, anchor.anchor_root, anchor.anchor_game).await
                 else {
                     return;
                 };
@@ -114,11 +107,34 @@ impl AnchorUpdater {
         }
     }
 
-    async fn next_game(&self, anchor_root: AnchorRoot, anchor_game: Address) -> Option<Address> {
+    async fn next_game(
+        &self,
+        verifier_client: &dyn AggregateVerifierClient,
+        anchor_root: AnchorRoot,
+        anchor_game: Address,
+    ) -> Option<Address> {
+        // Resolved from the anchor block, which is where the next game's range starts:
+        // the verifier switches to a shorter cadence at the Denim activation block, so a
+        // pair cached at startup silently stops matching any game past the boundary.
+        let (block_interval, intermediate_block_interval) = match resolve_intervals(
+            self.factory_client.as_ref(),
+            verifier_client,
+            self.game_type,
+            anchor_root.l2_block_number,
+        )
+        .await
+        {
+            Ok(intervals) => intervals,
+            Err(e) => {
+                warn!(error = %e, "failed to resolve anchor update intervals");
+                return None;
+            }
+        };
+
         let blocks = match game_lookup_blocks(
             anchor_root.l2_block_number,
-            self.block_interval,
-            self.intermediate_block_interval,
+            block_interval,
+            intermediate_block_interval,
         ) {
             Ok(blocks) => blocks,
             Err(e) => {
@@ -154,8 +170,8 @@ impl AnchorUpdater {
         let key = match game_lookup_key(
             anchor_root.l2_block_number,
             parent,
-            self.block_interval,
-            self.intermediate_block_interval,
+            block_interval,
+            intermediate_block_interval,
             &intermediate_roots,
         ) {
             Ok(key) => key,
@@ -309,14 +325,18 @@ mod tests {
 
     use super::*;
     use crate::test_utils::{
-        MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockL2Provider,
-        MockTxManager, addr, build_test_header_and_account, mock_state, receipt_with_status,
+        MockAggregateVerifier, MockAnchorStateRegistry, MockDisputeGameFactory, MockGameState,
+        MockL2Provider, MockTxManager, addr, build_test_header_and_account, mock_state,
+        receipt_with_status,
     };
 
     const ASR_ADDRESS: Address = Address::new([0xAA; 20]);
     const GAME_TYPE: u32 = 1;
     const BLOCK_INTERVAL: u64 = 100;
     const INTERMEDIATE_BLOCK_INTERVAL: u64 = 100;
+    const DENIM_ACTIVATION_BLOCK: u64 = 200;
+    const DENIM_BLOCK_INTERVAL: u64 = 50;
+    const DENIM_INTERMEDIATE_BLOCK_INTERVAL: u64 = 25;
 
     fn insert_l2_block(l2: &mut MockL2Provider, block: u64) -> B256 {
         let storage_hash = B256::repeat_byte(block as u8);
@@ -338,6 +358,12 @@ mod tests {
                 .unwrap()
                 .extra_data;
         factory.insert_uuid_game(GAME_TYPE, output_root, extra_data, game);
+    }
+
+    /// The mock verifier resolves the intervals the anchor tests build their games with.
+    fn verifier(games: HashMap<Address, MockGameState>) -> MockAggregateVerifier {
+        MockAggregateVerifier::new(games)
+            .with_intervals(BLOCK_INTERVAL, INTERMEDIATE_BLOCK_INTERVAL)
     }
 
     fn tx_success(tx_hash: B256) -> base_tx_manager::SendResponse {
@@ -362,8 +388,6 @@ mod tests {
             l2 as Arc<dyn L2Provider>,
             ASR_ADDRESS,
             GAME_TYPE,
-            BLOCK_INTERVAL,
-            INTERMEDIATE_BLOCK_INTERVAL,
         )
     }
 
@@ -379,7 +403,7 @@ mod tests {
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.anchor_state_registry = ASR_ADDRESS;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(HashMap::from([(game, state)]));
         let (submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
         let mut updater = updater(factory, anchor_registry, Arc::new(l2));
 
@@ -401,7 +425,7 @@ mod tests {
         insert_next_game(&factory, ASR_ADDRESS, output_root, game);
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(HashMap::from([(game, state)]));
         let (submitter, tx_manager) = submitter(vec![]);
         let mut updater = updater(factory, anchor_registry, Arc::new(l2));
 
@@ -421,7 +445,7 @@ mod tests {
         insert_next_game(&factory, ASR_ADDRESS, output_root, game);
         let state = mock_state(GameStatus::InProgress, Address::ZERO, 100);
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state.clone())]));
+        let verifier = verifier(HashMap::from([(game, state.clone())]));
         let (submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
         let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
 
@@ -452,7 +476,7 @@ mod tests {
         let mut state = mock_state(GameStatus::DefenderWins, Address::ZERO, 100);
         state.anchor_state_registry = ASR_ADDRESS;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(HashMap::from([(game, state)]));
         let (submitter, tx_manager) = submitter(vec![tx_success(tx_hash), tx_success(tx_hash)]);
         let mut updater = updater(Arc::clone(&factory), anchor_registry, Arc::new(l2));
 
@@ -474,7 +498,7 @@ mod tests {
         let output_root = insert_l2_block(&mut l2, BLOCK_INTERVAL);
         insert_next_game(&factory, ASR_ADDRESS, output_root, challenger_win);
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(
+        let verifier = verifier(HashMap::from([(
             challenger_win,
             mock_state(GameStatus::ChallengerWins, Address::ZERO, 100),
         )]));
@@ -502,7 +526,7 @@ mod tests {
         let mut next_state = mock_state(GameStatus::DefenderWins, Address::ZERO, 200);
         next_state.anchor_state_registry = ASR_ADDRESS;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([
+        let verifier = verifier(HashMap::from([
             (anchor_game, mock_state(GameStatus::DefenderWins, Address::ZERO, 100)),
             (next_game, next_state),
         ]));
@@ -528,12 +552,83 @@ mod tests {
         state.anchor_state_registry = ASR_ADDRESS;
         state.is_finalized = false;
 
-        let verifier = MockAggregateVerifier::new(HashMap::from([(game, state)]));
+        let verifier = verifier(HashMap::from([(game, state)]));
         let (submitter, tx_manager) = submitter(vec![]);
         let mut updater = updater(factory, anchor_registry, Arc::new(l2));
 
         updater.poll(&verifier, &submitter).await;
 
         assert!(tx_manager.recorded_calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn poll_finds_next_game_built_with_denim_intervals() {
+        // The anchor sits exactly at the Denim activation block, so the next game
+        // spans DENIM_BLOCK_INTERVAL and carries two intermediate roots instead of
+        // one. Its UUID is only reproducible with the post-activation pair.
+        let game = addr(1);
+        let tx_hash = B256::repeat_byte(0xDD);
+        let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
+        let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
+        anchor_registry.snapshot.lock().unwrap().anchor_root.l2_block_number =
+            DENIM_ACTIVATION_BLOCK;
+
+        let mut l2 = MockL2Provider::default();
+        let roots: Vec<B256> = (1..=DENIM_BLOCK_INTERVAL / DENIM_INTERMEDIATE_BLOCK_INTERVAL)
+            .map(|i| {
+                insert_l2_block(
+                    &mut l2,
+                    DENIM_ACTIVATION_BLOCK + i * DENIM_INTERMEDIATE_BLOCK_INTERVAL,
+                )
+            })
+            .collect();
+        // Present so the pre-Denim run fails on a UUID mismatch rather than on a
+        // missing output root.
+        insert_l2_block(&mut l2, DENIM_ACTIVATION_BLOCK + BLOCK_INTERVAL);
+        let l2 = Arc::new(l2);
+
+        let extra_data = game_lookup_key(
+            DENIM_ACTIVATION_BLOCK,
+            ASR_ADDRESS,
+            DENIM_BLOCK_INTERVAL,
+            DENIM_INTERMEDIATE_BLOCK_INTERVAL,
+            &roots,
+        )
+        .unwrap()
+        .extra_data;
+        factory.insert_uuid_game(GAME_TYPE, *roots.last().unwrap(), extra_data, game);
+
+        let mut state = mock_state(
+            GameStatus::DefenderWins,
+            Address::ZERO,
+            DENIM_ACTIVATION_BLOCK + DENIM_BLOCK_INTERVAL,
+        );
+        state.anchor_state_registry = ASR_ADDRESS;
+        let games = HashMap::from([(game, state)]);
+
+        let denim_verifier = verifier(games.clone()).with_denim_intervals(
+            DENIM_ACTIVATION_BLOCK,
+            DENIM_BLOCK_INTERVAL,
+            DENIM_INTERMEDIATE_BLOCK_INTERVAL,
+        );
+        let (denim_submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
+        let mut denim_updater =
+            updater(Arc::clone(&factory), Arc::clone(&anchor_registry), Arc::clone(&l2));
+        denim_updater.poll(&denim_verifier, &denim_submitter).await;
+
+        let calls = tx_manager.recorded_calls();
+        assert_eq!(calls.len(), 1, "anchor should advance to the post-activation game");
+        assert_eq!(calls[0].tx_data, encode_set_anchor_state_calldata(game));
+
+        // Same fixture against a verifier that never switches cadence — the pair the
+        // old startup-cached updater would have used. It must not find the game.
+        let (stale_submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
+        let mut stale_updater = updater(factory, anchor_registry, l2);
+        stale_updater.poll(&verifier(games), &stale_submitter).await;
+
+        assert!(
+            tx_manager.recorded_calls().is_empty(),
+            "pre-Denim intervals build a different UUID, so no game is found"
+        );
     }
 }

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -114,7 +114,7 @@ impl AnchorUpdater {
         anchor_game: Address,
     ) -> Option<Address> {
         // Resolved from the anchor block, which is where the next game's range starts:
-        // the verifier switches to a shorter cadence at the Denim activation block, so a
+        // the verifier switches to a shorter cadence at the Cobalt activation block, so a
         // pair cached at startup silently stops matching any game past the boundary.
         let (block_interval, intermediate_block_interval) = match resolve_intervals(
             self.factory_client.as_ref(),
@@ -334,9 +334,9 @@ mod tests {
     const GAME_TYPE: u32 = 1;
     const BLOCK_INTERVAL: u64 = 100;
     const INTERMEDIATE_BLOCK_INTERVAL: u64 = 100;
-    const DENIM_ACTIVATION_BLOCK: u64 = 200;
-    const DENIM_BLOCK_INTERVAL: u64 = 50;
-    const DENIM_INTERMEDIATE_BLOCK_INTERVAL: u64 = 25;
+    const FAST_ACTIVATION_BLOCK: u64 = 200;
+    const FAST_BLOCK_INTERVAL: u64 = 50;
+    const FAST_INTERMEDIATE_BLOCK_INTERVAL: u64 = 25;
 
     fn insert_l2_block(l2: &mut MockL2Provider, block: u64) -> B256 {
         let storage_hash = B256::repeat_byte(block as u8);
@@ -562,36 +562,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn poll_finds_next_game_built_with_denim_intervals() {
-        // The anchor sits exactly at the Denim activation block, so the next game
-        // spans DENIM_BLOCK_INTERVAL and carries two intermediate roots instead of
+    async fn poll_finds_next_game_built_with_fast_intervals() {
+        // The anchor sits exactly at the Cobalt activation block, so the next game
+        // spans FAST_BLOCK_INTERVAL and carries two intermediate roots instead of
         // one. Its UUID is only reproducible with the post-activation pair.
         let game = addr(1);
         let tx_hash = B256::repeat_byte(0xDD);
         let factory = Arc::new(MockDisputeGameFactory::new(vec![]));
         let anchor_registry = Arc::new(MockAnchorStateRegistry::new(Address::ZERO));
         anchor_registry.snapshot.lock().unwrap().anchor_root.l2_block_number =
-            DENIM_ACTIVATION_BLOCK;
+            FAST_ACTIVATION_BLOCK;
 
         let mut l2 = MockL2Provider::default();
-        let roots: Vec<B256> = (1..=DENIM_BLOCK_INTERVAL / DENIM_INTERMEDIATE_BLOCK_INTERVAL)
+        let roots: Vec<B256> = (1..=FAST_BLOCK_INTERVAL / FAST_INTERMEDIATE_BLOCK_INTERVAL)
             .map(|i| {
                 insert_l2_block(
                     &mut l2,
-                    DENIM_ACTIVATION_BLOCK + i * DENIM_INTERMEDIATE_BLOCK_INTERVAL,
+                    FAST_ACTIVATION_BLOCK + i * FAST_INTERMEDIATE_BLOCK_INTERVAL,
                 )
             })
             .collect();
-        // Present so the pre-Denim run fails on a UUID mismatch rather than on a
+        // Present so the slow-cadence run fails on a UUID mismatch rather than on a
         // missing output root.
-        insert_l2_block(&mut l2, DENIM_ACTIVATION_BLOCK + BLOCK_INTERVAL);
+        insert_l2_block(&mut l2, FAST_ACTIVATION_BLOCK + BLOCK_INTERVAL);
         let l2 = Arc::new(l2);
 
         let extra_data = game_lookup_key(
-            DENIM_ACTIVATION_BLOCK,
+            FAST_ACTIVATION_BLOCK,
             ASR_ADDRESS,
-            DENIM_BLOCK_INTERVAL,
-            DENIM_INTERMEDIATE_BLOCK_INTERVAL,
+            FAST_BLOCK_INTERVAL,
+            FAST_INTERMEDIATE_BLOCK_INTERVAL,
             &roots,
         )
         .unwrap()
@@ -601,20 +601,20 @@ mod tests {
         let mut state = mock_state(
             GameStatus::DefenderWins,
             Address::ZERO,
-            DENIM_ACTIVATION_BLOCK + DENIM_BLOCK_INTERVAL,
+            FAST_ACTIVATION_BLOCK + FAST_BLOCK_INTERVAL,
         );
         state.anchor_state_registry = ASR_ADDRESS;
         let games = HashMap::from([(game, state)]);
 
-        let denim_verifier = verifier(games.clone()).with_denim_intervals(
-            DENIM_ACTIVATION_BLOCK,
-            DENIM_BLOCK_INTERVAL,
-            DENIM_INTERMEDIATE_BLOCK_INTERVAL,
+        let cobalt_verifier = verifier(games.clone()).with_fast_intervals(
+            FAST_ACTIVATION_BLOCK,
+            FAST_BLOCK_INTERVAL,
+            FAST_INTERMEDIATE_BLOCK_INTERVAL,
         );
-        let (denim_submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
-        let mut denim_updater =
+        let (cobalt_submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
+        let mut cobalt_updater =
             updater(Arc::clone(&factory), Arc::clone(&anchor_registry), Arc::clone(&l2));
-        denim_updater.poll(&denim_verifier, &denim_submitter).await;
+        cobalt_updater.poll(&cobalt_verifier, &cobalt_submitter).await;
 
         let calls = tx_manager.recorded_calls();
         assert_eq!(calls.len(), 1, "anchor should advance to the post-activation game");
@@ -628,7 +628,7 @@ mod tests {
 
         assert!(
             tx_manager.recorded_calls().is_empty(),
-            "pre-Denim intervals build a different UUID, so no game is found"
+            "slow-cadence intervals build a different UUID, so no game is found"
         );
     }
 }

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -116,6 +116,14 @@ impl AnchorUpdater {
         // Resolved from the anchor block, which is where the next game's range starts:
         // the verifier switches to a shorter cadence at the Denim activation block, so a
         // pair cached at startup silently stops matching any game past the boundary.
+        //
+        // Known limitation: this reads the factory's *current* implementation, but the
+        // successor game may already exist and have been created with an older pair. Across a
+        // `setImplementation` that changes the pair the keyed lookup never matches and the
+        // anchor stalls at "next anchor game not found", which a restart no longer clears.
+        // Denim itself does not trigger it (the pair is a function of the starting block,
+        // not of which implementation is current). Fix by scanning the factory from the
+        // anchor index when the keyed lookup misses, if it ever bites.
         let (block_interval, intermediate_block_interval) = match resolve_intervals(
             self.factory_client.as_ref(),
             verifier_client,

--- a/crates/proof/challenge/src/anchor.rs
+++ b/crates/proof/challenge/src/anchor.rs
@@ -114,7 +114,7 @@ impl AnchorUpdater {
         anchor_game: Address,
     ) -> Option<Address> {
         // Resolved from the anchor block, which is where the next game's range starts:
-        // the verifier switches to a shorter cadence at the Cobalt activation block, so a
+        // the verifier switches to a shorter cadence at the Denim activation block, so a
         // pair cached at startup silently stops matching any game past the boundary.
         let (block_interval, intermediate_block_interval) = match resolve_intervals(
             self.factory_client.as_ref(),
@@ -563,7 +563,7 @@ mod tests {
 
     #[tokio::test]
     async fn poll_finds_next_game_built_with_fast_intervals() {
-        // The anchor sits exactly at the Cobalt activation block, so the next game
+        // The anchor sits exactly at the Denim activation block, so the next game
         // spans FAST_BLOCK_INTERVAL and carries two intermediate roots instead of
         // one. Its UUID is only reproducible with the post-activation pair.
         let game = addr(1);
@@ -606,15 +606,15 @@ mod tests {
         state.anchor_state_registry = ASR_ADDRESS;
         let games = HashMap::from([(game, state)]);
 
-        let cobalt_verifier = verifier(games.clone()).with_fast_intervals(
+        let denim_verifier = verifier(games.clone()).with_fast_intervals(
             FAST_ACTIVATION_BLOCK,
             FAST_BLOCK_INTERVAL,
             FAST_INTERMEDIATE_BLOCK_INTERVAL,
         );
-        let (cobalt_submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
-        let mut cobalt_updater =
+        let (denim_submitter, tx_manager) = submitter(vec![tx_success(tx_hash)]);
+        let mut denim_updater =
             updater(Arc::clone(&factory), Arc::clone(&anchor_registry), Arc::clone(&l2));
-        cobalt_updater.poll(&cobalt_verifier, &cobalt_submitter).await;
+        denim_updater.poll(&denim_verifier, &denim_submitter).await;
 
         let calls = tx_manager.recorded_calls();
         assert_eq!(calls.len(), 1, "anchor should advance to the post-activation game");

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -32,15 +32,12 @@
 //! Games that are not `IN_PROGRESS` or have been fully nullified (both
 //! provers zero) are skipped.
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
+use std::sync::Arc;
 
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient, GameAtIndex,
-    GameInfo, GameStatus,
+    GameInfo, GameStatus, resolve_intervals,
 };
 use eyre::Result;
 use futures::stream::{self, StreamExt};
@@ -131,10 +128,6 @@ pub struct GameScanner {
     factory_client: Arc<dyn DisputeGameFactoryClient>,
     verifier_client: Arc<dyn AggregateVerifierClient>,
     anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
-    /// Cache of `impl_address → intermediate_block_interval` to avoid repeated RPC calls.
-    /// A governance `setImplementation` call changes the address and automatically causes a
-    /// cache miss.
-    interval_cache: Mutex<HashMap<Address, u64>>,
     /// Cached `(anchor_game, factory_index)` for the current anchor game.
     anchor_index: Option<(Address, u64)>,
 }
@@ -158,13 +151,7 @@ impl GameScanner {
         verifier_client: Arc<dyn AggregateVerifierClient>,
         anchor_registry_client: Arc<dyn AnchorStateRegistryClient>,
     ) -> Self {
-        Self {
-            factory_client,
-            verifier_client,
-            anchor_registry_client,
-            interval_cache: Mutex::new(HashMap::new()),
-            anchor_index: None,
-        }
+        Self { factory_client, verifier_client, anchor_registry_client, anchor_index: None }
     }
 
     /// Scans for candidate games that need validation.
@@ -393,17 +380,22 @@ impl GameScanner {
         };
 
         // Fetch remaining fields only for actionable games.
-        let ((info, starting_block_number, l1_head), intermediate_block_interval) = tokio::try_join!(
-            async {
-                tokio::try_join!(
-                    self.verifier_client.game_info(factory.proxy),
-                    self.verifier_client.starting_block_number(factory.proxy),
-                    self.verifier_client.l1_head(factory.proxy),
-                )
-                .map_err(Into::into)
-            },
-            self.resolve_intermediate_block_interval(factory.game_type),
+        let (info, starting_block_number, l1_head) = tokio::try_join!(
+            self.verifier_client.game_info(factory.proxy),
+            self.verifier_client.starting_block_number(factory.proxy),
+            self.verifier_client.l1_head(factory.proxy),
         )?;
+
+        // Resolved from this game's own starting block: the verifier switches to a
+        // shorter cadence at the Denim activation block, so one interval per
+        // implementation is wrong once a single implementation serves both sides of it.
+        let (_, intermediate_block_interval) = resolve_intervals(
+            self.factory_client.as_ref(),
+            self.verifier_client.as_ref(),
+            factory.game_type,
+            starting_block_number,
+        )
+        .await?;
 
         Ok(Some(CandidateGame {
             index,
@@ -485,42 +477,6 @@ impl GameScanner {
                 None
             }
         }
-    }
-
-    /// Resolves the intermediate block interval for a game type, using a cache
-    /// to avoid repeated RPC calls for the same implementation address.
-    ///
-    /// The impl address is always fetched from the factory so that a governance
-    /// `setImplementation` call (which changes the address) automatically
-    /// invalidates the cached value.
-    async fn resolve_intermediate_block_interval(&self, game_type: u32) -> Result<u64> {
-        let impl_address = self.factory_client.game_impls(game_type).await?;
-        if impl_address == Address::ZERO {
-            return Err(eyre::eyre!(
-                "no game implementation registered in DisputeGameFactory for game type {game_type}"
-            ));
-        }
-
-        {
-            let cache = self.interval_cache.lock().expect("interval_cache lock poisoned");
-            if let Some(&interval) = cache.get(&impl_address) {
-                return Ok(interval);
-            }
-        }
-
-        let interval = self.verifier_client.read_intermediate_block_interval(impl_address).await?;
-
-        debug!(
-            game_type = game_type,
-            interval = interval,
-            impl_address = %impl_address,
-            "resolved intermediate block interval"
-        );
-
-        let mut cache = self.interval_cache.lock().expect("interval_cache lock poisoned");
-        cache.insert(impl_address, interval);
-
-        Ok(interval)
     }
 }
 
@@ -654,9 +610,11 @@ mod tests {
         assert_eq!(candidates[3].index, 4);
         assert_eq!(candidates[3].factory.game_type, 1);
         assert_eq!(candidates[3].info.l2_block_number, 400);
+        // One interval read per candidate: the pair depends on the game's own starting
+        // block, so it cannot be resolved once per implementation.
         assert_eq!(
             verifier.intermediate_block_interval_reads.lock().unwrap().as_slice(),
-            &[Address::repeat_byte(0x11)],
+            &[Address::repeat_byte(0x11); 4],
         );
     }
 
@@ -1096,6 +1054,38 @@ mod tests {
             game_zero.category,
             GameCategory::FraudulentZkChallenge { challenged_index: 1 },
             "old game should now classify under its late state transition"
+        );
+    }
+
+    /// Two games straddling the Denim activation block resolve different intervals.
+    #[tokio::test]
+    async fn test_scan_resolves_intervals_per_game_across_denim_activation() {
+        let factory =
+            Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1), factory_game(1, 1)]));
+
+        let mut verifier_games = HashMap::new();
+        // starting_block_number is l2_block_number - 10 in the mock.
+        verifier_games.insert(addr(0), mock_state(GameStatus::InProgress, Address::ZERO, 100));
+        verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 400));
+
+        let verifier =
+            Arc::new(MockAggregateVerifier::new(verifier_games).with_denim_intervals(300, 4, 2));
+
+        let mut scanner = GameScanner::new(
+            factory,
+            Arc::clone(&verifier) as Arc<dyn AggregateVerifierClient>,
+            mock_anchor_registry(Address::ZERO),
+        );
+
+        let candidates = scanner.scan().await.unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].starting_block_number, 90);
+        assert_eq!(candidates[0].intermediate_block_interval, 5, "pre-Denim game");
+        assert_eq!(candidates[1].starting_block_number, 390);
+        assert_eq!(
+            candidates[1].intermediate_block_interval, 2,
+            "post-Denim game must not inherit the pre-Denim interval"
         );
     }
 }

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -387,7 +387,7 @@ impl GameScanner {
         )?;
 
         // Resolved from this game's own starting block: the verifier switches to a
-        // shorter cadence at the Denim activation block, so one interval per
+        // shorter cadence at the Cobalt activation block, so one interval per
         // implementation is wrong once a single implementation serves both sides of it.
         let (_, intermediate_block_interval) = resolve_intervals(
             self.factory_client.as_ref(),
@@ -1057,9 +1057,9 @@ mod tests {
         );
     }
 
-    /// Two games straddling the Denim activation block resolve different intervals.
+    /// Two games straddling the Cobalt activation block resolve different intervals.
     #[tokio::test]
-    async fn test_scan_resolves_intervals_per_game_across_denim_activation() {
+    async fn test_scan_resolves_intervals_per_game_across_cadence_activation() {
         let factory =
             Arc::new(MockDisputeGameFactory::new(vec![factory_game(0, 1), factory_game(1, 1)]));
 
@@ -1069,7 +1069,7 @@ mod tests {
         verifier_games.insert(addr(1), mock_state(GameStatus::InProgress, Address::ZERO, 400));
 
         let verifier =
-            Arc::new(MockAggregateVerifier::new(verifier_games).with_denim_intervals(300, 4, 2));
+            Arc::new(MockAggregateVerifier::new(verifier_games).with_fast_intervals(300, 4, 2));
 
         let mut scanner = GameScanner::new(
             factory,
@@ -1081,11 +1081,11 @@ mod tests {
 
         assert_eq!(candidates.len(), 2);
         assert_eq!(candidates[0].starting_block_number, 90);
-        assert_eq!(candidates[0].intermediate_block_interval, 5, "pre-Denim game");
+        assert_eq!(candidates[0].intermediate_block_interval, 5, "slow-cadence game");
         assert_eq!(candidates[1].starting_block_number, 390);
         assert_eq!(
             candidates[1].intermediate_block_interval, 2,
-            "post-Denim game must not inherit the pre-Denim interval"
+            "fast-cadence game must not inherit the slow-cadence interval"
         );
     }
 }

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -37,7 +37,7 @@ use std::sync::Arc;
 use alloy_primitives::{Address, B256};
 use base_proof_contracts::{
     AggregateVerifierClient, AnchorStateRegistryClient, DisputeGameFactoryClient, GameAtIndex,
-    GameInfo, GameStatus, resolve_intervals,
+    GameInfo, GameStatus,
 };
 use eyre::Result;
 use futures::stream::{self, StreamExt};
@@ -386,16 +386,12 @@ impl GameScanner {
             self.verifier_client.l1_head(factory.proxy),
         )?;
 
-        // Resolved from this game's own starting block: the verifier switches to a
-        // shorter cadence at the Cobalt activation block, so one interval per
-        // implementation is wrong once a single implementation serves both sides of it.
-        let (_, intermediate_block_interval) = resolve_intervals(
-            self.factory_client.as_ref(),
-            self.verifier_client.as_ref(),
-            factory.game_type,
-            starting_block_number,
-        )
-        .await?;
+        // Read through the game proxy so implementation upgrades cannot change
+        // how an already-created game's checkpoints are interpreted.
+        let (_, intermediate_block_interval) = self
+            .verifier_client
+            .read_intervals_for_starting_block(factory.proxy, starting_block_number)
+            .await?;
 
         Ok(Some(CandidateGame {
             index,
@@ -610,11 +606,11 @@ mod tests {
         assert_eq!(candidates[3].index, 4);
         assert_eq!(candidates[3].factory.game_type, 1);
         assert_eq!(candidates[3].info.l2_block_number, 400);
-        // One interval read per candidate: the pair depends on the game's own starting
-        // block, so it cannot be resolved once per implementation.
+        // Existing games resolve through their own proxies, not the factory's current
+        // implementation.
         assert_eq!(
             verifier.intermediate_block_interval_reads.lock().unwrap().as_slice(),
-            &[Address::repeat_byte(0x11); 4],
+            &[addr(0), addr(1), addr(3), addr(4)],
         );
     }
 

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -1053,7 +1053,7 @@ mod tests {
         );
     }
 
-    /// Two games straddling the Cobalt activation block resolve different intervals.
+    /// Two games straddling the Denim activation block resolve different intervals.
     #[tokio::test]
     async fn test_scan_resolves_intervals_per_game_across_cadence_activation() {
         let factory =

--- a/crates/proof/challenge/src/scanner.rs
+++ b/crates/proof/challenge/src/scanner.rs
@@ -386,8 +386,13 @@ impl GameScanner {
             self.verifier_client.l1_head(factory.proxy),
         )?;
 
-        // Read through the game proxy so implementation upgrades cannot change
-        // how an already-created game's checkpoints are interpreted.
+        // Read through the game proxy so implementation upgrades cannot change how an
+        // already-created game's checkpoints are interpreted: a game is a CWIA clone, so
+        // it delegates to the implementation baked in at creation, not to whatever the
+        // factory points at now. Games created before the Denim-aware implementation land
+        // on `read_intervals_for_starting_block`'s missing-method fallback to
+        // `BLOCK_INTERVAL()` / `INTERMEDIATE_BLOCK_INTERVAL()`; if that fallback is ever
+        // tightened, every in-flight pre-upgrade game starts hitting the warn path below.
         let (_, intermediate_block_interval) = self
             .verifier_client
             .read_intervals_for_starting_block(factory.proxy, starting_block_number)
@@ -608,10 +613,9 @@ mod tests {
         assert_eq!(candidates[3].info.l2_block_number, 400);
         // Existing games resolve through their own proxies, not the factory's current
         // implementation.
-        assert_eq!(
-            verifier.intermediate_block_interval_reads.lock().unwrap().as_slice(),
-            &[addr(0), addr(1), addr(3), addr(4)],
-        );
+        let mut reads = verifier.intermediate_block_interval_reads.lock().unwrap().clone();
+        reads.sort();
+        assert_eq!(reads, [addr(0), addr(1), addr(3), addr(4)]);
     }
 
     /// Dual-proof games (TEE + ZK, no challenge) are now candidates.

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -100,7 +100,7 @@ impl ChallengerService {
                 config.game_type
             ));
         }
-        // The intervals are not read here: they change at the Denim activation block, so
+        // The intervals are not read here: they change at the Cobalt activation block, so
         // every consumer resolves them from the starting block of the game it is handling.
         info!(
             impl_address = %impl_address,

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -100,27 +100,12 @@ impl ChallengerService {
                 config.game_type
             ));
         }
-        let (block_interval, intermediate_block_interval) = tokio::try_join!(
-            verifier_client.read_block_interval(impl_address),
-            verifier_client.read_intermediate_block_interval(impl_address),
-        )?;
-        if block_interval == 0 || intermediate_block_interval == 0 {
-            return Err(eyre::eyre!(
-                "BLOCK_INTERVAL ({block_interval}) and INTERMEDIATE_BLOCK_INTERVAL ({intermediate_block_interval}) must be non-zero"
-            ));
-        }
-        if block_interval % intermediate_block_interval != 0 {
-            return Err(eyre::eyre!(
-                "BLOCK_INTERVAL ({block_interval}) is not divisible by INTERMEDIATE_BLOCK_INTERVAL ({intermediate_block_interval})"
-            ));
-        }
+        // The intervals are not read here: they change at the Denim activation block, so
+        // every consumer resolves them from the starting block of the game it is handling.
         info!(
-            block_interval,
-            intermediate_block_interval,
-            intermediate_roots_count = block_interval / intermediate_block_interval,
             impl_address = %impl_address,
             game_type = config.game_type,
-            "Read onchain config from AggregateVerifier"
+            "Resolved AggregateVerifier implementation"
         );
 
         let anchor_registry_client = AnchorStateRegistryContractClient::new(
@@ -161,8 +146,6 @@ impl ChallengerService {
             Arc::clone(&l2_client) as Arc<dyn L2Provider>,
             config.anchor_state_registry_addr,
             config.game_type,
-            block_interval,
-            intermediate_block_interval,
         );
 
         let bond_manager = if !config.bond_claim_addresses.is_empty() {

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -5,7 +5,6 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use alloy_primitives::Address;
 use alloy_provider::{Provider, ProviderBuilder, RootProvider};
 use base_balance_monitor::BalanceMonitorLayer;
 use base_cli_utils::RuntimeManager;
@@ -13,6 +12,7 @@ use base_health::HealthServer;
 use base_proof_contracts::{
     AggregateVerifierClient, AggregateVerifierContractClient, AnchorStateRegistryClient,
     AnchorStateRegistryContractClient, DisputeGameFactoryClient, DisputeGameFactoryContractClient,
+    resolve_intervals,
 };
 use base_proof_rpc::{L1Client, L1ClientConfig, L1Provider, L2Client, L2ClientConfig, L2Provider};
 use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
@@ -93,21 +93,6 @@ impl ChallengerService {
         );
 
         let verifier_client = AggregateVerifierContractClient::new(read_provider.clone());
-        let impl_address = factory_client.game_impls(config.game_type).await?;
-        if impl_address == Address::ZERO {
-            return Err(eyre::eyre!(
-                "no AggregateVerifier implementation registered for game type {}",
-                config.game_type
-            ));
-        }
-        // The intervals are not read here: they change at the Cobalt activation block, so
-        // every consumer resolves them from the starting block of the game it is handling.
-        info!(
-            impl_address = %impl_address,
-            game_type = config.game_type,
-            "Resolved AggregateVerifier implementation"
-        );
-
         let anchor_registry_client = AnchorStateRegistryContractClient::new(
             config.anchor_state_registry_addr,
             read_provider,
@@ -115,6 +100,15 @@ impl ChallengerService {
         info!(
             address = %config.anchor_state_registry_addr,
             "AnchorStateRegistry client initialized"
+        );
+        let anchor_block =
+            anchor_registry_client.anchor_snapshot().await?.anchor_root.l2_block_number;
+        let (block_interval, intermediate_block_interval) =
+            resolve_intervals(&factory_client, &verifier_client, config.game_type, anchor_block)
+                .await?;
+        info!(
+            anchor_block,
+            block_interval, intermediate_block_interval, "Validated proposal interval resolver"
         );
 
         let factory_client: Arc<dyn DisputeGameFactoryClient> = Arc::new(factory_client);

--- a/crates/proof/challenge/src/service.rs
+++ b/crates/proof/challenge/src/service.rs
@@ -108,7 +108,9 @@ impl ChallengerService {
                 .await?;
         info!(
             anchor_block,
-            block_interval, intermediate_block_interval, "Validated proposal interval resolver"
+            block_interval,
+            intermediate_block_interval,
+            "resolved proposal intervals at anchor block"
         );
 
         let factory_client: Arc<dyn DisputeGameFactoryClient> = Arc::new(factory_client);

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -242,13 +242,13 @@ pub struct MockAggregateVerifier {
     /// Addresses passed to the interval reads, used by tests that assert read counts.
     pub intermediate_block_interval_reads: Mutex<Vec<Address>>,
     /// `(block_interval, intermediate_block_interval)` returned for starting blocks
-    /// below `denim_activation_block`.
+    /// below `fast_activation_block`.
     pub intervals: (u64, u64),
-    /// First starting block that resolves to `denim_intervals`.
-    pub denim_activation_block: u64,
+    /// First starting block that resolves to `fast_intervals`.
+    pub fast_activation_block: u64,
     /// `(block_interval, intermediate_block_interval)` returned at or after
-    /// `denim_activation_block`.
-    pub denim_intervals: (u64, u64),
+    /// `fast_activation_block`.
+    pub fast_intervals: (u64, u64),
 }
 
 impl MockAggregateVerifier {
@@ -261,12 +261,12 @@ impl MockAggregateVerifier {
             delayed_weth_reads: Mutex::new(Vec::new()),
             intermediate_block_interval_reads: Mutex::new(Vec::new()),
             intervals: (10, 5),
-            denim_activation_block: u64::MAX,
-            denim_intervals: (10, 5),
+            fast_activation_block: u64::MAX,
+            fast_intervals: (10, 5),
         }
     }
 
-    /// Sets the interval pair returned for every starting block before Denim.
+    /// Sets the interval pair returned for every starting block before the speedup.
     #[must_use]
     pub const fn with_intervals(
         mut self,
@@ -278,17 +278,17 @@ impl MockAggregateVerifier {
     }
 
     /// Makes the verifier switch to `(block_interval, intermediate_block_interval)` for
-    /// games whose range starts at or after `activation_block`, as the Denim-aware
+    /// games whose range starts at or after `activation_block`, as the Cobalt-aware
     /// `AggregateVerifier` does.
     #[must_use]
-    pub const fn with_denim_intervals(
+    pub const fn with_fast_intervals(
         mut self,
         activation_block: u64,
         block_interval: u64,
         intermediate_block_interval: u64,
     ) -> Self {
-        self.denim_activation_block = activation_block;
-        self.denim_intervals = (block_interval, intermediate_block_interval);
+        self.fast_activation_block = activation_block;
+        self.fast_intervals = (block_interval, intermediate_block_interval);
         self
     }
 
@@ -384,10 +384,10 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         starting_block: u64,
     ) -> Result<(u64, u64), ContractError> {
         self.intermediate_block_interval_reads.lock().unwrap().push(impl_address);
-        if starting_block < self.denim_activation_block {
+        if starting_block < self.fast_activation_block {
             Ok(self.intervals)
         } else {
-            Ok(self.denim_intervals)
+            Ok(self.fast_intervals)
         }
     }
 

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -239,8 +239,16 @@ pub struct MockAggregateVerifier {
     pub status_reads: Mutex<Vec<Address>>,
     /// Addresses passed to `delayed_weth`, used by tests that assert cached reads.
     pub delayed_weth_reads: Mutex<Vec<Address>>,
-    /// Addresses passed to `read_intermediate_block_interval`, used by cache tests.
+    /// Addresses passed to the interval reads, used by tests that assert read counts.
     pub intermediate_block_interval_reads: Mutex<Vec<Address>>,
+    /// `(block_interval, intermediate_block_interval)` returned for starting blocks
+    /// below `denim_activation_block`.
+    pub intervals: (u64, u64),
+    /// First starting block that resolves to `denim_intervals`.
+    pub denim_activation_block: u64,
+    /// `(block_interval, intermediate_block_interval)` returned at or after
+    /// `denim_activation_block`.
+    pub denim_intervals: (u64, u64),
 }
 
 impl MockAggregateVerifier {
@@ -252,7 +260,36 @@ impl MockAggregateVerifier {
             status_reads: Mutex::new(Vec::new()),
             delayed_weth_reads: Mutex::new(Vec::new()),
             intermediate_block_interval_reads: Mutex::new(Vec::new()),
+            intervals: (10, 5),
+            denim_activation_block: u64::MAX,
+            denim_intervals: (10, 5),
         }
+    }
+
+    /// Sets the interval pair returned for every starting block before Denim.
+    #[must_use]
+    pub const fn with_intervals(
+        mut self,
+        block_interval: u64,
+        intermediate_block_interval: u64,
+    ) -> Self {
+        self.intervals = (block_interval, intermediate_block_interval);
+        self
+    }
+
+    /// Makes the verifier switch to `(block_interval, intermediate_block_interval)` for
+    /// games whose range starts at or after `activation_block`, as the Denim-aware
+    /// `AggregateVerifier` does.
+    #[must_use]
+    pub const fn with_denim_intervals(
+        mut self,
+        activation_block: u64,
+        block_interval: u64,
+        intermediate_block_interval: u64,
+    ) -> Self {
+        self.denim_activation_block = activation_block;
+        self.denim_intervals = (block_interval, intermediate_block_interval);
+        self
     }
 
     /// Updates the state for a specific game address.
@@ -330,7 +367,7 @@ impl AggregateVerifierClient for MockAggregateVerifier {
     }
 
     async fn read_block_interval(&self, _impl_address: Address) -> Result<u64, ContractError> {
-        Ok(10)
+        Ok(self.intervals.0)
     }
 
     async fn read_intermediate_block_interval(
@@ -338,16 +375,20 @@ impl AggregateVerifierClient for MockAggregateVerifier {
         impl_address: Address,
     ) -> Result<u64, ContractError> {
         self.intermediate_block_interval_reads.lock().unwrap().push(impl_address);
-        Ok(5)
+        Ok(self.intervals.1)
     }
 
     async fn read_intervals_for_starting_block(
         &self,
         impl_address: Address,
-        _starting_block: u64,
+        starting_block: u64,
     ) -> Result<(u64, u64), ContractError> {
         self.intermediate_block_interval_reads.lock().unwrap().push(impl_address);
-        Ok((10, 5))
+        if starting_block < self.denim_activation_block {
+            Ok(self.intervals)
+        } else {
+            Ok(self.denim_intervals)
+        }
     }
 
     async fn intermediate_output_roots(

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -278,7 +278,7 @@ impl MockAggregateVerifier {
     }
 
     /// Makes the verifier switch to `(block_interval, intermediate_block_interval)` for
-    /// games whose range starts at or after `activation_block`, as the Cobalt-aware
+    /// games whose range starts at or after `activation_block`, as the Denim-aware
     /// `AggregateVerifier` does.
     #[must_use]
     pub const fn with_fast_intervals(

--- a/crates/proof/challenge/src/test_utils.rs
+++ b/crates/proof/challenge/src/test_utils.rs
@@ -380,10 +380,10 @@ impl AggregateVerifierClient for MockAggregateVerifier {
 
     async fn read_intervals_for_starting_block(
         &self,
-        impl_address: Address,
+        verifier_address: Address,
         starting_block: u64,
     ) -> Result<(u64, u64), ContractError> {
-        self.intermediate_block_interval_reads.lock().unwrap().push(impl_address);
+        self.intermediate_block_interval_reads.lock().unwrap().push(verifier_address);
         if starting_block < self.fast_activation_block {
             Ok(self.intervals)
         } else {

--- a/crates/proof/challenge/tests/driver.rs
+++ b/crates/proof/challenge/tests/driver.rs
@@ -101,8 +101,6 @@ fn test_driver_with_l1_provider(
             l2_provider as Arc<dyn base_proof_rpc::L2Provider>,
             Address::repeat_byte(0xAA),
             1,
-            100,
-            100,
         ),
         poll_interval: Duration::from_millis(10),
         max_proof_duration: Duration::from_secs(4 * 60 * 60),

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -15,7 +15,37 @@ use async_trait::async_trait;
 use crate::{
     ContractError,
     anchor_state_registry::{AnchorPreflight, AnchorRoot, IAnchorStateRegistry},
+    dispute_game_factory::DisputeGameFactoryClient,
 };
+
+/// Resolves the `(block_interval, intermediate_block_interval)` pair that applies to a
+/// game of `game_type` whose range starts at `starting_block`.
+///
+/// Denim switches the verifier to a shorter cadence at a fixed L2 block, so the pair is
+/// a function of the starting block and must be resolved per game rather than read once
+/// at startup.
+///
+/// The implementation address is read from the factory on every call so a governance
+/// `setImplementation` is picked up without a restart. The implementation — not the game
+/// proxy — is queried on purpose: callers also resolve intervals for games that do not
+/// exist yet, and games created before the Denim-aware implementation was deployed run
+/// bytecode that has no `intervalsForStartingBlock`. For pre-Denim starting blocks the
+/// Denim-aware implementation returns the same pair the old one had.
+pub async fn resolve_intervals(
+    factory_client: &dyn DisputeGameFactoryClient,
+    verifier_client: &dyn AggregateVerifierClient,
+    game_type: u32,
+    starting_block: u64,
+) -> Result<(u64, u64), ContractError> {
+    let impl_address = factory_client.game_impls(game_type).await?;
+    if impl_address.is_zero() {
+        return Err(ContractError::validation(format!(
+            "no AggregateVerifier implementation registered for game type {game_type}"
+        )));
+    }
+
+    verifier_client.read_intervals_for_starting_block(impl_address, starting_block).await
+}
 
 sol! {
     /// `AggregateVerifier` (dispute game) contract interface.

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -21,16 +21,16 @@ use crate::{
 /// Resolves the `(block_interval, intermediate_block_interval)` pair that applies to a
 /// game of `game_type` whose range starts at `starting_block`.
 ///
-/// Denim switches the verifier to a shorter cadence at a fixed L2 block, so the pair is
+/// Cobalt switches the verifier to a shorter cadence at a fixed L2 block, so the pair is
 /// a function of the starting block and must be resolved per game rather than read once
 /// at startup.
 ///
 /// The implementation address is read from the factory on every call so a governance
 /// `setImplementation` is picked up without a restart. The implementation — not the game
 /// proxy — is queried on purpose: callers also resolve intervals for games that do not
-/// exist yet, and games created before the Denim-aware implementation was deployed run
-/// bytecode that has no `intervalsForStartingBlock`. For pre-Denim starting blocks the
-/// Denim-aware implementation returns the same pair the old one had.
+/// exist yet, and games created before the Cobalt-aware implementation was deployed run
+/// bytecode that has no `intervalsForStartingBlock`. For pre-Cobalt starting blocks the
+/// Cobalt-aware implementation returns the same pair the old one had.
 pub async fn resolve_intervals(
     factory_client: &dyn DisputeGameFactoryClient,
     verifier_client: &dyn AggregateVerifierClient,

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -26,11 +26,12 @@ use crate::{
 /// at startup.
 ///
 /// The implementation address is read from the factory on every call so a governance
-/// `setImplementation` is picked up without a restart. The implementation — not the game
-/// proxy — is queried on purpose: callers also resolve intervals for games that do not
-/// exist yet, and games created before the Denim-aware implementation was deployed run
-/// bytecode that has no `intervalsForStartingBlock`. For pre-Denim starting blocks the
-/// Denim-aware implementation returns the same pair the old one had.
+/// `setImplementation` is picked up without a restart. The implementation — not a game
+/// proxy — is queried because callers resolve intervals for games that do not exist yet
+/// (the anchor's successor, the proposer's next proposal). For an existing game, call
+/// `read_intervals_for_starting_block` on its proxy instead so the pair it was created
+/// with is used even after an implementation upgrade; legacy proxies without
+/// `intervalsForStartingBlock` fall back to their fixed interval getters.
 pub async fn resolve_intervals(
     factory_client: &dyn DisputeGameFactoryClient,
     verifier_client: &dyn AggregateVerifierClient,
@@ -276,17 +277,23 @@ pub trait AggregateVerifierClient: Send + Sync {
         impl_address: Address,
     ) -> Result<u64, ContractError>;
 
-    /// Reads the `(block_interval, intermediate_block_interval)` pair the
-    /// `AggregateVerifier` implementation applies to a game whose range starts
-    /// at `starting_block`.
+    /// Reads the `(block_interval, intermediate_block_interval)` pair that
+    /// `verifier_address` applies to a game whose range starts at `starting_block`.
     ///
     /// Denim switches the verifier to a shorter cadence at a fixed L2 block, so
     /// the pair is a function of the game's starting block. Callers must resolve
     /// it per game rather than reading `BLOCK_INTERVAL` once at startup.
-    /// Legacy implementations fall back to their fixed interval getters.
+    ///
+    /// `verifier_address` is either the factory's current implementation (for a game
+    /// that does not exist yet) or an existing game's proxy. A game proxy is a CWIA
+    /// clone, not an upgradeable proxy: it delegates to the implementation baked into
+    /// its bytecode at creation, so reading through it returns the pair the game was
+    /// created with regardless of any later `setImplementation`. Verifiers deployed
+    /// before `intervalsForStartingBlock` existed fall back to their fixed interval
+    /// getters.
     async fn read_intervals_for_starting_block(
         &self,
-        impl_address: Address,
+        verifier_address: Address,
         starting_block: u64,
     ) -> Result<(u64, u64), ContractError>;
 
@@ -514,11 +521,11 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
 
     async fn read_intervals_for_starting_block(
         &self,
-        impl_address: Address,
+        verifier_address: Address,
         starting_block: u64,
     ) -> Result<(u64, u64), ContractError> {
         let contract =
-            IAggregateVerifier::IAggregateVerifierInstance::new(impl_address, &self.provider);
+            IAggregateVerifier::IAggregateVerifierInstance::new(verifier_address, &self.provider);
         let result = match contract_call!(
             contract.intervalsForStartingBlock(U256::from(starting_block)).call(),
             "intervalsForStartingBlock failed"
@@ -526,8 +533,8 @@ impl AggregateVerifierClient for AggregateVerifierContractClient {
             Ok(result) => result,
             Err(error) if error.is_missing_method() => {
                 let (block_interval, intermediate_block_interval) = futures::try_join!(
-                    self.read_block_interval(impl_address),
-                    self.read_intermediate_block_interval(impl_address),
+                    self.read_block_interval(verifier_address),
+                    self.read_intermediate_block_interval(verifier_address),
                 )?;
                 if !block_interval.is_multiple_of(intermediate_block_interval) {
                     return Err(ContractError::validation(format!(

--- a/crates/proof/contracts/src/aggregate_verifier.rs
+++ b/crates/proof/contracts/src/aggregate_verifier.rs
@@ -21,16 +21,16 @@ use crate::{
 /// Resolves the `(block_interval, intermediate_block_interval)` pair that applies to a
 /// game of `game_type` whose range starts at `starting_block`.
 ///
-/// Cobalt switches the verifier to a shorter cadence at a fixed L2 block, so the pair is
+/// Denim switches the verifier to a shorter cadence at a fixed L2 block, so the pair is
 /// a function of the starting block and must be resolved per game rather than read once
 /// at startup.
 ///
 /// The implementation address is read from the factory on every call so a governance
 /// `setImplementation` is picked up without a restart. The implementation — not the game
 /// proxy — is queried on purpose: callers also resolve intervals for games that do not
-/// exist yet, and games created before the Cobalt-aware implementation was deployed run
-/// bytecode that has no `intervalsForStartingBlock`. For pre-Cobalt starting blocks the
-/// Cobalt-aware implementation returns the same pair the old one had.
+/// exist yet, and games created before the Denim-aware implementation was deployed run
+/// bytecode that has no `intervalsForStartingBlock`. For pre-Denim starting blocks the
+/// Denim-aware implementation returns the same pair the old one had.
 pub async fn resolve_intervals(
     factory_client: &dyn DisputeGameFactoryClient,
     verifier_client: &dyn AggregateVerifierClient,

--- a/crates/proof/contracts/src/lib.rs
+++ b/crates/proof/contracts/src/lib.rs
@@ -15,6 +15,7 @@ pub use aggregate_verifier::{
     already_proven_selector, encode_challenge_calldata, encode_claim_credit_calldata,
     encode_nullify_calldata, encode_resolve_calldata, encode_verify_proposal_proof_calldata,
     invalid_parent_game_selector, invalid_signer_selector, l1_origin_too_old_selector,
+    resolve_intervals,
 };
 
 mod delayed_weth;

--- a/crates/proof/proposer/src/proposal_intervals.rs
+++ b/crates/proof/proposer/src/proposal_intervals.rs
@@ -8,7 +8,9 @@
 
 use std::sync::Arc;
 
-use base_proof_contracts::{AggregateVerifierClient, DisputeGameFactoryClient, game_lookup_blocks};
+use base_proof_contracts::{
+    AggregateVerifierClient, DisputeGameFactoryClient, game_lookup_blocks, resolve_intervals,
+};
 
 use crate::error::ProposerError;
 
@@ -80,27 +82,18 @@ impl IntervalResolver {
         &self,
         starting_block: u64,
     ) -> Result<Intervals, ProposerError> {
-        let impl_address = self
-            .factory_client
-            .game_impls(self.game_type)
-            .await
-            .map_err(|e| ProposerError::Contract(format!("gameImpls lookup failed: {e}")))?;
-        if impl_address.is_zero() {
-            return Err(ProposerError::Contract(format!(
-                "no AggregateVerifier implementation registered for game type {}",
-                self.game_type
-            )));
-        }
-
-        let (block_interval, intermediate_block_interval) = self
-            .verifier_client
-            .read_intervals_for_starting_block(impl_address, starting_block)
-            .await
-            .map_err(|e| {
-                ProposerError::Contract(format!(
-                    "intervalsForStartingBlock({starting_block}) failed: {e}"
-                ))
-            })?;
+        let (block_interval, intermediate_block_interval) = resolve_intervals(
+            self.factory_client.as_ref(),
+            self.verifier_client.as_ref(),
+            self.game_type,
+            starting_block,
+        )
+        .await
+        .map_err(|e| {
+            ProposerError::Contract(format!(
+                "interval lookup for block {starting_block} failed: {e}"
+            ))
+        })?;
 
         Ok(Intervals { block_interval, intermediate_block_interval })
     }


### PR DESCRIPTION
#4930 has merged, so this diff is now against `main`. Depends on base/contracts#431, which adds `intervalsForStartingBlock(uint256)` to `AggregateVerifier`.

Implements section 3 of [the proof config switchover doc](https://bdocs.cbhq.net/d/denim-proof-config-switchover/v/latest/md).

## What changed?

**`crates/proof/contracts`**
- New `resolve_intervals(factory, verifier, game_type, starting_block)` helper: reads `gameImpls`, rejects a zero implementation, then calls `intervalsForStartingBlock` on it. Reading the implementation on every call means a governance `setImplementation` is picked up without a restart.
- It queries the *implementation* rather than a game proxy because its callers resolve intervals for games that do not exist yet — the anchor's successor, the proposer's next proposal. For a game that **does** exist, callers should call `read_intervals_for_starting_block` on the game's own proxy instead; see the `GameScanner` bullet below.
- `read_intervals_for_starting_block` therefore takes either address, and its parameter is named `verifier_address` rather than `impl_address`. Verifiers deployed before `intervalsForStartingBlock` existed hit the missing-method fallback to `BLOCK_INTERVAL()` / `INTERMEDIATE_BLOCK_INTERVAL()`, which is what keeps in-flight pre-upgrade games working.

**`crates/proof/challenge`**
- `AnchorUpdater` no longer takes `block_interval` / `intermediate_block_interval`. `next_game` resolves them from the anchor block — which is exactly where the next game's range starts — before building the lookup key.
- `GameScanner`: dropped `interval_cache` and `resolve_intermediate_block_interval`. `evaluate_game` now fetches `starting_block_number` first and resolves the interval from it — **through the game's own proxy, not the factory's current implementation**. A game is a CWIA clone, so it delegates to the implementation baked into its bytecode at creation; reading through it returns the pair the game was actually created with, and an implementation upgrade cannot retroactively change how an already-created game's checkpoints are interpreted. The starting block is already on the same code path, so this is one extra `eth_call` next to the seven the scanner already makes per game.
- `ChallengerService::new` still fails fast at startup, but on a resolution rather than on raw getters: it reads the anchor block from `AnchorStateRegistry`, then calls `resolve_intervals` for it. The `gameImpls != 0` check stays; the divisibility and non-zero checks moved into `read_intervals_for_starting_block`, where they now run on every resolution rather than once. The resolved pair is logged and discarded — nothing caches it. **Note:** this makes startup depend on `anchor_snapshot()` succeeding, which it did not before.
- `MockAggregateVerifier` gained `with_intervals` / `with_fast_intervals` so tests can model the cadence switch.

**`crates/proof/proposer`**
- `IntervalResolver::for_starting_block` delegates to the shared helper instead of duplicating the `gameImpls` lookup.

## Why?

The intervals are no longer process-wide constants. Post-Denim the verifier applies `BLOCK_INTERVAL = 6,000` / `INTERMEDIATE_BLOCK_INTERVAL = 300` to games starting at or after the activation block, and the pre-Denim `600` / `30` to everything before it. One implementation serves both sides, so anything that reads the pair once and keeps it is wrong for half the games it sees.

For `AnchorUpdater` the failure is silent: it computes the UUID of the game that should follow the anchor and looks it up in the factory. With a stale interval the UUID simply does not match anything, `games()` returns `address(0)`, and the updater logs `next anchor game not found` at debug and keeps going. The anchor stops advancing, which degrades the challenger's scan-start optimization (every tick rescans from a stale anchor) and the proposer's anchor fallback.

`GameScanner` was listed in the doc as already correct because its cache is keyed on implementation address and a `setImplementation` changes that address. That reasoning holds for an implementation swap but not for Denim: the switch happens *inside* one implementation, so the cache key never changes and every game gets whichever interval was resolved first. A wrong intermediate interval there produces a `CheckpointCountMismatch` per game (the Immunefi #74652 failure mode) rather than a silent stall — loud, but it stops the challenger from validating anything past the boundary.

## How to test?

```
cd crates/proof
cargo test -p base-challenger -p base-proposer -p base-proof-contracts
cargo clippy -p base-proof-contracts -p base-proposer -p base-challenger --all-targets -- -D warnings
```

Two new tests carry the regression, both written so they fail against the old behaviour rather than merely passing against the new one:

- `cargo test -p base-challenger --lib anchor::tests::poll_finds_next_game_built_with_fast_intervals` — anchor sits at the activation block; the next game spans the Denim interval and carries two intermediate roots. The same fixture is polled twice: once against a verifier that switches cadence (anchor advances, one `setAnchorState` tx) and once against a verifier that never switches, i.e. the pair the old startup-cached updater would have used (no tx — the UUID does not match). The pre-Denim target block is present in the mock L2 provider so the second arm fails on the UUID, not on a missing output root.
- `cargo test -p base-challenger --lib scanner::tests::test_scan_resolves_intervals_per_game_across_cadence_activation` — two games straddling the activation block; asserts they resolve `5` and `2` respectively. The old per-implementation cache returns one value for both.

`test_scan_happy_path` now asserts one interval read per candidate, keyed by each candidate's own proxy address, instead of one read per implementation — that assertion is both the cache removal and the read-through-the-proxy change.

Full run on this branch: 73 + 22 challenger, 59 proposer, 45 contracts, 0 failures.

## Known limitation

`AnchorUpdater::next_game` resolves from the factory's *current* implementation, but the successor game may already exist and have been created with an older pair. Across a `setImplementation` that changes the pair the keyed lookup never matches and the anchor stalls at `next anchor game not found` — and unlike the old startup-cached version, a restart no longer clears it. Denim itself does not trigger this: the pair is a function of the starting block, not of which implementation is current. Closing it means scanning the factory from the anchor index when the keyed lookup misses; left as a follow-up.

## Follow-ups

Nitro TEE and ZK (doc sections 4 and 5) are untouched and still need the same treatment.

---

### Update — back to Denim

The 200ms cadence switch has moved back to **Denim**, `ProtocolVersions` index 13. base/contracts#434 reverts the index in `AggregateVerifier` (12 → 13); the semver stays at 0.2.0 since that version has not shipped anywhere yet. This branch follows it in prose and fixture names.

Nothing functional moved in either direction. This service resolves the interval pair from the verifier per game and never names a fork itself, so the earlier Cobalt retarget and this one are both comment-and-identifier changes. The mock builders and test names introduced along the way are cadence-neutral (`fast_activation_block`, `with_fast_intervals`, `..._crosses_fast_activation_block`) and did not need renaming for either move.

Index 13 sits one past the end of the current Base mainnet schedule, where index 12 was in range but zero. `_firstFastBlock()` reports "unscheduled" for both, so the deploy-time requirement is unchanged: the activation has to be registered on `ProtocolVersions` before the fork or the verifier stays on the slow cadence silently.

The branch name still says `denim` — which is now correct again. It was never renamed, since that would close and reopen the PR.
