### PR TITLE
fix(devnet): Handle Docker-Owned Upgrade Signal Configs

### DIFF
--- a/etc/docker/Justfile
+++ b/etc/docker/Justfile
@@ -158,11 +158,11 @@ down:
 
 # Shows devnet block numbers and sync status
 status:
-    ./etc/scripts/devnet/status.sh
+    @./etc/scripts/devnet/status.sh
 
 # Shows peer counts and unsafe L2 height for each L2 node
 peer-status:
-    ./etc/scripts/devnet/peer-status.sh
+    @./etc/scripts/devnet/peer-status.sh
 
 # Shows devnet container status
 ps *services:
@@ -170,26 +170,26 @@ ps *services:
 
 # Shows funded test accounts with live balances and nonces
 accounts:
-    ./etc/scripts/devnet/accounts.sh
+    @./etc/scripts/devnet/accounts.sh
 
 # Sends test transactions to L1 and L2
 smoke:
-    ./etc/scripts/devnet/smoke.sh
+    @./etc/scripts/devnet/smoke.sh
 
 # Deploys, updates, or inspects the normal devnet L1 upgrade-signal contract
 upgrade-signal *args:
-    ./etc/scripts/devnet/upgrade-signal.sh {{ args }}
+    @./etc/scripts/devnet/upgrade-signal.sh {{ args }}
 
 # Moves one devnet upgrade to latest L2 timestamp + offset seconds
 upgrade-signal-future upgrade='azul' offset='120':
-    ./etc/scripts/devnet/upgrade-signal.sh move-future {{ quote(upgrade) }} --offset {{ quote(offset) }}
+    @./etc/scripts/devnet/upgrade-signal.sh move-future {{ quote(upgrade) }} --offset {{ quote(offset) }}
 
 # Runs full devnet checks (status + smoke tests)
 checks: status smoke
 
 # Sends an ingress transaction and verifies transaction events reached audit-archiver Postgres
 tx-observability-smoke:
-    ./etc/scripts/devnet/transaction-events-smoke.sh
+    @./etc/scripts/devnet/transaction-events-smoke.sh
 
 # Stream FB's from the builder via websocket
 flashblocks:
@@ -206,11 +206,11 @@ sequencer-logs:
 
 # Follow the active raft leader's unified sequencer logs, switching automatically on failover
 follow-leader:
-    ./etc/scripts/devnet/follow-leader.sh
+    @./etc/scripts/devnet/follow-leader.sh
 
 # Stop the active sequencer and transfer raft leadership (optionally to node 0, 1, or 2)
 transfer-leader to='':
-    ./etc/scripts/devnet/transfer-leader.sh {{ to }}
+    @./etc/scripts/devnet/transfer-leader.sh {{ to }}
 
 # TUI dashboard: HA conductor cluster monitor (requires devnet running)
 conductor:

--- a/etc/just/anvil-nitro-local.just
+++ b/etc/just/anvil-nitro-local.just
@@ -20,7 +20,7 @@ down:
 # Prints container, contract, signer, L2-finality, and latest-game status
 status:
     docker compose {{ _env }} {{ _anvil }} --profile nitro-local ps {{ _services }}
-    ./etc/scripts/devnet/anvil-nitro-local.sh status
+    @./etc/scripts/devnet/anvil-nitro-local.sh status
 
 # Tails proof node, prover-service, Nitro worker, and proposer logs
 logs:

--- a/etc/just/check.just
+++ b/etc/just/check.just
@@ -47,15 +47,15 @@ deny:
 
 # Checks no_std crates compile without std
 no-std:
-    {{justfile_directory()}}/etc/scripts/ci/check-no-std.sh
+    @{{justfile_directory()}}/etc/scripts/ci/check-no-std.sh
 
 # Checks proof crates compile for bare-metal FPVM
 no-std-proof:
-    {{justfile_directory()}}/etc/scripts/ci/check-no-std-proof.sh
+    @{{justfile_directory()}}/etc/scripts/ci/check-no-std-proof.sh
 
 # Checks crate dependency boundary rules
 crate-deps:
-    {{justfile_directory()}}/etc/scripts/ci/check-crate-deps.sh
+    @{{justfile_directory()}}/etc/scripts/ci/check-crate-deps.sh
 
 # Verifies git-based reth-* workspace deps match etc/upstream-pins/reth.toml
 reth-pin:

