### PR TITLE
fix(flashblocks): handle empty pending rebuilds and reject genesis inputs

### DIFF
--- a/crates/execution/flashblocks/Cargo.toml
+++ b/crates/execution/flashblocks/Cargo.toml
@@ -88,6 +88,7 @@ rstest.workspace = true
 alloy-eips.workspace = true
 serde_json.workspace = true
 base-execution-chainspec.workspace = true
+reth-provider = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = [ "metrics" ]

--- a/crates/execution/flashblocks/src/block_assembler.rs
+++ b/crates/execution/flashblocks/src/block_assembler.rs
@@ -69,10 +69,14 @@ impl BlockAssembler {
     /// Returns an error if:
     /// - The flashblocks slice is empty
     /// - The first flashblock is missing its base payload
+    /// - The base payload refers to genesis, which has no parent state
     /// - Block conversion fails
     pub fn assemble(flashblocks: &[Flashblock]) -> Result<AssembledBlock> {
         let first = flashblocks.first().ok_or(ProtocolError::EmptyFlashblocks)?;
         let base = first.base.clone().ok_or(ProtocolError::MissingBase)?;
+        if base.block_number == 0 {
+            return Err(ProtocolError::GenesisFlashblock.into());
+        }
         let latest_flashblock = flashblocks.last().ok_or(ProtocolError::EmptyFlashblocks)?;
 
         let transactions: Vec<Bytes> = flashblocks
@@ -299,6 +303,16 @@ mod tests {
         assert!(matches!(
             result,
             Err(crate::StateProcessorError::Protocol(ProtocolError::MissingBase))
+        ));
+    }
+
+    #[test]
+    fn assemble_rejects_genesis_base_even_with_nonzero_metadata() {
+        let mut flashblock = create_test_flashblock(0, true);
+        flashblock.base.as_mut().unwrap().block_number = 0;
+        assert!(matches!(
+            BlockAssembler::assemble(&[flashblock]),
+            Err(crate::StateProcessorError::Protocol(ProtocolError::GenesisFlashblock))
         ));
     }
 }

--- a/crates/execution/flashblocks/src/error.rs
+++ b/crates/execution/flashblocks/src/error.rs
@@ -18,6 +18,10 @@ pub enum ProtocolError {
     /// Cannot build from an empty flashblocks collection.
     #[error("empty flashblocks: cannot build state from zero flashblocks")]
     EmptyFlashblocks,
+
+    /// Genesis has no parent state on which to execute a flashblock.
+    #[error("cannot execute a genesis flashblock: block zero has no parent")]
+    GenesisFlashblock,
 }
 
 /// Errors related to state provider and infrastructure operations.

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -30,7 +30,8 @@ use tokio::sync::{Mutex, broadcast::Sender, mpsc::UnboundedReceiver};
 
 use crate::{
     AssembledBlock, BlockAssembler, ExecutionError, FlashblockCache, PendingBlocks,
-    PendingBlocksBuilder, PendingStateBuilder, ProviderError, Result, StateProcessorError,
+    PendingBlocksBuilder, PendingStateBuilder, ProtocolError, ProviderError, Result,
+    StateProcessorError,
     metrics::Metrics,
     validation::{
         CanonicalBlockReconciler, FlashblockSequenceValidator, ReconciliationStrategy,
@@ -850,8 +851,12 @@ where
                 .push(flashblock.clone());
         }
 
-        let earliest_block_number = flashblocks_per_block.keys().min().unwrap();
-        let canonical_block = earliest_block_number - 1;
+        let Some((&earliest_block_number, _)) = flashblocks_per_block.first_key_value() else {
+            self.clear_live_state();
+            return Ok(None);
+        };
+        let canonical_block =
+            earliest_block_number.checked_sub(1).ok_or(ProtocolError::GenesisFlashblock)?;
         let mut last_block_header = self
             .client
             .header_by_number(canonical_block)
@@ -994,5 +999,93 @@ where
         }
 
         self.publish_pending_blocks(pending_blocks_builder, db, state_overrides)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::{Header, Sealed};
+    use alloy_primitives::B256;
+    use alloy_rpc_types_engine::PayloadId;
+    use base_common_consensus::BasePrimitives;
+    use base_common_flashblocks::{
+        ExecutionPayloadBaseV1, ExecutionPayloadFlashblockDeltaV1, Metadata,
+    };
+    use base_execution_chainspec::BaseChainSpec;
+    use reth_provider::test_utils::MockEthProvider;
+    use rstest::rstest;
+    use tokio::sync::{broadcast, mpsc};
+
+    use super::*;
+
+    #[rstest]
+    #[case::caught_up(1)]
+    #[case::empty_after_depth_filter(3)]
+    #[tokio::test]
+    async fn canonical_update_clears_exhausted_pending(#[case] latest_header: u64) {
+        let client =
+            MockEthProvider::<BasePrimitives>::new().with_chain_spec(BaseChainSpec::mainnet());
+        // Keep provider tip at genesis so this queued canonical notification exercises
+        // reconciliation rather than the independent stale-snapshot eviction guard.
+        client.add_header(B256::ZERO, Header::default());
+        let flashblock = Flashblock {
+            payload_id: PayloadId::default(),
+            index: 0,
+            base: Some(ExecutionPayloadBaseV1 { block_number: 1, ..Default::default() }),
+            diff: ExecutionPayloadFlashblockDeltaV1::default(),
+            metadata: Metadata::new(1),
+        };
+        let mut builder = PendingBlocksBuilder::new();
+        builder.with_flashblocks([flashblock]);
+        builder.with_header(Sealed::new_unchecked(
+            Header { number: 1, ..Default::default() },
+            B256::ZERO,
+        ));
+        builder.with_header(Sealed::new_unchecked(
+            Header { number: latest_header, ..Default::default() },
+            B256::ZERO,
+        ));
+        // The depth case deliberately seeds inconsistent header/flashblock heights.
+        // Consistent snapshots with no remaining flashblocks select CatchUp first.
+        let pending = Arc::new(ArcSwapOption::from(Some(Arc::new(builder.build().unwrap()))));
+        let (tx, rx) = mpsc::unbounded_channel();
+        let (sender, _) = broadcast::channel(1);
+        let processor =
+            StateProcessor::new(client, Arc::clone(&pending), 0, Arc::new(Mutex::new(rx)), sender);
+        tx.send(StateUpdate::Canonical(RecoveredBlock::new_unhashed(
+            Block {
+                header: Header { number: 2, ..Default::default() },
+                body: BlockBody::default(),
+            },
+            Vec::new(),
+        )))
+        .unwrap();
+        drop(tx);
+        processor.start().await;
+        assert!(pending.load_full().is_none());
+    }
+
+    #[tokio::test]
+    async fn genesis_update_without_known_canonical_tip_does_not_panic() {
+        // With no headers, the provider reports an unknown tip, so the normal
+        // superseded-payload filter cannot reject block zero before rebuilding.
+        let client =
+            MockEthProvider::<BasePrimitives>::new().with_chain_spec(BaseChainSpec::mainnet());
+        let pending = Arc::new(ArcSwapOption::empty());
+        let (tx, rx) = mpsc::unbounded_channel();
+        let (sender, _) = broadcast::channel(1);
+        let processor =
+            StateProcessor::new(client, Arc::clone(&pending), 3, Arc::new(Mutex::new(rx)), sender);
+        tx.send(StateUpdate::Flashblock(Flashblock {
+            payload_id: PayloadId::default(),
+            index: 0,
+            base: Some(ExecutionPayloadBaseV1::default()),
+            diff: ExecutionPayloadFlashblockDeltaV1::default(),
+            metadata: Metadata::new(0),
+        }))
+        .unwrap();
+        drop(tx);
+        processor.start().await;
+        assert!(pending.load_full().is_none());
     }
 }


### PR DESCRIPTION
### Description
Closes #2785. Consolidates #3796 and #3728.
