### PR TITLE
fix(flashblocks): measure pending staleness from the snapshot tip

### DIFF
--- a/crates/execution/flashblocks/README.md
+++ b/crates/execution/flashblocks/README.md
@@ -24,20 +24,21 @@ node's real tip whenever applying updates is slower than receiving them.
 
 ### The invariant
 
-A published snapshot either tracks flashblocks anchored near the node's current canonical tip, or
+A published snapshot either still tracks flashblocks on the node's current canonical tip, or
 there is no snapshot at all.
 
 This matters because consumers execute against `PendingBlocks::canonical_block_number`, the
-canonical block the overlay is layered on. While that block stays close to the tip, callers read
-the node's in-memory canonical state. An overlay stranded on an old anchor forces them onto
-historical state instead, which is slow enough to starve the processor that produced the overlay
-and keep it stranded.
+canonical block the overlay is layered on. A snapshot whose tip has stopped advancing leaves
+that base stranded. Width from an inherited earliest header is a thicker overlay on an older
+base, not a stalled tip; `CanonicalBlockReconciler` rebuilds when that width exceeds
+`max_pending_blocks_depth`.
 
-`max_pending_blocks_depth` (CLI `--max-pending-blocks-depth`, default 3) sets the bound. It is
-measured from the earliest pending block, matching the depth `CanonicalBlockReconciler` already
-uses, so the reconciler never builds a snapshot that the tip checks then discard. The anchor is
-the block below the earliest pending block, so it may sit up to `max_pending_blocks_depth + 1`
-blocks behind the tip.
+`max_pending_blocks_depth` (CLI `--max-pending-blocks-depth`, default 3) sets the bound. Staleness
+is measured from the snapshot tip. `PendingBlocksBuilder::from_previous` keeps the inherited
+earliest header, so a healthy snapshot can grow wider than this bound while `latest` stays on
+the child of the tip. That width is bounded by `CanonicalBlockReconciler`'s `DepthLimitExceeded`
+rebuild, which retains post-canonical flashblocks instead of wiping. Measuring staleness from
+earliest would drop a live snapshot every few blocks and lose the rest of the current block.
 
 Bounding the distance rather than requiring the anchor to equal the tip is deliberate. When
 flashblocks for the next block arrive before the processor has applied the current canonical
@@ -56,10 +57,10 @@ a single expensive update. They use the notified block height directly instead o
 provider.
 
 - A canonical notification records the new height and immediately drops the published snapshot if
-  it is anchored more than `max_pending_blocks_depth` behind it. Because this runs at chain speed,
+  its tip is more than `max_pending_blocks_depth` behind it. Because this runs at chain speed,
   a snapshot cannot stay readable through a long apply. The drop is a compare-and-swap against the
   snapshot that was judged, so a snapshot the processor published concurrently, which is
-  necessarily anchored on a later tip, is left alone.
+  necessarily tracking a later tip, is left alone.
 - A flashblock for a block at or below the last notified canonical height is dropped before it is
   queued, so the queue never accumulates work that could not produce a publishable snapshot.
 
@@ -70,14 +71,15 @@ that lowers the tip does not suppress flashblocks built on the replacement chain
 queued update, because a lagging queue reports a stale height and makes a guard evaluate against a
 chain position the node left long ago.
 
-- Before an update is dispatched, a snapshot anchored more than `max_pending_blocks_depth` blocks
-  behind the tip is dropped. This covers advances the notification path did not report, such as the
-  gap between a canonical notification and the block becoming visible through the provider.
+- Before an update is dispatched, a snapshot whose tip is more than `max_pending_blocks_depth`
+  blocks behind the canonical tip is dropped. This covers advances the notification path did not
+  report, such as the gap between a canonical notification and the block becoming visible through
+  the provider.
 - Flashblocks whose block the node has already canonicalized are skipped before execution. This
   catches payloads that were fresh when queued and went stale while waiting, and cached payloads
   replayed after a canonical block arrives.
 - Every build path publishes through `publish_pending_blocks`, which re-reads the tip and refuses
-  to publish a snapshot that is anchored too far back or no longer extends past the tip. Because it
+  to publish a snapshot whose tip is too far back or no longer extends past the tip. Because it
   is the single funnel, this holds for the reorg and depth-limit rebuilds as well as for ordinary
   sequential appends.
 
@@ -127,7 +129,7 @@ cache and replayed once it lands.
 
 ### Observability
 
