### PR TITLE
ci: increase stale bot budget and shorten PR inactivity timeout

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,8 +22,9 @@ jobs:
 
       - uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10.1.0
         with:
+          operations-per-run: 500
           days-before-stale: 7
-          days-before-pr-stale: 21
+          days-before-pr-stale: 7
           days-before-close: 1
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'


### PR DESCRIPTION
The stale bot exhausts its default 30-operation budget before processing the full backlog. Increase `operations-per-run` to 500 so each daily run can process more items.

Mark pull requests stale after 7 days of inactivity, down from 21, matching issues. Both remain eligible for closure after one further inactive day; the `active` label remains exempt.

Validation: YAML syntax parsed successfully with Ruby/Psych; `git diff --check` passed. The observed progress-cache failure is outside this change.
