### PR TITLE
feat(eip8130): Fork-Aware Max Contract Size

### DIFF
--- a/crates/common/consensus/src/transaction/eip8130/constants.rs
+++ b/crates/common/consensus/src/transaction/eip8130/constants.rs
@@ -282,10 +282,23 @@ impl Eip8130Constants {
     /// before transaction-pool admission limits run.
     pub const MAX_CALL_PHASES_PER_TX: usize = 1_024;
 
-    /// Maximum runtime bytecode size for a create entry, matching EIP-170's
-    /// `MAX_CODE_SIZE` limit. EIP-8130 places runtime code directly, so the
-    /// mempool rejects oversized code before execution.
+    /// Maximum runtime bytecode size for a create entry before the EIP-7954
+    /// increase, matching EIP-170's `MAX_CODE_SIZE`. EIP-8130 places runtime code
+    /// directly (bypassing the EVM's own `CREATE` size check), so the mempool and
+    /// block execution reject oversized code explicitly.
     pub const MAX_CODE_SIZE: usize = 24_576;
+
+    /// Maximum runtime bytecode size for a create entry from the EIP-7954
+    /// (Amsterdam / Denim) increase. Mirrors revm's `eip7954::MAX_CODE_SIZE`.
+    pub const MAX_CODE_SIZE_AMSTERDAM: usize = 65_536;
+
+    /// The active runtime-bytecode size cap for a create entry: the EIP-7954
+    /// limit once EIP-7954 (Amsterdam / Denim) is active, otherwise the EIP-170
+    /// limit. Callers derive `amsterdam` from the block's resolved spec so this
+    /// tracks the same limit the EVM enforces for ordinary `CREATE`.
+    pub const fn max_code_size(amsterdam: bool) -> usize {
+        if amsterdam { Self::MAX_CODE_SIZE_AMSTERDAM } else { Self::MAX_CODE_SIZE }
+    }
 }
 
 #[cfg(test)]
