### PR TITLE
fix(consensus): reject non-canonical transaction encodings

### DIFF
--- a/crates/common/consensus/src/lib.rs
+++ b/crates/common/consensus/src/lib.rs
@@ -33,7 +33,7 @@ pub use transaction::{
     DEPOSIT_TX_TYPE_ID, Delegation, DepositInfo, DepositTransaction, EIP8130_REJECTION_MSG,
     EIP8130_TX_TYPE_ID, Eip8130Constants, Eip8130Contracts, Eip8130Signed, Eip8130StaticError,
     Eip8130TimestampError, InitialActor, OpTxType, Scope, SignedAccountChanges, SignedChange,
-    TxDeposit, TxEip8130,
+    TxDeposit, TxEip8130, decode_2718_canonical,
 };
 
 mod extra;

--- a/crates/common/consensus/src/transaction/canonical.rs
+++ b/crates/common/consensus/src/transaction/canonical.rs
@@ -1,0 +1,73 @@
+//! Canonical EIP-2718 transaction decoding.
+
+use alloy_eips::{
+    Decodable2718, Encodable2718,
+    eip2718::{Eip2718Error, Eip2718Result},
+};
+
+/// Decodes an EIP-2718 transaction and requires that `bytes` is its canonical encoding.
+///
+/// `decode_2718_exact` accepts inputs that re-encode differently, including a typed transaction
+/// body without its type byte and a legacy transaction with a `0x00` type byte. Consensus inputs
+/// must retain their wire encoding, so non-round-tripping transactions are rejected.
+pub fn decode_2718_canonical<T: Decodable2718 + Encodable2718>(bytes: &[u8]) -> Eip2718Result<T> {
+    let transaction = T::decode_2718_exact(bytes)?;
+
+    if transaction.encode_2718_len() != bytes.len() || transaction.encoded_2718() != bytes {
+        return Err(Eip2718Error::RlpError(alloy_rlp::Error::Custom(
+            "non-canonical transaction encoding",
+        )));
+    }
+
+    Ok(transaction)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{SignableTransaction, TxEip1559, TxLegacy};
+    use alloy_primitives::{Address, Bytes, Signature, U256};
+
+    use crate::BaseTxEnvelope;
+
+    #[test]
+    fn rejects_typed_body_without_type_byte() {
+        let encoded = TxEip1559 {
+            chain_id: 8453,
+            nonce: 1,
+            gas_limit: 21_000,
+            max_fee_per_gas: 2,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO.into(),
+            value: U256::ZERO,
+            access_list: Default::default(),
+            input: Bytes::new(),
+        }
+        .into_signed(Signature::test_signature())
+        .encoded_2718();
+
+        assert_eq!(encoded[0], 0x02);
+        assert!(decode_2718_canonical::<BaseTxEnvelope>(&encoded).is_ok());
+        assert!(decode_2718_canonical::<BaseTxEnvelope>(&encoded[1..]).is_err());
+    }
+
+    #[test]
+    fn rejects_type_tagged_legacy_transaction() {
+        let encoded = TxLegacy {
+            chain_id: Some(8453),
+            nonce: 1,
+            gas_price: 2,
+            gas_limit: 21_000,
+            to: Address::ZERO.into(),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        }
+        .into_signed(Signature::test_signature())
+        .encoded_2718();
+        let mut tagged = vec![0x00];
+        tagged.extend_from_slice(&encoded);
+
+        assert!(decode_2718_canonical::<BaseTxEnvelope>(&encoded).is_ok());
+        assert!(decode_2718_canonical::<BaseTxEnvelope>(&tagged).is_err());
+    }
+}

--- a/crates/common/consensus/src/transaction/deposit.rs
+++ b/crates/common/consensus/src/transaction/deposit.rs
@@ -310,9 +310,9 @@ impl Decodable2718 for TxDeposit {
         Ok(tx)
     }
 
-    fn fallback_decode(data: &mut &[u8]) -> Eip2718Result<Self> {
-        let tx = Self::decode(data)?;
-        Ok(tx)
+    fn fallback_decode(_data: &mut &[u8]) -> Eip2718Result<Self> {
+        // Deposits have no untyped form: reaching untyped dispatch means the 0x7E tag was absent.
+        Err(Eip2718Error::UnexpectedType(OpTxType::Deposit as u8))
     }
 }
 
