### PR TITLE
fix: passing 0 for advertise ports uses same values as listen ports

### DIFF
--- a/crates/consensus/cli/src/p2p.rs
+++ b/crates/consensus/cli/src/p2p.rs
@@ -649,14 +649,14 @@ impl P2PArgs {
         // If the advertise ip is set, we will disable the dynamic ENR updates.
         let static_ip = self.advertise_ip.is_some();
 
-        // If the advertise tcp port is null, use the listen tcp port
+        // If an advertised port is unset or zero, use the corresponding listen port.
         let advertise_tcp_port = match self.advertise_tcp_port {
-            None => self.listen_tcp_port,
+            None | Some(0) => self.listen_tcp_port,
             Some(port) => port,
         };
 
         let advertise_udp_port = match self.advertise_udp_port {
-            None => self.listen_udp_port,
+            None | Some(0) => self.listen_udp_port,
             Some(port) => port,
         };
 
@@ -1249,6 +1249,43 @@ mod tests {
         let err = err.to_string();
         assert!(err.contains("502"), "unexpected error: {err}");
         mock.assert_calls_async(2).await;
+    }
+
+    #[tokio::test]
+    async fn test_p2p_config_advertised_ports() {
+        for (tcp, udp, expected_tcp, expected_udp) in [
+            (None, None, 9222, 9223),
+            (Some("0"), Some("0"), 9222, 9223),
+            (Some("9333"), Some("9444"), 9333, 9444),
+            (Some("0"), Some("9444"), 9222, 9444),
+            (Some("9333"), Some("0"), 9333, 9223),
+        ] {
+            let mut cli_args = vec![
+                "test",
+                "--p2p.listen.tcp",
+                "9222",
+                "--p2p.listen.udp",
+                "9223",
+                "--p2p.advertise.ip",
+                "192.0.2.1",
+            ];
+            if let Some(port) = tcp {
+                cli_args.extend(["--p2p.advertise.tcp", port]);
+            }
+            if let Some(port) = udp {
+                cli_args.extend(["--p2p.advertise.udp", port]);
+            }
+            let args = MockCommand::parse_from(cli_args);
+            let config = args
+                .p2p
+                .config(&RollupConfig::default(), 8453, None, L1_RPC_TIMEOUT, Some(Address::ZERO))
+                .await
+                .unwrap();
+            let enr = config.discovery_address.build_enr(8453).unwrap();
+
+            assert_eq!(enr.tcp4(), Some(expected_tcp), "advertised TCP: {tcp:?}, UDP: {udp:?}");
+            assert_eq!(enr.udp4(), Some(expected_udp), "advertised TCP: {tcp:?}, UDP: {udp:?}");
+        }
     }
 
     #[tokio::test]

--- a/crates/consensus/cli/src/p2p.rs
+++ b/crates/consensus/cli/src/p2p.rs
@@ -813,6 +813,7 @@ mod tests {
     use base_consensus_providers::L1_RPC_TIMEOUT;
     use clap::Parser;
     use httpmock::{HttpMockRequest, HttpMockResponse, Method::POST, MockServer};
+    use rstest::rstest;
     use serde_json::{Value, json};
 
     use super::*;
@@ -1251,41 +1252,44 @@ mod tests {
         mock.assert_calls_async(2).await;
     }
 
+    #[rstest]
+    #[case::omitted(None, None, 9222, 9223)]
+    #[case::zero(Some("0"), Some("0"), 9222, 9223)]
+    #[case::overrides(Some("9333"), Some("9444"), 9333, 9444)]
+    #[case::zero_tcp(Some("0"), Some("9444"), 9222, 9444)]
+    #[case::zero_udp(Some("9333"), Some("0"), 9333, 9223)]
     #[tokio::test]
-    async fn test_p2p_config_advertised_ports() {
-        for (tcp, udp, expected_tcp, expected_udp) in [
-            (None, None, 9222, 9223),
-            (Some("0"), Some("0"), 9222, 9223),
-            (Some("9333"), Some("9444"), 9333, 9444),
-            (Some("0"), Some("9444"), 9222, 9444),
-            (Some("9333"), Some("0"), 9333, 9223),
-        ] {
-            let mut cli_args = vec![
-                "test",
-                "--p2p.listen.tcp",
-                "9222",
-                "--p2p.listen.udp",
-                "9223",
-                "--p2p.advertise.ip",
-                "192.0.2.1",
-            ];
-            if let Some(port) = tcp {
-                cli_args.extend(["--p2p.advertise.tcp", port]);
-            }
-            if let Some(port) = udp {
-                cli_args.extend(["--p2p.advertise.udp", port]);
-            }
-            let args = MockCommand::parse_from(cli_args);
-            let config = args
-                .p2p
-                .config(&RollupConfig::default(), 8453, None, L1_RPC_TIMEOUT, Some(Address::ZERO))
-                .await
-                .unwrap();
-            let enr = config.discovery_address.build_enr(8453).unwrap();
-
-            assert_eq!(enr.tcp4(), Some(expected_tcp), "advertised TCP: {tcp:?}, UDP: {udp:?}");
-            assert_eq!(enr.udp4(), Some(expected_udp), "advertised TCP: {tcp:?}, UDP: {udp:?}");
+    async fn test_p2p_config_advertised_ports(
+        #[case] tcp: Option<&str>,
+        #[case] udp: Option<&str>,
+        #[case] expected_tcp: u16,
+        #[case] expected_udp: u16,
+    ) {
+        let mut cli_args = vec![
+            "test",
+            "--p2p.listen.tcp",
+            "9222",
+            "--p2p.listen.udp",
+            "9223",
+            "--p2p.advertise.ip",
+            "192.0.2.1",
+        ];
+        if let Some(port) = tcp {
+            cli_args.extend(["--p2p.advertise.tcp", port]);
         }
+        if let Some(port) = udp {
+            cli_args.extend(["--p2p.advertise.udp", port]);
+        }
+        let args = MockCommand::parse_from(cli_args);
+        let config = args
+            .p2p
+            .config(&RollupConfig::default(), 8453, None, L1_RPC_TIMEOUT, Some(Address::ZERO))
+            .await
+            .unwrap();
+        let enr = config.discovery_address.build_enr(8453).unwrap();
+
+        assert_eq!(enr.tcp4(), Some(expected_tcp));
+        assert_eq!(enr.udp4(), Some(expected_udp));
     }
 
     #[tokio::test]

--- a/crates/consensus/derive/src/sources/blob_data.rs
+++ b/crates/consensus/derive/src/sources/blob_data.rs
@@ -123,7 +123,7 @@ impl BlobData {
 
     /// Reassemble 4 by 6 bit encoded chunks into 3 bytes of output and place them in their
     /// appropriate output positions.
-    pub fn reassemble_bytes(
+    pub const fn reassemble_bytes(
         &self,
         mut output_pos: usize,
         encoded_byte: &[u8],


### PR DESCRIPTION
### Description
Fixes https://github.com/base/base/issues/4937.