### PR TITLE
fix(release): backport batcher metrics and validator inbox override

### DIFF
--- a/crates/batcher/core/src/driver.rs
+++ b/crates/batcher/core/src/driver.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use base_batcher_encoder::{BatchPipeline, DerivationReconciliation, StepResult};
+use base_batcher_encoder::{BatchPipeline, BatcherMetrics, DerivationReconciliation, StepResult};
 use base_batcher_source::{
     L1HeadEvent, L1HeadSource, L2BlockEvent, SourceError, UnsafeBlockSource,
 };
@@ -275,7 +275,7 @@ where
                 }
                 DriverEvent::Reorg => {
                     warn!("L2 reorg detected, resetting pipeline and catching up from safe head");
-                    self.reset_to_safe_head();
+                    self.reset_to_safe_head(BatcherMetrics::RESET_SOURCE_REORG);
                 }
                 DriverEvent::Receipt(ids, o) => {
                     self.submissions.handle_outcome(&mut self.pipeline, ids, o);
@@ -326,16 +326,21 @@ where
         Ok(idle)
     }
 
-    /// Reset volatile state and restart delivery above the latest safe head.
-    fn reset_to_safe_head(&mut self) {
+    /// Drop buffered pipeline state, recording why it was dropped.
+    fn reset_pipeline(&mut self, reason: &'static str) {
+        BatcherMetrics::pipeline_reset_total(reason).increment(1);
         self.submissions.discard();
         self.pipeline.reset();
+        self.discard_pending_flush_acks();
+    }
+
+    /// Reset volatile state and restart delivery above the latest safe head.
+    fn reset_to_safe_head(&mut self, reason: &'static str) {
+        self.reset_pipeline(reason);
 
         if let Some(safe_head) = self.safe_head {
             self.source.reset_catchup(safe_head);
         }
-
-        self.discard_pending_flush_acks();
     }
 
     /// Reconcile buffered state with an ordered derivation-progress snapshot.
@@ -354,7 +359,7 @@ where
                 safe_hash = %head.hash,
                 "safe L2 head changed chain, resetting pipeline"
             );
-            self.reset_to_safe_head();
+            self.reset_to_safe_head(BatcherMetrics::RESET_SAFE_HEAD_REORG);
             return;
         }
 
@@ -369,7 +374,7 @@ where
                     safe_hash = %head.hash,
                     "safe L2 head does not match buffered chain, resetting pipeline"
                 );
-                self.reset_to_safe_head();
+                self.reset_to_safe_head(BatcherMetrics::RESET_SAFE_HEAD_MISMATCH);
             }
             DerivationReconciliation::StalledChannel => {
                 warn!(
@@ -377,7 +382,7 @@ where
                     safe_l2 = %head.number,
                     "rollup node passed a fully confirmed channel without deriving it, resetting pipeline"
                 );
-                self.reset_to_safe_head();
+                self.reset_to_safe_head(BatcherMetrics::RESET_STALLED_CHANNEL);
             }
         }
     }
@@ -424,7 +429,7 @@ where
                     error = %e,
                     "reorg detected during block ingestion, resetting pipeline and catching up from safe head"
                 );
-                self.reset_to_safe_head();
+                self.reset_to_safe_head(BatcherMetrics::RESET_INGEST_REORG);
             }
         }
     }
