### PR TITLE
feat(prefetch): expose worker metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4596,9 +4596,11 @@ name = "base-execution-state-prefetch"
 version = "0.0.0"
 dependencies = [
  "alloy-primitives",
+ "base-metrics",
  "base-node-runner",
  "base-precompile-storage",
  "criterion",
+ "metrics",
  "reth-provider",
  "tracing",
 ]

--- a/crates/execution/state-prefetch/Cargo.toml
+++ b/crates/execution/state-prefetch/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 # base
+base-metrics.workspace = true
 base-node-runner.workspace = true
 base-precompile-storage = { workspace = true, features = ["std"] }
 
@@ -25,6 +26,7 @@ reth-provider.workspace = true
 alloy-primitives.workspace = true
 
 # misc
+metrics = { workspace = true, optional = true }
 tracing = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
@@ -34,3 +36,10 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 [[bench]]
 name = "pool"
 harness = false
+
+[features]
+default = ["metrics"]
+metrics = [
+    "base-metrics/metrics",
+    "dep:metrics",
+]

--- a/crates/execution/state-prefetch/README.md
+++ b/crates/execution/state-prefetch/README.md
@@ -14,3 +14,7 @@ Prefetching is purely a page-cache warmer: fetched values are discarded and
 the metered journaled reads remain unchanged, so enabling or disabling it has
 no consensus-visible effect. It is disabled unless the node starts with a
 non-zero `--state.prefetch-workers` value.
+
+The pool exports `state.prefetch.read_seconds` along with hint, enqueue, drop,
+and read-error counters so operators can measure real storage latency and
+backpressure on enabled nodes.

--- a/crates/execution/state-prefetch/src/lib.rs
+++ b/crates/execution/state-prefetch/src/lib.rs
@@ -6,5 +6,8 @@
 mod extension;
 pub use extension::{StatePrefetchConfig, StatePrefetchExtension};
 
+mod metrics;
+pub use metrics::PrefetchMetrics;
+
 mod pool;
 pub use pool::{MAX_PREFETCH_WORKERS, StatePrefetchPool};

--- a/crates/execution/state-prefetch/src/metrics.rs
+++ b/crates/execution/state-prefetch/src/metrics.rs
@@ -1,0 +1,16 @@
+//! Metrics for the state prefetch pool.
+
+base_metrics::define_metrics! {
+    state.prefetch,
+    struct = PrefetchMetrics,
+    #[describe("Wall time in seconds of one prefetched storage read")]
+    read_seconds: histogram,
+    #[describe("Prefetch hint batches received from producers")]
+    hints_total: counter,
+    #[describe("Prefetch requests enqueued to workers")]
+    requests_enqueued_total: counter,
+    #[describe("Prefetch requests dropped because the global queue was full")]
+    requests_dropped_total: counter,
+    #[describe("Prefetch reads that failed or could not obtain a state provider")]
+    read_errors_total: counter,
+}

--- a/crates/execution/state-prefetch/src/pool.rs
+++ b/crates/execution/state-prefetch/src/pool.rs
@@ -7,12 +7,15 @@ use std::{
         mpsc,
     },
     thread,
+    time::Instant,
 };
 
 use alloy_primitives::B256;
 use base_precompile_storage::{PrefetchRequest, StatePrefetcher};
 use reth_provider::{StateProvider, StateProviderFactory};
 use tracing::trace;
+
+use crate::PrefetchMetrics;
 
 /// Global cap for queued requests across all workers. Increasing worker count
 /// does not increase the maximum retained queue memory.
@@ -88,6 +91,7 @@ impl StatePrefetchPool {
             let state = match provider.latest() {
                 Ok(state) => state,
                 Err(error) => {
+                    PrefetchMetrics::read_errors_total().increment(1);
                     trace!(error = %error, request = ?request, "prefetch state provider unavailable");
                     continue;
                 }
@@ -107,13 +111,18 @@ impl StatePrefetchPool {
 
     /// Performs one hinted read and discards the value.
     fn read<S: StateProvider + ?Sized>(state: &S, request: PrefetchRequest) {
-        if let Err(error) = state.storage(request.address, B256::from(request.slot)) {
-            trace!(
-                error = %error,
-                address = %request.address,
-                slot = %request.slot,
-                "prefetch read failed"
-            );
+        let started = Instant::now();
+        match state.storage(request.address, B256::from(request.slot)) {
+            Ok(_) => PrefetchMetrics::read_seconds().record(started.elapsed()),
+            Err(error) => {
+                PrefetchMetrics::read_errors_total().increment(1);
+                trace!(
+                    error = %error,
+                    address = %request.address,
+                    slot = %request.slot,
+                    "prefetch read failed"
+                );
+            }
         }
     }
 
@@ -137,13 +146,19 @@ impl StatePrefetchPool {
 
 impl StatePrefetcher for StatePrefetchPool {
     fn prefetch(&self, requests: &[PrefetchRequest]) {
+        PrefetchMetrics::hints_total().increment(1);
         for &request in requests {
             if !self.try_reserve_queue_slot() {
+                PrefetchMetrics::requests_dropped_total().increment(1);
                 continue;
             }
             let index = self.next_worker.fetch_add(1, Ordering::Relaxed) % self.senders.len();
-            if self.senders[index].try_send(request).is_err() {
-                self.queued_requests.fetch_sub(1, Ordering::Relaxed);
+            match self.senders[index].try_send(request) {
+                Ok(()) => PrefetchMetrics::requests_enqueued_total().increment(1),
+                Err(_) => {
+                    self.queued_requests.fetch_sub(1, Ordering::Relaxed);
+                    PrefetchMetrics::requests_dropped_total().increment(1);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- add storage-prefetch read-latency, hint, enqueue, drop, and error metrics
- instrument provider acquisition, worker reads, and global queue admission
- keep observability separate from the prefetch mechanism and optimization PRs

## Stack

1. #4877 — minimal B20 storage prefetch implementation
2. #4914 — global queue bound and allocation-free hints
3. #4974 — amortize state-provider acquisition
4. #4975 — pin hints to the real B20 SLOAD footprint
5. **#4976 — add worker metrics**

## Testing

- `cargo test -p base-execution-state-prefetch`
- `cargo clippy -p base-execution-state-prefetch --all-targets --all-features -- -D warnings`

Generated with Toshi
