### PR TITLE
build: restore maxperf release artifacts

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -98,11 +98,11 @@ jobs:
           if [ "${{ matrix.target.triple }}" = "aarch64-unknown-linux-gnu" ]; then
             case "${{ matrix.binary }}" in
               base|base-consensus|basectl)
-                cargo rustc --locked --release -p "${{ matrix.binary }}" --bin "${{ matrix.binary }}" -- -C link-arg=-lblst
+                cargo rustc --locked --profile maxperf -p "${{ matrix.binary }}" --bin "${{ matrix.binary }}" -- -C link-arg=-lblst
                 exit
             esac
           fi
-          cargo build --locked --release --bin "${{ matrix.binary }}"
+          cargo build --locked --profile maxperf --bin "${{ matrix.binary }}"
 
       - name: Package binary
         run: |
@@ -110,7 +110,7 @@ jobs:
           TARGET="${{ matrix.target.triple }}"
           BIN="${{ matrix.binary }}"
           ARCHIVE="${BIN}-${TAG}-${TARGET}.tar.gz"
-          tar -czf "$ARCHIVE" -C target/release "$BIN"
+          tar -czf "$ARCHIVE" -C target/maxperf "$BIN"
           if command -v sha256sum &>/dev/null; then
             sha256sum "$ARCHIVE" > "${ARCHIVE}.sha256"
           else
@@ -208,7 +208,7 @@ jobs:
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}
           TARGET: ${{ matrix.image.target }}
-          PROFILE: release
+          PROFILE: maxperf
         run: |
           depot bake --project "${{ vars.DEPOT_PROJECT_ID }}" -f etc/docker/docker-bake.hcl "$TARGET" \
             --set "${TARGET}.tags=${IMAGE}" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,11 @@ strip = "symbols"
 panic = "unwind"
 codegen-units = 16
 
+[profile.maxperf]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
+
 # `release` sets `strip = "symbols"` (see above). This profile keeps `release` codegen identical
 # (opt-level=3, lto="thin", codegen-units=16, panic="unwind") while restoring
 # symbols. Debug info is not loaded at runtime, so it costs nothing but binary

--- a/docs/guides/RELEASE.md
+++ b/docs/guides/RELEASE.md
@@ -42,7 +42,7 @@ Once you are satisfied with an RC, run the **Publish Release** workflow (`Action
 - Enter the version number (e.g., `0.6.0` — no `v` prefix, no `releases/` prefix)
 - The workflow validates that the release branch exists and `Cargo.toml` is not `0.0.0`
 - Creates the final tag `vX.Y.Z` on the release branch
-- Builds the `base` image once (`PROFILE=release`) and tags it as `vX.Y.Z`, `X.Y`, `X`, and `latest` on `ghcr.io/base/node`
+- Builds the `base` image once (`PROFILE=maxperf`) and tags it as `vX.Y.Z`, `X.Y`, `X`, and `latest` on `ghcr.io/base/node`
 - Creates a draft GitHub release with auto-generated changelog and uploads binaries
 - Review and publish the draft release on GitHub
 


### PR DESCRIPTION
## Summary
- restore the `maxperf` Cargo profile with fat LTO and one codegen unit
- build RC and final-release Docker images and native binary artifacts with `maxperf`
- retain `release` for normal builds and document `maxperf` for final publishing

## Validation
- `git diff --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `docker buildx bake -f etc/docker/docker-bake.hcl --print base` (verified the default profile remains `release`)