### PR TITLE
fix(payload): allow --enable-metering without a resource schedule

### DIFF
--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -47,9 +47,10 @@ use crate::upgrade_signal::{
 pub struct MeteringArgs {
     /// Enable metering RPC for transaction bundle simulation.
     ///
-    /// Turns on `base_meterBundle`. Native payload admission also requires a
-    /// non-empty `--payload.resource-metering-schedule`. The Flashblocks
-    /// builder uses `--builder.enable-resource-metering` instead.
+    /// Turns on `base_meterBundle`. The native payload builder throttles
+    /// transactions against resource-unit budgets only when this is set and
+    /// `--payload.resource-metering-schedule` is a non-empty file. The
+    /// Flashblocks builder uses `--builder.enable-resource-metering` instead.
     #[arg(long = "enable-metering", env = "ENABLE_METERING", value_name = "ENABLE_METERING")]
     pub enable_metering: bool,
 
@@ -82,7 +83,8 @@ pub struct MeteringArgs {
     )]
     pub metering_target_flashblocks_per_block: Option<usize>,
 
-    /// Resource-metering schedule for native payload admission.
+    /// Resource-unit schedule used to throttle transactions in the native
+    /// payload builder.
     #[command(flatten)]
     pub resource_metering: ResourceMeteringArgs,
 }