@@ -466,10 +471,8 @@ where
                     match cmd {
                         AdminCommand::Flush { ack } => return Ok(DriverEvent::Flush(ack)),
                         AdminCommand::Pause => {
-                            self.submissions.discard();
-                            self.pipeline.reset();
+                            self.reset_pipeline(BatcherMetrics::RESET_ADMIN_PAUSE);
                             self.stopped = true;
-                            self.discard_pending_flush_acks();
                             info!(stopped = true, "batcher paused via admin");
                         }
                         AdminCommand::Resume => {

--- a/crates/batcher/core/src/submissions.rs
+++ b/crates/batcher/core/src/submissions.rs
@@ -123,6 +123,13 @@ impl<TM: TxManager> SubmissionQueue<TM> {
                     match BatchTxCandidateBuilder::blob_tx_candidate(self.inbox, &sub.frames) {
                         Ok((candidate, payload_size)) => {
                             blob_payload_bytes = Some(payload_size);
+                            BatcherMetrics::blobs_per_tx().record(sub.frames.len() as f64);
+                            for frame in &sub.frames {
+                                BatcherMetrics::blob_fill_ratio().record(
+                                    (1 + frame.encoded_len()) as f64
+                                        / BlobEncoder::BLOB_MAX_DATA_SIZE as f64,
+                                );
+                            }
                             candidate
                         }
                         Err(e) => {

--- a/crates/batcher/encoder/src/encoder.rs
+++ b/crates/batcher/encoder/src/encoder.rs
@@ -172,11 +172,8 @@ impl BatchEncoder {
         BatcherMetrics::channel_closed_total(close_reason).increment(1);
         BatcherMetrics::channel_duration_blocks().record(duration_blocks as f64);
         BatcherMetrics::l2_blocks_per_channel().record(blocks_added as f64);
-        BatcherMetrics::input_bytes(BatcherMetrics::STAGE_CLOSED).set(input_bytes as f64);
-        BatcherMetrics::output_bytes().set(compressed_bytes as f64);
         BatcherMetrics::input_bytes_total().increment(input_bytes);
         BatcherMetrics::output_bytes_total().increment(closed_da_backlog_bytes);
-        BatcherMetrics::channel_num_frames().set(frame_count as f64);
         if input_bytes > 0 {
             let ratio = compressed_bytes as f64 / input_bytes as f64;
             BatcherMetrics::channel_compression_ratio().record(ratio);
@@ -307,6 +304,7 @@ impl BatchEncoder {
             "confirmed channel exceeded derivation timeout, replaying blocks"
         );
 
+        BatcherMetrics::channel_replay_total().increment(1);
         self.ready_channels.truncate(chan_idx);
         self.pending.retain(|_, pending| pending.channel_idx < chan_idx);
         self.current_channel = None;
@@ -517,8 +515,6 @@ impl BatchPipeline for BatchEncoder {
             ChannelAddOutcome::Accepted | ChannelAddOutcome::AcceptedAndFull => {
                 // The queue cursor is the acceptance boundary. Advancing it
                 // earlier would lose a block when the channel rejects a candidate.
-                BatcherMetrics::input_bytes(BatcherMetrics::STAGE_ADDED)
-                    .set(open.input_bytes() as f64);
                 self.block_cursor += 1;
 
                 if outcome == ChannelAddOutcome::AcceptedAndFull {

--- a/crates/batcher/encoder/src/metrics.rs
+++ b/crates/batcher/encoder/src/metrics.rs
@@ -5,30 +5,43 @@ base_metrics::define_metrics! {
     struct = BatcherMetrics,
     #[describe("Total number of encoding channels opened")]
     channel_opened_total: counter,
-    #[describe("Total number of encoding channels closed")]
-    #[label(reason)]
+    #[describe("Total number of encoding channels closed, by reason")]
+    #[label(
+        name = "reason",
+        default = ["size_full", "timeout", "force", "discard"]
+    )]
     channel_closed_total: counter,
     #[describe("Total number of channels for which every frame was confirmed on L1")]
     channel_fully_submitted_total: counter,
+    #[describe(
+        "Total channel replay operations caused by an expired derivation confirmation window"
+    )]
+    channel_replay_total: counter,
+    #[describe("Total number of batcher pipeline resets, by reason")]
+    #[label(
+        name = "reason",
+        default = [
+            "source_reorg",
+            "ingest_reorg",
+            "safe_head_reorg",
+            "safe_head_mismatch",
+            "stalled_channel",
+            "admin_pause",
+        ]
+    )]
+    pipeline_reset_total: counter,
     #[describe("Total number of L1 batch submissions")]
-    #[label(outcome)]
+    #[label(name = "outcome", default = ["submitted", "confirmed", "failed", "requeued"])]
     submission_total: counter,
     #[describe("Total bytes of frame payload submitted to the DA layer")]
-    #[label(da_type)]
+    #[label(name = "da_type", default = ["blob", "calldata"])]
     da_bytes_submitted_total: counter,
     #[describe("Total bytes of frame payload packed into EIP-4844 blobs")]
     blob_used_bytes_total: counter,
-    #[describe("Number of input bytes to a channel")]
-    #[label(name = "stage", default = ["added", "closed"])]
-    input_bytes: gauge,
-    #[describe("Number of compressed output bytes from a channel")]
-    output_bytes: gauge,
     #[describe("Total number of input bytes to channels")]
     input_bytes_total: counter,
     #[describe("Total number of compressed output bytes from channels")]
     output_bytes_total: counter,
-    #[describe("Total number of frames in the closed channel")]
-    channel_num_frames: gauge,
     #[describe("Batcher signer account balance in ether")]
     #[no_zero]
     balance: gauge,
@@ -44,13 +57,19 @@ base_metrics::define_metrics! {
     channel_duration_blocks: histogram,
     #[describe("Number of L2 blocks included in each closed channel")]
     l2_blocks_per_channel: histogram,
+    #[describe("Number of EIP-4844 blobs per blob transaction submission attempt")]
+    blobs_per_tx: histogram,
+    #[describe(
+        "Fraction of one blob's frame capacity used, sampled per blob submission attempt"
+    )]
+    blob_fill_ratio: histogram,
 }
 
 impl BatcherMetrics {
     /// Channel closed because the compressed frame data reached the target size.
     pub const REASON_SIZE_FULL: &'static str = "size_full";
 
-    /// Channel closed because it reached `max_channel_duration` L1 blocks.
+    /// Channel closed because it reached its configured L1 deadline.
     pub const REASON_TIMEOUT: &'static str = "timeout";
 
     /// Channel closed by an explicit force-flush signal.
@@ -59,11 +78,23 @@ impl BatcherMetrics {
     /// Channel discarded without producing frames because the span batch exceeded limits.
     pub const REASON_DISCARD: &'static str = "discard";
 
-    /// Channel input bytes after blocks have been added.
-    pub const STAGE_ADDED: &'static str = "added";
+    /// The block source signalled an L2 reorg.
+    pub const RESET_SOURCE_REORG: &'static str = "source_reorg";
 
-    /// Channel input bytes after the channel has been closed.
-    pub const STAGE_CLOSED: &'static str = "closed";
+    /// A parent-hash mismatch surfaced while adding a block to the pipeline.
+    pub const RESET_INGEST_REORG: &'static str = "ingest_reorg";
+
+    /// The derivation status reported a safe head that moved back or changed hash.
+    pub const RESET_SAFE_HEAD_REORG: &'static str = "safe_head_reorg";
+
+    /// The derived safe head does not match the buffered chain.
+    pub const RESET_SAFE_HEAD_MISMATCH: &'static str = "safe_head_mismatch";
+
+    /// The rollup node passed a fully confirmed channel without deriving it.
+    pub const RESET_STALLED_CHANNEL: &'static str = "stalled_channel";
+
+    /// The batcher was paused through the admin API.
+    pub const RESET_ADMIN_PAUSE: &'static str = "admin_pause";
 
     /// Submission accepted and handed to the tx manager.
     pub const OUTCOME_SUBMITTED: &'static str = "submitted";

--- a/crates/batcher/service/src/l2_block_parity.rs
+++ b/crates/batcher/service/src/l2_block_parity.rs
@@ -21,8 +21,11 @@ pub const DEFAULT_MAX_BLOCKS_PER_TICK: usize = 25;
 /// Provider abstraction for derived L2 block parity checks.
 #[async_trait]
 pub trait L2BlockProvider: Send + Sync {
-    /// Fetch the latest L2 block number from this provider.
-    async fn latest_block_number(&self) -> eyre::Result<u64>;
+    /// Fetch the unsafe L2 head number from this provider.
+    async fn unsafe_block_number(&self) -> eyre::Result<u64>;
+
+    /// Fetch the safe L2 head number from this provider.
+    async fn safe_block_number(&self) -> eyre::Result<u64>;
 
     /// Fetch an L2 block snapshot by number.
     async fn block_by_number(&self, number: u64) -> eyre::Result<Option<L2BlockSnapshot>>;
@@ -45,11 +48,21 @@ impl RpcL2BlockProvider {
 
 #[async_trait]
 impl L2BlockProvider for RpcL2BlockProvider {
-    async fn latest_block_number(&self) -> eyre::Result<u64> {
+    async fn unsafe_block_number(&self) -> eyre::Result<u64> {
         self.provider
             .get_block_number()
             .await
-            .map_err(|e| eyre::eyre!("failed to fetch L2 latest block number: {e}"))
+            .map_err(|e| eyre::eyre!("failed to fetch unsafe L2 head number: {e}"))
+    }
+
+    async fn safe_block_number(&self) -> eyre::Result<u64> {
+        let block = self
+            .provider
+            .get_block_by_number(BlockNumberOrTag::Safe)
+            .await
+            .map_err(|e| eyre::eyre!("failed to fetch safe L2 head: {e}"))?
+            .ok_or_else(|| eyre::eyre!("safe L2 head unavailable"))?;
+        Ok(block.header.number)
     }
 
     async fn block_by_number(&self, number: u64) -> eyre::Result<Option<L2BlockSnapshot>> {
@@ -148,13 +161,6 @@ pub struct L2BlockParityStats {
     pub missing_blocks: usize,
 }
 
-impl L2BlockParityStats {
-    /// Returns true if this pass found no mismatch or missing block.
-    pub const fn is_aligned(self) -> bool {
-        self.mismatches == 0 && self.missing_blocks == 0
-    }
-}
-
 /// One derived L2 block parity comparison result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum L2BlockParityResult {
@@ -227,9 +233,21 @@ where
         })
     }
 
+    /// Comparable L2 blocks the cursor has not reached yet.
+    ///
+    /// Measured against the common unsafe head because a pass never walks past
+    /// `min(sequencer, validator)`: a validator trailing the sequencer is already reported by
+    /// `validator_unsafe_lag_blocks`, so what is left here is the monitor's own progress. A pass
+    /// advances by at most `max_blocks_per_tick`, so this grows both while the monitor is
+    /// catching up and while the cursor is parked on a block it cannot fetch.
+    pub const fn verification_backlog(&self, common_unsafe: u64) -> u64 {
+        common_unsafe.saturating_add(1).saturating_sub(self.next_block)
+    }
+
     /// Runs the monitor loop until cancelled.
     pub async fn run(&mut self, cancellation: CancellationToken) {
         L2BlockParityMetrics::enabled().set(1.0);
+        L2BlockParityMetrics::start_l2_block().set(self.next_block as f64);
         info!(
             start_block = %self.next_block,
             poll_interval_ms = %self.config.poll_interval.as_millis(),
@@ -243,7 +261,8 @@ where
             }
 
             if let Err(error) = self.process_once().await {
-                L2BlockParityMetrics::fetch_errors_total().increment(1);
+                L2BlockParityMetrics::fetch_errors_total(L2BlockParityMetrics::SCOPE_PASS)
+                    .increment(1);
                 error!(error = %error, "derived L2 block parity pass failed");
             }
 
@@ -258,30 +277,39 @@ where
 
     /// Processes one parity pass.
     pub async fn process_once(&mut self) -> eyre::Result<L2BlockParityStats> {
-        let sequencer_latest = self.sequencer.latest_block_number().await?;
-        let validator_latest = self.validator.latest_block_number().await?;
+        let sequencer_unsafe = self.sequencer.unsafe_block_number().await?;
+        let validator_unsafe = self.validator.unsafe_block_number().await?;
         // Metrics gauges are f64-backed; integer block numbers remain exact
         // through 2^53, far above any realistic L2 height for this monitor.
-        L2BlockParityMetrics::sequencer_latest_l2_block().set(sequencer_latest as f64);
-        L2BlockParityMetrics::validator_latest_l2_block().set(validator_latest as f64);
-        L2BlockParityMetrics::lag_blocks()
-            .set(sequencer_latest.saturating_sub(validator_latest) as f64);
+        L2BlockParityMetrics::sequencer_unsafe_l2_block().set(sequencer_unsafe as f64);
+        L2BlockParityMetrics::validator_unsafe_l2_block().set(validator_unsafe as f64);
+        L2BlockParityMetrics::validator_unsafe_lag_blocks()
+            .set(sequencer_unsafe.saturating_sub(validator_unsafe) as f64);
+        match self.sequencer.safe_block_number().await {
+            Ok(number) => L2BlockParityMetrics::sequencer_safe_l2_block().set(number as f64),
+            Err(error) => warn!(error = %error, "failed to fetch sequencer safe L2 head"),
+        }
+        match self.validator.safe_block_number().await {
+            Ok(number) => L2BlockParityMetrics::validator_safe_l2_block().set(number as f64),
+            Err(error) => warn!(error = %error, "failed to fetch validator safe L2 head"),
+        }
 
-        let common_latest = sequencer_latest.min(validator_latest);
-        if common_latest < self.next_block {
-            let aligned = if sequencer_latest == validator_latest { 1.0 } else { 0.0 };
-            L2BlockParityMetrics::aligned().set(aligned);
+        let common_unsafe = sequencer_unsafe.min(validator_unsafe);
+        L2BlockParityMetrics::verification_backlog_blocks()
+            .set(self.verification_backlog(common_unsafe) as f64);
+
+        if common_unsafe < self.next_block {
             debug!(
                 next_block = %self.next_block,
-                sequencer_latest = %sequencer_latest,
-                validator_latest = %validator_latest,
+                sequencer_unsafe = %sequencer_unsafe,
+                validator_unsafe = %validator_unsafe,
                 "waiting for parity validator to reach next comparable L2 block"
             );
             return Ok(L2BlockParityStats::default());
         }
 
         let max_blocks = self.config.validated_max_blocks_per_tick()?;
-        let last_block = common_latest.min(self.next_block.saturating_add(max_blocks - 1));
+        let last_block = common_unsafe.min(self.next_block.saturating_add(max_blocks - 1));
         let mut stats = L2BlockParityStats::default();
 
         for number in self.next_block..=last_block {
@@ -292,7 +320,8 @@ where
                     self.next_block = next_block;
                 }
                 Err(error) => {
-                    L2BlockParityMetrics::fetch_errors_total().increment(1);
+                    L2BlockParityMetrics::fetch_errors_total(L2BlockParityMetrics::SCOPE_BLOCK)
+                        .increment(1);
                     warn!(
                         error = %error,
                         l2_block = %number,
@@ -303,13 +332,8 @@ where
             }
         }
 
-        let caught_up = self.next_block > common_latest;
-        let aligned = if caught_up && stats.is_aligned() && sequencer_latest == validator_latest {
-            1.0
-        } else {
-            0.0
-        };
-        L2BlockParityMetrics::aligned().set(aligned);
+        L2BlockParityMetrics::verification_backlog_blocks()
+            .set(self.verification_backlog(common_unsafe) as f64);
 
         if stats.checked > 0 || stats.missing_blocks > 0 {
             debug!(
@@ -318,8 +342,8 @@ where
                 mismatches = %stats.mismatches,
                 missing_blocks = %stats.missing_blocks,
                 next_block = %self.next_block,
-                sequencer_latest = %sequencer_latest,
-                validator_latest = %validator_latest,
+                sequencer_unsafe = %sequencer_unsafe,
+                validator_unsafe = %validator_unsafe,
                 "derived L2 block parity pass processed"
             );
         }
@@ -372,6 +396,9 @@ where
                 stats.mismatches += 1;
                 L2BlockParityMetrics::checked_total().increment(1);
                 L2BlockParityMetrics::mismatches_total().increment(1);
+                // Latched for the process lifetime: a divergence is a permanent fact about the
+                // chain, not a condition that clears once the next block happens to match.
+                L2BlockParityMetrics::divergence_detected().set(1.0);
                 L2BlockParityMetrics::last_checked_l2_block().set(sequencer.number as f64);
                 L2BlockParityMetrics::last_mismatch_l2_block().set(sequencer.number as f64);
                 let tx_mismatch = sequencer.first_tx_hash_mismatch(&validator);
@@ -425,15 +452,17 @@ mod tests {
 
     #[derive(Debug, Default)]
     struct MockL2BlockProvider {
-        latest: u64,
+        unsafe_head: u64,
+        safe_head: u64,
         blocks: BTreeMap<u64, L2BlockSnapshot>,
         fail_blocks: BTreeSet<u64>,
     }
 
     impl MockL2BlockProvider {
-        fn new(latest: u64, blocks: impl IntoIterator<Item = L2BlockSnapshot>) -> Self {
+        fn new(unsafe_head: u64, blocks: impl IntoIterator<Item = L2BlockSnapshot>) -> Self {
             Self {
-                latest,
+                unsafe_head,
+                safe_head: unsafe_head,
                 blocks: blocks.into_iter().map(|block| (block.number, block)).collect(),
                 fail_blocks: BTreeSet::new(),
             }
@@ -447,8 +476,12 @@ mod tests {
 
     #[async_trait]
     impl L2BlockProvider for Arc<Mutex<MockL2BlockProvider>> {
-        async fn latest_block_number(&self) -> eyre::Result<u64> {
-            Ok(self.lock().await.latest)
+        async fn unsafe_block_number(&self) -> eyre::Result<u64> {
+            Ok(self.lock().await.unsafe_head)
+        }
+
+        async fn safe_block_number(&self) -> eyre::Result<u64> {
+            Ok(self.lock().await.safe_head)
         }
 
         async fn block_by_number(&self, number: u64) -> eyre::Result<Option<L2BlockSnapshot>> {
@@ -548,6 +581,22 @@ mod tests {
 
         assert_eq!(stats, L2BlockParityStats::default());
         assert_eq!(monitor.next_block, 4);
+    }
+
+    #[tokio::test]
+    async fn verification_backlog_counts_blocks_left_below_the_common_unsafe_head() {
+        let sequencer = Arc::new(Mutex::new(MockL2BlockProvider::new(9, [])));
+        let validator = Arc::new(Mutex::new(MockL2BlockProvider::new(9, [])));
+        let config = L2BlockParityMonitorConfig::new(7, Duration::from_secs(1));
+        let monitor = L2BlockParityMonitor::new(sequencer, validator, config);
+
+        // Blocks 7, 8 and 9 are comparable and none has been compared yet.
+        assert_eq!(monitor.verification_backlog(9), 3);
+        // Caught up: the cursor sits one past the common unsafe head.
+        assert_eq!(monitor.verification_backlog(6), 0);
+        // A common unsafe head below the cursor is a validator that has not caught up,
+        // not backlog.
+        assert_eq!(monitor.verification_backlog(2), 0);
     }
 
     #[tokio::test]

--- a/crates/batcher/service/src/metrics.rs
+++ b/crates/batcher/service/src/metrics.rs
@@ -4,12 +4,29 @@ base_metrics::define_metrics! {
     batcher.l2_block_parity, struct = L2BlockParityMetrics,
     #[describe("Whether derived L2 block parity monitoring is running")]
     enabled: gauge,
-    #[describe("Latest L2 block reported by the sequencer RPC")]
-    sequencer_latest_l2_block: gauge,
-    #[describe("Latest L2 block reported by the shadow parity validator RPC")]
-    validator_latest_l2_block: gauge,
-    #[describe("Current sequencer-to-validator L2 block lag")]
-    lag_blocks: gauge,
+    #[describe("Whether a derived L2 block hash mismatch has been observed since process start")]
+    divergence_detected: gauge,
+    #[describe("L2 block this monitor run started comparing from")]
+    #[no_zero]
+    start_l2_block: gauge,
+    #[describe("Unsafe L2 head reported by the sequencer RPC")]
+    #[no_zero]
+    sequencer_unsafe_l2_block: gauge,
+    #[describe("Safe L2 head reported by the sequencer RPC")]
+    #[no_zero]
+    sequencer_safe_l2_block: gauge,
+    #[describe("Unsafe L2 head reported by the shadow parity validator RPC")]
+    #[no_zero]
+    validator_unsafe_l2_block: gauge,
+    #[describe("Safe L2 head reported by the shadow parity validator RPC")]
+    #[no_zero]
+    validator_safe_l2_block: gauge,
+    #[describe("Blocks the validator unsafe L2 head trails the sequencer unsafe L2 head")]
+    #[no_zero]
+    validator_unsafe_lag_blocks: gauge,
+    #[describe("Comparable derived L2 blocks not compared yet")]
+    #[no_zero]
+    verification_backlog_blocks: gauge,
     #[describe("Total derived L2 blocks compared")]
     checked_total: counter,
     #[describe("Total derived L2 block hash matches")]
@@ -18,10 +35,11 @@ base_metrics::define_metrics! {
     mismatches_total: counter,
     #[describe("Total derived L2 blocks skipped because one side did not return the block")]
     missing_blocks_total: counter,
-    #[describe("Total RPC fetch errors seen by derived L2 block parity monitoring")]
+    #[describe(
+        "Total errors that prevent a parity pass or block comparison from completing, by scope"
+    )]
+    #[label(name = "scope", default = ["pass", "block"])]
     fetch_errors_total: counter,
-    #[describe("Latest derived L2 block parity alignment state: 1 for aligned, 0 for mismatch or lag")]
-    aligned: gauge,
     #[describe("Latest L2 block compared by derived block parity monitoring")]
     #[no_zero]
     last_checked_l2_block: gauge,
@@ -31,4 +49,12 @@ base_metrics::define_metrics! {
     #[describe("Latest derived L2 block where parity mismatched")]
     #[no_zero]
     last_mismatch_l2_block: gauge,
+}
+
+impl L2BlockParityMetrics {
+    /// An error aborted the pass before it compared any block.
+    pub const SCOPE_PASS: &'static str = "pass";
+
+    /// An error aborted one block comparison, leaving the cursor parked on that height.
+    pub const SCOPE_BLOCK: &'static str = "block";
 }

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -162,7 +162,10 @@ pub struct ConsensusFollowNodeConfigArgs {
 impl ConsensusFollowNodeArgs {
     /// Loads the configured L2 rollup config.
     pub fn load_rollup_config(&self) -> eyre::Result<RollupConfig> {
-        self.config.l2_config.load(&self.chain.l2_chain_id).map_err(|e| eyre::eyre!(e))
+        let mut config =
+            self.config.l2_config.load(&self.chain.l2_chain_id).map_err(|e| eyre::eyre!(e))?;
+        self.config.l1_rpc_args.apply_da_batch_inbox_override(&mut config);
+        Ok(config)
     }
 
     /// Builds a follow node with default external endpoint configuration.
@@ -288,6 +291,8 @@ impl ConsensusFollowNodeArgs {
 
 #[cfg(test)]
 mod tests {
+    use alloy_chains::Chain;
+    use alloy_primitives::address;
     use clap::Parser;
 
     use super::*;
@@ -316,6 +321,23 @@ mod tests {
     #[test]
     fn proofs_default_to_disabled() {
         assert!(!parse_config(&[]).proofs);
+    }
+
+    #[test]
+    fn applies_da_batch_inbox_override() {
+        let inbox = address!("3333333333333333333333333333333333333333");
+        let config = parse_config(&[
+            "--l1.dangerously-override-da-batch-inbox",
+            "0x3333333333333333333333333333333333333333",
+        ]);
+        let args = ConsensusFollowNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            config,
+        );
+
+        let config = args.load_rollup_config().unwrap();
+
+        assert_eq!(config.batch_inbox_address, inbox);
     }
 
     #[test]

--- a/crates/consensus/cli/src/l1.rs
+++ b/crates/consensus/cli/src/l1.rs
@@ -3,7 +3,9 @@
 use std::{num::ParseIntError, time::Duration};
 
 use alloy_primitives::Address;
+use base_common_genesis::RollupConfig;
 use base_consensus_providers::L1_RPC_TIMEOUT;
+use tracing::warn;
 use url::Url;
 
 const DEFAULT_L1_TRUST_RPC: bool = true;
@@ -54,6 +56,13 @@ pub struct L1ClientArgs {
         env = "BASE_NODE_L1_DANGEROUSLY_OVERRIDE_DA_BATCHER_SENDER"
     )]
     pub l1_da_batcher_sender_override: Option<Address>,
+    /// Dangerous validator-only override for the batch inbox accepted by the L1
+    /// data-availability pipeline.
+    #[arg(
+        long = "l1.dangerously-override-da-batch-inbox",
+        env = "BASE_NODE_L1_DANGEROUSLY_OVERRIDE_DA_BATCH_INBOX"
+    )]
+    pub l1_da_batch_inbox_override: Option<Address>,
     /// Number of L1 blocks to keep distance from the L1 head for the verifier (derivation
     /// pipeline). Controlled via `BASE_NODE_VERIFIER_L1_CONFS`. Defaults to 0, meaning
     /// the verifier derives from the latest L1 head with no confirmation delay.
@@ -82,8 +91,26 @@ impl Default for L1ClientArgs {
             l1_beacon: Url::parse("http://localhost:5052").unwrap(),
             l1_slot_duration_override: None,
             l1_da_batcher_sender_override: None,
+            l1_da_batch_inbox_override: None,
             l1_verifier_confs: 0,
             l1_finalized_poll_interval: None,
+        }
+    }
+}
+
+impl L1ClientArgs {
+    /// Applies the configured L1 data-availability batch inbox override.
+    pub fn apply_da_batch_inbox_override(&self, config: &mut RollupConfig) {
+        let Some(inbox) = self.l1_da_batch_inbox_override else {
+            return;
+        };
+        if config.batch_inbox_address != inbox {
+            warn!(
+                configured_inbox = %config.batch_inbox_address,
+                override_inbox = %inbox,
+                "overriding the L1 data-availability batch inbox filter"
+            );
+            config.batch_inbox_address = inbox;
         }
     }
 }

--- a/crates/consensus/cli/src/node.rs
+++ b/crates/consensus/cli/src/node.rs
@@ -351,7 +351,11 @@ impl From<EmbeddedSequencerConsensusNodeConfigArgs> for ConsensusNodeConfigArgs 
 impl ConsensusNodeArgs {
     /// Loads the configured L2 rollup config.
     pub fn load_rollup_config(&self) -> eyre::Result<RollupConfig> {
-        self.config.l2_config.load(&self.chain.l2_chain_id).map_err(|e| eyre::eyre!(e))
+        let mut config =
+            self.config.l2_config.load(&self.chain.l2_chain_id).map_err(|e| eyre::eyre!(e))?;
+        self.validate_da_batch_inbox_override()?;
+        self.config.l1_rpc_args.apply_da_batch_inbox_override(&mut config);
+        Ok(config)
     }
 
     /// Validates that a non-shadow sequencer has a signing key configured.
@@ -381,6 +385,18 @@ impl ConsensusNodeArgs {
         {
             eyre::bail!(
                 "--l1.dangerously-override-da-batcher-sender is only supported in validator mode"
+            );
+        }
+        Ok(())
+    }
+
+    /// Validates that the dangerous DA batch inbox override is only used by validators.
+    pub fn validate_da_batch_inbox_override(&self) -> eyre::Result<()> {
+        if self.config.l1_rpc_args.l1_da_batch_inbox_override.is_some()
+            && !self.config.node_mode.is_validator()
+        {
+            eyre::bail!(
+                "--l1.dangerously-override-da-batch-inbox is only supported in validator mode"
             );
         }
         Ok(())
@@ -418,6 +434,8 @@ impl ConsensusNodeArgs {
     ) -> eyre::Result<RollupNode> {
         self.validate_sequencer_key()?;
         self.validate_da_batcher_sender_override()?;
+        self.validate_da_batch_inbox_override()?;
+        self.config.l1_rpc_args.apply_da_batch_inbox_override(&mut cfg);
         if let Some(sender) = self.config.l1_rpc_args.l1_da_batcher_sender_override {
             warn!(
                 %sender,
@@ -726,6 +744,29 @@ mod tests {
         assert_eq!(config.l1_rpc_args.l1_da_batcher_sender_override, Some(batcher));
     }
 
+    #[test]
+    fn embedded_consensus_applies_da_batch_inbox_override() {
+        let inbox = address!("3333333333333333333333333333333333333333");
+        let args = CommandParser::<EmbeddedConsensusNodeConfigArgs>::parse_from([
+            "base",
+            "--l1-eth-rpc",
+            "http://localhost:8545",
+            "--l1-beacon",
+            "http://localhost:5052",
+            "--l1.dangerously-override-da-batch-inbox",
+            "0x3333333333333333333333333333333333333333",
+        ])
+        .args;
+        let args = ConsensusNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            ConsensusNodeConfigArgs::from(args),
+        );
+
+        let config = args.load_rollup_config().unwrap();
+
+        assert_eq!(config.batch_inbox_address, inbox);
+    }
+
     fn upgrade_schedule(signals: &[(BaseUpgrade, u64)]) -> UpgradeSignalSchedule {
         UpgradeSignalSchedule::new(
             1,
@@ -939,6 +980,29 @@ mod tests {
         );
 
         assert!(args.validate_da_batcher_sender_override().is_err());
+    }
+
+    #[test]
+    fn da_batch_inbox_override_is_rejected_in_sequencer_mode() {
+        let args = ConsensusNodeArgs::new(
+            ConsensusChainArgs { l2_chain_id: Chain::from(8453_u64) },
+            ConsensusNodeConfigArgs {
+                node_mode: NodeMode::Sequencer,
+                l1_rpc_args: L1ClientArgs {
+                    l1_da_batch_inbox_override: Some(address!(
+                        "3333333333333333333333333333333333333333"
+                    )),
+                    ..L1ClientArgs::default()
+                },
+                ..default_node_config_args()
+            },
+        );
+
+        let error = args.load_rollup_config().unwrap_err();
+
+        assert!(error.to_string().contains(
+            "--l1.dangerously-override-da-batch-inbox is only supported in validator mode"
+        ));
     }
 
     #[test]

--- a/crates/utilities/tx-manager/src/lib.rs
+++ b/crates/utilities/tx-manager/src/lib.rs
@@ -40,7 +40,7 @@ mod queue;
 pub use queue::{SendResult, TxQueue};
 
 mod metrics;
-pub use metrics::{BaseTxMetrics, NoopTxMetrics, TxManagerMetrics, TxMetrics};
+pub use metrics::{BaseTxMetrics, NoopTxMetrics, SendOutcome, TxManagerMetrics, TxMetrics};
 
 mod blob;
 pub use blob::{BlobTxBuilder, MAX_BLOBS_PER_TX};

--- a/crates/utilities/tx-manager/src/manager.rs
+++ b/crates/utilities/tx-manager/src/manager.rs
@@ -62,8 +62,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     BlobTxBuilder, BumpedFees, FeeCalculator, FeeOverride, GasPriceCaps, NonceManager,
-    RpcErrorClassifier, SendHandle, SendResponse, SendState, SignerConfig, TxCandidate, TxManager,
-    TxManagerConfig, TxManagerError, TxManagerResult, TxMetrics,
+    RpcErrorClassifier, SendHandle, SendOutcome, SendResponse, SendState, SignerConfig,
+    TxCandidate, TxManager, TxManagerConfig, TxManagerError, TxManagerResult, TxMetrics,
 };
 
 /// Number of wei in one gwei (10^9), as `f64` for fractional-precision
@@ -598,7 +598,7 @@ where
                 let raw_blob_cap = FeeCalculator::calc_blob_fee_cap(raw_blob_base_fee);
                 let blob_base_fee = raw_blob_base_fee.max(self.config.min_blob_fee);
                 let blob_cap = FeeCalculator::calc_blob_fee_cap(blob_base_fee);
-                self.metrics.record_blob_fee(blob_cap as f64 / WEI_PER_GWEI);
+                self.metrics.record_blob_fee_cap(blob_cap as f64 / WEI_PER_GWEI);
                 (Some(blob_cap), Some(raw_blob_cap))
             }
             None => (None, None),
@@ -1007,11 +1007,12 @@ where
 
         let latency_ms =
             u64::try_from(self.runtime.now().saturating_sub(start).as_millis()).unwrap_or(u64::MAX);
-        self.metrics.record_send_latency(latency_ms);
 
         if result.is_ok() {
+            self.metrics.record_send_latency(latency_ms, SendOutcome::Confirmed);
             self.metrics.record_tx_confirmed();
         } else {
+            self.metrics.record_send_latency(latency_ms, SendOutcome::Failed);
             self.metrics.record_tx_failed();
         }
 

--- a/crates/utilities/tx-manager/src/metrics.rs
+++ b/crates/utilities/tx-manager/src/metrics.rs
@@ -8,18 +8,19 @@ base_metrics::define_metrics! {
     #[describe("Maximum possible transaction fee in gwei")]
     #[label(name)]
     tx_max_fee_gwei: histogram,
-    #[describe("Number of gas bump events")]
+    #[describe("Total number of gas bump events")]
     #[label(name)]
-    tx_gas_bump_count: counter,
-    #[describe("Send-loop latency in milliseconds")]
+    tx_gas_bump_total: counter,
+    #[describe("Send-loop latency in milliseconds, by outcome")]
     #[label(name)]
+    #[label(name = "outcome")]
     tx_send_latency_ms: histogram,
     #[describe("Current nonce value")]
     #[label(name)]
     current_nonce: gauge,
-    #[describe("Number of transaction publish errors")]
+    #[describe("Total number of transaction publish errors")]
     #[label(name)]
-    tx_publish_error_count: counter,
+    tx_publish_error_total: counter,
     #[describe("Base fee in gwei")]
     #[label(name)]
     basefee_gwei: gauge,
@@ -28,16 +29,37 @@ base_metrics::define_metrics! {
     tipcap_gwei: gauge,
     #[describe("Blob fee cap in gwei")]
     #[label(name)]
-    blob_fee_gwei: gauge,
-    #[describe("Number of RPC errors")]
+    blob_fee_cap_gwei: gauge,
+    #[describe("Total number of RPC errors")]
     #[label(name)]
-    rpc_error_count: counter,
-    #[describe("Number of confirmed transactions")]
+    rpc_error_total: counter,
+    #[describe("Total number of confirmed transactions")]
     #[label(name)]
-    tx_confirmed_count: counter,
-    #[describe("Number of failed send attempts (includes timeouts where the tx may still confirm)")]
+    tx_confirmed_total: counter,
+    #[describe(
+        "Total failed send attempts, including timeouts where the transaction may still confirm"
+    )]
     #[label(name)]
-    tx_failed_count: counter,
+    tx_failed_total: counter,
+}
+
+/// How a send loop ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendOutcome {
+    /// The transaction reached the required confirmation depth.
+    Confirmed,
+    /// The send returned an error, including timeouts where the transaction may still confirm.
+    Failed,
+}
+
+impl SendOutcome {
+    /// Returns the metric label value.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Confirmed => "confirmed",
+            Self::Failed => "failed",
+        }
+    }
 }
 
 /// Trait abstracting metrics collection for the transaction manager.
@@ -51,8 +73,8 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
     /// Record a gas bump event.
     fn record_gas_bump(&self);
 
-    /// Record the send-loop latency in milliseconds (all exit paths).
-    fn record_send_latency(&self, latency_ms: u64);
+    /// Record the send-loop latency in milliseconds, split by how the send ended.
+    fn record_send_latency(&self, latency_ms: u64, outcome: SendOutcome);
 
     /// Record the current nonce.
     fn record_current_nonce(&self, nonce: u64);
@@ -67,7 +89,7 @@ pub trait TxMetrics: Send + Sync + Debug + 'static {
     fn record_tipcap(&self, tipcap_gwei: f64);
 
     /// Record the blob fee cap in gwei (fractional precision preserved).
-    fn record_blob_fee(&self, blob_fee_gwei: f64);
+    fn record_blob_fee_cap(&self, blob_fee_cap_gwei: f64);
 
     /// Record an RPC error.
     fn record_rpc_error(&self);
@@ -96,12 +118,12 @@ pub struct NoopTxMetrics;
 impl TxMetrics for NoopTxMetrics {
     fn record_tx_max_fee(&self, _fee_gwei: f64) {}
     fn record_gas_bump(&self) {}
-    fn record_send_latency(&self, _latency_ms: u64) {}
+    fn record_send_latency(&self, _latency_ms: u64, _outcome: SendOutcome) {}
     fn record_current_nonce(&self, _nonce: u64) {}
     fn record_publish_error(&self) {}
     fn record_basefee(&self, _basefee_gwei: f64) {}
     fn record_tipcap(&self, _tipcap_gwei: f64) {}
-    fn record_blob_fee(&self, _blob_fee_gwei: f64) {}
+    fn record_blob_fee_cap(&self, _blob_fee_cap_gwei: f64) {}
     fn record_rpc_error(&self) {}
     fn record_tx_confirmed(&self) {}
     fn record_tx_failed(&self) {}
@@ -130,15 +152,15 @@ impl BaseTxMetrics {
     /// immediately in the metrics endpoint.
     pub fn new(name: &'static str) -> Self {
         let this = Self { name };
-        TxManagerMetrics::tx_gas_bump_count(name).absolute(0);
+        TxManagerMetrics::tx_gas_bump_total(name).absolute(0);
         TxManagerMetrics::current_nonce(name).set(0.0);
-        TxManagerMetrics::tx_publish_error_count(name).absolute(0);
+        TxManagerMetrics::tx_publish_error_total(name).absolute(0);
         TxManagerMetrics::basefee_gwei(name).set(0.0);
         TxManagerMetrics::tipcap_gwei(name).set(0.0);
-        TxManagerMetrics::blob_fee_gwei(name).set(0.0);
-        TxManagerMetrics::rpc_error_count(name).absolute(0);
-        TxManagerMetrics::tx_confirmed_count(name).absolute(0);
-        TxManagerMetrics::tx_failed_count(name).absolute(0);
+        TxManagerMetrics::blob_fee_cap_gwei(name).set(0.0);
+        TxManagerMetrics::rpc_error_total(name).absolute(0);
+        TxManagerMetrics::tx_confirmed_total(name).absolute(0);
+        TxManagerMetrics::tx_failed_total(name).absolute(0);
         this
     }
 }
@@ -149,11 +171,11 @@ impl TxMetrics for BaseTxMetrics {
     }
 
     fn record_gas_bump(&self) {
-        TxManagerMetrics::tx_gas_bump_count(self.name).increment(1);
+        TxManagerMetrics::tx_gas_bump_total(self.name).increment(1);
     }
 
-    fn record_send_latency(&self, latency_ms: u64) {
-        TxManagerMetrics::tx_send_latency_ms(self.name).record(latency_ms as f64);
+    fn record_send_latency(&self, latency_ms: u64, outcome: SendOutcome) {
+        TxManagerMetrics::tx_send_latency_ms(self.name, outcome.as_str()).record(latency_ms as f64);
     }
 
     fn record_current_nonce(&self, nonce: u64) {
@@ -161,7 +183,7 @@ impl TxMetrics for BaseTxMetrics {
     }
 
     fn record_publish_error(&self) {
-        TxManagerMetrics::tx_publish_error_count(self.name).increment(1);
+        TxManagerMetrics::tx_publish_error_total(self.name).increment(1);
     }
 
     fn record_basefee(&self, basefee_gwei: f64) {
@@ -172,20 +194,20 @@ impl TxMetrics for BaseTxMetrics {
         TxManagerMetrics::tipcap_gwei(self.name).set(tipcap_gwei);
     }
 
-    fn record_blob_fee(&self, blob_fee_gwei: f64) {
-        TxManagerMetrics::blob_fee_gwei(self.name).set(blob_fee_gwei);
+    fn record_blob_fee_cap(&self, blob_fee_cap_gwei: f64) {
+        TxManagerMetrics::blob_fee_cap_gwei(self.name).set(blob_fee_cap_gwei);
     }
 
     fn record_rpc_error(&self) {
-        TxManagerMetrics::rpc_error_count(self.name).increment(1);
+        TxManagerMetrics::rpc_error_total(self.name).increment(1);
     }
 
     fn record_tx_confirmed(&self) {
-        TxManagerMetrics::tx_confirmed_count(self.name).increment(1);
+        TxManagerMetrics::tx_confirmed_total(self.name).increment(1);
     }
 
     fn record_tx_failed(&self) {
-        TxManagerMetrics::tx_failed_count(self.name).increment(1);
+        TxManagerMetrics::tx_failed_total(self.name).increment(1);
     }
 }
 
@@ -198,12 +220,12 @@ mod tests {
         let m = NoopTxMetrics;
         m.record_tx_max_fee(1.5);
         m.record_gas_bump();
-        m.record_send_latency(120);
+        m.record_send_latency(120, SendOutcome::Confirmed);
         m.record_current_nonce(42);
         m.record_publish_error();
         m.record_basefee(30.123);
         m.record_tipcap(2.456);
-        m.record_blob_fee(1.0);
+        m.record_blob_fee_cap(1.0);
         m.record_rpc_error();
         m.record_tx_confirmed();
         m.record_tx_failed();
@@ -214,12 +236,12 @@ mod tests {
         let m = BaseTxMetrics::new("test");
         m.record_tx_max_fee(1.5);
         m.record_gas_bump();
-        m.record_send_latency(120);
+        m.record_send_latency(120, SendOutcome::Failed);
         m.record_current_nonce(42);
         m.record_publish_error();
         m.record_basefee(30.123);
         m.record_tipcap(2.456);
-        m.record_blob_fee(1.0);
+        m.record_blob_fee_cap(1.0);
         m.record_rpc_error();
         m.record_tx_confirmed();
         m.record_tx_failed();


### PR DESCRIPTION
## Summary

Backport #4766 and #4884 to `releases/v1.3.2`:

- expose queryable parity, pipeline, channel, submission, and transaction-manager metrics for the shadow batcher
- add a validator batch inbox override so the parity validator can derive from the shadow batcher's inbox
- adapt the encoder metrics to the `v1.3.2` architecture, which uses one frame per blob and different channel-close reasons

## Backported commits

- `ea5d65cee` — fix(batcher): make parity and submission metrics queryable (#4766)
- `55e8c656a` — feat(consensus): support validator batch inbox override (#4884)

## Validation

- `git diff --cached --check`
- Full Rust build and tests deferred to CI.

Merging this PR will push to `releases/v1.3.2` and automatically start a new Create RC run.

type=routine
risk=low
impact=sev5
