### PR TITLE
build: use release for normal builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # Public operator node. `docker compose up` pulls ghcr.io/base/node.
-# Pass --build to compile this tree (PROFILE=maxperf, same as base/node). Pin with NODE_TAG=vX.Y.Z.
+# Pass --build to compile this tree with PROFILE=release. Pin with NODE_TAG=vX.Y.Z.
 services:
   execution:
     image: ghcr.io/base/node:${NODE_TAG:-latest}
@@ -8,7 +8,7 @@ services:
       dockerfile: etc/docker/Dockerfile.rust-services
       target: base
       args:
-        PROFILE: ${PROFILE:-maxperf}
+        PROFILE: ${PROFILE:-release}
     restart: unless-stopped
     ports:
       - "8545:8545" # RPC
@@ -28,7 +28,7 @@ services:
       dockerfile: etc/docker/Dockerfile.rust-services
       target: base
       args:
-        PROFILE: ${PROFILE:-maxperf}
+        PROFILE: ${PROFILE:-release}
     restart: unless-stopped
     depends_on:
       - execution

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the Dockerfiles and Compose configuration for the **local devnet** and internal Rust services.
 
-The public operator image (`ghcr.io/base/node`) is the `base` target in `Dockerfile.rust-services`. Published images and operator `--build` use `PROFILE=maxperf` (same as `base/node`). The bake/Dockerfile default stays `release`; `just devnet` builds `dev`. Operator entrypoints live in `etc/scripts/node/`; operators edit `.env.mainnet` / `.env.sepolia` at the repo root. Root `docker-compose.yml` pulls the published image, or compiles this tree with `--build`. `just devnet up` overrides the entrypoint to `./base`.
+The public operator image (`ghcr.io/base/node`) is the `base` target in `Dockerfile.rust-services`. Published images use `PROFILE=maxperf`, while operator `--build` uses `PROFILE=release`. The bake/Dockerfile default stays `release`; `just devnet` builds `dev`. Operator entrypoints live in `etc/scripts/node/`; operators edit `.env.mainnet` / `.env.sepolia` at the repo root. Root `docker-compose.yml` pulls the published image, or compiles this tree with `--build`. `just devnet up` overrides the entrypoint to `./base`.
 
 ## Dockerfiles
 


### PR DESCRIPTION
## Summary
- retain `maxperf` for RC and final-release artifact builds
- default normal operator `--build` usage to Cargo’s `release` profile
- preserve explicit `maxperf` build selection

## Validation
- `git diff --check`
- `docker compose config --quiet`