@@ -92,9 +94,9 @@ pub struct MeteringArgs {
 pub struct ResourceMeteringArgs {
     /// JSON file containing the startup resource-metering schedule.
     ///
-    /// Resource metering runs when `--enable-metering` is set and this schedule
-    /// is non-empty. Per-dimension `dryRun` in the file observes a budget
-    /// without excluding transactions.
+    /// The native payload builder throttles transactions against this schedule
+    /// when `--enable-metering` is set and the file is non-empty. Per-dimension
+    /// `dryRun` observes a budget without excluding transactions.
     #[arg(long = "payload.resource-metering-schedule", env = "PAYLOAD_RESOURCE_METERING_SCHEDULE")]
     pub resource_metering_schedule: Option<PathBuf>,
 

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -47,9 +47,9 @@ use crate::upgrade_signal::{
 pub struct MeteringArgs {
     /// Enable metering RPC for transaction bundle simulation.
     ///
-    /// Native kill switch for payload resource metering: a loaded schedule is
-    /// evaluated only when this is set. The Flashblocks builder uses
-    /// `--builder.enable-resource-metering` instead.
+    /// Turns on `base_meterBundle`. Native payload admission also requires a
+    /// non-empty `--payload.resource-metering-schedule`. The Flashblocks
+    /// builder uses `--builder.enable-resource-metering` instead.
     #[arg(long = "enable-metering", env = "ENABLE_METERING", value_name = "ENABLE_METERING")]
     pub enable_metering: bool,
 
@@ -82,7 +82,7 @@ pub struct MeteringArgs {
     )]
     pub metering_target_flashblocks_per_block: Option<usize>,
 
-    /// Resource-metering schedule. Evaluated when `--enable-metering` is set.
+    /// Resource-metering schedule for native payload admission.
     #[command(flatten)]
     pub resource_metering: ResourceMeteringArgs,
 }
@@ -888,7 +888,6 @@ fn is_inspector_opcode_name(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::address;
-    use base_execution_payload_builder::ResourceMeteringError;
     use clap::{Args, Parser};
 
     use super::*;
@@ -1356,13 +1355,14 @@ mod tests {
         assert_eq!(args.metering.metering_target_flashblocks_per_block, Some(4));
         assert!(args.metering.resource_metering.resource_metering_schedule.is_none());
 
-        let err = ResourceMeteringConfig::from_parts(
+        let config = ResourceMeteringConfig::from_parts(
             args.metering.enable_metering,
             args.metering.resource_metering.resource_metering_schedule.as_deref(),
             Arc::new(NoopMeteringProvider),
         )
-        .expect_err("enable-metering without a schedule must fail closed");
-        assert!(matches!(err, ResourceMeteringError::MissingSchedule));
+        .expect("enable-metering without a schedule must still boot");
+        assert!(config.enabled);
+        assert!(!config.is_active());
     }
 
     #[test]

--- a/crates/execution/payload/src/config.rs
+++ b/crates/execution/payload/src/config.rs
@@ -28,7 +28,8 @@ pub struct BaseBuilderConfig {
     pub manifest_precheck_enabled: bool,
     /// Hard cutoff on cumulative validity-predicate evaluation time per payload build.
     pub predicate_eval_hard_cutoff: Duration,
-    /// Resource metering and throttling configuration for payload admission.
+    /// Resource-unit metering used to throttle transactions in the native
+    /// payload builder.
     pub resource_metering: ResourceMeteringConfig,
     /// Shared, cross-job cache of permanently rejected transaction hashes.
     ///
@@ -69,7 +70,8 @@ impl BaseBuilderConfig {
         }
     }
 
-    /// Sets resource metering and throttling for payload admission.
+    /// Sets resource-unit metering used to throttle transactions in the native
+    /// payload builder.
     pub fn with_resource_metering(mut self, resource_metering: ResourceMeteringConfig) -> Self {
         self.resource_metering = resource_metering;
         self
@@ -118,12 +120,13 @@ impl Default for ResourceMeteringConfig {
 impl ResourceMeteringConfig {
     /// Builds a shared config from startup flags.
     ///
-    /// `--enable-metering` turns on `base_meterBundle`. Payload admission
-    /// runs only when that flag is set and a non-empty schedule file is
-    /// loaded. A missing schedule leaves admission inactive so mempool
-    /// clients can serve meterBundle without a builder schedule. An empty
-    /// schedule file fails closed because the operator asked to load
-    /// admission config and it has no dimensions.
+    /// `--enable-metering` turns on `base_meterBundle`. The native payload
+    /// builder throttles transactions against resource-unit budgets only when
+    /// that flag is set and a non-empty schedule file is loaded. A missing
+    /// schedule leaves those budgets inactive so mempool clients can serve
+    /// meterBundle without a builder schedule. An empty schedule file fails
+    /// closed because the operator asked to load a schedule and it has no
+    /// dimensions.
     pub fn from_parts(
         enabled: bool,
         schedule_path: Option<&Path>,
@@ -468,7 +471,7 @@ mod tests {
     }
 
     #[test]
-    fn enabled_metering_without_schedule_leaves_admission_inactive() {
+    fn enabled_metering_without_schedule_leaves_resource_throttling_inactive() {
         let config = ResourceMeteringConfig::from_parts(true, None, Arc::new(NoopMeteringProvider))
             .expect("enable-metering without a schedule must still boot");
         assert!(config.enabled);

--- a/crates/execution/payload/src/config.rs
+++ b/crates/execution/payload/src/config.rs
@@ -118,23 +118,28 @@ impl Default for ResourceMeteringConfig {
 impl ResourceMeteringConfig {
     /// Builds a shared config from startup flags.
     ///
-    /// Enabling metering without a non-empty schedule file fails closed so
-    /// operators cannot boot with `--enable-metering` and silently admit every
-    /// transaction.
+    /// `--enable-metering` turns on `base_meterBundle`. Payload admission
+    /// runs only when that flag is set and a non-empty schedule file is
+    /// loaded. A missing schedule leaves admission inactive so mempool
+    /// clients can serve meterBundle without a builder schedule. An empty
+    /// schedule file fails closed because the operator asked to load
+    /// admission config and it has no dimensions.
     pub fn from_parts(
         enabled: bool,
         schedule_path: Option<&Path>,
         provider: SharedMeteringProvider,
     ) -> Result<Self, ResourceMeteringError> {
         let schedule = if enabled {
-            let Some(path) = schedule_path else {
-                return Err(ResourceMeteringError::MissingSchedule);
-            };
-            let schedule = ResourceMeteringSchedule::from_file(path)?;
-            if schedule.is_empty() {
-                return Err(ResourceMeteringError::EmptySchedule);
+            match schedule_path {
+                Some(path) => {
+                    let schedule = ResourceMeteringSchedule::from_file(path)?;
+                    if schedule.is_empty() {
+                        return Err(ResourceMeteringError::EmptySchedule);
+                    }
+                    schedule
+                }
+                None => ResourceMeteringSchedule::default(),
             }
-            schedule
         } else {
             if let Some(path) = schedule_path {
                 warn!(
@@ -463,10 +468,12 @@ mod tests {
     }
 
     #[test]
-    fn enabled_metering_without_schedule_fails_closed() {
-        let err = ResourceMeteringConfig::from_parts(true, None, Arc::new(NoopMeteringProvider))
-            .expect_err("enable-metering without a schedule must fail");
-        assert!(matches!(err, ResourceMeteringError::MissingSchedule));
+    fn enabled_metering_without_schedule_leaves_admission_inactive() {
+        let config = ResourceMeteringConfig::from_parts(true, None, Arc::new(NoopMeteringProvider))
+            .expect("enable-metering without a schedule must still boot");
+        assert!(config.enabled);
+        assert!(config.schedule.is_empty());
+        assert!(!config.is_active());
     }
 
     #[test]

--- a/crates/execution/payload/src/resource_metering.rs
+++ b/crates/execution/payload/src/resource_metering.rs
@@ -585,9 +585,6 @@ pub enum ResourceMeteringError {
     /// The schedule file was not valid JSON.
     #[error("failed to parse resource metering schedule JSON: {0}")]
     ParseJson(String),
-    /// Metering is enabled but no schedule file was provided.
-    #[error("resource metering is enabled but no schedule file was provided")]
-    MissingSchedule,
     /// Metering is enabled but the schedule file has no dimensions.
     #[error("resource metering is enabled but the schedule has no dimensions")]
     EmptySchedule,


### PR DESCRIPTION
## Summary
- `--enable-metering` turns on `base_meterBundle` and no longer requires `--payload.resource-metering-schedule`.
- The native payload builder throttles transactions against resource-unit budgets only when that flag is set and a non-empty schedule file is loaded (`is_active()` is already `enabled && !schedule.is_empty()`).
- An empty schedule file still fails closed. Builder throttling remains on `--builder.enable-resource-metering` and is unchanged.

#4675 reused `--enable-metering` as the native resource-unit throttling kill switch, which aborted mempool `base-client` processes. Helm always passes that flag so those nodes can serve meterBundle, and they never evaluate the resource-unit schedule.

## Test plan
- `cargo test --lib -p base-execution-payload-builder -p base-execution-cli`
- Confirm `--enable-metering` without a schedule boots and leaves resource-unit throttling inactive
- Confirm a schedule file with no dimensions still fails at startup

type=routine
risk=low
impact=sev5