### PR TITLE
perf(prefetch): amortize state provider reads

### DIFF
--- a/crates/execution/state-prefetch/src/pool.rs
+++ b/crates/execution/state-prefetch/src/pool.rs
@@ -11,12 +11,15 @@ use std::{
 
 use alloy_primitives::B256;
 use base_precompile_storage::{PrefetchRequest, StatePrefetcher};
-use reth_provider::StateProviderFactory;
+use reth_provider::{StateProvider, StateProviderFactory};
 use tracing::trace;
 
 /// Global cap for queued requests across all workers. Increasing worker count
 /// does not increase the maximum retained queue memory.
 const MAX_QUEUED_REQUESTS: usize = 4_096;
+
+/// Maximum reads served by one state-provider handle before a worker refreshes it.
+const MAX_READS_PER_PROVIDER: usize = 128;
 
 /// Maximum number of prefetch worker threads a pool will spawn.
 pub const MAX_PREFETCH_WORKERS: usize = 256;
@@ -72,6 +75,9 @@ impl StatePrefetchPool {
     }
 
     /// Reads hinted state until every sender is dropped.
+    ///
+    /// One state-provider handle is amortized across each drained batch, capped so a busy queue
+    /// cannot pin a long-lived read transaction or serve an arbitrarily stale snapshot.
     fn worker_loop<P: StateProviderFactory>(
         provider: P,
         receiver: mpsc::Receiver<PrefetchRequest>,
@@ -79,17 +85,35 @@ impl StatePrefetchPool {
     ) {
         while let Ok(request) = receiver.recv() {
             queued_requests.fetch_sub(1, Ordering::Relaxed);
-            let result = provider.latest().and_then(|state| {
-                state.storage(request.address, B256::from(request.slot)).map(|_| ())
-            });
-            if let Err(error) = result {
-                trace!(
-                    error = %error,
-                    address = %request.address,
-                    slot = %request.slot,
-                    "prefetch read failed"
-                );
+            let state = match provider.latest() {
+                Ok(state) => state,
+                Err(error) => {
+                    trace!(error = %error, request = ?request, "prefetch state provider unavailable");
+                    continue;
+                }
+            };
+            Self::read(&*state, request);
+            for _ in 1..MAX_READS_PER_PROVIDER {
+                match receiver.try_recv() {
+                    Ok(request) => {
+                        queued_requests.fetch_sub(1, Ordering::Relaxed);
+                        Self::read(&*state, request);
+                    }
+                    Err(_) => break,
+                }
             }
+        }
+    }
+
+    /// Performs one hinted read and discards the value.
+    fn read<S: StateProvider + ?Sized>(state: &S, request: PrefetchRequest) {
+        if let Err(error) = state.storage(request.address, B256::from(request.slot)) {
+            trace!(
+                error = %error,
+                address = %request.address,
+                slot = %request.slot,
+                "prefetch read failed"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- reuse one latest-state provider across each drained worker batch
- cap each provider handle at 128 reads to bound snapshot age and read-transaction lifetime
- add an end-to-end Criterion benchmark for worker-pool slot throughput

This optimization is retained because the same benchmark improves materially when applied to the parent implementation.

## Benchmark

`cargo bench -p base-execution-state-prefetch --bench pool --all-features -- state_prefetch_pool/read_slots --noplot`

4 workers, 4,096 slot requests per iteration:

| Implementation | Median | Throughput |
|---|---:|---:|
| Parent: provider per request | 2.89 ms | 1.42 Melem/s |
| This PR: up to 128 reads per provider | 672.29 µs | 6.09 Melem/s |

Criterion reported a **76.76% time reduction** and **330% throughput increase** across 100 samples.

## Stack

1. #4877 — minimal B20 storage prefetch implementation
2. #4914 — global queue bound and benchmarked hint-path optimizations
3. **#4974 — benchmarked state-provider batching**
4. #4975 — pin hints to the real B20 SLOAD footprint
5. #4976 — add worker metrics

## Testing

- `cargo test -p base-execution-state-prefetch`
- benchmark command above
- `cargo clippy -p base-execution-state-prefetch --all-targets --all-features -- -D warnings`

Generated with Toshi
