### PR TITLE
Retarget builder cutover coverage to Denim

### DIFF
--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -154,18 +154,18 @@ Anvil mines one block every 12 seconds. Do not use timestamp-warp RPCs in
 this variant: Base derives Beacon slots from L1 timestamps, so arbitrary time
 jumps would break the one-slot-per-execution-block mapping used to fetch blobs.
 
-Cobalt activates at block 22 by default and switches the sequencer to its 200ms
+Denim activates at block 25 by default and switches the sequencer to its 200ms
 cadence. The local Nitro stack exercises proof generation across this boundary:
 
 ```bash
 just anvil-nitro-local up
 ```
 
-Set `L2_BASE_COBALT_BLOCK` to another block to move activation, or set it to an
-empty value to leave Cobalt unscheduled.
+Set `L2_BASE_DENIM_BLOCK` to another block to move activation, or set it to an
+empty value to leave Denim unscheduled.
 
-To exercise Cobalt validity transactions on the native payload builder, the
-deployment must schedule Cobalt and configure both sides of the forwarding path:
+To exercise validity transactions on the native payload builder, the deployment
+must schedule Denim and configure both sides of the forwarding path:
 
 - builder: `--builder.enable-experimental-validity-transactions` and
   `--builder.payload-builder-cutover`. The builder flag also registers
@@ -173,11 +173,10 @@ deployment must schedule Cobalt and configure both sides of the forwarding path:
 - ingress/client: `--enable-experimental-validity-transactions` and a
   `--builder-rpc-urls` endpoint targeting the builder
 