-- `pending_drop_stale`: snapshots dropped for being anchored too far behind the tip.
+- `pending_drop_stale`: snapshots dropped because their tip is too far behind the canonical tip.
 - `flashblock_superseded`: flashblocks skipped because their block was already canonical.
 - `pending_clear_catchup`, `pending_clear_reorg`: clears by reconciliation outcome.
 - `pending_snapshot_height`, `pending_snapshot_fb_index`: current snapshot position.

--- a/crates/execution/flashblocks/src/processor.rs
+++ b/crates/execution/flashblocks/src/processor.rs
@@ -121,21 +121,21 @@ where
         self.canonical_tip().map_or(notified, |best| notified.max(best))
     }
 
-    /// Returns `true` when `pending_blocks` is anchored within `max_depth` blocks of canonical
+    /// Returns `true` when `pending_blocks` still tracks within `max_depth` blocks of canonical
     /// height `best`.
     ///
-    /// Consumers execute against [`PendingBlocks::canonical_block_number`], so an overlay
-    /// anchored far behind the tip makes them walk historical state. The distance is measured
-    /// from the earliest pending block so that this bound is the one
-    /// [`CanonicalBlockReconciler`] already applies, which means the reconciler never builds a
-    /// snapshot that this check then throws away. The anchor itself is the block below that, so
-    /// it may sit up to `max_depth + 1` blocks behind `best`.
+    /// Staleness is measured from the snapshot tip. [`PendingBlocksBuilder::from_previous`]
+    /// keeps the inherited earliest header so a healthy snapshot can grow wider than
+    /// `max_depth` while `latest` stays on the child of `best`. That width is bounded by
+    /// [`CanonicalBlockReconciler`]'s `DepthLimitExceeded` rebuild, which retains
+    /// post-canonical flashblocks. Measuring from earliest here would wipe a live snapshot
+    /// every few blocks and drop the rest of the current block.
     fn is_anchored_near(&self, pending_blocks: &PendingBlocks, best: BlockNumber) -> bool {
-        best.saturating_sub(pending_blocks.earliest_block_number()) <= self.max_depth
+        best.saturating_sub(pending_blocks.latest_block_number()) <= self.max_depth
     }
 
-    /// Returns `true` when `pending_blocks` is usable as live pending state, meaning it is
-    /// anchored near the tip and still extends past it.
+    /// Returns `true` when `pending_blocks` is usable as live pending state, meaning its tip
+    /// is still near the canonical tip and still extends past it.
     ///
     /// This deliberately compares heights only. Detecting that the anchor itself was reorged
     /// out means comparing its hash against canonical history, which is a statement about
@@ -149,9 +149,9 @@ where
 
         if !self.is_anchored_near(pending_blocks, best) {
             debug!(
-                message = "pending snapshot anchored too far behind canonical tip, dropping",
+                message = "pending snapshot tip too far behind canonical tip, dropping",
                 canonical_tip = best,
-                earliest_pending_block = pending_blocks.earliest_block_number(),
+                latest_pending_block = pending_blocks.latest_block_number(),
                 max_depth = self.max_depth,
             );
             return false;
@@ -169,7 +169,7 @@ where
         true
     }
 
-    /// Returns the published snapshot, dropping it first if it is stranded too far behind the
+    /// Returns the published snapshot, dropping it first if its tip is too far behind the
     /// canonical tip to become usable again.
     ///
     /// `FlashblocksState` drops stranded overlays as canonical notifications arrive, which is
@@ -188,9 +188,8 @@ where
         }
 
         debug!(
-            message = "pending snapshot anchored too far behind canonical tip, dropping",
+            message = "pending snapshot tip too far behind canonical tip, dropping",
             canonical_tip = best,
-            earliest_pending_block = pending_blocks.earliest_block_number(),
             latest_pending_block = pending_blocks.latest_block_number(),
             max_depth = self.max_depth,
         );

--- a/crates/execution/flashblocks/src/state.rs
+++ b/crates/execution/flashblocks/src/state.rs
@@ -84,7 +84,7 @@ impl FlashblocksState {
         });
     }
 
-    /// Drops the published snapshot when it is anchored more than `max_pending_blocks_depth`
+    /// Drops the published snapshot when its tip is more than `max_pending_blocks_depth`
     /// blocks behind `canonical_block_number`.
     ///
     /// [`StateProcessor`] enforces the same bound, but only once it reaches the matching queue
