### PR TITLE
chore(devnet): upgrade Reth to v2.5.2 and Lighthouse to v8.2.2

### DIFF
--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -169,8 +169,8 @@ build-image target='base' profile='dev':
 # Prepares Docker images needed for system tests
 pull-images:
     docker build --load -t devnet-setup:local -f etc/docker/Dockerfile.devnet .
-    docker pull ghcr.io/paradigmxyz/reth:v1.11.4
-    docker pull sigp/lighthouse:v8.0.1
+    docker pull ghcr.io/paradigmxyz/reth:v2.5.2
+    docker pull sigp/lighthouse:v8.2.2
 
 # Reth's unoptimized node launch overflows the 2 MiB stack libtest gives each test thread,
 # which SIGSEGVs on Linux. Do not move to nextest.toml `[env]`; nextest silently drops it.

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     entrypoint: ["/usr/local/bin/setup-l1.sh"]
 
   l1-el:
-    image: ghcr.io/paradigmxyz/reth:v1.11.4
+    image: ghcr.io/paradigmxyz/reth:v2.5.2
     container_name: l1-el
     depends_on:
       setup-l1:
@@ -78,7 +78,7 @@ services:
     restart: unless-stopped
 
   l1-cl:
-    image: sigp/lighthouse:v8.0.1
+    image: sigp/lighthouse:v8.2.2
     container_name: l1-cl
     depends_on:
       setup-l1:
@@ -123,7 +123,7 @@ services:
     restart: unless-stopped
 
   l1-vc:
-    image: sigp/lighthouse:v8.0.1
+    image: sigp/lighthouse:v8.2.2
     container_name: l1-vc
     depends_on:
       l1-cl:

--- a/etc/systems/src/images.rs
+++ b/etc/systems/src/images.rs
@@ -1,7 +1,7 @@
 //! Docker image constants for system test containers.
 
 /// Docker image for Reth.
-pub const RETH_IMAGE: &str = "ghcr.io/paradigmxyz/reth:v1.11.4";
+pub const RETH_IMAGE: &str = "ghcr.io/paradigmxyz/reth:v2.5.2";
 /// Docker image for op-deployer.
 pub const OP_DEPLOYER_IMAGE: &str =
     "us-docker.pkg.dev/oplabs-tools-artifacts/images/op-deployer:v0.6.0-rc.3";

--- a/etc/systems/src/l1/lighthouse.rs
+++ b/etc/systems/src/l1/lighthouse.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 const LIGHTHOUSE_IMAGE_NAME: &str = "sigp/lighthouse";
-const LIGHTHOUSE_IMAGE_TAG: &str = "v8.0.1";
+const LIGHTHOUSE_IMAGE_TAG: &str = "v8.2.2";
 const LIGHTHOUSE_TESTNET_DIR: &str = "/genesis/cl";
 const LIGHTHOUSE_JWT_PATH: &str = "/genesis/jwt.hex";
 const LIGHTHOUSE_BEACON_DATA_DIR: &str = "/data/beacon";


### PR DESCRIPTION
### Description
Upgrade devnet Reth from v1.11.4 to v2.5.2 and Lighthouse from v8.0.1 to v8.2.2
