### PR TITLE
feat(node): Follow Mode For Unified Binary

### DIFF
--- a/bin/base/src/commands/command.rs
+++ b/bin/base/src/commands/command.rs
@@ -9,8 +9,8 @@ use reth_cli_runner::CliRunner;
 
 use crate::{
     commands::{
-        bootnode::BootnodeCommand, reth::RethCommand, rpc::RpcCommand, sequencer::SequencerCommand,
-        snapshot::SnapshotCommand, update::UpdateCommand,
+        bootnode::BootnodeCommand, follow::FollowCommand, reth::RethCommand, rpc::RpcCommand,
+        sequencer::SequencerCommand, snapshot::SnapshotCommand, update::UpdateCommand,
     },
     config::ChainResolver,
 };
@@ -28,6 +28,9 @@ pub(crate) enum BaseCommand {
     /// Run the integrated node in RPC mode.
     #[command(name = "rpc")]
     Rpc(Box<RpcCommand>),
+    /// Run the integrated node in follow mode (execution + consensus follow node).
+    #[command(name = "follow")]
+    Follow(Box<FollowCommand>),
     /// Run integrated execution, builder, and consensus services in sequencer mode.
     #[command(name = "sequencer")]
     Sequencer(Box<SequencerCommand>),
@@ -58,6 +61,7 @@ impl BaseCommand {
             }
             Self::Bootnode(bootnode) => (*bootnode).run(chain_resolver.resolve()?, metrics_enabled),
             Self::Rpc(rpc) => (*rpc).run(chain_resolver.resolve()?, metrics_enabled),
+            Self::Follow(follow) => (*follow).run(chain_resolver.resolve()?, metrics_enabled),
             Self::Sequencer(sequencer) => {
                 (*sequencer).run(chain_resolver.resolve()?, metrics_enabled)
             }

--- a/bin/base/src/commands/follow.rs
+++ b/bin/base/src/commands/follow.rs
@@ -137,8 +137,9 @@ impl FollowCommand {
 
 #[cfg(test)]
 mod tests {
-    use crate::{cli::BaseCli, commands::BaseCommand};
     use clap::Parser;
+
+    use crate::{cli::BaseCli, commands::BaseCommand};
 
     const REQUIRED_FOLLOW_ARGS: &[&str] = &[
         "--source-l2-rpc",

--- a/bin/base/src/commands/follow.rs
+++ b/bin/base/src/commands/follow.rs
@@ -1,0 +1,201 @@
+//! Integrated follow-mode node command.
+//!
+//! Runs an execution node (reth) and a consensus follow node in a single process. The follow node
+//! reads canonical payloads from `--source-l2-rpc` and inserts them into the embedded execution
+//! node over its engine IPC socket, gating on Proofs `ExEx` progress when `--proofs` is set. This
+//! is the unified-binary equivalent of the standalone `base-consensus follow` command.
+
+use std::sync::Arc;
+
+use base_consensus_cli::{
+    CliMetrics, ConsensusFollowNodeArgs, ConsensusFollowNodeConfigArgs,
+    EmbeddedConsensusFollowNodeConfigArgs, FollowNodeOverrides,
+};
+use base_execution_chainspec::BaseChainSpec;
+use base_execution_cli::{ExecutionNodeArgs, chainspec::chain_value_parser};
+use clap::Args;
+use reth_cli_runner::CliRunner;
+use tokio_util::sync::CancellationToken;
+
+use crate::{commands::rpc::engine_ipc_url, config::ResolvedChainConfig};
+
+/// Arguments for `base follow`.
+#[derive(Args, Clone, Debug)]
+#[command(
+    mut_arg("builder_disallow", |arg| arg.hide(true).long("__builder-disallow-disabled")),
+    mut_arg("sequencer", |arg| arg
+        .hide(true)
+        .long("__rollup-sequencer-disabled")
+        .alias(None::<&'static str>)),
+    mut_arg("sequencer_headers", |arg| arg
+        .hide(true)
+        .long("__rollup-sequencer-headers-disabled")
+        .alias(None::<&'static str>))
+)]
+pub(crate) struct FollowCommand {
+    /// Execution chain spec to use instead of the root chain selection.
+    #[arg(long = "execution-chain", value_parser = chain_value_parser)]
+    pub(crate) execution_chain: Option<Arc<BaseChainSpec>>,
+
+    /// Execution node arguments.
+    #[command(flatten)]
+    pub(crate) execution: ExecutionNodeArgs,
+
+    /// Follow-node arguments.
+    #[command(flatten)]
+    pub(crate) follow: EmbeddedConsensusFollowNodeConfigArgs,
+}
+
+impl FollowCommand {
+    /// Runs the `follow` flavor.
+    pub(crate) fn run(
+        self,
+        resolved_chain: ResolvedChainConfig,
+        metrics_enabled: bool,
+    ) -> eyre::Result<()> {
+        let Self { execution_chain, execution, follow } = self;
+        let mut execution_chain = match execution_chain {
+            Some(chain) => chain,
+            None => resolved_chain.execution_chain_spec()?,
+        };
+        let consensus_chain = resolved_chain.consensus_chain_args();
+        let mut execution = execution;
+        let follow_config: ConsensusFollowNodeConfigArgs = follow.into();
+        execution
+            .standard
+            .rollup_args
+            .upgrade_signal_l1_rpc
+            .apply_default_from(&follow_config.l1_rpc_args.l1_eth_rpc);
+        let follow_args = ConsensusFollowNodeArgs::new(consensus_chain, follow_config);
+        let mut rollup_config = follow_args.load_rollup_config()?;
+
+        CliRunner::try_default_runtime()?.run_command_until_exit(|ctx| async move {
+            execution
+                .standard
+                .rollup_args
+                .upgrade_signal
+                .apply_startup_to_sinks(
+                    &execution.standard.rollup_args.upgrade_signal_l1_rpc,
+                    "integrated follow startup",
+                    execution_chain.chain().id(),
+                    Arc::make_mut(&mut execution_chain),
+                    &mut rollup_config,
+                )
+                .await?;
+
+            if metrics_enabled {
+                CliMetrics::init_rollup_config(&rollup_config);
+            }
+            let _upgrade_countdown_metrics = metrics_enabled
+                .then(|| CliMetrics::spawn_upgrade_countdown_recorder(rollup_config.clone()));
+
+            let execution = execution
+                .into_launch_config(execution_chain)
+                .with_unified_auth_endpoint()
+                .with_upgrade_signal_startup_already_applied();
+            let l2_engine_rpc = engine_ipc_url(execution.auth_ipc_path())?;
+            let task_executor = ctx.task_executor.clone();
+            let launched = execution.launch_default(ctx).await?;
+            let handle = launched.handle;
+            // Keep the execution node handle alive until both services have coordinated shutdown.
+            let execution_node = handle.node;
+            let execution_exit = handle.node_exit_future;
+
+            let follow_cancellation = CancellationToken::new();
+            let follow_exit = follow_args.start_with_overrides(
+                FollowNodeOverrides::embedded_execution(l2_engine_rpc),
+                follow_cancellation.clone(),
+            );
+            tokio::pin!(execution_exit);
+            tokio::pin!(follow_exit);
+
+            let result = tokio::select! {
+                result = &mut execution_exit => {
+                    follow_cancellation.cancel();
+                    let follow_result = follow_exit.await;
+                    result?;
+                    follow_result
+                }
+                result = &mut follow_exit => {
+                    let follow_result = result;
+                    task_executor
+                        .initiate_graceful_shutdown()
+                        .map_err(|e| eyre::eyre!("failed to signal execution node shutdown: {e}"))?
+                        .ignore_guard()
+                        .await;
+                    let execution_result = execution_exit.await;
+                    follow_result?;
+                    execution_result
+                }
+            };
+
+            drop(execution_node);
+            result
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{cli::BaseCli, commands::BaseCommand};
+    use clap::Parser;
+
+    const REQUIRED_FOLLOW_ARGS: &[&str] = &[
+        "--source-l2-rpc",
+        "http://source-l2:8545",
+        "--l1-eth-rpc",
+        "http://localhost:8545",
+        "--l1-beacon",
+        "http://localhost:5052",
+    ];
+
+    fn follow_args(args: &'static [&'static str]) -> Vec<&'static str> {
+        let mut full_args = Vec::from(args);
+        full_args.extend_from_slice(REQUIRED_FOLLOW_ARGS);
+        full_args
+    }
+
+    #[test]
+    fn parses_follow_source_and_proofs() {
+        let cli = BaseCli::parse_from(follow_args(&[
+            "base",
+            "follow",
+            "--follow.proofs",
+            "--follow.proofs.max-blocks-ahead",
+            "64",
+        ]));
+
+        let BaseCommand::Follow(follow) = cli.command else {
+            panic!("expected follow command");
+        };
+
+        assert_eq!(follow.follow.source_l2_rpc.as_str(), "http://source-l2:8545/");
+        assert!(follow.follow.proofs);
+        assert_eq!(follow.follow.proofs_max_blocks_ahead, 64);
+    }
+
+    #[test]
+    fn proofs_default_to_disabled() {
+        let cli = BaseCli::parse_from(follow_args(&["base", "follow"]));
+
+        let BaseCommand::Follow(follow) = cli.command else {
+            panic!("expected follow command");
+        };
+
+        assert!(!follow.follow.proofs);
+    }
+
+    #[test]
+    fn rejects_engine_rpc_arg() {
+        // The engine endpoint is supplied by the embedded execution node, not a flag.
+        let err = BaseCli::try_parse_from(follow_args(&[
+            "base",
+            "follow",
+            "--l2-engine-rpc",
+            "http://localhost:8551",
+        ]))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("--l2-engine-rpc"));
+    }
+}

--- a/bin/base/src/commands/mod.rs
+++ b/bin/base/src/commands/mod.rs
@@ -3,6 +3,7 @@
 mod bootnode;
 mod command;
 pub(crate) use command::BaseCommand;
+mod follow;
 mod reth;
 mod rpc;
 mod sequencer;

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -204,7 +204,7 @@ pub struct EmbeddedConsensusFollowNodeConfigArgs {
     /// Gate sync behind proofs progress via `debug_proofsSyncStatus`.
     ///
     /// Namespaced as `--follow.proofs` (not `--proofs`) to avoid colliding with the execution
-    /// node's `--proofs`/`--proofs-history` ExEx toggle when both are flattened into the unified
+    /// node's `--proofs`/`--proofs-history` `ExEx` toggle when both are flattened into the unified
     /// `base follow` command. The `BASE_NODE_PROOFS` env var is unchanged.
     #[arg(long = "follow.proofs", default_value_t = false, env = "BASE_NODE_PROOFS")]
     pub proofs: bool,

--- a/crates/consensus/cli/src/follow.rs
+++ b/crates/consensus/cli/src/follow.rs
@@ -13,13 +13,31 @@ use base_consensus_providers::{L1RpcProvider, OnlineBeaconClient};
 use base_consensus_rpc::RpcBuilder;
 use clap::Args;
 use reth_node_core::args::TraceArgs;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use url::Url;
 
 use crate::{
-    ConsensusChainArgs, L1ClientArgs, L1ConfigFile, L2ClientArgs, L2ConfigFile, LogArgs,
-    MetricsArgs, RpcArgs, metrics::CliMetrics,
+    ConsensusChainArgs, EmbeddedL2ClientArgs, EmbeddedRpcArgs, L1ClientArgs, L1ConfigFile,
+    L2ClientArgs, L2ConfigFile, LogArgs, MetricsArgs, RpcArgs, metrics::CliMetrics,
 };
+
+/// Overrides supplied by callers that embed a follow node alongside an execution node.
+#[derive(Clone, Debug, Default)]
+pub struct FollowNodeOverrides {
+    /// Override for the L2 Engine API endpoint.
+    ///
+    /// The unified binary sets this to the co-located execution node's IPC socket so the follow
+    /// node inserts payloads over IPC instead of a network engine endpoint.
+    pub l2_engine_rpc: Option<Url>,
+}
+
+impl FollowNodeOverrides {
+    /// Creates overrides for a follow node embedded alongside an execution node.
+    pub const fn embedded_execution(l2_engine_rpc: Url) -> Self {
+        Self { l2_engine_rpc: Some(l2_engine_rpc) }
+    }
+}
 
 /// Standalone consensus follow-node command.
 #[derive(Args, Clone, Debug)]
@@ -159,6 +177,94 @@ pub struct ConsensusFollowNodeConfigArgs {
     pub l1_rpc_args: L1ClientArgs,
 }
 
+/// Follow-node configuration arguments for embedded callers (the unified binary).
+///
+/// Mirrors [`ConsensusFollowNodeConfigArgs`] but omits the `--l2-engine-rpc` argument: the L2
+/// engine endpoint is provided by the co-located execution node over IPC and supplied via
+/// [`FollowNodeOverrides::embedded_execution`]. Follow mode reads canonical payloads from
+/// `--source-l2-rpc` rather than P2P gossip, so no P2P arguments are exposed.
+#[derive(Args, Clone, Debug)]
+pub struct EmbeddedConsensusFollowNodeConfigArgs {
+    /// The URL of the node to follow.
+    #[arg(long = "source-l2-rpc", env = "BASE_NODE_SOURCE_L2_RPC")]
+    pub source_l2_rpc: Url,
+
+    /// Local L2 execution RPC URL (non-engine, e.g. the embedded execution node's HTTP port).
+    #[arg(
+        long = "l2-rpc-url",
+        default_value = "http://localhost:8545",
+        env = "BASE_NODE_L2_RPC_URL"
+    )]
+    pub l2_rpc_url: Url,
+
+    /// L2 engine CLI arguments (JWT/timeout/trust; the engine endpoint is supplied by execution).
+    #[clap(flatten)]
+    pub l2_client_args: EmbeddedL2ClientArgs,
+
+    /// Gate sync behind proofs progress via `debug_proofsSyncStatus`.
+    ///
+    /// Namespaced as `--follow.proofs` (not `--proofs`) to avoid colliding with the execution
+    /// node's `--proofs`/`--proofs-history` ExEx toggle when both are flattened into the unified
+    /// `base follow` command. The `BASE_NODE_PROOFS` env var is unchanged.
+    #[arg(long = "follow.proofs", default_value_t = false, env = "BASE_NODE_PROOFS")]
+    pub proofs: bool,
+
+    /// Maximum number of blocks the follow node may advance beyond the proofs
+    /// `ExEx` head. Only effective when `--follow.proofs` is enabled.
+    #[arg(
+        long = "follow.proofs.max-blocks-ahead",
+        default_value_t = 16,
+        env = "BASE_NODE_PROOFS_MAX_BLOCKS_AHEAD"
+    )]
+    pub proofs_max_blocks_ahead: u64,
+
+    /// Delay after each successful source payload insert, in milliseconds.
+    #[arg(
+        long = "follow.insert-delay-ms",
+        default_value = "0",
+        value_parser = |arg: &str| -> Result<Duration, ParseIntError> {
+            Ok(Duration::from_millis(arg.parse()?))
+        },
+        env = "BASE_NODE_FOLLOW_INSERT_DELAY_MS"
+    )]
+    pub insert_delay: Duration,
+
+    /// RPC CLI arguments.
+    #[command(flatten)]
+    pub rpc_flags: EmbeddedRpcArgs,
+
+    /// L2 configuration file.
+    #[clap(flatten)]
+    pub l2_config: L2ConfigFile,
+
+    /// L1 configuration file.
+    #[clap(flatten)]
+    pub l1_config: L1ConfigFile,
+
+    /// L1 RPC CLI arguments.
+    #[clap(flatten)]
+    pub l1_rpc_args: L1ClientArgs,
+}
+
+impl From<EmbeddedConsensusFollowNodeConfigArgs> for ConsensusFollowNodeConfigArgs {
+    fn from(args: EmbeddedConsensusFollowNodeConfigArgs) -> Self {
+        Self {
+            source_l2_rpc: args.source_l2_rpc,
+            l2_rpc_url: args.l2_rpc_url,
+            // The placeholder engine endpoint is always replaced by the embedded-execution
+            // override before the follow node is built.
+            l2_client_args: args.l2_client_args.into(),
+            proofs: args.proofs,
+            proofs_max_blocks_ahead: args.proofs_max_blocks_ahead,
+            insert_delay: args.insert_delay,
+            rpc_flags: args.rpc_flags.into(),
+            l2_config: args.l2_config,
+            l1_config: args.l1_config,
+            l1_rpc_args: args.l1_rpc_args,
+        }
+    }
+}
+
 impl ConsensusFollowNodeArgs {
     /// Loads the configured L2 rollup config.
     pub fn load_rollup_config(&self) -> eyre::Result<RollupConfig> {
@@ -170,9 +276,17 @@ impl ConsensusFollowNodeArgs {
 
     /// Builds a follow node with default external endpoint configuration.
     pub async fn build_follow_node(&self) -> eyre::Result<FollowNode> {
+        self.build_follow_node_with_overrides(&FollowNodeOverrides::default()).await
+    }
+
+    /// Builds a follow node with caller-supplied endpoint overrides.
+    pub async fn build_follow_node_with_overrides(
+        &self,
+        overrides: &FollowNodeOverrides,
+    ) -> eyre::Result<FollowNode> {
         let cfg = self.load_rollup_config()?;
         let local_l2_provider = self.local_l2_provider();
-        self.follow_node(cfg, local_l2_provider).await
+        self.follow_node(cfg, local_l2_provider, overrides).await
     }
 
     /// Builds a follow node from explicit runtime dependencies.
@@ -180,8 +294,12 @@ impl ConsensusFollowNodeArgs {
         &self,
         cfg: RollupConfig,
         local_l2_provider: RootProvider<Base>,
+        overrides: &FollowNodeOverrides,
     ) -> eyre::Result<FollowNode> {
-        let l2_engine_rpc = self.config.l2_client_args.l2_engine_rpc.clone();
+        let l2_engine_rpc = overrides
+            .l2_engine_rpc
+            .clone()
+            .unwrap_or_else(|| self.config.l2_client_args.l2_engine_rpc.clone());
         let jwt_secret =
             self.config.l2_client_args.resolve_jwt_secret_for_endpoint(&l2_engine_rpc).await?;
         let rollup_config = Arc::new(cfg.clone());
@@ -216,8 +334,20 @@ impl ConsensusFollowNodeArgs {
         }))
     }
 
-    /// Starts a follow node.
+    /// Starts a follow node with default external endpoint configuration.
     pub async fn start(&self) -> eyre::Result<()> {
+        self.start_with_overrides(FollowNodeOverrides::default(), CancellationToken::new()).await
+    }
+
+    /// Starts a follow node with caller-supplied endpoint overrides and cancellation.
+    ///
+    /// The unified binary uses this to point the follow node at the embedded execution node's
+    /// engine IPC socket and to stop the follow runtime when execution exits.
+    pub async fn start_with_overrides(
+        &self,
+        overrides: FollowNodeOverrides,
+        cancellation: CancellationToken,
+    ) -> eyre::Result<()> {
         let cfg = self.load_rollup_config()?;
         if !self.config.proofs {
             warn!(
@@ -238,10 +368,14 @@ impl ConsensusFollowNodeArgs {
             self.check_proofs_rpc(&local_l2_provider).await?;
         }
 
-        self.follow_node(cfg, local_l2_provider).await?.start().await.map_err(|e| {
-            error!(target: "rollup_node", error = %e, "Failed to start follow node");
-            eyre::eyre!(e)
-        })?;
+        self.follow_node(cfg, local_l2_provider, &overrides)
+            .await?
+            .start_with_cancellation(cancellation)
+            .await
+            .map_err(|e| {
+                error!(target: "rollup_node", error = %e, "Failed to start follow node");
+                eyre::eyre!(e)
+            })?;
 
         Ok(())
     }

--- a/crates/consensus/cli/src/lib.rs
+++ b/crates/consensus/cli/src/lib.rs
@@ -22,6 +22,7 @@ pub use config::{ConfigError, L1ConfigFile, L2ConfigFile};
 mod follow;
 pub use follow::{
     ConsensusFollowNodeArgs, ConsensusFollowNodeCommand, ConsensusFollowNodeConfigArgs,
+    EmbeddedConsensusFollowNodeConfigArgs, FollowNodeOverrides,
 };
 
 mod l1;

--- a/crates/consensus/service/src/follow/node.rs
+++ b/crates/consensus/service/src/follow/node.rs
@@ -85,9 +85,20 @@ where
         }
     }
 
-    /// Starts the follow node.
+    /// Starts the follow node, creating a fresh cancellation token.
     pub async fn start(&self) -> Result<(), FollowError> {
-        let cancellation = CancellationToken::new();
+        self.start_with_cancellation(CancellationToken::new()).await
+    }
+
+    /// Starts the follow node, driven by an externally supplied cancellation token.
+    ///
+    /// Cancelling the token stops the follow runtime, which lets an embedding caller (e.g. the
+    /// unified binary running execution in-process) coordinate a clean shutdown across both
+    /// services. The follow node also stops on an internal [`ShutdownSignal`].
+    pub async fn start_with_cancellation(
+        &self,
+        cancellation: CancellationToken,
+    ) -> Result<(), FollowError> {
         let local = Arc::new(LocalL2Client::new(
             self.local_l2_provider.clone(),
             self.l1_provider.clone(),


### PR DESCRIPTION
## Summary

Adds a `base follow` subcommand that runs an execution node (reth) and a consensus follow node together in the unified binary, so a follow-mode proofs node no longer requires the legacy split execution/consensus binary. The follow node inserts payloads into the co-located execution node over its engine IPC socket and gates sync on Proofs ExEx progress when enabled, reading canonical payloads from a source L2 RPC rather than P2P gossip. The follow-node builder gains an embedded-execution override and an externally driven cancellation token so the unified command can coordinate a clean shutdown across both services. Because reth already owns `--proofs`, the follow-side gating flags are namespaced as `--follow.proofs` while keeping the existing `BASE_NODE_PROOFS` environment variables unchanged.