@@ -489,6 +489,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::BaseTxEnvelope;
 
     #[test]
     fn test_deposit_transaction_trait() {
@@ -555,6 +556,15 @@ mod tests {
         let mut buf_a = BytesMut::default();
         tx_a.encode(&mut buf_a);
         assert_eq!(&buf_a[..], &bytes[1..]);
+    }
+
+    #[test]
+    fn bare_deposit_body_is_rejected() {
+        let encoded = TxDeposit::default().encoded_2718();
+
+        assert_eq!(encoded[0], OpTxType::Deposit as u8);
+        assert!(BaseTxEnvelope::decode_2718_exact(&encoded).is_ok());
+        assert!(BaseTxEnvelope::decode_2718_exact(&encoded[1..]).is_err());
     }
 
     #[test]

--- a/crates/common/consensus/src/transaction/envelope.rs
+++ b/crates/common/consensus/src/transaction/envelope.rs
@@ -24,14 +24,6 @@ use crate::{
 
 /// The Ethereum [EIP-2718] Transaction Envelope, modified for Base.
 ///
-/// # Note:
-///
-/// This enum distinguishes between tagged and untagged legacy transactions, as
-/// the in-protocol merkle tree may commit to EITHER 0-prefixed or raw.
-/// Therefore we must ensure that encoding returns the precise byte-array that
-/// was decoded, preserving the presence or absence of the `TransactionType`
-/// flag.
-///
 /// [EIP-2718]: https://eips.ethereum.org/EIPS/eip-2718
 #[derive(Debug, Clone, TransactionEnvelope)]
 #[envelope(tx_type_name = OpTxType, typed = BaseTypedTransaction, serde_cfg(feature = "serde"))]

--- a/crates/common/consensus/src/transaction/mod.rs
+++ b/crates/common/consensus/src/transaction/mod.rs
@@ -1,5 +1,8 @@
 //! Transaction types for Base chains.
 
+mod canonical;
+pub use canonical::decode_2718_canonical;
+
 mod deposit;
 pub use deposit::{DepositTransaction, TxDeposit};
 

--- a/crates/common/rpc-types-engine/src/attributes.rs
+++ b/crates/common/rpc-types-engine/src/attributes.rs
@@ -3,7 +3,6 @@
 use alloc::vec::Vec;
 
 use alloy_eips::{
-    Decodable2718,
     eip1559::BaseFeeParams,
     eip2718::{Eip2718Result, WithEncoded},
 };
@@ -11,7 +10,7 @@ use alloy_primitives::{B64, B256, Bytes, keccak256};
 use alloy_rlp::{Encodable, Result};
 use alloy_rpc_types_engine::{PayloadAttributes, PayloadId};
 use base_common_consensus::{
-    BaseTxEnvelope, EIP1559ParamError, HoloceneExtraData, JovianExtraData,
+    BaseTxEnvelope, EIP1559ParamError, HoloceneExtraData, JovianExtraData, decode_2718_canonical,
 };
 use sha2::Digest;
 
@@ -148,10 +147,7 @@ impl BasePayloadAttributes {
     ///
     /// This iterator will be empty if there are no transactions in the attributes.
     pub fn decoded_transactions(&self) -> impl Iterator<Item = Eip2718Result<BaseTxEnvelope>> + '_ {
-        self.transactions
-            .iter()
-            .flatten()
-            .map(|tx_bytes| BaseTxEnvelope::decode_2718_exact(tx_bytes.as_ref()))
+        self.transactions.iter().flatten().map(|tx_bytes| decode_2718_canonical(tx_bytes.as_ref()))
     }
 
     /// Returns iterator over decoded transactions with their original encoded bytes.
@@ -215,10 +211,37 @@ mod test {
     use alloc::vec;
     use core::str::FromStr;
 
-    use alloy_primitives::{Address, B256, FixedBytes, address, b64, b256, bytes};
+    use alloy_consensus::{SignableTransaction, TxEip1559};
+    use alloy_eips::Encodable2718;
+    use alloy_primitives::{
+        Address, B256, Bytes, FixedBytes, Signature, address, b64, b256, bytes,
+    };
     use alloy_rpc_types_engine::PayloadAttributes;
 
     use super::*;
+
+    #[test]
+    fn decoded_transactions_reject_non_canonical_encoding() {
+        let encoded = TxEip1559 {
+            chain_id: 8453,
+            nonce: 1,
+            gas_limit: 21_000,
+            max_fee_per_gas: 2,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO.into(),
+            value: Default::default(),
+            access_list: Default::default(),
+            input: Default::default(),
+        }
+        .into_signed(Signature::test_signature())
+        .encoded_2718();
+        let attributes = BasePayloadAttributes {
+            transactions: Some(vec![Bytes::copy_from_slice(&encoded[1..])]),
+            ..Default::default()
+        };
+
+        assert!(attributes.decoded_transactions().next().unwrap().is_err());
+    }
 
     #[test]
     fn test_payload_id_parity_op_geth() {

--- a/crates/common/rpc-types-engine/src/payload/mod.rs
+++ b/crates/common/rpc-types-engine/src/payload/mod.rs
@@ -27,6 +27,7 @@ use alloy_rpc_types_engine::{
 pub use v5::BaseExecutionPayloadEnvelopeV5;
 
 use crate::BaseExecutionPayloadSidecar;
+use base_common_consensus::decode_2718_canonical;
 
 /// An execution payload, which can be either [`ExecutionPayloadV2`], [`ExecutionPayloadV3`], or
 /// [`BaseExecutionPayloadV4`].
@@ -593,11 +594,11 @@ impl BaseExecutionPayload {
     /// - `parent_beacon_block_root`
     ///
     /// See also: [`BaseExecutionPayload::try_into_block_with_sidecar`]
-    pub fn try_into_block<T: Decodable2718 + Typed2718>(
+    pub fn try_into_block<T: Decodable2718 + Encodable2718 + Typed2718>(
         self,
     ) -> Result<Block<T>, BasePayloadError> {
         self.try_into_block_with(|tx| {
-            T::decode_2718_exact(tx.as_ref())
+            decode_2718_canonical(tx.as_ref())
                 .map_err(alloy_rlp::Error::from)
                 .map_err(PayloadError::from)
         })
@@ -648,12 +649,12 @@ impl BaseExecutionPayload {
     ///
     /// See also docs for
     /// [`ExecutionPayload::try_into_block_with_sidecar`](alloy_rpc_types_engine::ExecutionPayload::try_into_block_with_sidecar).
-    pub fn try_into_block_with_sidecar<T: Decodable2718 + Typed2718>(
+    pub fn try_into_block_with_sidecar<T: Decodable2718 + Encodable2718 + Typed2718>(
         self,
         sidecar: &BaseExecutionPayloadSidecar,
     ) -> Result<Block<T>, BasePayloadError> {
         self.try_into_block_with_sidecar_with(sidecar, |tx| {
-            T::decode_2718_exact(tx.as_ref())
+            decode_2718_canonical(tx.as_ref())
                 .map_err(alloy_rlp::Error::from)
                 .map_err(PayloadError::from)
         })
@@ -699,21 +700,21 @@ impl BaseExecutionPayload {
     /// Returns an iterator over the decoded transactions in this payload.
     ///
     /// This iterator will decode transactions on the fly.
-    pub fn decoded_transactions<T: Decodable2718>(
+    pub fn decoded_transactions<T: Decodable2718 + Encodable2718>(
         &self,
     ) -> impl Iterator<Item = alloy_eips::eip2718::Eip2718Result<T>> + '_ {
-        self.transactions().iter().map(|tx_bytes| T::decode_2718_exact(tx_bytes.as_ref()))
+        self.transactions().iter().map(|tx_bytes| decode_2718_canonical::<T>(tx_bytes.as_ref()))
     }
 
     /// Returns iterator over decoded transactions with their original encoded bytes.
     ///
     /// This iterator will decode transactions on the fly and return them with their bytes.
-    pub fn decoded_transactions_with_encoded<T: Decodable2718>(
+    pub fn decoded_transactions_with_encoded<T: Decodable2718 + Encodable2718>(
         &self,
     ) -> impl Iterator<Item = alloy_eips::eip2718::Eip2718Result<alloy_eips::eip2718::WithEncoded<T>>> + '_
     {
         self.transactions().iter().map(|tx_bytes| {
-            T::decode_2718_exact(tx_bytes.as_ref())
+            decode_2718_canonical::<T>(tx_bytes.as_ref())
                 .map(|tx| alloy_eips::eip2718::WithEncoded::new(tx_bytes.clone(), tx))
         })
     }
@@ -730,7 +731,7 @@ impl BaseExecutionPayload {
         >,
     > + '_
     where
-        T: Decodable2718 + alloy_consensus::transaction::SignerRecoverable,
+        T: Decodable2718 + Encodable2718 + alloy_consensus::transaction::SignerRecoverable,
     {
         self.decoded_transactions::<T>().map(|res| {
             res.map_err(alloy_consensus::crypto::RecoveryError::from_source)
@@ -752,10 +753,10 @@ impl BaseExecutionPayload {
         >,
     > + '_
     where
-        T: Decodable2718 + alloy_consensus::transaction::SignerRecoverable,
+        T: Decodable2718 + Encodable2718 + alloy_consensus::transaction::SignerRecoverable,
     {
         self.transactions().iter().map(|tx_bytes| {
-            T::decode_2718_exact(tx_bytes.as_ref())
+            decode_2718_canonical::<T>(tx_bytes.as_ref())
                 .map_err(alloy_consensus::crypto::RecoveryError::from_source)
                 .and_then(|tx| {
                     tx.try_into_recovered().map(|recovered| {

--- a/crates/consensus/engine/src/attributes.rs
+++ b/crates/consensus/engine/src/attributes.rs
@@ -1,11 +1,11 @@
 //! Contains a utility method to check if attributes match a block.
 
-use alloy_eips::{Decodable2718, eip1559::BaseFeeParams};
+use alloy_eips::{Encodable2718, eip1559::BaseFeeParams};
 use alloy_network::TransactionResponse;
 use alloy_primitives::{Address, B256, Bytes};
 use alloy_rpc_types_eth::{Block, BlockTransactions, Withdrawals};
 use base_common_consensus::{
-    BaseTxEnvelope, EIP1559ParamError, HoloceneExtraData, JovianExtraData,
+    BaseTxEnvelope, EIP1559ParamError, HoloceneExtraData, JovianExtraData, decode_2718_canonical,
 };
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types::Transaction;
@@ -147,23 +147,22 @@ impl AttributesMatch {
                 block_tx_hash = %block_tx.tx_hash(),
                 "Checking attributes transaction against block transaction",
             );
-            // Let's try to deserialize the attributes transaction
-            let Ok(attr_tx) = BaseTxEnvelope::decode_2718_exact(attr_tx_bytes.as_ref()) else {
-                error!(
-                    "Impossible to deserialize transaction from attributes. If we have stored these attributes it means the transactions where well formatted. This is a bug"
-                );
+            if attr_tx_bytes.as_ref() == block_tx.inner.inner.inner().encoded_2718().as_slice() {
+                continue;
+            }
 
+            let Ok(attr_tx) = decode_2718_canonical::<BaseTxEnvelope>(attr_tx_bytes) else {
+                warn!(
+                    target: "engine",
+                    ?attr_tx_bytes,
+                    "Attributes transaction is not canonically encoded"
+                );
                 return AttributesMismatch::MalformedAttributesTransaction.into();
             };
 
-            if &attr_tx != block_tx.inner.inner.inner() {
-                warn!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch in derived attributes");
-                return AttributesMismatch::TransactionContent(
-                    attr_tx.tx_hash(),
-                    block_tx.tx_hash(),
-                )
+            warn!(target: "engine", ?attr_tx, ?block_tx, "Transaction mismatch in derived attributes");
+            return AttributesMismatch::TransactionContent(attr_tx.tx_hash(), block_tx.tx_hash())
                 .into();
-            }
         }
 
         Self::Match
@@ -603,6 +602,27 @@ mod tests {
         let (attributes, block) = test_transactions_match_helper();
         let check = AttributesMatch::check(&cfg, &attributes, &block);
         assert_eq!(check, AttributesMatch::Match);
+    }
+
+    #[test]
+    fn attributes_mismatch_non_canonical_transaction_encoding() {
+        let cfg = rollup_config!(ChainConfig::MAINNET);
+        let (mut attributes, block) = loop {
+            let (attributes, block) = test_transactions_match_helper();
+            if attributes.attributes.transactions.as_ref().is_some_and(|transactions| {
+                transactions.iter().any(|tx| matches!(tx[0], 0x01 | 0x02 | 0x04))
+            }) {
+                break (attributes, block);
+            }
+        };
+        let transactions = attributes.attributes.transactions.as_mut().unwrap();
+        let index = transactions.iter().position(|tx| matches!(tx[0], 0x01 | 0x02 | 0x04)).unwrap();
+        transactions[index] = Bytes::copy_from_slice(&transactions[index][1..]);
+
+        assert_eq!(
+            AttributesMatch::check(&cfg, &attributes, &block),
+            AttributesMismatch::MalformedAttributesTransaction.into()
+        );
     }
 
     #[test]

--- a/crates/consensus/protocol/src/attributes.rs
+++ b/crates/consensus/protocol/src/attributes.rs
@@ -89,7 +89,12 @@ impl AttributesWithParent {
 
     /// Returns the number of transactions in the attributes.
     pub fn count_transactions(&self) -> u64 {
-        self.attributes().decoded_transactions().count().try_into().unwrap()
+        self.attributes
+            .transactions
+            .as_ref()
+            .map_or(0, |transactions| transactions.len())
+            .try_into()
+            .unwrap()
     }
 }
 
@@ -111,6 +116,17 @@ mod tests {
         assert_eq!(attributes_with_parent.parent(), &parent);
         assert_eq!(attributes_with_parent.is_last_in_span(), is_last_in_span);
         assert_eq!(attributes_with_parent.derived_from(), None);
+    }
+
+    #[test]
+    fn count_transactions_counts_undecodable_entries() {
+        let attributes = BasePayloadAttributes {
+            transactions: Some(vec![vec![OpTxType::Deposit as u8, 0xaa].into(), vec![0xff].into()]),
+            ..Default::default()
+        };
+        let attributes = AttributesWithParent::new(attributes, L2BlockInfo::default(), None, true);
+
+        assert_eq!(attributes.count_transactions(), 2);
     }
 
     /// Test that the [`AttributesWithParent::as_deposits_only`] method strips out all

--- a/crates/execution/evm/src/config.rs
+++ b/crates/execution/evm/src/config.rs
@@ -3,7 +3,6 @@ use core::{fmt::Debug, marker::PhantomData};
 
 use alloy_consensus::{BlockHeader, Header};
 #[cfg(feature = "std")]
-use alloy_eips::Decodable2718;
 use alloy_evm::{EvmFactory, FromRecoveredTx, FromTxWithEncoded};
 #[cfg(feature = "std")]
 use alloy_primitives::Bytes;
@@ -249,8 +248,10 @@ where
     ) -> Result<impl ExecutableTxIterator<Self>, Self::Error> {
         let transactions = payload.payload.transactions().clone();
         let convert = |encoded: Bytes| {
-            let tx = TxTy::<Self::Primitives>::decode_2718_exact(encoded.as_ref())
-                .map_err(AnyError::new)?;
+            let tx = base_common_consensus::decode_2718_canonical::<TxTy<Self::Primitives>>(
+                encoded.as_ref(),
+            )
+            .map_err(AnyError::new)?;
             let signer = tx.try_recover().map_err(AnyError::new)?;
             Ok::<_, AnyError>(WithEncoded::new(encoded, tx.with_signer(signer)))
         };

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -10,7 +10,7 @@ use alloy_consensus::{
     Block, BlockBody, Header,
     transaction::{Recovered, SignerRecoverable},
 };
-use alloy_eips::{BlockNumberOrTag, Decodable2718};
+use alloy_eips::BlockNumberOrTag;
 use alloy_network::TransactionResponse;
 use alloy_primitives::{Address, BlockNumber};
 use alloy_rpc_types_eth::state::StateOverride;
@@ -472,7 +472,9 @@ where
                     .diff
                     .transactions
                     .iter()
-                    .map(|tx| BaseTxEnvelope::decode_2718_exact(tx.as_ref()))
+                    .map(|tx| {
+                        base_common_consensus::decode_2718_canonical::<BaseTxEnvelope>(tx.as_ref())
+                    })
                     .collect::<std::result::Result<_, _>>()
                     .map_err(|e| ExecutionError::BlockConversion(e.to_string()))?,
                 ..Default::default()

--- a/crates/execution/payload/src/payload.rs
+++ b/crates/execution/payload/src/payload.rs
@@ -4,7 +4,10 @@ use std::{fmt::Debug, sync::Arc};
 
 use alloy_consensus::{Block, BlockHeader};
 use alloy_eips::{
-    eip1559::BaseFeeParams, eip2718::Decodable2718, eip4895::Withdrawals, eip7685::Requests,
+    eip1559::BaseFeeParams,
+    eip2718::{Decodable2718, Encodable2718},
+    eip4895::Withdrawals,
+    eip7685::Requests,
 };
 use alloy_primitives::{Address, B64, B256, Bytes, U256};
 use alloy_rpc_types_engine::{
@@ -13,7 +16,7 @@ use alloy_rpc_types_engine::{
 };
 use base_common_chains::Upgrades;
 use base_common_consensus::{
-    BasePrimitives, EIP1559ParamError, HoloceneExtraData, JovianExtraData,
+    BasePrimitives, EIP1559ParamError, HoloceneExtraData, JovianExtraData, decode_2718_canonical,
 };
 /// Re-export for use in downstream arguments.
 pub use base_common_rpc_types_engine::BasePayloadAttributes;
@@ -139,7 +142,9 @@ impl<T> BasePayloadBuilderAttributes<T> {
     }
 }
 
-impl<T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> BasePayloadBuilderAttributes<T> {
+impl<T: Decodable2718 + Encodable2718 + Send + Sync + Debug + Unpin + 'static>
+    BasePayloadBuilderAttributes<T>
+{
     /// Creates payload builder attributes for the given parent block and RPC payload attributes.
     pub fn try_new(
         parent: B256,
@@ -158,9 +163,7 @@ impl<T: Decodable2718 + Send + Sync + Debug + Unpin + 'static> BasePayloadBuilde
             .transactions
             .unwrap_or_default()
             .into_iter()
-            .map(|data| {
-                Decodable2718::decode_2718_exact(data.as_ref()).map(|tx| WithEncoded::new(data, tx))
-            })
+            .map(|data| decode_2718_canonical(data.as_ref()).map(|tx| WithEncoded::new(data, tx)))
             .collect::<Result<_, _>>()?;
 
         let payload_attributes = EthPayloadBuilderAttributes {
@@ -226,7 +229,7 @@ impl<T> serde::Serialize for BasePayloadBuilderAttributes<T> {
 
 impl<'de, T> serde::Deserialize<'de> for BasePayloadBuilderAttributes<T>
 where
-    T: Decodable2718 + Send + Sync + Debug + Unpin + 'static,
+    T: Decodable2718 + Encodable2718 + Send + Sync + Debug + Unpin + 'static,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -239,7 +242,7 @@ where
 
 impl<T> reth_payload_primitives::PayloadAttributes for BasePayloadBuilderAttributes<T>
 where
-    T: Clone + Decodable2718 + Send + Sync + Debug + Unpin + 'static,
+    T: Clone + Decodable2718 + Encodable2718 + Send + Sync + Debug + Unpin + 'static,
 {
     fn payload_id(&self, parent_hash: &B256) -> PayloadId {
         self.as_rpc_payload_attributes().payload_id(parent_hash, 3)


### PR DESCRIPTION
## Summary

Backports the canonical EIP-2718 transaction-encoding protections from #4970 to `releases/v1.3.2`.

Ports the relevant protections from ethereum-optimism/optimism#22778 to Base's transaction, payload, and flashblock handling.

- Reject a deposit transaction RLP body when its required `0x7e` EIP-2718 type byte is absent.
- Require payload and attributes transactions to decode and re-encode byte-for-byte before accepting them.
- Compare attributes transaction bytes directly during consolidation, rather than accepting different byte encodings that decode to the same transaction.
- Keep attributes transaction counts independent of decoding success.

## Testing

- `cargo test -p base-common-consensus -p base-common-rpc-types-engine -p base-protocol -p base-consensus-engine -p base-execution-payload-builder --lib`
- `cargo check -p base-flashblocks --lib`