### PR TITLE
chore(devnet): force kill batcher on devnet teardown

### DIFF
--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -362,6 +362,8 @@ services:
       target: base
     entrypoint: /app/base
     container_name: base-batcher
+    # Skip the L1 receipt drain when stopping the disposable devnet batcher.
+    stop_signal: SIGKILL
     depends_on:
       base-builder:
         condition: service_healthy


### PR DESCRIPTION
### Description
Prior to this change stopping the batcher takes 10.2s, but after it takes 0.27s. Sending SIGKILL skips the L1 receipt drain, which otherwise runs until Docker's stop timeout during devnet teardown.