@@ -297,6 +310,18 @@ mod tests {
     const EIP1559_TX_TYPE: u8 = 0x02;
     const EIP7702_TX_TYPE: u8 = 0x04;
     const DEPOSIT_TX_TYPE: u8 = 0x7E;
+
+    #[test]
+    fn max_code_size_tracks_amsterdam_activation() {
+        // Pre-Amsterdam is EIP-170's 24,576; from Amsterdam it is EIP-7954's 65,536.
+        assert_eq!(Eip8130Constants::max_code_size(false), 24_576);
+        assert_eq!(Eip8130Constants::max_code_size(true), 65_536);
+        assert_eq!(Eip8130Constants::max_code_size(false), Eip8130Constants::MAX_CODE_SIZE);
+        assert_eq!(
+            Eip8130Constants::max_code_size(true),
+            Eip8130Constants::MAX_CODE_SIZE_AMSTERDAM
+        );
+    }
 
     #[test]
     fn type_bytes_are_distinct() {

--- a/crates/common/evm/src/eip8130.rs
+++ b/crates/common/evm/src/eip8130.rs
@@ -785,6 +785,13 @@ impl Eip8130Executor {
         // a different path and skew the estimate. No signature is verified here.
         let payer = tx.payer.unwrap_or(sender);
 
+        // Active runtime code-size cap (EIP-170 pre-Amsterdam, EIP-7954 after),
+        // resolved before `ctx` is borrowed so estimation applies the same create
+        // size limit as inclusion.
+        let eth_spec: SpecId = ctx.cfg().spec().into();
+        let max_code_size =
+            Eip8130Constants::max_code_size(eth_spec.is_enabled_in(SpecId::AMSTERDAM));
+
         let internals = EvmInternals::from_context(ctx);
         let mut provider = JournalStorageProvider::new(internals, Address::ZERO);
 
@@ -808,7 +815,8 @@ impl Eip8130Executor {
             //    calls run against post-change code and create/delegation gas is
             //    priced. Must precede actor/policy resolution so an actor
             //    authorized in this same estimate request is visible.
-            let has_explicit_delegation = Self::apply_account_changes(signed, sctx, sender, now)?;
+            let has_explicit_delegation =
+                Self::apply_account_changes(signed, sctx, sender, now, max_code_size)?;
 
             // 3. Resolve the acting actor's real policy gate. No signature
             //    recovery: the optional RPC hint names the intended actor (e.g. a
@@ -965,6 +973,14 @@ impl Eip8130Executor {
             return Err(BaseTransactionError::eip8130("transaction validity window has expired"));
         }
 
+        // Runtime code-size cap for enshrined creates: track the EVM's active
+        // limit (EIP-170 pre-Amsterdam, EIP-7954 from Amsterdam/Denim) so an
+        // EIP-8130 create is held to the same cap as an ordinary `CREATE`.
+        // Resolved before `ctx` is borrowed by the storage provider below.
+        let eth_spec: SpecId = ctx.cfg().spec().into();
+        let max_code_size =
+            Eip8130Constants::max_code_size(eth_spec.is_enabled_in(SpecId::AMSTERDAM));
+
         let internals = EvmInternals::from_context(ctx);
         let mut provider = JournalStorageProvider::new(internals, Address::ZERO);
 
@@ -982,9 +998,14 @@ impl Eip8130Executor {
             //    resulting post-apply state. `AccountConfiguration` storage
             //    transitions are written here; the deferred account-code effects
             //    are installed in step 2.
-            let applied_tx =
-                TransactionAuthorizer::authorize_and_apply(signed, &mut acc, chain_id, now)
-                    .map_err(BaseTransactionError::eip8130)?;
+            let applied_tx = TransactionAuthorizer::authorize_and_apply(
+                signed,
+                &mut acc,
+                chain_id,
+                now,
+                max_code_size,
+            )
+            .map_err(BaseTransactionError::eip8130)?;
             let has_explicit_delegation = applied_tx.applied.delegation.is_some();
             let sender_actor = applied_tx.actors.sender.resolved;
             let payer_policy_gated = applied_tx
@@ -1655,6 +1676,7 @@ impl Eip8130Executor {
         sctx: StorageCtx<'_>,
         sender: Address,
         now: u64,
+        max_code_size: usize,
     ) -> Result<bool, BaseTransactionError> {
         let mut acc_mut = AccountConfigurationStorage::new(sctx);
         let mut created_effect: Option<(Address, Bytes)> = None;
@@ -1670,8 +1692,9 @@ impl Eip8130Executor {
                             ApplyError::InvalidCreatePosition,
                         ));
                     }
-                    let created = AccountChangeApplier::apply_create(&mut acc_mut, entry)
-                        .map_err(BaseTransactionError::eip8130)?;
+                    let created =
+                        AccountChangeApplier::apply_create(&mut acc_mut, entry, max_code_size)
+                            .map_err(BaseTransactionError::eip8130)?;
                     created_effect = Some((created.address, created.code));
                 }
                 AccountChange::ConfigChange(cc) => {

--- a/crates/execution/eip8130/src/apply.rs
+++ b/crates/execution/eip8130/src/apply.rs
@@ -841,12 +841,13 @@ impl AccountChangeApplier {
     pub fn apply_create(
         storage: &mut AccountConfigurationStorage<'_>,
         entry: &CreateEntry,
+        max_code_size: usize,
     ) -> Result<CreatedAccount, ApplyError> {
         // Validate the runtime before deriving the address so every caller (pool
         // admission and block inclusion) rejects the same set of malformed
         // runtimes at the shared choke point, matching the reference contract's
-        // CREATE2 deploy (EIP-170 size, EIP-3541 leading-byte).
-        Self::validate_create_runtime(&entry.code)?;
+        // CREATE2 deploy (active code-size cap, EIP-3541 leading-byte).
+        Self::validate_create_runtime(&entry.code, max_code_size)?;
         let address = Self::compute_address(entry.user_salt, &entry.code, &entry.initial_actors)?;
         // Block re-initialization of an account that already holds EIP-8130 state.
         // `local_sequence` doubles as the created/imported flag; `local_epoch`
@@ -1030,16 +1031,21 @@ impl AccountChangeApplier {
     ///
     /// - non-empty ([`ApplyError::EmptyBytecode`]): a codeless create would leave
     ///   an account with actor config but no code, breaking the EOA invariant.
-    /// - at most EIP-170 `MAX_CODE_SIZE` ([`ApplyError::CreateCodeExceedsMaxSize`]).
+    /// - at most `max_code_size` ([`ApplyError::CreateCodeExceedsMaxSize`]), the
+    ///   block's active deployed-code cap (EIP-170 pre-Amsterdam, EIP-7954 after),
+    ///   matching the limit the EVM enforces for ordinary `CREATE`.
     /// - not `0xEF`-prefixed per EIP-3541 ([`ApplyError::CreateCodeStartsWithEf`]),
     ///   which also keeps a `0xEF01`-prefixed runtime away from the panicking
     ///   `Bytecode` designator constructor and from being reinterpreted as an
     ///   EIP-7702 delegation.
-    pub fn validate_create_runtime(bytecode: &[u8]) -> Result<(), ApplyError> {
+    pub fn validate_create_runtime(
+        bytecode: &[u8],
+        max_code_size: usize,
+    ) -> Result<(), ApplyError> {
         if bytecode.is_empty() {
             return Err(ApplyError::EmptyBytecode);
         }
-        if bytecode.len() > Eip8130Constants::MAX_CODE_SIZE {
+        if bytecode.len() > max_code_size {
             return Err(ApplyError::CreateCodeExceedsMaxSize);
         }
         if bytecode[0] == 0xEF {
@@ -1088,6 +1094,8 @@ mod tests {
     use crate::{AccountCreated, ActorAuthorized, ActorRevoked, DelegationApplied};
 
     const ACCOUNT: Address = address!("0x00000000000000000000000000000000000000a1");
+    /// Pre-Amsterdam (EIP-170) deployed-code cap used by the tests.
+    const MAX_CODE: usize = Eip8130Constants::MAX_CODE_SIZE;
     const K1: Address = Eip8130Constants::K1_AUTHENTICATOR;
     const AUTHENTICATOR: Address = address!("0x00000000000000000000000000000000000000bb");
     const MANAGER: Address = address!("0x00000000000000000000000000000000000000cc");
@@ -2035,39 +2043,45 @@ mod tests {
 
     #[test]
     fn validate_create_runtime_enforces_create2_deploy_rules() {
-        // Empty runtime is rejected (codeless create).
+        const PRE: usize = Eip8130Constants::MAX_CODE_SIZE;
+        const AMS: usize = Eip8130Constants::MAX_CODE_SIZE_AMSTERDAM;
+        // Empty runtime is rejected (codeless create), regardless of the cap.
         assert_eq!(
-            AccountChangeApplier::validate_create_runtime(&[]),
+            AccountChangeApplier::validate_create_runtime(&[], PRE),
             Err(ApplyError::EmptyBytecode)
         );
-        // A runtime at exactly MAX_CODE_SIZE is allowed; one byte over is not.
-        assert!(
-            AccountChangeApplier::validate_create_runtime(&vec![
-                0x00u8;
-                Eip8130Constants::MAX_CODE_SIZE
-            ])
-            .is_ok()
-        );
+        // A runtime at exactly the active cap is allowed; one byte over is not.
+        assert!(AccountChangeApplier::validate_create_runtime(&vec![0x00u8; PRE], PRE).is_ok());
         assert_eq!(
-            AccountChangeApplier::validate_create_runtime(&vec![
-                0x00u8;
-                Eip8130Constants::MAX_CODE_SIZE + 1
-            ]),
+            AccountChangeApplier::validate_create_runtime(&vec![0x00u8; PRE + 1], PRE),
+            Err(ApplyError::CreateCodeExceedsMaxSize)
+        );
+        // EIP-7954: under the Amsterdam cap a runtime between the old and new
+        // limits is accepted, and the new boundary is enforced.
+        assert!(AccountChangeApplier::validate_create_runtime(&vec![0x00u8; PRE + 1], AMS).is_ok());
+        assert!(AccountChangeApplier::validate_create_runtime(&vec![0x00u8; AMS], AMS).is_ok());
+        assert_eq!(
+            AccountChangeApplier::validate_create_runtime(&vec![0x00u8; AMS + 1], AMS),
+            Err(ApplyError::CreateCodeExceedsMaxSize)
+        );
+        // A runtime over the old cap is still rejected under the pre-Amsterdam cap.
+        assert_eq!(
+            AccountChangeApplier::validate_create_runtime(&vec![0x00u8; AMS], PRE),
             Err(ApplyError::CreateCodeExceedsMaxSize)
         );
         // EIP-3541: any runtime beginning with 0xEF is rejected, including the
         // 3-byte 0xEF0100 prefix that would otherwise panic the EIP-7702
         // designator constructor, and a full 0xEF0100||target designator.
         assert_eq!(
-            AccountChangeApplier::validate_create_runtime(&[0xEF, 0x00]),
+            AccountChangeApplier::validate_create_runtime(&[0xEF, 0x00], PRE),
             Err(ApplyError::CreateCodeStartsWithEf)
         );
         assert_eq!(
-            AccountChangeApplier::validate_create_runtime(&[0xEF, 0x01, 0x00]),
+            AccountChangeApplier::validate_create_runtime(&[0xEF, 0x01, 0x00], PRE),
             Err(ApplyError::CreateCodeStartsWithEf)
         );
         // An ordinary runtime is accepted.
-        assert!(AccountChangeApplier::validate_create_runtime(&[0x60, 0x00]).is_ok());
+        assert!(AccountChangeApplier::validate_create_runtime(&[0x60, 0x00], PRE).is_ok());
     }
 
     #[test]
@@ -2113,7 +2127,7 @@ mod tests {
             )
             .unwrap();
 
-            let created = AccountChangeApplier::apply_create(acc, &entry).unwrap();
+            let created = AccountChangeApplier::apply_create(acc, &entry, MAX_CODE).unwrap();
             assert_eq!(created.address, expected);
             assert_eq!(created.code, entry.code);
 
@@ -2129,7 +2143,7 @@ mod tests {
 
             // Re-creating the same account is rejected.
             assert_eq!(
-                AccountChangeApplier::apply_create(acc, &entry),
+                AccountChangeApplier::apply_create(acc, &entry, MAX_CODE),
                 Err(ApplyError::AlreadyInitialized { account: expected })
             );
         });
@@ -2160,7 +2174,7 @@ mod tests {
 
             // create must still reject (the guard checks both sequences).
             assert_eq!(
-                AccountChangeApplier::apply_create(acc, &entry),
+                AccountChangeApplier::apply_create(acc, &entry, MAX_CODE),
                 Err(ApplyError::AlreadyInitialized { account: expected })
             );
         });
@@ -2192,7 +2206,7 @@ mod tests {
             acc.set_account_state(expected, state).unwrap();
 
             assert_eq!(
-                AccountChangeApplier::apply_create(acc, &entry),
+                AccountChangeApplier::apply_create(acc, &entry, MAX_CODE),
                 Err(ApplyError::AlreadyInitialized { account: expected })
             );
         });
@@ -2209,7 +2223,7 @@ mod tests {
             let empty =
                 CreateEntry { user_salt: B256::ZERO, code: code.clone(), initial_actors: vec![] };
             assert_eq!(
-                AccountChangeApplier::apply_create(acc, &empty),
+                AccountChangeApplier::apply_create(acc, &empty, MAX_CODE),
                 Err(ApplyError::NoInitialActors)
             );
 
@@ -2222,7 +2236,7 @@ mod tests {
                 ],
             };
             assert_eq!(
-                AccountChangeApplier::apply_create(acc, &unsorted),
+                AccountChangeApplier::apply_create(acc, &unsorted, MAX_CODE),
                 Err(ApplyError::ActorsNotSortedOrDuplicate)
             );
         });
@@ -2241,7 +2255,7 @@ mod tests {
                 initial_actors: vec![InitialActor::owner(B256::repeat_byte(1), AUTHENTICATOR)],
             };
             assert_eq!(
-                AccountChangeApplier::apply_create(acc, &entry),
+                AccountChangeApplier::apply_create(acc, &entry, MAX_CODE),
                 Err(ApplyError::EmptyBytecode)
             );
         });
@@ -2270,7 +2284,7 @@ mod tests {
             )
             .unwrap();
             assert_eq!(
-                AccountChangeApplier::apply_create(acc, &entry),
+                AccountChangeApplier::apply_create(acc, &entry, MAX_CODE),
                 Err(ApplyError::CreateCodeStartsWithEf)
             );
             // No partially-initialized account is left behind on rejection.
@@ -2292,7 +2306,7 @@ mod tests {
             )
             .unwrap();
             assert_eq!(
-                AccountChangeApplier::apply_create(acc, &entry),
+                AccountChangeApplier::apply_create(acc, &entry, MAX_CODE),
                 Err(ApplyError::CreateCodeExceedsMaxSize)
             );
             assert!(!acc.get_account_state(expected).unwrap().is_initialized());
@@ -2305,7 +2319,7 @@ mod tests {
                 code: Bytes::from(vec![0x00u8; Eip8130Constants::MAX_CODE_SIZE]),
                 initial_actors: actors.clone(),
             };
-            assert!(AccountChangeApplier::apply_create(acc, &entry).is_ok());
+            assert!(AccountChangeApplier::apply_create(acc, &entry, MAX_CODE).is_ok());
         });
     }
 
@@ -2420,7 +2434,7 @@ mod tests {
             initial_actors: vec![InitialActor::owner(actor_id, Eip8130Constants::K1_AUTHENTICATOR)],
         };
         with_storage(|acc| {
-            let created = AccountChangeApplier::apply_create(acc, &entry).unwrap();
+            let created = AccountChangeApplier::apply_create(acc, &entry, MAX_CODE).unwrap();
             let state = acc.get_account_state(created.address).unwrap();
             assert!(state.default_eoa_revoked(), "create must revoke the default EOA");
         });
@@ -2534,7 +2548,7 @@ mod tests {
         .unwrap();
 
         let events = with_storage_events(|acc| {
-            AccountChangeApplier::apply_create(acc, &entry).unwrap();
+            AccountChangeApplier::apply_create(acc, &entry, MAX_CODE).unwrap();
         });
         assert_eq!(events.len(), 2);
 

--- a/crates/execution/eip8130/src/transaction.rs
+++ b/crates/execution/eip8130/src/transaction.rs
@@ -72,6 +72,10 @@ impl TransactionAuthorizer {
     ///    sender to be an admin (unrestricted) actor on the unlocked account,
     ///    via any canonical authenticator.
     ///
+    /// `max_code_size` is the block's active deployed-code cap (EIP-170
+    /// pre-Amsterdam, EIP-7954 after), applied to a create entry's runtime so the
+    /// enshrined deploy honors the same limit the EVM enforces for `CREATE`.
+    ///
     /// Returns the [`AppliedTransaction`] (with every `AccountConfiguration`
     /// storage transition already written to `storage`), or the first
     /// [`TxAuthError`] encountered. On error the caller MUST discard `storage`'s
@@ -83,6 +87,7 @@ impl TransactionAuthorizer {
         storage: &mut AccountConfigurationStorage<'_>,
         local_chain_id: u64,
         now: u64,
+        max_code_size: usize,
     ) -> Result<AppliedTransaction, TxAuthError> {
         // Resolve the sender account up front (without authenticating it yet):
         // config changes mutate this account and a create must derive to it. For
@@ -122,7 +127,8 @@ impl TransactionAuthorizer {
                     if index != 0 || applied.created.is_some() {
                         return Err(ApplyError::InvalidCreatePosition.into());
                     }
-                    let created = AccountChangeApplier::apply_create(storage, entry)?;
+                    let created =
+                        AccountChangeApplier::apply_create(storage, entry, max_code_size)?;
                     if created.address != sender_account {
                         return Err(ApplyError::CreateAddressMismatch {
                             derived: created.address,
@@ -276,6 +282,8 @@ mod tests {
 
     const NOW: u64 = 1_000;
     const LOCAL: u64 = 8453;
+    /// Pre-Amsterdam (EIP-170) deployed-code cap used by the tests.
+    const MAX_CODE: usize = Eip8130Constants::MAX_CODE_SIZE;
     const K1: Address = Eip8130Constants::K1_AUTHENTICATOR;
 
     fn key(byte: u8) -> K256SigningKey {
@@ -421,7 +429,9 @@ mod tests {
             &k,
         );
         with_storage(|acc| {
-            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).unwrap();
+            let out =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .unwrap();
             assert_eq!(out.actors.sender.account, account);
             assert!(out.actors.payer.is_none());
             assert_eq!(out.config_changes.len(), 2);
@@ -449,7 +459,7 @@ mod tests {
         );
         with_storage(|acc| {
             assert_eq!(
-                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE),
                 Err(TxAuthError::BadSequence { expected: 1, got: 0 }),
             );
         });
@@ -476,7 +486,9 @@ mod tests {
             &k,
         );
         with_storage(|acc| {
-            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).unwrap();
+            let out =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .unwrap();
             assert_eq!(out.config_changes.len(), 3);
             assert_eq!(acc.get_change_sequences(account).unwrap(), (2, 1));
         });
@@ -496,7 +508,7 @@ mod tests {
             b[16..20].copy_from_slice(&1u32.to_be_bytes());
             acc.account_state.at_mut(&account).write(U256::from_be_bytes(b)).unwrap();
             assert_eq!(
-                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE),
                 Err(TxAuthError::StaleEpoch { expected: 1, got: 0 }),
             );
         });
@@ -515,7 +527,7 @@ mod tests {
         with_storage(|acc| {
             acc.account_state.at_mut(&account).write(pack_state(u64::MAX, 0, 0, 0)).unwrap();
             assert_eq!(
-                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE),
                 Err(TxAuthError::SequenceSaturated),
             );
         });
@@ -553,10 +565,11 @@ mod tests {
                 .unwrap();
 
             let ordinary =
-                TransactionAuthorizer::authorize_and_apply(&ordinary, acc, LOCAL, NOW).unwrap();
+                TransactionAuthorizer::authorize_and_apply(&ordinary, acc, LOCAL, NOW, MAX_CODE)
+                    .unwrap();
             assert_eq!(ordinary.actors.sender.resolved.scope, Eip8130Constants::SCOPE_OPERATOR);
             assert_eq!(
-                TransactionAuthorizer::authorize_and_apply(&delegation, acc, LOCAL, NOW),
+                TransactionAuthorizer::authorize_and_apply(&delegation, acc, LOCAL, NOW, MAX_CODE),
                 Err(TxAuthError::DelegationUnauthorized),
             );
         });
@@ -583,7 +596,9 @@ mod tests {
                 .at_mut(&account)
                 .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))
                 .unwrap();
-            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).unwrap();
+            let out =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .unwrap();
             assert_eq!(out.actors.sender.account, account);
             assert_eq!(out.actors.sender.resolved.actor_id, signer_id);
             assert_ne!(
@@ -633,7 +648,7 @@ mod tests {
                 .write(pack(K1, Eip8130Constants::SCOPE_SPONSOR_PAYER, 0))
                 .unwrap();
             assert_eq!(
-                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE),
                 Err(TxAuthError::DelegationUnauthorized),
             );
         });
@@ -655,7 +670,7 @@ mod tests {
                 .write(pack_state(0, 0, Eip8130Constants::FLAG_LOCKED, 0))
                 .unwrap();
             assert_eq!(
-                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE),
                 Err(TxAuthError::AccountIsLocked),
             );
         });
@@ -672,7 +687,9 @@ mod tests {
         );
 
         with_storage(|acc| {
-            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).unwrap();
+            let out =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .unwrap();
             assert_eq!(out.applied.delegation, Some(DelegationEffect::new(account, target)));
         });
     }
@@ -691,7 +708,9 @@ mod tests {
         assert!(signed.sender_auth().starts_with(K1.as_slice()));
 
         with_storage(|acc| {
-            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).unwrap();
+            let out =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .unwrap();
 
             assert_eq!(out.actors.sender.account, account);
             assert_eq!(
@@ -786,8 +805,9 @@ mod tests {
         let hash = tx.sender_signature_hash();
         let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
         with_storage(|acc| {
-            let err = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW)
-                .expect_err("create + delegation must be rejected");
+            let err =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .expect_err("create + delegation must be rejected");
             assert!(
                 matches!(err, TxAuthError::Apply(ApplyError::CreateAndDelegation)),
                 "expected CreateAndDelegation, got {err:?}"
@@ -841,8 +861,9 @@ mod tests {
         let hash = tx.sender_signature_hash();
         let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
         with_storage(|acc| {
-            let err = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW)
-                .expect_err("delegation + create must be rejected");
+            let err =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .expect_err("delegation + create must be rejected");
             assert!(
                 matches!(err, TxAuthError::Apply(ApplyError::CreateAndDelegation)),
                 "expected CreateAndDelegation, got {err:?}"
@@ -869,7 +890,9 @@ mod tests {
                 .at_mut(&account)
                 .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))
                 .unwrap();
-            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).unwrap();
+            let out =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .unwrap();
             assert!(out.config_changes[0].is_admin());
             assert_eq!(acc.get_change_sequences(account).unwrap(), (1, 0));
         });
@@ -920,7 +943,9 @@ mod tests {
                 .at_mut(&sender_account)
                 .write(pack(K1, Eip8130Constants::SCOPE_UNRESTRICTED, 0))
                 .unwrap();
-            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).unwrap();
+            let out =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .unwrap();
             assert_eq!(out.actors.sender.account, sender_account);
             assert_eq!(out.actors.payer.expect("payer present").account, payer_account);
             assert_eq!(out.config_changes.len(), 1);
@@ -994,8 +1019,9 @@ mod tests {
         let (derived, signed) = create_tx_and_signed(&k, vec![]);
 
         with_storage(|acc| {
-            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW)
-                .expect("create tx on empty account must authorize");
+            let out =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .expect("create tx on empty account must authorize");
             assert_eq!(out.actors.sender.account, derived);
             assert!(out.actors.sender.resolved.is_admin(), "create sender must be unrestricted");
             assert!(out.actors.payer.is_none());
@@ -1055,8 +1081,9 @@ mod tests {
         let signed = Eip8130Signed::new(tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
 
         with_storage(|acc| {
-            let out = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW)
-                .expect("create + config change must authorize against post-create state");
+            let out =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .expect("create + config change must authorize against post-create state");
             assert_eq!(out.actors.sender.account, derived);
             assert_eq!(out.config_changes.len(), 1, "config change applied after create");
             assert!(out.applied.created.is_some(), "create entry applied");
@@ -1113,7 +1140,7 @@ mod tests {
         with_storage(|acc| {
             assert!(
                 matches!(
-                    TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW),
+                    TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE),
                     Err(TxAuthError::Authorize(AuthorizeError::AuthenticatorMismatch { .. }))
                 ),
                 "signer not in initial_actors must be rejected"
@@ -1158,7 +1185,8 @@ mod tests {
 
         with_storage(|acc| {
             assert!(
-                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW).is_err(),
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .is_err(),
                 "create without explicit sender must be rejected"
             );
         });
@@ -1182,8 +1210,9 @@ mod tests {
         signed = Eip8130Signed::new(new_tx, auth_blob(K1, &sig(&k, hash)), Bytes::new());
 
         with_storage(|acc| {
-            let err = TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW)
-                .expect_err("create + delegation must be rejected");
+            let err =
+                TransactionAuthorizer::authorize_and_apply(&signed, acc, LOCAL, NOW, MAX_CODE)
+                    .expect_err("create + delegation must be rejected");
             assert!(
                 matches!(err, TxAuthError::Apply(ApplyError::CreateAndDelegation)),
                 "expected CreateAndDelegation, got {err:?}"

--- a/crates/execution/txpool/src/validator.rs
+++ b/crates/execution/txpool/src/validator.rs
@@ -47,6 +47,7 @@ use reth_transaction_pool::{
 };
 use revm::{
     context::journaled_state::JournalCheckpoint,
+    primitives::hardfork::SpecId,
     state::{AccountInfo, Bytecode},
 };
 
@@ -1001,6 +1002,14 @@ where
         let classification_generation = self.limit_class_cache_generation();
         let local_chain_id = self.inner.chain_spec().chain().id();
         let now = self.block_timestamp();
+        // Active runtime code-size cap for enshrined creates (EIP-170
+        // pre-Amsterdam, EIP-7954 after). Derived from the same resolved spec the
+        // EVM uses at inclusion, so admission and execution agree.
+        let max_code_size = Eip8130Constants::max_code_size(
+            BaseSpecId::from_timestamp(self.chain_spec(), now)
+                .into_eth_spec()
+                .is_enabled_in(SpecId::AMSTERDAM),
+        );
         let state = self.client().latest().map_err(|error| Self::provider_unavailable(error))?;
 
         // Authorize *and apply* the account changes against a writable overlay so
@@ -1022,6 +1031,7 @@ where
                     &mut account_config,
                     local_chain_id,
                     now,
+                    max_code_size,
                 )?
             };
             if let Some(delegation) = applied.applied.delegation {
@@ -1877,11 +1887,16 @@ where
                         return Err(InvalidTransactionError::TxTypeNotSupported.into());
                     }
                     // Reject at admission the runtime code shapes the enshrined
-                    // deploy (`AccountChangeApplier::apply_create`) refuses:
-                    // EIP-170 oversize and the EIP-3541 reserved leading `0xEF`
-                    // byte (which `CREATE2` would reject with `address(0)`).
+                    // deploy (`AccountChangeApplier::apply_create`) refuses: the
+                    // EIP-3541 reserved leading `0xEF` byte (which `CREATE2` would
+                    // reject with `address(0)`) and grossly oversized code. This is
+                    // a coarse structural fast-fail bounded by the largest possible
+                    // cap (EIP-7954); the exact fork-aware code-size limit (EIP-170
+                    // pre-Amsterdam, EIP-7954 after) is enforced authoritatively by
+                    // `apply_create` in `validate_eip8130_full`, which always runs
+                    // after this precheck during admission.
                     if create.code.is_empty()
-                        || create.code.len() > Eip8130Constants::MAX_CODE_SIZE
+                        || create.code.len() > Eip8130Constants::MAX_CODE_SIZE_AMSTERDAM
                         || create.code.first() == Some(&0xEF)
                         || create.initial_actors.is_empty()
                     {


### PR DESCRIPTION
## Summary

Makes the EIP-8130 account-abstraction create path honor a fork-aware deployed-code size cap so it tracks EIP-7954's increase from 24,576 to 65,536 bytes at Amsterdam (Denim), matching the limit revm enforces for an ordinary `CREATE`. The active cap is threaded through the shared `apply_create` choke point used by both transaction-pool admission and block execution, and is derived from the same resolved spec on both sides so admission and execution can never disagree. The cheap structural precheck is relaxed to the largest possible cap while the authoritative `apply_create` (which always runs after it during admission) enforces the exact fork limit. Behavior is byte-identical before Denim, and the raised limit activates automatically once op-revm exposes an OP-Stack Amsterdam spec.