@@ -96,10 +96,10 @@ impl FlashblocksState {
         let published = self.pending_blocks.load();
         let Some(stale) = published.as_ref() else { return };
 
-        // Measured from the earliest pending block so this matches the bound the processor and
-        // the reconciler apply, and the three cannot disagree about which snapshots survive.
-        let earliest_pending_block = stale.earliest_block_number();
-        if canonical_block_number.saturating_sub(earliest_pending_block)
+        // Measured from the snapshot tip. Width from the inherited earliest header is bounded
+        // by the reconciler's rebuild, not by this wipe.
+        let latest_pending_block = stale.latest_block_number();
+        if canonical_block_number.saturating_sub(latest_pending_block)
             <= self.max_pending_blocks_depth
         {
             return;
@@ -114,9 +114,9 @@ impl FlashblocksState {
         }
 
         debug!(
-            message = "dropping pending snapshot anchored too far behind the canonical tip",
+            message = "dropping pending snapshot whose tip is too far behind the canonical tip",
             canonical_block_number,
-            earliest_pending_block,
+            latest_pending_block,
             max_depth = self.max_pending_blocks_depth,
         );
         Metrics::pending_drop_stale().increment(1);
@@ -243,15 +243,28 @@ mod tests {
         }
     }
 
-    /// Builds a snapshot whose earliest pending block is `block_number`, which is the height
-    /// the staleness bound is measured from.
+    /// Builds a single-block snapshot at `block_number`. Earliest and latest are the same,
+    /// so this fixture cannot distinguish width from staleness.
     fn pending_anchored_at(block_number: u64) -> PendingBlocks {
+        pending_spanning(block_number, block_number)
+    }
+
+    /// Builds a snapshot whose earliest and latest pending blocks differ, matching the
+    /// shape [`PendingBlocksBuilder::from_previous`] produces on a live chain.
+    fn pending_spanning(earliest: u64, latest: u64) -> PendingBlocks {
         let mut builder = PendingBlocksBuilder::new();
-        builder.with_flashblocks([flashblock_for_block(block_number)]);
+        builder.with_flashblocks([flashblock_for_block(earliest)]);
         builder.with_header(Sealed::new_unchecked(
-            Header { number: block_number, ..Default::default() },
+            Header { number: earliest, ..Default::default() },
             B256::ZERO,
         ));
+        if latest != earliest {
+            builder.with_flashblocks([flashblock_for_block(latest)]);
+            builder.with_header(Sealed::new_unchecked(
+                Header { number: latest, ..Default::default() },
+                B256::ZERO,
+            ));
+        }
         builder.build().expect("pending fixture builds")
     }
 
@@ -276,7 +289,7 @@ mod tests {
 
         assert!(
             state.get_pending_blocks().is_none(),
-            "a snapshot anchored past max_pending_blocks_depth must not survive the notification"
+            "a snapshot whose tip is past max_pending_blocks_depth must not survive the notification"
         );
     }
 
@@ -290,6 +303,34 @@ mod tests {
         assert!(
             state.get_pending_blocks().is_some(),
             "normal lag must not clear pending, or every notification would drop live state"
+        );
+    }
+
+    #[test]
+    fn canonical_notification_keeps_pending_that_still_tracks_the_tip() {
+        let state = FlashblocksState::new(MAX_DEPTH);
+        // Wider than max_depth, but latest is the child of the canonical tip.
+        state.set_pending_blocks_for_testing(Some(pending_spanning(1, 1 + MAX_DEPTH + 2)));
+
+        state.on_canonical_block_received(canonical_block(1 + MAX_DEPTH + 1));
+
+        assert!(
+            state.get_pending_blocks().is_some(),
+            "a snapshot that still extends the tip must survive even when it spans more than max_depth"
+        );
+    }
+
+    #[test]
+    fn canonical_notification_drops_pending_that_stopped_tracking_the_tip() {
+        let state = FlashblocksState::new(MAX_DEPTH);
+        // Latest fell more than max_depth behind the canonical tip.
+        state.set_pending_blocks_for_testing(Some(pending_spanning(1, 2)));
+
+        state.on_canonical_block_received(canonical_block(2 + MAX_DEPTH + 1));
+
+        assert!(
+            state.get_pending_blocks().is_none(),
+            "a snapshot whose tip stopped advancing must still be dropped"
         );
     }
 


### PR DESCRIPTION
## Summary

Pending snapshots were being dropped on a healthy node because staleness was measured from the inherited earliest header, which never advances as the chain moves. That made a live snapshot look older every block, so the node threw away the block it had just built and subscribers missed the rest of it. This measures staleness from the snapshot tip instead, and leaves snapshot width to the existing reconciler rebuild.

Fixes #4916