### PR TITLE
fix(system-tests): share CI L1 infrastructure

### DIFF
--- a/.depot/workflows/ci-core.yml
+++ b/.depot/workflows/ci-core.yml
@@ -245,7 +245,7 @@ jobs:
     name: System Tests
     if: inputs.run_system_tests
     runs-on: depot-ubuntu-24.04-16
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -265,7 +265,26 @@ jobs:
       - name: Pre-pull docker images
         run: just devnet pull-images
       - name: Run system tests
-        run: just devnet tests-ci
+        shell: bash
+        run: |
+          set -euo pipefail
+          just build::contracts
+          runtime_dir="$(mktemp -d)"
+          runtime_file="$runtime_dir/shared-l1.json"
+          network_name="base-system-tests-shared-l1-$GITHUB_RUN_ID"
+          cargo run --locked -p base-system-tests --bin base-devnet -- \
+            shared-l1 --runtime-file "$runtime_file" --network-name "$network_name" &
+          fixture_pid=$!
+          cleanup() {
+            kill -INT "$fixture_pid" 2>/dev/null || true
+            wait "$fixture_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          until [ -f "$runtime_file" ]; do
+            kill -0 "$fixture_pid"
+            sleep 1
+          done
+          BASE_SYSTEM_TEST_SHARED_L1_RUNTIME="$runtime_file" just devnet tests-ci
       - name: Check for JUnit testcases
         if: always()
         id: junit-results

--- a/.depot/workflows/ci-pr.yml
+++ b/.depot/workflows/ci-pr.yml
@@ -19,7 +19,7 @@ jobs:
         just build::affected-ci "${DIFF_BASE:?}"
       clippy_command: >-
         just check::clippy-affected-ci "${DIFF_BASE:?}"
-      run_system_tests: false
+      run_system_tests: true
       run_sigsegv: false
       test_command: >-
         just test-affected-ci "${DIFF_BASE:?}"

--- a/etc/systems/Cargo.toml
+++ b/etc/systems/Cargo.toml
@@ -52,7 +52,7 @@ base-common-chains.workspace = true
 
 # reth
 reth-db.workspace = true
-reth-tasks.workspace = true
+reth-tasks = { workspace = true, features = ["rayon"] }
 reth-provider.workspace = true
 reth-node-core.workspace = true
 base-node-core.workspace = true

--- a/etc/systems/src/benchmark_report.rs
+++ b/etc/systems/src/benchmark_report.rs
@@ -344,6 +344,7 @@ mod tests {
                 config: Some(
                     TestConfig::from_yaml(
                         r#"
+transaction_submission_rpcs: http://127.0.0.1:1
 transactions:
   - weight: 100
     type: precompile

--- a/etc/systems/src/config/l2_intent.rs
+++ b/etc/systems/src/config/l2_intent.rs
@@ -6,7 +6,7 @@ use super::accounts;
 
 /// Generates the L2 intent configuration for op-deployer as TOML.
 pub fn l2_intent_toml(l1_chain_id: u64, l2_chain_id: u64) -> String {
-    let l2_chain_id_hex = format!("{l2_chain_id:#x}");
+    let l2_chain_id_hex = chain_id_hash(l2_chain_id);
     let deployer = format_address(accounts::DEPLOYER.address);
     let sequencer = format_address(accounts::SEQUENCER.address);
     let batcher = format_address(accounts::BATCHER.address);
@@ -53,6 +53,27 @@ l2ContractsLocator = "embedded"
     )
 }
 
+fn chain_id_hash(value: u64) -> String {
+    format!("0x{value:064x}")
+}
+
 fn format_address(address: Address) -> String {
     format!("{address:#x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::chain_id_hash;
+
+    #[test]
+    fn chain_ids_use_hash_encoding() {
+        assert_eq!(
+            chain_id_hash(84_538_453),
+            "0x000000000000000000000000000000000000000000000000000000000509f455"
+        );
+        assert_eq!(
+            chain_id_hash(8453),
+            "0x0000000000000000000000000000000000000000000000000000000000002105"
+        );
+    }
 }

--- a/etc/systems/src/deployer/base_deployer.rs
+++ b/etc/systems/src/deployer/base_deployer.rs
@@ -1,6 +1,9 @@
 //! op-deployer container wrapper.
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use alloy_primitives::{Address, B256};
 use alloy_signer_local::PrivateKeySigner;
@@ -21,6 +24,7 @@ use crate::{
 const OUTPUT_DIR: &str = "/output";
 const WORKDIR: &str = "/op-deployer";
 const INTENT_PATH: &str = "/config/intent.toml";
+const DEPLOYMENT_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Role address configuration for the deployment.
 #[derive(Debug, Clone, Copy)]
@@ -126,12 +130,13 @@ impl DeployerContainer {
 
         let image = GenericImage::new(image_name, image_tag)
             .with_entrypoint("sh")
-            .with_wait_for(WaitFor::exit(ExitWaitStrategy::default().with_exit_code(0)));
+            .with_wait_for(WaitFor::exit(ExitWaitStrategy::default()));
 
         let cmd = vec!["-c".to_string(), script];
         let output_dir = self.output_dir.to_string_lossy().to_string();
         let mut request = image
             .with_cmd(cmd)
+            .with_startup_timeout(DEPLOYMENT_TIMEOUT)
             .with_env_var("L1_RPC_URL", self.l1_rpc_url.to_string())
             .with_env_var("L1_CHAIN_ID", self.l1_chain_id.to_string())
             .with_env_var("L2_CHAIN_ID", self.l2_chain_id.to_string())
@@ -143,7 +148,20 @@ impl DeployerContainer {
             request = request.with_network(network.clone());
         }
 
-        let _container = request.start().wrap_err("Failed to run op-deployer container")?;
+        let container = request.start().wrap_err("Failed to run op-deployer container")?;
+        let exit_code = container
+            .exit_code()
+            .wrap_err("Failed to read op-deployer container exit code")?
+            .ok_or_else(|| eyre!("op-deployer container was still running after exit wait"))?;
+        if exit_code != 0 {
+            let stdout_bytes = container.stdout_to_vec()?;
+            let stderr_bytes = container.stderr_to_vec()?;
+            let stdout = String::from_utf8_lossy(&stdout_bytes);
+            let stderr = String::from_utf8_lossy(&stderr_bytes);
+            return Err(eyre!(
+                "op-deployer container exited with code {exit_code}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+            ));
+        }
 
         self.artifacts().wrap_err("Failed to load deployment artifacts")
     }
@@ -181,45 +199,45 @@ fn deploy_script() -> String {
     format!(
         r#"set -e
 
-WORKDIR=\"{WORKDIR}\"
-OUTPUT_DIR=\"{OUTPUT_DIR}\"
-INTENT_PATH=\"{INTENT_PATH}\"
+WORKDIR="{WORKDIR}"
+OUTPUT_DIR="{OUTPUT_DIR}"
+INTENT_PATH="{INTENT_PATH}"
 
-mkdir -p \"$WORKDIR\" \"$OUTPUT_DIR\"
+mkdir -p "$WORKDIR" "$OUTPUT_DIR"
 
-if [ -f \"$OUTPUT_DIR/genesis.json\" ] && [ -f \"$OUTPUT_DIR/rollup.json\" ] && [ -f \"$OUTPUT_DIR/l1-addresses.json\" ]; then
-  echo \"Deployment artifacts already exist, skipping op-deployer\"
+if [ -f "$OUTPUT_DIR/genesis.json" ] && [ -f "$OUTPUT_DIR/rollup.json" ] && [ -f "$OUTPUT_DIR/l1-addresses.json" ]; then
+  echo "Deployment artifacts already exist, skipping op-deployer"
   exit 0
 fi
 
 op-deployer init \
-  --l1-chain-id \"$L1_CHAIN_ID\" \
-  --l2-chain-ids \"$L2_CHAIN_ID\" \
+  --l1-chain-id "$L1_CHAIN_ID" \
+  --l2-chain-ids "$L2_CHAIN_ID" \
   --intent-type custom \
-  --workdir \"$WORKDIR\"
+  --workdir "$WORKDIR"
 
-cp \"$INTENT_PATH\" \"$WORKDIR/intent.toml\"
+cp "$INTENT_PATH" "$WORKDIR/intent.toml"
 
 op-deployer apply \
-  --workdir \"$WORKDIR\" \
+  --workdir "$WORKDIR" \
   --deployment-target live \
-  --l1-rpc-url \"$L1_RPC_URL\" \
-  --private-key \"$DEPLOYER_KEY\"
+  --l1-rpc-url "$L1_RPC_URL" \
+  --private-key "$DEPLOYER_KEY"
 
 op-deployer inspect genesis \
-  --workdir \"$WORKDIR\" \
-  \"$L2_CHAIN_ID\" \
-  > \"$OUTPUT_DIR/genesis.json\"
+  --workdir "$WORKDIR" \
+  "$L2_CHAIN_ID" \
+  > "$OUTPUT_DIR/genesis.json"
 
 op-deployer inspect rollup \
-  --workdir \"$WORKDIR\" \
-  \"$L2_CHAIN_ID\" \
-  > \"$OUTPUT_DIR/rollup.json\"
+  --workdir "$WORKDIR" \
+  "$L2_CHAIN_ID" \
+  > "$OUTPUT_DIR/rollup.json"
 
 op-deployer inspect l1 \
-  --workdir \"$WORKDIR\" \
-  \"$L2_CHAIN_ID\" \
-  > \"$OUTPUT_DIR/l1-addresses.json\"
+  --workdir "$WORKDIR" \
+  "$L2_CHAIN_ID" \
+  > "$OUTPUT_DIR/l1-addresses.json"
 "#,
     )
 }

--- a/etc/systems/src/devnet_cli.rs
+++ b/etc/systems/src/devnet_cli.rs
@@ -8,7 +8,7 @@ use eyre::{Result, WrapErr};
 use serde::Serialize;
 
 use crate::{
-    DevnetBlockInterval, DevnetConfig, DevnetL2State, DevnetPrefund, DevnetSnapshotHead,
+    DevnetBlockInterval, DevnetConfig, DevnetL2State, DevnetPrefund, DevnetSnapshotHead, SharedL1,
     SnapshotChainConfig, SnapshotL2Stack, SystemTestStackBuilder,
 };
 
@@ -26,6 +26,19 @@ pub struct DevnetCli {
 pub enum DevnetCommand {
     /// Continue Base snapshot datadirs without an L1.
     Snapshot(SnapshotArgs),
+    /// Start a CI-scoped shared L1 and write its runtime manifest.
+    SharedL1(SharedL1Args),
+}
+
+/// Arguments for a CI-scoped shared L1 fixture.
+#[derive(Debug, Args)]
+pub struct SharedL1Args {
+    /// File written after the shared L1 is ready for consumers.
+    #[arg(long)]
+    pub runtime_file: PathBuf,
+    /// Docker network shared with live L2 deployments.
+    #[arg(long)]
+    pub network_name: String,
 }
 
 /// Arguments for an L1-free Base snapshot network.
@@ -95,7 +108,19 @@ impl DevnetCli {
     pub async fn run(self) -> Result<()> {
         match self.command {
             DevnetCommand::Snapshot(args) => args.run().await,
+            DevnetCommand::SharedL1(args) => args.run().await,
         }
+    }
+}
+
+impl SharedL1Args {
+    /// Starts the fixture, publishes its manifest, and waits for shutdown.
+    pub async fn run(self) -> Result<()> {
+        let stack = SharedL1::start(self.network_name).await?;
+        stack.runtime().write(&self.runtime_file)?;
+        println!("shared L1 ready: {}", self.runtime_file.display());
+        tokio::signal::ctrl_c().await.wrap_err("failed to listen for Ctrl-C")?;
+        stack.shutdown().await
     }
 }
 
@@ -190,7 +215,9 @@ mod tests {
         ])
         .unwrap();
 
-        let DevnetCommand::Snapshot(args) = cli.command;
+        let DevnetCommand::Snapshot(args) = cli.command else {
+            panic!("expected snapshot command")
+        };
         assert_eq!(args.chain, "sepolia");
         assert_eq!(args.builder_datadir.to_str(), Some("/tmp/builder"));
         assert!(args.prefund_address.is_some());

--- a/etc/systems/src/l1/lighthouse.rs
+++ b/etc/systems/src/l1/lighthouse.rs
@@ -11,6 +11,7 @@ use testcontainers::{
 
 use super::config::L1ContainerConfig;
 use crate::{
+    config::DEPLOYER,
     containers::{L1_BEACON_HTTP_PORT, L1_BEACON_NAME, L1_VALIDATOR_NAME},
     network::{ensure_network_exists, ensure_network_exists_with_name, network_name},
     unique_name,
@@ -127,7 +128,8 @@ impl LighthouseValidatorContainer {
         }
 
         let command = validator_command(beacon_endpoint.as_ref());
-        let image = lighthouse_image();
+        let image = lighthouse_image()
+            .with_wait_for(WaitFor::message_on_stdout("Block production service started"));
 
         let name = if config.use_stable_names {
             L1_VALIDATOR_NAME.to_string()
@@ -190,6 +192,7 @@ fn validator_command(beacon_endpoint: &str) -> Vec<String> {
         format!("--testnet-dir={LIGHTHOUSE_TESTNET_DIR}"),
         format!("--datadir={LIGHTHOUSE_VALIDATOR_DATA_DIR}"),
         format!("--beacon-nodes={beacon_endpoint}"),
+        format!("--suggested-fee-recipient={:#x}", DEPLOYER.address),
         "--init-slashing-protection".to_string(),
     ]
 }

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -29,11 +29,12 @@ use reth_node_core::{
     dirs::{DataDirPath, MaybePlatformPath},
     exit::NodeExitFuture,
 };
-use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig, TokioConfig};
+use reth_tasks::{Runtime, RuntimeBuilder, TokioConfig};
 use tempfile::TempDir;
 use tracing::warn;
 use url::Url;
 
+use super::TestNodeRuntime;
 use crate::{config::BUILDER, setup::BUILDER_ENODE_ID};
 
 /// Configuration for starting an in-process builder.
@@ -136,7 +137,7 @@ impl InProcessBuilder {
             .wrap_err("Failed to write JWT secret")?;
 
         let runtime = RuntimeBuilder::new(
-            RuntimeConfig::default()
+            TestNodeRuntime::config()
                 .with_tokio(TokioConfig::existing_handle(tokio::runtime::Handle::current())),
         )
         .build()?;

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -28,10 +28,12 @@ use reth_node_core::{
     exit::NodeExitFuture,
 };
 use reth_provider::providers::BlockchainProvider;
-use reth_tasks::{Runtime, RuntimeBuilder, RuntimeConfig, TokioConfig};
+use reth_tasks::{Runtime, RuntimeBuilder, TokioConfig};
 use tempfile::TempDir;
 use tracing::warn;
 use url::Url;
+
+use super::TestNodeRuntime;
 
 type BuiltExtensions = (Vec<Box<dyn BaseNodeExtension>>, Option<FlashblocksConfig>);
 
@@ -130,7 +132,7 @@ impl InProcessClient {
 
         let (data_dir, temp_dir) = Self::prepare_datadir(config.datadir.clone())?;
         let runtime = RuntimeBuilder::new(
-            RuntimeConfig::default()
+            TestNodeRuntime::config()
                 .with_tokio(TokioConfig::existing_handle(tokio::runtime::Handle::current())),
         )
         .build()?;

--- a/etc/systems/src/l2/mod.rs
+++ b/etc/systems/src/l2/mod.rs
@@ -3,6 +3,9 @@
 mod config;
 pub use config::L2ContainerConfig;
 
+mod runtime;
+pub use runtime::TestNodeRuntime;
+
 mod in_process_batcher;
 pub use in_process_batcher::{InProcessBatcher, InProcessBatcherConfig};
 

--- a/etc/systems/src/l2/runtime.rs
+++ b/etc/systems/src/l2/runtime.rs
@@ -1,0 +1,35 @@
+//! Bounded Rayon runtime configuration for in-process test nodes.
+
+use reth_tasks::{RayonConfig, RuntimeConfig};
+
+/// Small, fixed Rayon thread-pool sizing for the reth runtime backing an in-process test node.
+///
+/// The in-process nodes share the test Tokio runtime, but Reth's default Rayon pools are sized
+/// from the host core count. A system-test stack runs a builder and client node, and several
+/// stacks share one CI runner. Capping those pools prevents the combined nodes from
+/// oversubscribing CPU and memory, which otherwise stalls block production and causes receipt
+/// timeouts.
+#[derive(Debug, Clone, Copy)]
+pub struct TestNodeRuntime;
+
+impl TestNodeRuntime {
+    /// Threads for the Rayon CPU, RPC, and storage pools.
+    const POOL_THREADS: usize = 2;
+    /// Threads for the proof, prewarming, BAL streaming, and state-trie overlay pools.
+    const WORKER_POOL_THREADS: usize = 1;
+
+    /// Returns a [`RuntimeConfig`] with bounded Rayon pools.
+    pub fn config() -> RuntimeConfig {
+        RuntimeConfig::default().with_rayon(RayonConfig {
+            cpu_threads: Some(Self::POOL_THREADS),
+            rpc_threads: Some(Self::POOL_THREADS),
+            storage_threads: Some(Self::POOL_THREADS),
+            proof_storage_worker_threads: Some(Self::WORKER_POOL_THREADS),
+            proof_account_worker_threads: Some(Self::WORKER_POOL_THREADS),
+            prewarming_threads: Some(Self::WORKER_POOL_THREADS),
+            bal_streaming_threads: Some(Self::WORKER_POOL_THREADS),
+            state_trie_overlay_worker_threads: Some(Self::WORKER_POOL_THREADS),
+            ..Default::default()
+        })
+    }
+}

--- a/etc/systems/src/lib.rs
+++ b/etc/systems/src/lib.rs
@@ -48,7 +48,7 @@ pub use docker::{
 };
 
 mod devnet_cli;
-pub use devnet_cli::{DevnetCli, DevnetCommand, SnapshotArgs, SnapshotRuntime};
+pub use devnet_cli::{DevnetCli, DevnetCommand, SharedL1Args, SnapshotArgs, SnapshotRuntime};
 
 mod host;
 pub use host::{host_address, with_host_port_if_needed};
@@ -70,7 +70,7 @@ pub use l2::{
     InProcessStandaloneSequencer, InProcessStandaloneSequencerConfig, L2ClientConsensus,
     L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig, ShadowSequencer,
     ShadowSequencerConfig, ShadowSequencersConfig, SnapshotBoundary, SnapshotL2Stack,
-    SnapshotL2StackConfig,
+    SnapshotL2StackConfig, TestNodeRuntime,
 };
 
 mod network;
@@ -91,6 +91,9 @@ pub use setup::{
     EL_BOOTNODE_ENODE_ID, EL_BOOTNODE_P2P_KEY, L1GenesisOutput, L2DeploymentOutput, SetupContainer,
     SetupImage,
 };
+
+mod shared_l1;
+pub use shared_l1::{SHARED_L1_RUNTIME_ENV, SharedL1, SharedL1Runtime};
 
 mod smoke;
 #[cfg(feature = "upgrade-signal")]

--- a/etc/systems/src/prometheus_metrics.rs
+++ b/etc/systems/src/prometheus_metrics.rs
@@ -348,17 +348,19 @@ mod tests {
     #[test]
     fn computes_labeled_histogram_averages() {
         let previous = PrometheusSnapshot::parse(
-            "# TYPE build_duration histogram\n\\
-             build_duration_sum{stage=\"execution\"} 4\n\\
-             build_duration_count{stage=\"execution\"} 2\n",
+            r#"# TYPE build_duration histogram
+build_duration_sum{stage="execution"} 4
+build_duration_count{stage="execution"} 2
+"#,
         );
         let current = PrometheusSnapshot::parse(
-            "# TYPE build_duration histogram\n\\
-             build_duration_sum{stage=\"execution\"} 10\n\\
-             build_duration_count{stage=\"execution\"} 4\n",
+            r#"# TYPE build_duration histogram
+build_duration_sum{stage="execution"} 10
+build_duration_count{stage="execution"} 4
+"#,
         );
         let delta = current.delta(&previous);
-        assert_eq!(delta["build_duration_avg_stage_execution"], 3.0);
+        assert_eq!(delta["build_duration_stage_execution_avg"], 3.0);
     }
 
     #[test]

--- a/etc/systems/src/setup/container.rs
+++ b/etc/systems/src/setup/container.rs
@@ -150,6 +150,10 @@ pub struct L1GenesisOutput {
 }
 
 impl L1GenesisOutput {
+    /// Reuses generated L1 files rooted at `output_dir`.
+    pub fn from_output_dir(output_dir: impl Into<PathBuf>) -> Self {
+        Self { output_dir: output_dir.into() }
+    }
     /// Returns the path to the EL genesis JSON file.
     pub fn el_genesis_path(&self) -> PathBuf {
         self.output_dir.join("el/genesis.json")
@@ -198,6 +202,10 @@ pub struct L2DeploymentOutput {
 }
 
 impl L2DeploymentOutput {
+    /// Reuses generated L2 deployment files rooted at `output_dir`.
+    pub fn from_output_dir(output_dir: impl Into<PathBuf>) -> Self {
+        Self { output_dir: output_dir.into() }
+    }
     /// Returns the path to the L2 genesis JSON file.
     pub fn genesis_path(&self) -> PathBuf {
         self.output_dir.join("l2/genesis.json")

--- a/etc/systems/src/shared_l1.rs
+++ b/etc/systems/src/shared_l1.rs
@@ -1,0 +1,135 @@
+//! Long-lived L1 fixture used to amortize system-test infrastructure startup.
+
+use std::path::Path;
+
+use eyre::{Result, WrapErr};
+use serde::{Deserialize, Serialize};
+use tempfile::TempDir;
+
+use crate::{L1ContainerConfig, L1Stack, L1StackConfig, SetupContainer};
+
+/// Environment variable pointing at the CI-scoped shared-L1 manifest.
+pub const SHARED_L1_RUNTIME_ENV: &str = "BASE_SYSTEM_TEST_SHARED_L1_RUNTIME";
+
+/// Connection details for one CI-scoped L1 fixture.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SharedL1Runtime {
+    /// L1 chain ID.
+    pub chain_id: u64,
+    /// Docker network on which the L1 containers are reachable.
+    pub network_name: String,
+    /// Host-reachable L1 JSON-RPC URL.
+    pub rpc_url: String,
+    /// Container-network L1 JSON-RPC URL.
+    pub internal_rpc_url: String,
+    /// Host-reachable L1 beacon API URL.
+    pub beacon_url: String,
+    /// Container-network L1 beacon API URL.
+    pub internal_beacon_url: String,
+    /// L1 genesis JSON consumed by in-process consensus nodes.
+    pub genesis_json: String,
+}
+
+impl SharedL1Runtime {
+    /// Writes this runtime manifest atomically enough for CI consumers waiting on its existence.
+    pub fn write(&self, path: impl AsRef<Path>) -> Result<()> {
+        let path = path.as_ref();
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        std::fs::create_dir_all(parent)?;
+        let file_name = path.file_name().ok_or_else(|| {
+            eyre::eyre!("shared L1 runtime path has no file name: {}", path.display())
+        })?;
+        let temporary = parent.join(format!(".{}.tmp", file_name.to_string_lossy()));
+        std::fs::write(&temporary, serde_json::to_vec(self)?)?;
+        std::fs::rename(temporary, path)?;
+        Ok(())
+    }
+
+    /// Reads a shared-L1 runtime manifest.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        serde_json::from_slice(&std::fs::read(path)?)
+            .wrap_err_with(|| format!("failed to read shared L1 runtime {}", path.display()))
+    }
+
+    /// Loads the shared fixture selected for this process, if any.
+    pub fn from_env() -> Result<Option<Self>> {
+        std::env::var_os(SHARED_L1_RUNTIME_ENV).map_or(Ok(None), |path| Self::load(path).map(Some))
+    }
+}
+
+/// Owns a long-lived L1 stack and the generated files it requires.
+#[derive(Debug)]
+pub struct SharedL1 {
+    _output_dir: TempDir,
+    stack: L1Stack,
+    runtime: SharedL1Runtime,
+}
+
+impl SharedL1 {
+    /// Starts an L1 stack on `network_name` and returns its consumer manifest.
+    pub async fn start(network_name: String) -> Result<Self> {
+        let output_dir = TempDir::new().wrap_err("failed to create shared L1 output directory")?;
+        let setup = SetupContainer::new(output_dir.path());
+        let (genesis, _) = tokio::task::spawn_blocking(move || setup.generate_genesis())
+            .await
+            .wrap_err("shared L1 genesis task panicked")?
+            .wrap_err("failed to generate shared L1 genesis")?;
+        let genesis_json = genesis.read_el_genesis()?;
+        let stack = L1Stack::start(L1StackConfig {
+            el_genesis_json: genesis_json.clone(),
+            jwt_secret_hex: genesis.read_jwt_secret()?,
+            testnet_dir: genesis.testnet_dir(),
+            container_config: Some(L1ContainerConfig {
+                network_name: Some(network_name.clone()),
+                tmpfs_datadir: true,
+                ..Default::default()
+            }),
+        })
+        .await
+        .wrap_err("failed to start shared L1")?;
+        let runtime = SharedL1Runtime {
+            chain_id: 1337,
+            network_name,
+            rpc_url: stack.rpc_url().await?.to_string(),
+            internal_rpc_url: stack.reth().internal_rpc_url(),
+            beacon_url: stack.beacon_url().await?,
+            internal_beacon_url: stack.beacon().internal_beacon_url(),
+            genesis_json,
+        };
+        Ok(Self { _output_dir: output_dir, stack, runtime })
+    }
+
+    /// Returns the connection details that consumers use to attach to this L1.
+    pub const fn runtime(&self) -> &SharedL1Runtime {
+        &self.runtime
+    }
+
+    /// Stops the owned L1 containers.
+    pub async fn shutdown(self) -> Result<()> {
+        drop(self.stack);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SharedL1Runtime;
+
+    #[test]
+    fn runtime_manifest_round_trips() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("shared-l1.json");
+        let runtime = SharedL1Runtime {
+            chain_id: 1337,
+            network_name: "shared-l1".to_string(),
+            rpc_url: "http://127.0.0.1:8545".to_string(),
+            internal_rpc_url: "http://l1-reth:8545".to_string(),
+            beacon_url: "http://127.0.0.1:4052".to_string(),
+            internal_beacon_url: "http://l1-beacon:4052".to_string(),
+            genesis_json: "{}".to_string(),
+        };
+        runtime.write(&path).unwrap();
+        assert_eq!(SharedL1Runtime::load(path).unwrap().network_name, "shared-l1");
+    }
+}

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -6,7 +6,11 @@ use std::{
     sync::{Mutex, OnceLock},
     time::Duration,
 };
-use std::{num::NonZeroU64, path::PathBuf};
+use std::{
+    fs::{self, OpenOptions},
+    num::NonZeroU64,
+    path::PathBuf,
+};
 
 use alloy_network::Ethereum;
 use alloy_primitives::B256;
@@ -28,7 +32,7 @@ use url::Url;
 #[cfg(feature = "upgrade-signal")]
 use crate::upgrade_signal::{MockProtocolVersionsClient, UpgradeSignalStackOptions};
 use crate::{
-    BATCHER, BUILDER, SEQUENCER,
+    BATCHER, BUILDER, DEPLOYER, DeployerContainer, RoleAddresses, SEQUENCER, SharedL1Runtime,
     l1::{L1ContainerConfig, L1Execution, L1RpcProxy, L1Stack, L1StackConfig},
     l2::{
         L2ClientConsensusMode, L2ContainerConfig, L2Stack, L2StackConfig, ShadowSequencersConfig,
@@ -39,6 +43,44 @@ use crate::{
 };
 
 const DEFAULT_SHADOW_BLOCKS_PER_CYCLE: NonZeroU64 = NonZeroU64::new(3).unwrap();
+
+fn deploy_against_shared_l1(
+    runtime: &SharedL1Runtime,
+    output_dir: &std::path::Path,
+    l2_chain_id: u64,
+) -> Result<(L1GenesisOutput, L2DeploymentOutput)> {
+    // All consumers share the fixture's funded deployer account. Serialize live deployments
+    // across nextest processes so independently constructed op-deployer instances do not race
+    // the account nonce.
+    let deployment_lock_path = std::env::temp_dir()
+        .join(format!("base-system-tests-{}.deployment.lock", runtime.network_name));
+    let deployment_lock = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&deployment_lock_path)
+        .wrap_err("failed to open shared L1 deployment lock")?;
+    deployment_lock.lock().wrap_err("failed to acquire shared L1 deployment lock")?;
+
+    fs::create_dir_all(output_dir.join("el"))?;
+    fs::write(output_dir.join("el/genesis.json"), &runtime.genesis_json)?;
+    DeployerContainer::new(
+        runtime.internal_rpc_url.parse().wrap_err("invalid shared L1 internal RPC URL")?,
+        runtime.chain_id,
+        l2_chain_id,
+        DEPLOYER.private_key,
+        RoleAddresses::default(),
+    )
+    .with_network(&runtime.network_name)
+    .with_output_dir(output_dir.join("l2"))
+    .deploy()
+    .wrap_err("failed to deploy isolated L2 contracts against shared L1")?;
+    Ok((
+        L1GenesisOutput::from_output_dir(output_dir),
+        L2DeploymentOutput::from_output_dir(output_dir),
+    ))
+}
 
 /// Longest wait for a live L1 schedule change to be re-applied by a runtime-admin node (the
 /// upgrade signal poll interval is 12s).
@@ -103,7 +145,7 @@ pub struct SystemTestStack {
     l2_chain_id: u64,
     l1_genesis: L1GenesisOutput,
     l2_deployment: L2DeploymentOutput,
-    l1_stack: L1Stack,
+    l1_stack: L1StackHandle,
     l2_stack: L2Stack,
     l1_rpc_proxy: Option<L1RpcProxy>,
     #[cfg(feature = "upgrade-signal")]
@@ -112,6 +154,36 @@ pub struct SystemTestStack {
     /// (and their upgrade-signal writer tasks) must shut down first.
     #[cfg(feature = "upgrade-signal")]
     _runtime_upgrade_signal_guard: Option<RuntimeUpgradeSignalGuard>,
+}
+
+/// Either a dedicated L1 owned by this stack or a CI-scoped shared fixture.
+#[derive(Debug)]
+enum L1StackHandle {
+    Dedicated(Box<L1Stack>),
+    Shared(SharedL1Runtime),
+}
+
+impl L1StackHandle {
+    fn stack(&self) -> &L1Stack {
+        match self {
+            Self::Dedicated(stack) => stack,
+            Self::Shared(_) => panic!("shared L1 does not expose exclusive stack control"),
+        }
+    }
+
+    async fn rpc_url(&self) -> Result<Url> {
+        match self {
+            Self::Dedicated(stack) => stack.rpc_url().await,
+            Self::Shared(runtime) => runtime.rpc_url.parse().wrap_err("invalid shared L1 RPC URL"),
+        }
+    }
+
+    async fn beacon_url(&self) -> Result<String> {
+        match self {
+            Self::Dedicated(stack) => stack.beacon_url().await,
+            Self::Shared(runtime) => Ok(runtime.beacon_url.clone()),
+        }
+    }
 }
 
 impl std::fmt::Debug for SystemTestStack {
@@ -125,8 +197,8 @@ impl std::fmt::Debug for SystemTestStack {
 
 impl SystemTestStack {
     /// Returns a reference to the L1 stack.
-    pub const fn l1_stack(&self) -> &L1Stack {
-        &self.l1_stack
+    pub fn l1_stack(&self) -> &L1Stack {
+        self.l1_stack.stack()
     }
 
     /// Returns a reference to the L2 stack.
@@ -161,12 +233,18 @@ impl SystemTestStack {
 
     /// Returns the internal RPC URL of the L1 Reth node.
     pub fn l1_internal_rpc_url(&self) -> String {
-        self.l1_stack.reth().internal_rpc_url()
+        match &self.l1_stack {
+            L1StackHandle::Dedicated(stack) => stack.reth().internal_rpc_url(),
+            L1StackHandle::Shared(runtime) => runtime.internal_rpc_url.clone(),
+        }
     }
 
     /// Returns the internal beacon URL of the L1 Lighthouse beacon node.
     pub fn l1_internal_beacon_url(&self) -> String {
-        self.l1_stack.beacon().internal_beacon_url()
+        match &self.l1_stack {
+            L1StackHandle::Dedicated(stack) => stack.beacon().internal_beacon_url(),
+            L1StackHandle::Shared(runtime) => runtime.internal_beacon_url.clone(),
+        }
     }
 
     /// Returns the L2 client's RPC URL.
@@ -324,6 +402,7 @@ pub struct SystemTestStackBuilder {
     shadow_start_block: Option<u64>,
     tmpfs_datadirs: bool,
     l1_fault_injection: bool,
+    shared_l1: Option<SharedL1Runtime>,
     extra_builder_extensions: Vec<Box<dyn BaseNodeExtension>>,
     extra_client_extensions: Vec<Box<dyn BaseNodeExtension>>,
     #[cfg(feature = "upgrade-signal")]
@@ -331,6 +410,15 @@ pub struct SystemTestStackBuilder {
 }
 
 impl SystemTestStackBuilder {
+    const fn has_custom_fork_activation(&self) -> bool {
+        self.isthmus_activation_block.is_some()
+            || self.base_azul_activation_block.is_some()
+            || self.base_beryl_activation_block.is_some()
+            || self.base_cobalt_activation_block.is_some()
+            || self.base_denim_activation_block.is_some()
+            || self.base_zenith_activation_block.is_some()
+    }
+
     /// Creates a new `SystemTestStackBuilder` with default configuration.
     pub fn new() -> Self {
         Self::default()
@@ -443,6 +531,15 @@ impl SystemTestStackBuilder {
     /// Routes L2 services through a controllable L1 RPC proxy and enables L1 reorg control.
     pub const fn with_l1_fault_injection(mut self) -> Self {
         self.l1_fault_injection = true;
+        self
+    }
+
+    /// Uses a CI-scoped L1 fixture instead of starting a dedicated L1 stack.
+    ///
+    /// The shared fixture is intentionally incompatible with L1 fault injection: reorg tests
+    /// must own and mutate their L1 exclusively.
+    pub fn with_shared_l1(mut self, runtime: SharedL1Runtime) -> Self {
+        self.shared_l1 = Some(runtime);
         self
     }
 
@@ -566,13 +663,33 @@ impl SystemTestStackBuilder {
     }
 
     /// Builds and starts the system test stack.
-    pub async fn build(self) -> Result<SystemTestStack> {
+    pub async fn build(mut self) -> Result<SystemTestStack> {
+        if self.shared_l1.is_none()
+            && !self.l1_fault_injection
+            && !self.has_custom_fork_activation()
+        {
+            self.shared_l1 = SharedL1Runtime::from_env()?;
+        }
         self.devnet_config.validate().wrap_err("Invalid devnet configuration")?;
         eyre::ensure!(
             self.devnet_config.l1_mode == DevnetL1Mode::Real
                 && self.devnet_config.l2_state == DevnetL2State::Fresh,
             "system test launcher currently supports only real L1 with fresh L2 state"
         );
+        if let Some(shared_l1) = &self.shared_l1 {
+            eyre::ensure!(
+                !self.l1_fault_injection,
+                "L1 fault-injection tests must use an exclusive L1 stack"
+            );
+            eyre::ensure!(
+                self.devnet_config.l1_chain_id == shared_l1.chain_id,
+                "shared L1 chain ID does not match this system-test configuration"
+            );
+            eyre::ensure!(
+                !self.has_custom_fork_activation(),
+                "custom fork-activation tests must use a dedicated L1 stack"
+            );
+        }
 
         let l1_chain_id = self.devnet_config.l1_chain_id;
         let l2_chain_id = self.devnet_config.l2_chain_id;
@@ -624,14 +741,21 @@ impl SystemTestStackBuilder {
             setup = setup.with_base_zenith_activation_block(block);
         }
 
-        let (l1_genesis, l2_deployment) =
+        let shared_l1 = self.shared_l1.clone();
+        let (l1_genesis, l2_deployment) = if let Some(shared_l1) = &shared_l1 {
+            let output_dir = output_dir.clone();
+            let shared_l1 = shared_l1.clone();
+            tokio::task::spawn_blocking(move || {
+                deploy_against_shared_l1(&shared_l1, &output_dir, l2_chain_id)
+            })
+            .await
+            .wrap_err("shared L1 deployment task panicked")??
+        } else {
             tokio::task::spawn_blocking(move || setup.generate_genesis())
                 .await
                 .wrap_err("Genesis setup task panicked")?
-                .wrap_err("Failed to generate L1/L2 genesis")?;
-
-        let el_genesis_json = l1_genesis.read_el_genesis()?;
-        let jwt_secret_hex = l1_genesis.read_jwt_secret()?;
+                .wrap_err("Failed to generate L1/L2 genesis")?
+        };
 
         let (l1_container_config, l2_container_config) = if self.devnet_config.use_stable_ports {
             let config = &self.devnet_config.stable;
@@ -678,18 +802,22 @@ impl SystemTestStackBuilder {
             })
         });
 
-        let l1_config = L1StackConfig {
-            el_genesis_json,
-            jwt_secret_hex,
-            testnet_dir: l1_genesis.testnet_dir(),
-            container_config: l1_container_config,
+        let l1_stack = if let Some(shared_l1) = shared_l1 {
+            L1StackHandle::Shared(shared_l1)
+        } else {
+            let l1_config = L1StackConfig {
+                el_genesis_json: l1_genesis.read_el_genesis()?,
+                jwt_secret_hex: l1_genesis.read_jwt_secret()?,
+                testnet_dir: l1_genesis.testnet_dir(),
+                container_config: l1_container_config,
+            };
+            let execution = L1Execution::start(l1_config)
+                .await
+                .wrap_err("Failed to start L1 execution layer")?;
+            L1StackHandle::Dedicated(Box::new(
+                execution.start_consensus().await.wrap_err("Failed to start L1 consensus")?,
+            ))
         };
-
-        // Both chain configurations are complete before L1 starts.
-        let l1_execution =
-            L1Execution::start(l1_config).await.wrap_err("Failed to start L1 execution layer")?;
-        let l1_stack =
-            l1_execution.start_consensus().await.wrap_err("Failed to start L1 consensus")?;
 
         let jwt_secret = JwtSecret::random();
 
@@ -748,7 +876,7 @@ impl SystemTestStackBuilder {
         #[cfg(not(feature = "upgrade-signal"))]
         let (l2_upgrade_signal, l2_execution_upgrade_signal) = (None, None);
 
-        let direct_l1_rpc_url = l1_stack.reth().rpc_url().await?;
+        let direct_l1_rpc_url = l1_stack.rpc_url().await?;
         let l1_rpc_proxy = if self.l1_fault_injection {
             Some(L1RpcProxy::start(direct_l1_rpc_url.clone()).await?)
         } else {
@@ -769,7 +897,7 @@ impl SystemTestStackBuilder {
             sequencer_key: SEQUENCER.private_key,
             batcher_key: BATCHER.private_key,
             l1_rpc_url: l2_l1_rpc_url,
-            l1_beacon_url: l1_stack.beacon().beacon_url().await?,
+            l1_beacon_url: l1_stack.beacon_url().await?,
             l1_slot_duration: slot_duration,
             container_config: l2_container_config,
             tx_forwarding_config: self.tx_forwarding_config,

--- a/etc/systems/tests/builder_cutover.rs
+++ b/etc/systems/tests/builder_cutover.rs
@@ -21,7 +21,9 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 const L1_CHAIN_ID: u64 = 1337;
 const L2_CHAIN_ID: u64 = 84538453;
-const DENIM_ACTIVATION_BLOCK: u64 = 10;
+// Leave enough pre-Denim runway for both stacks to start under the system-test concurrency used
+// in CI. A very early activation makes the "pre-cutover" transaction race node startup.
+const DENIM_ACTIVATION_BLOCK: u64 = 25;
 const BLOCK_TIMEOUT: Duration = Duration::from_secs(45);
 const REPLAY_QUIET_TIMEOUT: Duration = Duration::from_secs(2);
 

--- a/etc/systems/tests/shadow_retention.rs
+++ b/etc/systems/tests/shadow_retention.rs
@@ -93,10 +93,12 @@ impl TestDatabase {
 
 fn shadow_row(number: i64) -> ShadowBlockRow {
     let now = Utc::now();
+    let mut hash = vec![0; 32];
+    hash[24..].copy_from_slice(&number.to_be_bytes());
 
     ShadowBlockRow {
         number,
-        hash: number.to_be_bytes().to_vec(),
+        hash,
         canonical_hash: None,
         created_at: now,
         updated_at: now,


### PR DESCRIPTION
## Summary
- launch one CI-scoped Reth/Lighthouse/validator fixture for system tests
- attach ordinary system stacks to its runtime manifest and live-deploy L2 contract artifacts on the shared Docker network
- preserve dedicated L1 ownership for fault-injection, reorg, and custom fork-activation tests
- serialize shared-fixture deployments across nextest processes so the funded deployer nonce cannot race
- bound in-process Reth Rayon pools and stabilize the builder-cutover fixture under concurrent startup
- repair deterministic system-test fixtures and CI contract-artifact setup

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p base-system-tests --lib` (35 passed)
- `cargo clippy -p base-system-tests --all-targets --all-features -- -D warnings`
- concurrent shared-L1 smoke tests (2 passed)
- `BASE_SYSTEM_TEST_SHARED_L1_RUNTIME=... just devnet tests-ci` (109 passed; full local CI-profile system-test suite)