--- a/etc/scripts/devnet/upgrade-signal-test.sh
+++ b/etc/scripts/devnet/upgrade-signal-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Regression checks using real filesystem permissions and Docker, with offline RPC/tool stubs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$(id -u)" == 0 ]]; then
+  echo "Run as a non-root user to exercise Docker-owned config permissions." >&2
+  exit 1
+fi
+TEST_DIR="$(mktemp -d)"
+trap 'docker run --rm -v "$TEST_DIR:/test" alpine sh -c "rm -rf /test/*"; rmdir "$TEST_DIR"' EXIT
+mkdir -p "$TEST_DIR/bin" "$TEST_DIR/user configs"
+cat >"$TEST_DIR/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+echo azul
+EOF
+cat >"$TEST_DIR/bin/cast" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  block-number) echo 1 ;;
+  code) echo 0x1234 ;;
+  send) echo '{}' ;;
+  call)
+    if [[ "$2" == --json ]]; then echo '[[123]]'; else echo 4294967296; fi
+    ;;
+  *) exit 1 ;;
+esac
+EOF
+chmod +x "$TEST_DIR/bin/"*
+export PATH="$TEST_DIR/bin:$PATH"
+export UPGRADE_SIGNAL_CONTRACT=0x1111111111111111111111111111111111111111
+export UPGRADE_SIGNAL_CONTAINER_L1_RPC=http://l1-el:4545
+export UPGRADE_SIGNAL_MODE=runtime-admin UPGRADE_SIGNAL_L1_BLOCK_TAG=latest
+export UPGRADE_SIGNAL_ENV_FILES=
+export UPGRADE_SIGNAL_ROLLUP_JSON="$TEST_DIR/rollup.json"
+printf '%s\n' '{"genesis":{"l2_time":123},"base":{"azul":0}}' >"$UPGRADE_SIGNAL_ROLLUP_JSON"
+
+# Match setup-devnet's root-owned directory and existing output file.
+docker run --rm -v "$TEST_DIR:/test" alpine sh -c '
+  mkdir -p "/test/root configs"
+  echo stale > "/test/root configs/upgrade-signal.env"
+  chmod 755 "/test/root configs"
+  chmod 644 "/test/root configs/upgrade-signal.env"
+'
+[[ ! -w "$TEST_DIR/root configs" ]]
+[[ ! -w "$TEST_DIR/root configs/upgrade-signal.env" ]]
+
+for output in "user configs/new.env" "root configs/upgrade-signal.env" "root configs/new.env"; do
+  export UPGRADE_SIGNAL_ENV_OUT="$TEST_DIR/$output"
+  # Repeat to cover both creation and replacement without accumulating content.
+  for attempt in 1 2; do
+    bash "$SCRIPT_DIR/upgrade-signal.sh" setup >"$TEST_DIR/output"
+    diff -u <(printf '%s\n' \
+      "BASE_NODE_UPGRADE_SIGNAL_CONTRACT=$UPGRADE_SIGNAL_CONTRACT" \
+      "BASE_NODE_UPGRADE_SIGNAL_L1_RPC=$UPGRADE_SIGNAL_CONTAINER_L1_RPC" \
+      "BASE_NODE_UPGRADE_SIGNAL_MODE=$UPGRADE_SIGNAL_MODE" \
+      "BASE_NODE_UPGRADE_SIGNAL_L1_BLOCK_TAG=$UPGRADE_SIGNAL_L1_BLOCK_TAG") "$UPGRADE_SIGNAL_ENV_OUT"
+  done
+  echo "PASS: $output"
+done

--- a/etc/scripts/devnet/upgrade-signal.sh
+++ b/etc/scripts/devnet/upgrade-signal.sh
@@ -150,9 +150,21 @@ contract_code() {
 
 write_env_file() {
   local contract="$1"
-  mkdir -p "$(dirname "$ENV_OUT")"
+  local env_dir
+  env_dir="$(dirname "$ENV_OUT")"
+  mkdir -p "$env_dir"
 
-  cat >"$ENV_OUT" <<EOF
+  local writer=(tee "$ENV_OUT")
+  if [[ -e "$ENV_OUT" && ! -w "$ENV_OUT" ]] || [[ ! -e "$ENV_OUT" && ! -w "$env_dir" ]]; then
+    # setup-devnet creates root-owned bind-mounted configs on Linux. Write only
+    # this file through Docker, without elevating the RPC/deployment commands or
+    # changing ownership of the configs shared with the running containers.
+    require_cmd docker
+    env_dir="$(cd "$env_dir" && pwd)"
+    writer=(docker run --rm -i --network none -v "$env_dir:/configs" alpine tee "/configs/$(basename "$ENV_OUT")")
+  fi
+
+  "${writer[@]}" >/dev/null <<EOF
 BASE_NODE_UPGRADE_SIGNAL_CONTRACT=$contract
 BASE_NODE_UPGRADE_SIGNAL_L1_RPC=$CONTAINER_L1_RPC
 BASE_NODE_UPGRADE_SIGNAL_MODE=$MODE


### PR DESCRIPTION
## Summary

Write upgrade-signal environment files through Docker when root-owned devnet configs prevent host writes, without elevating deployment commands or changing shared config ownership. Suppress command echo for shell-script Just recipes while preserving script output. Add regression coverage using real Docker-owned files and directories with offline RPC stubs; permission tests, Bash syntax checks, and command-echo verification pass.