-The default devnet compose files include these flags and schedule Cobalt at
-block 22 followed by Denim at block 25. The later Denim activation changes neither
-builder selection nor block cadence. Native payload building supports balance,
-storage, and block-number predicates; `flashblock_index` predicates remain specific
-to the Flashblocks builder and are rejected after the Cobalt cutover.
+The default devnet compose files include these flags and schedule Denim at block 25.
+Native payload building supports balance, storage, and block-number predicates;
+`flashblock_index` predicates remain specific to the Flashblocks builder and are
+rejected after the Denim cutover.
 
 Zenith is the permanently unscheduled, genesis-only gate for future hardfork feature testing.
 Zenith mode additionally activates Zenith at block 100:

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -60,7 +60,7 @@ pub struct InProcessBuilderConfig {
     /// Whether to accept experimental validity-bearing transactions and expose
     /// `base_sendRawTransactionValidity`.
     pub enable_experimental_validity_transactions: bool,
-    /// Whether to run both payload builders and cut over to basic at Cobalt.
+    /// Whether to run both payload builders and cut over to basic at Denim.
     pub payload_builder_cutover: bool,
     /// Additional node extensions installed after the builder's built-in RPC wiring.
     ///

--- a/etc/systems/src/l2/snapshot_stack.rs
+++ b/etc/systems/src/l2/snapshot_stack.rs
@@ -268,7 +268,7 @@ impl SnapshotL2Stack {
             .checked_sub(legacy_elapsed)
             .ok_or_else(|| eyre::eyre!("snapshot is too far ahead to anchor locally"))?;
         if block_interval == DevnetBlockInterval::TwoHundredMilliseconds {
-            config.set_upgrade_activation_timestamp(BaseUpgrade::Cobalt, first_block_timestamp);
+            config.set_upgrade_activation_timestamp(BaseUpgrade::Denim, first_block_timestamp);
         }
         let (planned_timestamp, planned_millis) =
             config.l2_block_timestamp_parts(first_block_number);
@@ -287,7 +287,7 @@ impl SnapshotL2Stack {
     ) -> BaseChainSpec {
         if block_interval == DevnetBlockInterval::TwoHundredMilliseconds {
             chain_spec
-                .set_fork(BaseUpgrade::Cobalt, ForkCondition::Timestamp(first_block_timestamp));
+                .set_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(first_block_timestamp));
         }
         chain_spec
     }
@@ -473,7 +473,7 @@ mod tests {
     }
 
     #[test]
-    fn subsecond_cl_and_el_activate_cobalt_at_same_timestamp() {
+    fn subsecond_cl_and_el_activate_denim_at_same_timestamp() {
         let activation = 2_000_000_000;
         let rollup = SnapshotL2Stack::anchored_rollup_config(
             ChainConfig::mainnet().rollup_config(),
@@ -488,11 +488,11 @@ mod tests {
             DevnetBlockInterval::TwoHundredMilliseconds,
         );
 
-        assert!(!rollup.is_cobalt_active(activation - 1));
-        assert!(rollup.is_cobalt_active(activation));
-        assert!(!chain_spec.is_cobalt_active_at_timestamp(activation - 1));
-        assert!(chain_spec.is_cobalt_active_at_timestamp(activation));
-        assert_eq!(chain_spec.fork(BaseUpgrade::Cobalt), ForkCondition::Timestamp(activation));
+        assert!(!rollup.is_denim_active(activation - 1));
+        assert!(rollup.is_denim_active(activation));
+        assert!(!chain_spec.is_denim_active_at_timestamp(activation - 1));
+        assert!(chain_spec.is_denim_active_at_timestamp(activation));
+        assert_eq!(chain_spec.fork(BaseUpgrade::Denim), ForkCondition::Timestamp(activation));
     }
 
     #[test]

--- a/etc/systems/src/l2/stack.rs
+++ b/etc/systems/src/l2/stack.rs
@@ -82,7 +82,7 @@ pub struct L2StackConfig {
     /// Whether both L2 nodes enable experimental validity transaction transport,
     /// including `base_sendRawTransactionValidity` on the builder.
     pub enable_experimental_validity_transactions: bool,
-    /// Whether the active builder cuts over from flashblocks to basic at Cobalt.
+    /// Whether the active builder cuts over from flashblocks to basic at Denim.
     pub payload_builder_cutover: bool,
     /// Number of L1 blocks to keep distance from the L1 head for the client (validator)
     /// consensus node's derivation pipeline.

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -422,7 +422,7 @@ impl SystemTestStackBuilder {
         self
     }
 
-    /// Runs both payload builders and cuts selection from flashblocks to basic at Cobalt.
+    /// Runs both payload builders and cuts selection from flashblocks to basic at Denim.
     pub const fn with_payload_builder_cutover(mut self) -> Self {
         self.payload_builder_cutover = true;
         self

--- a/etc/systems/tests/builder_cutover.rs
+++ b/etc/systems/tests/builder_cutover.rs
@@ -1,4 +1,4 @@
-//! End-to-end tests for the Cobalt builder and 200ms cutover, with and without later Denim.
+//! End-to-end test for the Denim payload-builder and block-time cutover.
 
 use std::time::Duration;
 
@@ -10,7 +10,6 @@ use alloy_provider::{Provider, RootProvider};
 use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use base_common_flashblocks::{FlashblocksPayloadV1, Metadata};
-use base_common_genesis::{BaseUpgrade, RollupConfig};
 use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_system_tests::{ANVIL_ACCOUNT_1, SystemTestStackBuilder};
@@ -21,92 +20,54 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 const L1_CHAIN_ID: u64 = 1337;
 const L2_CHAIN_ID: u64 = 84538453;
-const COBALT_ACTIVATION_BLOCK: u64 = 10;
+const DENIM_ACTIVATION_BLOCK: u64 = 10;
 const BLOCK_TIMEOUT: Duration = Duration::from_secs(45);
 const REPLAY_QUIET_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[tokio::test]
-async fn cuts_over_builder_and_block_time_at_cobalt() -> Result<()> {
-    verify_cutover(None).await
-}
-
-#[tokio::test]
-async fn denim_keeps_native_builder_and_cobalt_cadence() -> Result<()> {
-    verify_cutover(Some(COBALT_ACTIVATION_BLOCK + 10)).await
-}
-
-async fn verify_cutover(denim_activation_block: Option<u64>) -> Result<()> {
+async fn cuts_over_builder_and_block_time_at_denim() -> Result<()> {
     base_node_runner::test_utils::init_silenced_tracing();
 
-    let mut setup = SystemTestStackBuilder::new()
+    let system = SystemTestStackBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
-        .with_base_cobalt_activation_block(COBALT_ACTIVATION_BLOCK)
-        .with_payload_builder_cutover();
-    if let Some(block) = denim_activation_block {
-        setup = setup.with_base_denim_activation_block(block);
-    }
-    let system = setup.build().await?;
+        .with_base_denim_activation_block(DENIM_ACTIVATION_BLOCK)
+        .with_payload_builder_cutover()
+        .build()
+        .await?;
     let builder = system.l2_builder_provider()?;
     let client = system.l2_client_provider()?;
     let signer = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_1.private_key)?;
-    let rollup_config: RollupConfig =
-        serde_json::from_slice(&std::fs::read(system.l2_deployment().rollup_config_path())?)?;
-    let denim_timestamp = rollup_config.upgrade_activation_timestamp(BaseUpgrade::Denim);
-    assert_eq!(denim_timestamp.is_some(), denim_activation_block.is_some());
 
     let pre_cutover_receipt_block =
         send_transaction(&builder, &signer).await.wrap_err("pre-cutover transaction failed")?;
     assert!(
-        pre_cutover_receipt_block < COBALT_ACTIVATION_BLOCK,
+        pre_cutover_receipt_block < DENIM_ACTIVATION_BLOCK,
         "pre-cutover transaction landed at block {pre_cutover_receipt_block}"
     );
 
-    wait_for_block(&builder, COBALT_ACTIVATION_BLOCK + 1).await?;
+    wait_for_block(&builder, DENIM_ACTIVATION_BLOCK + 1).await?;
     let post_cutover_receipt_block =
         send_transaction(&builder, &signer).await.wrap_err("post-cutover transaction failed")?;
     assert!(
-        post_cutover_receipt_block > COBALT_ACTIVATION_BLOCK,
+        post_cutover_receipt_block > DENIM_ACTIVATION_BLOCK,
         "post-cutover transaction landed at block {post_cutover_receipt_block}"
     );
 
-    let mut last_verified_block = post_cutover_receipt_block + 4;
-    if let Some(timestamp) = denim_timestamp {
-        let metrics_url = system.l2_stack().builder().metrics_url()?;
-        let metrics_before = reqwest::get(metrics_url.clone()).await?.text().await?;
-        let flashblocks_builds_before = selected_build_count(&metrics_before, "flashblocks")?;
-        let basic_builds_before = selected_build_count(&metrics_before, "basic")?;
-        assert!(flashblocks_builds_before > 0, "Flashblocks was never selected before Cobalt");
-        assert!(basic_builds_before > 0, "basic builder was never selected after Cobalt");
-
-        // Use the generated schedule rather than assuming the harness's requested block number
-        // still identifies the activation after Cobalt changes the block cadence.
-        let denim_active_head = wait_for_timestamp(&builder, timestamp).await?;
-        let post_denim_receipt_block =
-            send_transaction(&builder, &signer).await.wrap_err("post-Denim transaction failed")?;
-        assert!(
-            post_denim_receipt_block > denim_active_head,
-            "post-Denim transaction landed at block {post_denim_receipt_block}"
-        );
-        last_verified_block = post_denim_receipt_block + 4;
-        wait_for_block(&builder, last_verified_block).await?;
-
-        let metrics_after = reqwest::get(metrics_url).await?.text().await?;
-        assert_eq!(
-            selected_build_count(&metrics_after, "flashblocks")?,
-            flashblocks_builds_before,
-            "Denim restarted Flashblocks builder selection"
-        );
-        assert!(
-            selected_build_count(&metrics_after, "basic")? > basic_builds_before,
-            "basic builder was not selected after Denim"
-        );
-    }
-
+    let last_verified_block = post_cutover_receipt_block + 4;
     wait_for_block(&builder, last_verified_block).await?;
     wait_for_block(&client, last_verified_block).await?;
+    let metrics = reqwest::get(system.l2_stack().builder().metrics_url()?).await?.text().await?;
+    assert!(
+        selected_build_count(&metrics, "flashblocks")? > 0,
+        "Flashblocks was never selected before Denim"
+    );
+    assert!(
+        selected_build_count(&metrics, "basic")? > 0,
+        "basic builder was never selected after Denim"
+    );
     verify_chain_and_cadence(&builder, &client, last_verified_block).await?;
-    verify_flashblocks_stop_at_cobalt(&system.l2_stack().builder().flashblocks_url()).await?;
+    verify_flashblocks_stop_at_denim(&system.l2_stack().builder().flashblocks_url()).await?;
 
     Ok(())
 }
@@ -165,23 +126,6 @@ async fn wait_for_block(provider: &RootProvider<Base>, target: u64) -> Result<()
     .wrap_err_with(|| format!("timed out waiting for block {target}"))?
 }
 
-async fn wait_for_timestamp(provider: &RootProvider<Base>, timestamp: u64) -> Result<u64> {
-    timeout(BLOCK_TIMEOUT, async {
-        loop {
-            let block = provider
-                .get_block_by_number(BlockNumberOrTag::Latest)
-                .await?
-                .ok_or_eyre("builder block missing")?;
-            if block.header.timestamp >= timestamp {
-                return Ok(block.header.number);
-            }
-            sleep(Duration::from_millis(100)).await;
-        }
-    })
-    .await
-    .wrap_err_with(|| format!("timed out waiting for timestamp {timestamp}"))?
-}
-
 async fn verify_chain_and_cadence(
     builder: &RootProvider<Base>,
     client: &RootProvider<Base>,
@@ -210,7 +154,7 @@ async fn verify_chain_and_cadence(
             .timestamp_ms
             .unwrap_or_else(|| builder_block.header.timestamp.saturating_mul(1_000));
         if let Some(previous) = previous_timestamp_ms {
-            let expected_delta = if number <= COBALT_ACTIVATION_BLOCK { 2_000 } else { 200 };
+            let expected_delta = if number <= DENIM_ACTIVATION_BLOCK { 2_000 } else { 200 };
             assert_eq!(timestamp_ms - previous, expected_delta, "block {number} cadence mismatch");
         }
 
@@ -221,7 +165,7 @@ async fn verify_chain_and_cadence(
     Ok(())
 }
 
-async fn verify_flashblocks_stop_at_cobalt(url: &str) -> Result<()> {
+async fn verify_flashblocks_stop_at_denim(url: &str) -> Result<()> {
     let replay_url = format!("{url}?block_number=0&flashblock_index=0");
     let (stream, _) = connect_async(replay_url).await?;
     let (_, mut messages) = stream.split();
@@ -236,14 +180,14 @@ async fn verify_flashblocks_stop_at_cobalt(url: &str) -> Result<()> {
         positions.push((metadata.block_number, flashblock.index));
     }
 
-    assert!(!positions.is_empty(), "no pre-Cobalt flashblocks were published");
+    assert!(!positions.is_empty(), "no pre-Denim flashblocks were published");
     assert!(
-        positions.iter().any(|(number, _)| *number == COBALT_ACTIVATION_BLOCK - 1),
-        "no Flashblocks were published immediately before Cobalt: {positions:?}"
+        positions.iter().any(|(number, _)| *number == DENIM_ACTIVATION_BLOCK - 1),
+        "no Flashblocks were published immediately before Denim: {positions:?}"
     );
     assert!(
-        positions.iter().all(|(number, _)| *number < COBALT_ACTIVATION_BLOCK),
-        "post-Cobalt flashblock published at {positions:?}"
+        positions.iter().all(|(number, _)| *number < DENIM_ACTIVATION_BLOCK),
+        "post-Denim flashblock published at {positions:?}"
     );
 
     Ok(())

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -33,6 +33,7 @@ use tokio::time::{sleep, timeout};
 const L1_CHAIN_ID: u64 = 1337;
 const L2_CHAIN_ID: u64 = 84538453;
 const COBALT_ACTIVATION_BLOCK: u64 = 0;
+const DENIM_ACTIVATION_BLOCK: u64 = 0;
 const ZENITH_ACTIVATION_BLOCK: u64 = 0;
 const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 const PENDING_TX_TIMEOUT: Duration = Duration::from_secs(15);
@@ -51,13 +52,14 @@ async fn wait_for_pending_transaction(provider: &RootProvider<Base>, tx_hash: B2
     .wrap_err("transaction did not become pending on the builder")?
 }
 
-/// Starts a separate mempool and builder pair using the native Cobalt payload builder with validity
+/// Starts a separate mempool and builder pair using the native Denim payload builder with validity
 /// transport enabled on both nodes and Zenith active for EIP-8130 transactions.
 async fn start_validity_system() -> Result<SystemTestStack> {
     let system = SystemTestStackBuilder::new()
         .with_l1_chain_id(L1_CHAIN_ID)
         .with_l2_chain_id(L2_CHAIN_ID)
         .with_base_cobalt_activation_block(COBALT_ACTIVATION_BLOCK)
+        .with_base_denim_activation_block(DENIM_ACTIVATION_BLOCK)
         .with_base_zenith_activation_block(ZENITH_ACTIVATION_BLOCK)
         .with_tx_forwarding(
             TxForwardingConfig::new(vec![]).with_resend_after_ms(2000).with_max_batch_size(100),
@@ -435,7 +437,7 @@ async fn test_validity_transaction_submitted_directly_to_builder_is_included() -
 }
 
 /// Verifies a Zenith EIP-8130 transaction can carry validity predicates through forwarding and be
-/// included by the native Cobalt payload builder.
+/// included by the native Denim payload builder.
 #[tokio::test]
 async fn test_eip8130_validity_transaction_is_included_by_native_builder() -> Result<()> {
     let system = start_validity_system().await?;
@@ -561,7 +563,7 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
     client_provider.wait_for_balance(storage_signer.address(), Duration::from_secs(15)).await?;
 
     let current_block = builder_provider.get_block_number().await?;
-    // Native Cobalt blocks advance every 200 ms, so leave enough time to submit and observe all
+    // Native Denim blocks advance every 200 ms, so leave enough time to submit and observe all
     // three transactions before the future predicate becomes true.
     let target_block = current_block + 50;
     let recipient: Address = "0x000000000000000000000000000000000000dEaD".parse()?;


### PR DESCRIPTION
- Exercise the payload-builder and 200ms transition at Denim.
- Align snapshot CL/EL schedules and forwarding fixtures with Denim.
- Preserve stronger cutover assertions, Zenith coverage, and IPC isolation.