### PR TITLE
fix: check blob encoding version at correct byte offset

### DIFF
--- a/crates/consensus/derive/src/sources/blob_data.rs
+++ b/crates/consensus/derive/src/sources/blob_data.rs
@@ -30,7 +30,7 @@ impl BlobData {
         let data = self.data.as_ref().ok_or(BlobDecodingError::MissingData)?;
 
         // Validate the blob encoding version
-        if data[VERSIONED_HASH_VERSION_KZG as usize] != BLOB_ENCODING_VERSION {
+        if data[0] != BLOB_ENCODING_VERSION {
             return Err(BlobDecodingError::InvalidEncodingVersion);
         }
 
@@ -221,7 +221,7 @@ mod tests {
     #[test]
     fn test_blob_data_decode_invalid_length() {
         let mut data = vec![0u8; 32];
-        data[VERSIONED_HASH_VERSION_KZG as usize] = BLOB_ENCODING_VERSION;
+        data[0] = BLOB_ENCODING_VERSION;
         data[2] = 0xFF;
         data[3] = 0xFF;
         data[4] = 0xFF;
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn test_blob_data_decode() {
         let mut data = vec![0u8; alloy_eips::eip4844::BYTES_PER_BLOB];
-        data[VERSIONED_HASH_VERSION_KZG as usize] = BLOB_ENCODING_VERSION;
+        data[0] = BLOB_ENCODING_VERSION;
         data[2] = 0x00;
         data[3] = 0x00;
         data[4] = 0x01;
@@ -243,7 +243,7 @@ mod tests {
     #[test]
     fn test_blob_data_decode_invalid_field_element() {
         let mut data = vec![0u8; alloy_eips::eip4844::BYTES_PER_BLOB + 10];
-        data[VERSIONED_HASH_VERSION_KZG as usize] = BLOB_ENCODING_VERSION;
+        data[0] = BLOB_ENCODING_VERSION;
         data[2] = 0x00;
         data[3] = 0x00;
         data[4] = 0x01;


### PR DESCRIPTION
## Summary
Fixes #4633

### Problem
`BlobData::decode()` validated the encoding version at `data[VERSIONED_HASH_VERSION_KZG as usize]` (index 1) instead of `data[0]`. `VERSIONED_HASH_VERSION_KZG` is `0x01` — EIP-4844's versioned-hash prefix byte, an unrelated constant.

Byte 0 is the actual encoding-version byte (confirmed by `encoded_byte[0] = data[0]` two lines later). Byte 1 is unused padding (always zero). The check was validating the padding byte, so any blob with an unsupported version at byte 0 but `data[1] == 0` passed validation, producing garbage output.

### Fix
- Changed `data[VERSIONED_HASH_VERSION_KZG as usize]` to `data[0]` (1 line)
- Updated 3 test cases that wrote the version byte to the same wrong offset, masking the bug