### PR TITLE
feat(snapshotter): improve compression and upload progress logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5985,6 +5985,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "blake3",
+ "humantime",
  "rayon",
  "reth-cli-commands",
  "reth-node-core",
@@ -6181,8 +6182,6 @@ dependencies = [
  "bollard",
  "clap",
  "futures",
- "human_bytes",
- "humantime",
  "serde_json",
  "serial_test",
  "tempfile",

--- a/crates/infra/snapshotter/Cargo.toml
+++ b/crates/infra/snapshotter/Cargo.toml
@@ -16,10 +16,8 @@ anyhow = { workspace = true }
 bollard = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
-humantime = { workspace = true }
 alloy-eips = { workspace = true }
 async-trait = { workspace = true }
-human_bytes = { workspace = true }
 serde_json = { workspace = true }
 base-reth-cli = { workspace = true }
 alloy-provider = { workspace = true, features = ["reqwest"] }

--- a/crates/infra/snapshotter/src/lib.rs
+++ b/crates/infra/snapshotter/src/lib.rs
@@ -9,14 +9,14 @@
 
 pub use base_reth_cli::{
     ChunkFilename, ChunkedArchive, ComponentManifest, ManifestGenerationParams, OutputFileChecksum,
-    SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
+    ProgressDisplay, SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
 };
 
 mod config;
 pub use config::{DEFAULT_TIP_THRESHOLD_SECS, S3ConfigType, SnapshotterConfig};
 
 mod progress;
-pub use progress::{ProgressDisplay, UploadProgress};
+pub use progress::UploadProgress;
 
 mod container;
 pub use container::{ContainerManager, DockerContainerManager};

--- a/crates/infra/snapshotter/src/progress.rs
+++ b/crates/infra/snapshotter/src/progress.rs
@@ -13,8 +13,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use human_bytes::human_bytes as format_bytes;
-use humantime::{FormattedDuration, format_duration};
+use base_reth_cli::ProgressDisplay;
 use tracing::{info, warn};
 
 /// Interval between periodic progress logs during snapshot artifact uploads.
@@ -22,27 +21,6 @@ pub(crate) const PROGRESS_LOG_INTERVAL: Duration = Duration::from_secs(3);
 
 const UPLOAD_STALL_WARNING_AFTER: Duration = Duration::from_secs(5 * 60);
 const MAX_STALLED_UPLOADS_IN_LOG: usize = 5;
-
-/// Formats snapshot upload progress for structured logs.
-#[derive(Debug)]
-pub struct ProgressDisplay;
-
-impl ProgressDisplay {
-    /// Returns the integer completion percentage for a completed and total count.
-    pub fn percent(done: u64, total: u64) -> u64 {
-        done.saturating_mul(100).checked_div(total).unwrap_or(100)
-    }
-
-    /// Formats completed and total byte counts with human-readable binary units.
-    pub fn human_byte_progress(done: u64, total: u64) -> String {
-        format!("{}/{}", format_bytes(done as f64), format_bytes(total as f64))
-    }
-
-    /// Formats a duration at whole-second precision for periodic progress logs.
-    pub fn duration(duration: Duration) -> FormattedDuration {
-        format_duration(Duration::from_secs(duration.as_secs()))
-    }
-}
 
 /// Cumulative upload progress shared across concurrent artifact uploads. A spawned
 /// ticker reads the atomic byte counter and logs throughput once per interval.
@@ -221,8 +199,11 @@ impl UploadProgress {
 
                 info!(
                     files = %format!("{files_done}/{total_files}"),
-                    progress = %format!("{}%", ProgressDisplay::percent(done, total_bytes)),
+                    progress = %ProgressDisplay::precise_percent(done, total_bytes),
                     bytes = %ProgressDisplay::human_byte_progress(done, total_bytes),
+                    speed = %ProgressDisplay::speed(done as f64 / started.elapsed().as_secs_f64()),
+                    eta = %ProgressDisplay::eta(done, total_bytes, started.elapsed())
+                        .map_or_else(|| "unknown".to_string(), |eta| eta.to_string()),
                     elapsed = %ProgressDisplay::duration(started.elapsed()),
                     active_uploads = active_count,
                     "uploading snapshot artifacts (progress)"
@@ -306,12 +287,23 @@ mod tests {
 
     #[test]
     fn formats_byte_progress_with_binary_units() {
-        assert_eq!(ProgressDisplay::human_byte_progress(1536, 2 * 1024 * 1024), "1.5 KiB/2 MiB");
+        assert_eq!(
+            ProgressDisplay::human_byte_progress(1536, 2 * 1024 * 1024),
+            "1.50 KiB/2.00 MiB"
+        );
+        assert_eq!(ProgressDisplay::speed(10.25 * 1024.0 * 1024.0), "10.25 MiB/s");
+        assert_eq!(ProgressDisplay::precise_percent(1, 8), "12.50%");
     }
 
     #[test]
     fn formats_durations_at_whole_second_precision() {
         let duration = Duration::from_secs(5 * 60 + 3) + Duration::from_millis(241);
         assert_eq!(ProgressDisplay::duration(duration).to_string(), "5m 3s");
+        assert_eq!(
+            ProgressDisplay::eta(25, 100, Duration::from_secs(10))
+                .expect("incomplete progress has an ETA")
+                .to_string(),
+            "30s"
+        );
     }
 }

--- a/crates/utilities/reth-cli/Cargo.toml
+++ b/crates/utilities/reth-cli/Cargo.toml
@@ -18,6 +18,7 @@ anyhow.workspace = true
 blake3.workspace = true
 rayon.workspace = true
 tracing.workspace = true
+humantime.workspace = true
 serde_json.workspace = true
 reth-node-core.workspace = true
 reth-prune-types.workspace = true

--- a/crates/utilities/reth-cli/src/lib.rs
+++ b/crates/utilities/reth-cli/src/lib.rs
@@ -16,5 +16,5 @@ pub use snapshots::Snapshots;
 mod snapshot_manifest;
 pub use snapshot_manifest::{
     ChunkFilename, ChunkedArchive, ComponentManifest, ManifestGenerationParams, OutputFileChecksum,
-    SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
+    ProgressDisplay, SingleArchive, SnapshotGenerator, SnapshotManifest, SnapshotManifestExt,
 };

--- a/crates/utilities/reth-cli/src/snapshot_manifest.rs
+++ b/crates/utilities/reth-cli/src/snapshot_manifest.rs
@@ -10,9 +10,11 @@ use std::{
     collections::{BTreeMap, HashMap},
     io::Read,
     path::{Path, PathBuf},
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, bail};
+use humantime::{FormattedDuration, format_duration};
 use rayon::prelude::*;
 pub use reth_cli_commands::download::manifest::{
     ChunkedArchive, ComponentManifest, OutputFileChecksum, SingleArchive, SnapshotManifest,
@@ -26,6 +28,9 @@ const DEFAULT_BLOCKS_PER_FILE: u64 = 500_000;
 /// At 500k blocks per file, 100k chunks covers 50 billion blocks.
 const MAX_CHUNKS: u64 = 100_000;
 
+/// Interval between progress logs while compressing a database component.
+const COMPRESSION_LOG_INTERVAL: Duration = Duration::from_secs(3);
+
 /// Static file component types that produce chunked archives.
 const CHUNKED_COMPONENTS: &[(&str, &str)] = &[
     ("headers", "headers"),
@@ -35,6 +40,62 @@ const CHUNKED_COMPONENTS: &[(&str, &str)] = &[
     ("account_changesets", "account-change-sets"),
     ("storage_changesets", "storage-change-sets"),
 ];
+
+/// Formats snapshot compression and upload progress for structured logs.
+#[derive(Debug)]
+pub struct ProgressDisplay;
+
+impl ProgressDisplay {
+    /// Returns the integer completion percentage for a completed and total count.
+    pub fn percent(done: u64, total: u64) -> u64 {
+        done.saturating_mul(100).checked_div(total).unwrap_or(100)
+    }
+
+    /// Returns completion percentage with two decimal places.
+    pub fn precise_percent(done: u64, total: u64) -> String {
+        if total == 0 {
+            return "100.00%".to_string();
+        }
+        format!("{:.2}%", done as f64 * 100.0 / total as f64)
+    }
+
+    /// Formats a byte count with two decimal places and human-readable binary units.
+    pub fn bytes(bytes: f64) -> String {
+        const UNITS: &[&str] = &["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"];
+
+        let bytes = bytes.max(0.0);
+        let unit = if bytes == 0.0 {
+            0
+        } else {
+            ((bytes.log2() / 10.0).floor() as usize).min(UNITS.len() - 1)
+        };
+        format!("{:.2} {}", bytes / 1024_f64.powi(unit as i32), UNITS[unit])
+    }
+
+    /// Formats completed and total byte counts with human-readable binary units.
+    pub fn human_byte_progress(done: u64, total: u64) -> String {
+        format!("{}/{}", Self::bytes(done as f64), Self::bytes(total as f64))
+    }
+
+    /// Formats bytes per second with human-readable binary units.
+    pub fn speed(bytes_per_second: f64) -> String {
+        format!("{}/s", Self::bytes(bytes_per_second))
+    }
+
+    /// Calculates the ETA from average throughput since an operation started.
+    pub fn eta(done: u64, total: u64, elapsed: Duration) -> Option<FormattedDuration> {
+        if done == 0 || done >= total {
+            return None;
+        }
+        let seconds = total.saturating_sub(done) as f64 / (done as f64 / elapsed.as_secs_f64());
+        Some(Self::duration(Duration::from_secs_f64(seconds)))
+    }
+
+    /// Formats a duration at whole-second precision for periodic progress logs.
+    pub fn duration(duration: Duration) -> FormattedDuration {
+        format_duration(Duration::from_secs(duration.as_secs()))
+    }
+}
 
 /// Convenience helpers for snapshotter-specific manifest lookups.
 pub trait SnapshotManifestExt {
@@ -327,22 +388,22 @@ impl SnapshotGenerator {
             .into_par_iter()
             .map(|(component, archive_name, files)| {
                 let (size, output_files) =
-                    package_single_component(params.output_dir, archive_name, &files)?;
+                    package_single_component(params.output_dir, component, archive_name, &files)?;
                 let decompressed_size = output_files.iter().map(|file| file.size).sum();
-                Ok((component, archive_name, files.len(), size, decompressed_size, output_files))
+                info!(
+                    component = %component,
+                    compressed_size = %ProgressDisplay::bytes(size as f64),
+                    raw_size = %ProgressDisplay::bytes(decompressed_size as f64),
+                    file_count = files.len(),
+                    "packaged database component"
+                );
+                Ok((component, archive_name, size, decompressed_size, output_files))
             })
             .collect::<Result<Vec<_>>>()?;
 
-        for (component, archive_name, file_count, size, decompressed_size, output_files) in
+        for (component, archive_name, size, decompressed_size, output_files) in
             packaged_single_components
         {
-            info!(
-                component,
-                compressed_size = size,
-                decompressed_size,
-                file_count,
-                "packaged database component"
-            );
             components.insert(
                 component.to_string(),
                 ComponentManifest::Single(SingleArchive {
@@ -602,6 +663,7 @@ fn collect_files_inner(
 
 fn package_single_component(
     output_dir: &Path,
+    component: &str,
     archive_name: &str,
     files: &[PlannedFile],
 ) -> Result<(u64, Vec<OutputFileChecksum>)> {
@@ -609,7 +671,17 @@ fn package_single_component(
         bail!("cannot package empty archive: {archive_name}");
     }
     let archive_path = output_dir.join(archive_name);
-    let output_files = write_archive_from_planned_files(&archive_path, files)?;
+    let raw_size = files.iter().try_fold(0u64, |total, file| {
+        std::fs::metadata(&file.source_path).map(|metadata| total.saturating_add(metadata.len()))
+    })?;
+    info!(
+        component = %component,
+        raw_size = %ProgressDisplay::bytes(raw_size as f64),
+        file_count = files.len(),
+        "packaging database component"
+    );
+    let mut progress = CompressionProgress::new(component, &archive_path, raw_size);
+    let output_files = write_archive_from_planned_files(&archive_path, files, Some(&mut progress))?;
     let size = std::fs::metadata(&archive_path)?.len();
     Ok((size, output_files))
 }
@@ -627,7 +699,7 @@ fn write_chunk_archive(path: &Path, source_files: &[PathBuf]) -> Result<Vec<Outp
         })
         .collect::<Result<Vec<_>>>()?;
 
-    write_archive_from_planned_files(path, &planned)
+    write_archive_from_planned_files(path, &planned, None)
 }
 
 fn chunk_output_files_for_source_files(
@@ -651,13 +723,15 @@ fn chunk_output_files_for_source_files(
 fn write_archive_from_planned_files(
     path: &Path,
     files: &[PlannedFile],
+    progress: Option<&mut CompressionProgress>,
 ) -> Result<Vec<OutputFileChecksum>> {
     let file = std::fs::File::create(path)?;
     let mut encoder = zstd::Encoder::new(file, 0)?;
     encoder.include_checksum(true)?;
     let mut builder = tar::Builder::new(encoder);
 
-    let output_files = compute_output_files_and_archive(files, Some((&mut builder, path)))?;
+    let output_files =
+        compute_output_files_and_archive(files, Some((&mut builder, path)), progress)?;
 
     let encoder = builder.into_inner()?;
     encoder.finish()?;
@@ -668,19 +742,20 @@ fn write_archive_from_planned_files(
 fn compute_output_files_for_planned_files(
     files: &[PlannedFile],
 ) -> Result<Vec<OutputFileChecksum>> {
-    compute_output_files_and_archive(files, None)
+    compute_output_files_and_archive(files, None, None)
 }
 
 fn compute_output_files_and_archive(
     files: &[PlannedFile],
     mut archive: Option<(&mut tar::Builder<zstd::Encoder<'_, std::fs::File>>, &Path)>,
+    mut progress: Option<&mut CompressionProgress>,
 ) -> Result<Vec<OutputFileChecksum>> {
     let mut output_files = Vec::with_capacity(files.len());
     for planned in files {
         let expected_size = std::fs::metadata(&planned.source_path)?.len();
 
         let source_file = std::fs::File::open(&planned.source_path)?;
-        let mut reader = HashingReader::new(source_file);
+        let mut reader = HashingReader::new(source_file, progress.as_deref_mut());
 
         if let Some((builder, archive_path)) = archive.as_mut() {
             let mut header = tar::Header::new_gnu();
@@ -718,15 +793,65 @@ fn compute_output_files_and_archive(
     Ok(output_files)
 }
 
-struct HashingReader<R> {
+struct CompressionProgress {
+    component: String,
+    archive_path: PathBuf,
+    raw_size: u64,
+    raw_processed: u64,
+    started: Instant,
+    last_log: Instant,
+}
+
+impl CompressionProgress {
+    fn new(component: &str, archive_path: &Path, raw_size: u64) -> Self {
+        let now = Instant::now();
+        Self {
+            component: component.to_string(),
+            archive_path: archive_path.to_path_buf(),
+            raw_size,
+            raw_processed: 0,
+            started: now,
+            last_log: now,
+        }
+    }
+
+    fn add(&mut self, bytes: u64) {
+        self.raw_processed = self.raw_processed.saturating_add(bytes).min(self.raw_size);
+        if self.last_log.elapsed() < COMPRESSION_LOG_INTERVAL {
+            return;
+        }
+
+        let elapsed = self.started.elapsed();
+        let compressed_size =
+            std::fs::metadata(&self.archive_path).map_or(0, |metadata| metadata.len());
+        let speed = self.raw_processed as f64 / elapsed.as_secs_f64();
+        let eta = ProgressDisplay::eta(self.raw_processed, self.raw_size, elapsed)
+            .map_or_else(|| "unknown".to_string(), |eta| eta.to_string());
+        info!(
+            component = %self.component,
+            raw_size = %ProgressDisplay::bytes(self.raw_size as f64),
+            raw_processed = %ProgressDisplay::bytes(self.raw_processed as f64),
+            compressed_size = %ProgressDisplay::bytes(compressed_size as f64),
+            progress = %ProgressDisplay::precise_percent(self.raw_processed, self.raw_size),
+            speed = %ProgressDisplay::speed(speed),
+            eta = %eta,
+            elapsed = %ProgressDisplay::duration(elapsed),
+            "packaging database component (progress)"
+        );
+        self.last_log = Instant::now();
+    }
+}
+
+struct HashingReader<'a, R> {
     inner: R,
     hasher: blake3::Hasher,
     bytes_read: u64,
+    progress: Option<&'a mut CompressionProgress>,
 }
 
-impl<R: Read> HashingReader<R> {
-    fn new(inner: R) -> Self {
-        Self { inner, hasher: blake3::Hasher::new(), bytes_read: 0 }
+impl<'a, R: Read> HashingReader<'a, R> {
+    fn new(inner: R, progress: Option<&'a mut CompressionProgress>) -> Self {
+        Self { inner, hasher: blake3::Hasher::new(), bytes_read: 0, progress }
     }
 
     fn finalize(self) -> String {
@@ -734,12 +859,15 @@ impl<R: Read> HashingReader<R> {
     }
 }
 
-impl<R: Read> Read for HashingReader<R> {
+impl<R: Read> Read for HashingReader<'_, R> {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let n = self.inner.read(buf)?;
         if n > 0 {
             self.bytes_read += n as u64;
             self.hasher.update(&buf[..n]);
+            if let Some(progress) = self.progress.as_mut() {
+                progress.add(n as u64);
+            }
         }
         Ok(n)
     }


### PR DESCRIPTION
## Summary
- emit start, periodic progress, and completion logs independently for each parallel database component
- report raw and compressed sizes, precise percentage, throughput, elapsed time, and ETA during compression
- add throughput and ETA to upload progress and format byte counts and percentages with two decimal places
- share progress formatting between compression and upload paths