### PR TITLE
Remove Cobalt absolute schedule validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,7 +3986,6 @@ dependencies = [
  "base-consensus-disc",
  "base-consensus-peers",
  "base-metrics",
- "base-protocol",
  "derive_more 2.1.1",
  "discv5 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",

--- a/crates/consensus/engine/README.md
+++ b/crates/consensus/engine/README.md
@@ -37,7 +37,6 @@ The engine implements a task-driven architecture where operations are queued and
 ```
 
 - **Automatic Forkchoice Handling**: [`Engine::build`](crate::Engine::build) automatically performs forkchoice updates during block building, eliminating the need for explicit forkchoice management in user code.
-- **Rollup Schedule Validation**: [`InsertTask`](crate::InsertTask) validates Cobalt payload timestamps against the absolute rollup schedule before calling `engine_newPayload`.
 - **Internal Synchronization**: [`SynchronizeTask`](crate::SynchronizeTask) handles internal execution layer synchronization and is primarily used by other tasks rather than directly by users.
 - **Priority-Based Execution**: Tasks are executed in priority order to ensure optimal sequencer performance and block processing efficiency.
 

--- a/crates/consensus/engine/src/task_queue/tasks/insert/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/error.rs
@@ -5,7 +5,7 @@
 use alloy_rpc_types_engine::PayloadStatusEnum;
 use alloy_transport::{RpcError, TransportErrorKind};
 use base_common_rpc_types_engine::BasePayloadError;
-use base_protocol::{BaseTimeScheduleError, FromBlockError};
+use base_protocol::FromBlockError;
 
 use crate::{
     EngineTaskError, SynchronizeTaskError, task_queue::tasks::task::EngineTaskErrorSeverity,
@@ -31,9 +31,6 @@ pub enum InsertTaskError {
     /// Error converting the payload + chain genesis into an L2 block info.
     #[error(transparent)]
     L2BlockInfoConstruction(#[from] FromBlockError),
-    /// The payload timestamp does not match the absolute rollup schedule.
-    #[error(transparent)]
-    InvalidBaseTimeSchedule(#[from] BaseTimeScheduleError),
     /// The forkchoice update call to consolidate the block into the engine state failed.
     #[error(transparent)]
     ForkchoiceUpdateFailed(#[from] SynchronizeTaskError),
@@ -47,8 +44,7 @@ impl EngineTaskError for InsertTaskError {
         match self {
             Self::EmptyAuthoritativePayloads
             | Self::FromBlockError(_)
-            | Self::L2BlockInfoConstruction(_)
-            | Self::InvalidBaseTimeSchedule(_) => EngineTaskErrorSeverity::Critical,
+            | Self::L2BlockInfoConstruction(_) => EngineTaskErrorSeverity::Critical,
             Self::InsertFailed(_)
             | Self::UnexpectedPayloadStatus(_)
             | Self::ForkchoiceUpdateDidNotApply => EngineTaskErrorSeverity::Temporary,

--- a/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/insert/task.rs
@@ -12,7 +12,7 @@ use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::{
     BaseExecutionPayload, BaseExecutionPayloadEnvelope, BaseExecutionPayloadSidecar,
 };
-use base_protocol::{BaseTimeUpdateTx, L2BlockInfo};
+use base_protocol::L2BlockInfo;
 use tokio::sync::mpsc;
 
 use crate::{
@@ -254,13 +254,6 @@ impl<EngineClient_: EngineClient> InsertTask<EngineClient_> {
             return Ok(state.sync_state.unsafe_head());
         }
 
-        BaseTimeUpdateTx::validate_block_timestamp(
-            &self.rollup_config,
-            &block.body.transactions,
-            block.header.number,
-            block.header.timestamp,
-        )?;
-
         // Insert the new payload.
         let insert_time_start = Instant::now();
         let response = match execution_payload {
@@ -388,15 +381,12 @@ mod tests {
     use alloy_primitives::{Address, B256, Bloom, FixedBytes, U256};
     use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum};
     use base_common_consensus::{BaseTxEnvelope, TxDeposit};
-    use base_common_genesis::{BaseUpgradeConfig, RollupConfig, UpgradeConfig};
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadEnvelope};
-    use base_protocol::{
-        BaseTimeScheduleError, BaseTimeUpdateTx, BlockInfo, L1BlockInfoBedrock, L2BlockInfo,
-    };
+    use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
 
     use super::{InsertPayloadPolicy, InsertPayloadSafety, InsertTask};
     use crate::{
-        Engine, EngineTaskError, EngineTaskErrorSeverity, EngineTaskExt, InsertTaskError,
+        Engine, EngineTaskExt, InsertTaskError,
         test_utils::{TestEngineStateBuilder, test_engine_client_builder},
     };
 
@@ -453,36 +443,6 @@ mod tests {
 
     fn bedrock_payload(block_number: u64) -> BaseExecutionPayload {
         bedrock_payload_with_parent(block_number, B256::ZERO)
-    }
-
-    fn cobalt_config() -> Arc<RollupConfig> {
-        Arc::new(RollupConfig {
-            block_time: 2,
-            upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { cobalt: Some(2), ..Default::default() },
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-    }
-
-    fn cobalt_payload(
-        block_number: u64,
-        timestamp: u64,
-        timestamp_millis_part: u16,
-    ) -> BaseExecutionPayload {
-        let BaseExecutionPayload::V1(mut payload) = bedrock_payload(block_number) else {
-            unreachable!()
-        };
-        payload.timestamp = timestamp;
-        payload.transactions.push(
-            BaseTxEnvelope::from(
-                BaseTimeUpdateTx::new(timestamp_millis_part).unwrap().into_deposit_tx(block_number),
-            )
-            .encoded_2718()
-            .into(),
-        );
-        BaseExecutionPayload::V1(payload)
     }
 
     fn canyon_payload(block_number: u64) -> BaseExecutionPayload {
@@ -649,85 +609,6 @@ mod tests {
             "stale unsafe payload should not be sent to engine_newPayload"
         );
         assert_eq!(state.sync_state.unsafe_head(), current_unsafe);
-    }
-
-    #[tokio::test]
-    async fn cobalt_schedule_mismatch_is_rejected_before_new_payload() {
-        let client = test_client();
-        let mut state = TestEngineStateBuilder::new().build();
-
-        for (payload, expected_error) in [
-            (
-                cobalt_payload(2, 3, 200),
-                BaseTimeScheduleError::InvalidTimestamp { expected: 2, actual: 3 },
-            ),
-            (
-                cobalt_payload(2, 2, 400),
-                BaseTimeScheduleError::InvalidTimestampMillisPart { expected: 200, actual: 400 },
-            ),
-        ] {
-            let error = InsertTask::unsafe_payload(
-                Arc::clone(&client),
-                cobalt_config(),
-                BaseExecutionPayloadEnvelope {
-                    parent_beacon_block_root: None,
-                    execution_payload: payload,
-                },
-            )
-            .execute_with_result(&mut state)
-            .await
-            .unwrap_err();
-
-            assert_eq!(error.severity(), EngineTaskErrorSeverity::Critical);
-            assert!(matches!(
-                &error,
-                InsertTaskError::InvalidBaseTimeSchedule(actual) if *actual == expected_error
-            ));
-        }
-
-        assert!(client.last_new_payload_v2().await.is_none());
-    }
-
-    #[tokio::test]
-    async fn local_cobalt_schedule_mismatch_is_returned_to_caller() {
-        let client = test_client();
-        let mut state = TestEngineStateBuilder::new().build();
-        let envelope = BaseExecutionPayloadEnvelope {
-            parent_beacon_block_root: None,
-            execution_payload: cobalt_payload(2, 3, 200),
-        };
-
-        let error = InsertTask::new(
-            Arc::clone(&client),
-            cobalt_config(),
-            envelope,
-            InsertPayloadSafety::Unsafe,
-        )
-        .execute(&mut state)
-        .await
-        .unwrap_err();
-
-        assert!(matches!(error, InsertTaskError::InvalidBaseTimeSchedule(_)));
-        assert!(client.last_new_payload_v2().await.is_none());
-    }
-
-    #[tokio::test]
-    async fn stale_unsafe_payload_is_dropped_before_schedule_validation() {
-        let client = test_client();
-        let current_unsafe = l2_block_info(4, B256::with_last_byte(4), B256::with_last_byte(3));
-        let mut state = TestEngineStateBuilder::new().with_unsafe_head(current_unsafe).build();
-        let envelope = BaseExecutionPayloadEnvelope {
-            parent_beacon_block_root: None,
-            execution_payload: cobalt_payload(2, 3, 200),
-        };
-
-        let result = InsertTask::unsafe_payload(Arc::clone(&client), cobalt_config(), envelope)
-            .execute_with_result(&mut state)
-            .await
-            .expect("stale payload should be dropped before validation");
-
-        assert_eq!(result, current_unsafe);
-        assert!(client.last_new_payload_v2().await.is_none());
     }
 
     #[tokio::test]

--- a/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
+++ b/crates/consensus/engine/src/task_queue/tasks/seal/error.rs
@@ -75,8 +75,7 @@ impl SealTaskError {
                 }
                 InsertTaskError::EmptyAuthoritativePayloads
                 | InsertTaskError::FromBlockError(_)
-                | InsertTaskError::L2BlockInfoConstruction(_)
-                | InsertTaskError::InvalidBaseTimeSchedule(_) => true,
+                | InsertTaskError::L2BlockInfoConstruction(_) => true,
                 InsertTaskError::InsertFailed(_)
                 | InsertTaskError::UnexpectedPayloadStatus(_)
                 | InsertTaskError::ForkchoiceUpdateDidNotApply => false,
@@ -116,7 +115,7 @@ impl EngineTaskError for SealTaskError {
 mod tests {
     use alloy_rpc_types_engine::PayloadStatusEnum;
     use alloy_transport::RpcError;
-    use base_protocol::{BaseTimeScheduleError, FromBlockError};
+    use base_protocol::FromBlockError;
     use rstest::rstest;
 
     use super::*;
@@ -174,13 +173,6 @@ mod tests {
     )]
     #[case::l2_block_info_construction(
         InsertTaskError::L2BlockInfoConstruction(FromBlockError::InvalidGenesisHash),
-        true
-    )]
-    #[case::invalid_base_time_schedule(
-        InsertTaskError::InvalidBaseTimeSchedule(BaseTimeScheduleError::InvalidTimestamp {
-            expected: 1,
-            actual: 2,
-        }),
         true
     )]
     fn test_insertion_non_forkchoice_error_is_fatal(

--- a/crates/consensus/gossip/Cargo.toml
+++ b/crates/consensus/gossip/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 # consensus
 base-metrics.workspace = true
-base-protocol.workspace = true
 base-consensus-disc.workspace = true
 base-consensus-peers.workspace = true
 base-common-genesis.workspace = true

--- a/crates/consensus/gossip/src/block_validity.rs
+++ b/crates/consensus/gossip/src/block_validity.rs
@@ -9,7 +9,6 @@ use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::{
     BaseExecutionPayload, BaseExecutionPayloadV4, BasePayloadError, NetworkPayloadEnvelope,
 };
-use base_protocol::{BaseTimeScheduleError, BaseTimeUpdateTx};
 use libp2p::gossipsub::MessageAcceptance;
 
 use super::BlockHandler;
@@ -51,9 +50,6 @@ pub enum BlockInvalidError {
     /// Invalid block.
     #[error(transparent)]
     InvalidBlock(#[from] BasePayloadError),
-    /// The block timestamp does not match the absolute Cobalt schedule.
-    #[error(transparent)]
-    InvalidBaseTimeSchedule(#[from] BaseTimeScheduleError),
     /// The block has an invalid parent beacon block root.
     #[error("Payload is on v3+ topic, but has empty parent beacon root")]
     ParentBeaconRoot,
@@ -151,7 +147,6 @@ impl BlockHandler {
                     BlockInvalidError::BlockSeen { .. } => "block_seen",
                     BlockInvalidError::InvalidBlock(_)
                     | BlockInvalidError::BaseFeePerGasOverflow(_) => "invalid_block",
-                    BlockInvalidError::InvalidBaseTimeSchedule(_) => "invalid_base_time_schedule",
                     BlockInvalidError::ParentBeaconRoot => "parent_beacon_root",
                     BlockInvalidError::BlobGasUsed => "blob_gas_used",
                     BlockInvalidError::ExcessBlobGas => "excess_blob_gas",
@@ -214,14 +209,6 @@ impl BlockHandler {
 
         // CHECK: The payload is valid for the specific version of this block.
         self.validate_version_specific_payload(envelope)?;
-
-        // Reject invalid schedules before gossip acceptance, forwarding, or recording as seen.
-        BaseTimeUpdateTx::validate_block_timestamp(
-            &self.rollup_config,
-            &block.body.transactions,
-            block.header.number,
-            block.header.timestamp,
-        )?;
 
         if let Some(seen_hashes_at_height) =
             self.seen_hashes.get_mut(&envelope.payload.block_number())

--- a/crates/consensus/gossip/src/handler.rs
+++ b/crates/consensus/gossip/src/handler.rs
@@ -154,104 +154,12 @@ impl BlockHandler {
 #[cfg(test)]
 mod tests {
     use alloy_chains::Chain;
-    use alloy_consensus::proofs::calculate_transaction_root;
-    use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
     use alloy_primitives::{B256, Signature};
     use alloy_rpc_types_engine::{ExecutionPayloadV2, ExecutionPayloadV3};
-    use base_common_consensus::{BaseTxEnvelope, TxDeposit};
-    use base_common_genesis::{BaseUpgradeConfig, ChainGenesis, UpgradeConfig};
     use base_common_rpc_types_engine::{BaseExecutionPayload, BaseExecutionPayloadV4, PayloadHash};
-    use base_protocol::BaseTimeUpdateTx;
 
     use super::*;
     use crate::{v2_valid_block, v3_valid_block, v4_valid_block};
-
-    #[test]
-    fn cobalt_schedules_are_checked_before_gossip_acceptance() {
-        let template = v4_valid_block();
-        let activation = template.header.timestamp;
-        let config = RollupConfig {
-            l2_chain_id: Chain::base_mainnet(),
-            block_time: 2,
-            genesis: ChainGenesis { l2_time: activation - 2, ..Default::default() },
-            upgrades: UpgradeConfig {
-                isthmus_time: Some(0),
-                base: BaseUpgradeConfig { cobalt: Some(activation), ..Default::default() },
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        for (number, timestamp, millis, valid) in [
-            (0, activation - 2, None, true),
-            (1, activation, Some(0), true),
-            (2, activation, Some(200), true),
-            (3, activation, Some(400), true),
-            (4, activation, Some(600), true),
-            (5, activation, Some(800), true),
-            (6, activation + 1, Some(0), true),
-            (2, activation + 1, Some(200), false),
-            (2, activation - 1, Some(200), false),
-            (2, activation, Some(400), false),
-            (1, activation, None, false),
-            (2, activation, None, false),
-        ] {
-            let mut block = template.clone();
-            block.header.number = number;
-            block.header.timestamp = timestamp;
-            block.header.requests_hash = Some(EMPTY_REQUESTS_HASH);
-            block.body.transactions = vec![BaseTxEnvelope::from(TxDeposit::default())];
-            if let Some(millis) = millis {
-                block
-                    .body
-                    .transactions
-                    .push(BaseTimeUpdateTx::new(millis).unwrap().into_deposit_tx(number).into());
-            }
-            block.header.transactions_root = calculate_transaction_root(&block.body.transactions);
-
-            let envelope = NetworkPayloadEnvelope {
-                payload: BaseExecutionPayload::V4(
-                    BaseExecutionPayloadV4::from_v3_with_withdrawals_root(
-                        ExecutionPayloadV3::from_block_slow(&block),
-                        block.header.withdrawals_root.unwrap(),
-                    ),
-                ),
-                signature: Signature::test_signature(),
-                payload_hash: PayloadHash(B256::ZERO),
-                parent_beacon_block_root: block.header.parent_beacon_block_root,
-            };
-            let encoded = envelope.encode_v4().unwrap();
-            let decoded = NetworkPayloadEnvelope::decode_v4(&encoded).unwrap();
-            let msg = decoded.payload_hash.signature_message(config.l2_chain_id.id());
-            let signer = decoded.signature.recover_address_from_prehash(&msg).unwrap();
-            let (_, signer_recv) = tokio::sync::watch::channel(signer);
-            let mut handler = BlockHandler::new(config.clone(), signer_recv);
-            let message = Message {
-                source: None,
-                sequence_number: None,
-                topic: handler.blocks_v4_topic.clone().into(),
-                data: encoded,
-            };
-
-            let (acceptance, forwarded) = handler.handle(message.clone());
-            assert!(
-                matches!(
-                    (valid, acceptance),
-                    (true, MessageAcceptance::Accept) | (false, MessageAcceptance::Reject)
-                ),
-                "block {number}, timestamp {timestamp}, millis {millis:?}"
-            );
-            assert_eq!(forwarded.is_some(), valid);
-
-            // Only accepted blocks become seen; invalid schedules must remain rejected on replay.
-            let (acceptance, forwarded) = handler.handle(message);
-            assert!(matches!(
-                (valid, acceptance),
-                (true, MessageAcceptance::Ignore) | (false, MessageAcceptance::Reject)
-            ));
-            assert!(forwarded.is_none());
-        }
-    }
 
     #[test]
     fn test_valid_decode() {

--- a/crates/consensus/protocol/src/base_time.rs
+++ b/crates/consensus/protocol/src/base_time.rs
@@ -106,42 +106,6 @@ impl BaseTimeUpdateTx {
         Ok(timestamp.wrapping_mul(1_000).wrapping_add(u64::from(base_time.timestamp_millis_part())))
     }
 
-    /// Validates a Cobalt block's timestamp against the absolute rollup schedule.
-    pub fn validate_block_timestamp<T: BaseTransaction>(
-        rollup_config: &RollupConfig,
-        transactions: &[T],
-        block_number: u64,
-        timestamp: u64,
-    ) -> Result<(), BaseTimeScheduleError> {
-        let Some(cobalt_activation_block) = rollup_config.cobalt_activation_block_number() else {
-            return Ok(());
-        };
-        let blocks_since_genesis = block_number.saturating_sub(rollup_config.genesis.l2.number);
-        if blocks_since_genesis < cobalt_activation_block {
-            return Ok(());
-        }
-
-        let (expected_timestamp, expected_millis_part) =
-            rollup_config.l2_block_timestamp_parts(block_number);
-        if timestamp != expected_timestamp {
-            return Err(BaseTimeScheduleError::InvalidTimestamp {
-                expected: expected_timestamp,
-                actual: timestamp,
-            });
-        }
-
-        let actual_millis_part =
-            Self::extract_from_transactions(transactions, block_number)?.timestamp_millis_part();
-        if actual_millis_part != expected_millis_part {
-            return Err(BaseTimeScheduleError::InvalidTimestampMillisPart {
-                expected: expected_millis_part,
-                actual: actual_millis_part,
-            });
-        }
-
-        Ok(())
-    }
-
     /// Validates and decodes a `BaseTime` metadata deposit.
     pub fn validate_deposit(
         deposit: &TxDeposit,
@@ -261,30 +225,6 @@ pub enum BaseTimeMetadataError {
     InvalidCalldata(BaseTimeUpdateDecodeError),
 }
 
-/// An error validating a Cobalt block timestamp against the rollup schedule.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub enum BaseTimeScheduleError {
-    /// The whole-second timestamp does not match the scheduled timestamp.
-    #[error("invalid L2 block timestamp: expected {expected}, got {actual}")]
-    InvalidTimestamp {
-        /// The scheduled timestamp.
-        expected: u64,
-        /// The block's timestamp.
-        actual: u64,
-    },
-    /// The `BaseTime` metadata deposit is invalid.
-    #[error(transparent)]
-    InvalidMetadata(#[from] BaseTimeMetadataError),
-    /// The millisecond component does not match the scheduled timestamp.
-    #[error("invalid BaseTime timestamp millis part: expected {expected}, got {actual}")]
-    InvalidTimestampMillisPart {
-        /// The scheduled millisecond component.
-        expected: u16,
-        /// The block's millisecond component.
-        actual: u16,
-    },
-}
-
 #[cfg(test)]
 mod tests {
     use alloy_consensus::{Sealable, TxLegacy};
@@ -292,11 +232,9 @@ mod tests {
     use base_common_consensus::{
         BaseTransactionSigned, BaseTypedTransaction, Predeploys, SystemAddresses, TxDeposit,
     };
-    use base_common_genesis::{BaseUpgradeConfig, ChainGenesis, RollupConfig, UpgradeConfig};
 
     use super::{
-        BaseTimeMetadataError, BaseTimeScheduleError, BaseTimeUpdateDecodeError,
-        BaseTimeUpdateError, BaseTimeUpdateTx,
+        BaseTimeMetadataError, BaseTimeUpdateDecodeError, BaseTimeUpdateError, BaseTimeUpdateTx,
     };
     use crate::REGOLITH_SYSTEM_TX_GAS;
 
@@ -396,73 +334,6 @@ mod tests {
         ];
 
         assert_eq!(BaseTimeUpdateTx::extract_timestamp_ms(&transactions, 9, 42), Ok(42_600));
-    }
-
-    #[test]
-    fn validates_cobalt_block_timestamp_against_absolute_schedule() {
-        let config = RollupConfig {
-            genesis: ChainGenesis { l2_time: 10, ..Default::default() },
-            block_time: 2,
-            upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { cobalt: Some(14), ..Default::default() },
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let transactions = |block_number, millis_part| -> Vec<BaseTransactionSigned> {
-            vec![
-                TxDeposit::default().seal_slow().into(),
-                base_time_deposit(block_number, millis_part).seal_slow().into(),
-            ]
-        };
-
-        assert_eq!(
-            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(2, 0), 2, 14),
-            Ok(())
-        );
-        assert_eq!(
-            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(3, 200), 3, 14),
-            Ok(())
-        );
-        assert_eq!(
-            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(7, 0), 7, 15),
-            Ok(())
-        );
-        assert_eq!(
-            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(3, 200), 3, 15),
-            Err(BaseTimeScheduleError::InvalidTimestamp { expected: 14, actual: 15 })
-        );
-        assert_eq!(
-            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(3, 400), 3, 14),
-            Err(BaseTimeScheduleError::InvalidTimestampMillisPart { expected: 200, actual: 400 })
-        );
-        assert_eq!(
-            BaseTimeUpdateTx::validate_block_timestamp(&config, &transactions(7, 800), 7, 15),
-            Err(BaseTimeScheduleError::InvalidTimestampMillisPart { expected: 0, actual: 800 })
-        );
-    }
-
-    #[test]
-    fn skips_schedule_validation_before_cobalt() {
-        let config = RollupConfig {
-            genesis: ChainGenesis { l2_time: 10, ..Default::default() },
-            block_time: 2,
-            upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { cobalt: Some(14), ..Default::default() },
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-
-        assert_eq!(
-            BaseTimeUpdateTx::validate_block_timestamp::<BaseTransactionSigned>(
-                &config,
-                &[],
-                1,
-                u64::MAX,
-            ),
-            Ok(())
-        );
     }
 
     #[test]

--- a/crates/consensus/protocol/src/lib.rs
+++ b/crates/consensus/protocol/src/lib.rs
@@ -53,8 +53,7 @@ pub use deposits::{DepositDecodeError, Deposits};
 
 mod base_time;
 pub use base_time::{
-    BaseTimeMetadataError, BaseTimeScheduleError, BaseTimeUpdateDecodeError, BaseTimeUpdateError,
-    BaseTimeUpdateTx,
+    BaseTimeMetadataError, BaseTimeUpdateDecodeError, BaseTimeUpdateError, BaseTimeUpdateTx,
 };
 
 mod timing;

--- a/crates/consensus/service/src/actors/engine/engine_request_processor.rs
+++ b/crates/consensus/service/src/actors/engine/engine_request_processor.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use alloy_eips::BlockNumberOrTag;
-use base_common_consensus::BaseTxEnvelope;
 use base_common_genesis::RollupConfig;
 use base_common_rpc_types_engine::BaseExecutionPayloadEnvelope;
 use base_consensus_derive::{ResetSignal, Signal};
@@ -10,7 +9,7 @@ use base_consensus_engine::{
     EngineTaskErrorSeverity, EngineTaskErrors, FinalizeTask, ForkchoiceCheckpointLabel,
     ForkchoiceCheckpointReader, InsertTask, InsertTaskResult, NoopForkchoiceCheckpointReader,
 };
-use base_protocol::{BaseTimeUpdateTx, L2BlockInfo};
+use base_protocol::L2BlockInfo;
 use tokio::{sync::mpsc, task::JoinHandle};
 
 use crate::{
@@ -456,24 +455,6 @@ where
 
     /// Handles an unsafe payload supplied through the admin API.
     pub fn handle_admin_unsafe_l2_block(&mut self, envelope: BaseExecutionPayloadEnvelope) {
-        // Admin injection bypasses gossip validation. Leave conversion errors to InsertTask,
-        // but drop invalid schedules at ingress just as the gossip handler does.
-        if let Ok(block) = envelope.execution_payload.clone().try_into_block::<BaseTxEnvelope>()
-            && let Err(error) = BaseTimeUpdateTx::validate_block_timestamp(
-                &self.rollup,
-                &block.body.transactions,
-                block.header.number,
-                block.header.timestamp,
-            )
-        {
-            warn!(
-                target: "engine",
-                %error,
-                block_number = block.header.number,
-                "Dropping admin payload with invalid BaseTime schedule"
-            );
-            return;
-        }
         self.handle_external_unsafe_l2_block(envelope);
     }
 
@@ -705,7 +686,7 @@ mod tests {
             test_engine_client_builder,
         },
     };
-    use base_protocol::{BaseTimeUpdateTx, BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
+    use base_protocol::{BlockInfo, L1BlockInfoBedrock, L2BlockInfo};
     use rstest::rstest;
     use tokio::sync::{mpsc, watch};
 
@@ -829,61 +810,6 @@ mod tests {
         let engine = Engine::new(initial_state, state_tx, queue_tx);
 
         (EngineProcessor::new(client, config, derivation_client, engine), queue_rx)
-    }
-
-    #[rstest]
-    #[case::wrong_second(3, Some(200), false)]
-    #[case::wrong_slot(2, Some(400), false)]
-    #[case::missing_metadata(2, None, false)]
-    #[case::valid(2, Some(200), true)]
-    #[tokio::test]
-    async fn admin_payload_schedule_is_checked_before_enqueue(
-        #[case] timestamp: u64,
-        #[case] millis: Option<u16>,
-        #[case] valid: bool,
-    ) {
-        let config = RollupConfig {
-            block_time: 2,
-            upgrades: UpgradeConfig {
-                base: BaseUpgradeConfig { cobalt: Some(2), ..Default::default() },
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let unsafe_head = l2_head(1, B256::with_last_byte(1));
-        let mut envelope = unsafe_payload(2, unsafe_head.block_info.hash, B256::with_last_byte(2));
-        let BaseExecutionPayload::V1(payload) = &mut envelope.execution_payload else {
-            unreachable!();
-        };
-        payload.timestamp = timestamp;
-        payload.transactions = vec![l1_info_deposit_tx_bytes().into()];
-        if let Some(millis) = millis {
-            payload.transactions.push(
-                BaseTxEnvelope::from(BaseTimeUpdateTx::new(millis).unwrap().into_deposit_tx(2))
-                    .encoded_2718()
-                    .into(),
-            );
-        }
-
-        if !valid {
-            let (mut local, _) = unsafe_payload_processor(true, unsafe_head, None, config.clone());
-            local.handle_local_unsafe_l2_block(envelope.clone(), None);
-            let error = local.engine.drain().await.unwrap_err();
-            assert_eq!(error.severity(), EngineTaskErrorSeverity::Critical);
-            assert!(local.client.last_new_payload_v2().await.is_none());
-        }
-
-        let (mut admin, queue_rx) = unsafe_payload_processor(true, unsafe_head, None, config);
-        admin.client.set_new_payload_v2_response(valid_fcu().payload_status).await;
-        admin.client.set_fork_choice_updated_v3_response(valid_fcu()).await;
-        admin.handle_admin_unsafe_l2_block(envelope);
-        assert_eq!(*queue_rx.borrow(), usize::from(valid));
-        admin.engine.drain().await.unwrap();
-        assert_eq!(admin.client.last_new_payload_v2().await.is_some(), valid);
-        assert_eq!(
-            admin.engine_state().sync_state.unsafe_head().block_info.number,
-            if valid { 2 } else { 1 }
-        );
     }
 
     #[rstest]


### PR DESCRIPTION
Remove the absolute Cobalt schedule gate from consensus payload ingestion.

- Restore engine, gossip, and admin payload handling without schedule rejection.
- Remove the unused validation API, errors, tests, and dependency.