### PR TITLE
fix(system-tests): repair broken unit tests and bound upgrade signal L1 waits

### DIFF
--- a/.depot/workflows/ci-pr.yml
+++ b/.depot/workflows/ci-pr.yml
@@ -19,7 +19,7 @@ jobs:
         just build::affected-ci "${DIFF_BASE:?}"
       clippy_command: >-
         just check::clippy-affected-ci "${DIFF_BASE:?}"
-      run_system_tests: false
+      run_system_tests: true
       run_sigsegv: false
       test_command: >-
         just test-affected-ci "${DIFF_BASE:?}"

--- a/etc/systems/src/benchmark_report.rs
+++ b/etc/systems/src/benchmark_report.rs
@@ -344,6 +344,7 @@ mod tests {
                 config: Some(
                     TestConfig::from_yaml(
                         r#"
+transaction_submission_rpcs: http://127.0.0.1:1
 transactions:
   - weight: 100
     type: precompile

--- a/etc/systems/src/l1/lighthouse.rs
+++ b/etc/systems/src/l1/lighthouse.rs
@@ -85,6 +85,11 @@ impl LighthouseBeaconContainer {
         Ok(Self { container, name })
     }
 
+    /// Returns the container's trailing output for failure diagnostics.
+    pub async fn logs(&self) -> Result<String> {
+        super::ContainerLogs::tail(&self.container).await
+    }
+
     /// Returns the beacon API URL (host-accessible).
     pub async fn beacon_url(&self) -> Result<String> {
         let host = self.container.get_host().await?;
@@ -111,6 +116,11 @@ pub struct LighthouseValidatorContainer {
 }
 
 impl LighthouseValidatorContainer {
+    /// Returns the container's trailing output for failure diagnostics.
+    pub async fn logs(&self) -> Result<String> {
+        super::ContainerLogs::tail(&self.container).await
+    }
+
     /// Starts a Lighthouse validator client.
     pub async fn start(
         testnet_dir: impl AsRef<Path>,

--- a/etc/systems/src/l1/logs.rs
+++ b/etc/systems/src/l1/logs.rs
@@ -1,0 +1,59 @@
+//! Container log capture for L1 failure diagnostics.
+
+use eyre::Result;
+use testcontainers::{ContainerAsync, GenericImage};
+
+/// Tails a container's output so a stalled L1 can be diagnosed from CI test output.
+///
+/// The L1 clients run in Docker, so their logs never reach the test harness's own output.
+/// Without this, a devnet L1 that accepts RPC but never advances is indistinguishable from a
+/// slow one.
+#[derive(Debug, Clone, Copy)]
+pub struct ContainerLogs;
+
+impl ContainerLogs {
+    /// Number of trailing lines kept from each stream.
+    pub const TAIL_LINES: usize = 80;
+
+    /// Returns the trailing stdout and stderr of a container, labelled by stream.
+    pub async fn tail(container: &ContainerAsync<GenericImage>) -> Result<String> {
+        let stdout = container.stdout_to_vec().await.unwrap_or_default();
+        let stderr = container.stderr_to_vec().await.unwrap_or_default();
+        Ok(format!(
+            "stdout:\n{}\nstderr:\n{}",
+            Self::tail_lines(&stdout),
+            Self::tail_lines(&stderr)
+        ))
+    }
+
+    /// Returns the last [`Self::TAIL_LINES`] lines of a captured stream.
+    pub fn tail_lines(raw: &[u8]) -> String {
+        let text = String::from_utf8_lossy(raw);
+        let lines: Vec<&str> = text.lines().collect();
+        let start = lines.len().saturating_sub(Self::TAIL_LINES);
+        lines[start..].join("\n")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContainerLogs;
+
+    #[test]
+    fn tail_lines_keeps_only_the_trailing_window() {
+        let raw = (0..200).map(|line| format!("line {line}")).collect::<Vec<_>>().join("\n");
+
+        let tailed = ContainerLogs::tail_lines(raw.as_bytes());
+
+        assert_eq!(tailed.lines().count(), ContainerLogs::TAIL_LINES);
+        assert!(tailed.starts_with("line 120"));
+        assert!(tailed.ends_with("line 199"));
+    }
+
+    #[test]
+    fn tail_lines_keeps_short_output_intact() {
+        let tailed = ContainerLogs::tail_lines(b"only line");
+
+        assert_eq!(tailed, "only line");
+    }
+}

--- a/etc/systems/src/l1/mod.rs
+++ b/etc/systems/src/l1/mod.rs
@@ -4,6 +4,10 @@
 mod config;
 pub use config::L1ContainerConfig;
 
+/// Container log capture for L1 failure diagnostics.
+mod logs;
+pub use logs::ContainerLogs;
+
 /// Lighthouse beacon and validator containers.
 mod lighthouse;
 pub use lighthouse::{LighthouseBeaconContainer, LighthouseValidatorContainer};

--- a/etc/systems/src/l1/reth.rs
+++ b/etc/systems/src/l1/reth.rs
@@ -130,6 +130,11 @@ impl RethContainer {
         Ok(Self { container, name, reorg_control_enabled: config.enable_reorg_control })
     }
 
+    /// Returns the container's trailing output for failure diagnostics.
+    pub async fn logs(&self) -> Result<String> {
+        super::ContainerLogs::tail(&self.container).await
+    }
+
     /// Returns the public RPC URL of the container.
     pub async fn rpc_url(&self) -> Result<Url> {
         self.host_url(HTTP_PORT).await

--- a/etc/systems/src/l1/stack.rs
+++ b/etc/systems/src/l1/stack.rs
@@ -119,7 +119,11 @@ impl L1Stack {
     }
 
     /// How long the chain may stay at block zero before its client logs are captured.
-    pub const STALL_DIAGNOSTIC_DELAY: Duration = Duration::from_secs(60);
+    ///
+    /// A healthy devnet L1 leaves block zero within a couple of slots, so this only needs to be
+    /// long enough to tell "stalled" from "starting". Every second here is charged to tests that
+    /// are already failing, and overshooting pushes them past their own nextest timeouts.
+    pub const STALL_DIAGNOSTIC_DELAY: Duration = Duration::from_secs(20);
 
     /// Poll interval while watching for the first L1 block.
     const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);

--- a/etc/systems/src/l1/stack.rs
+++ b/etc/systems/src/l1/stack.rs
@@ -1,7 +1,9 @@
 //! L1 stack orchestration (Reth + Lighthouse).
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
+use alloy_network::Ethereum;
+use alloy_provider::{Provider, RootProvider};
 use eyre::{Result, WrapErr};
 use url::Url;
 
@@ -114,6 +116,53 @@ impl L1Stack {
     /// Returns a reference to the Lighthouse beacon container.
     pub const fn beacon(&self) -> &LighthouseBeaconContainer {
         &self.beacon
+    }
+
+    /// How long the chain may stay at block zero before its client logs are captured.
+    pub const STALL_DIAGNOSTIC_DELAY: Duration = Duration::from_secs(60);
+
+    /// Poll interval while watching for the first L1 block.
+    const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+    /// Captures L1 client logs when the chain never leaves block zero.
+    ///
+    /// Purely diagnostic and never fails a caller. Both L1 clients run in Docker, so a devnet
+    /// that serves RPC while never advancing leaves no trace in the harness's own output; the
+    /// tests that depend on it just time out somewhere further downstream.
+    pub async fn log_diagnostics_if_stalled(&self) {
+        let Ok(rpc_url) = self.rpc_url().await else {
+            return;
+        };
+        let provider = RootProvider::<Ethereum>::new_http(rpc_url);
+        let advanced = tokio::time::timeout(Self::STALL_DIAGNOSTIC_DELAY, async {
+            loop {
+                if provider.get_block_number().await.is_ok_and(|number| number > 0) {
+                    return;
+                }
+                tokio::time::sleep(Self::BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .is_ok();
+
+        if advanced {
+            return;
+        }
+
+        eprintln!(
+            "L1 stalled at block 0 for {:?}; capturing client logs",
+            Self::STALL_DIAGNOSTIC_DELAY
+        );
+        for (client, logs) in [
+            ("reth", self.reth.logs().await),
+            ("beacon", self.beacon.logs().await),
+            ("validator", self.validator.logs().await),
+        ] {
+            match logs {
+                Ok(logs) => eprintln!("===== L1 {client} =====\n{logs}"),
+                Err(error) => eprintln!("===== L1 {client} ===== unavailable: {error}"),
+            }
+        }
     }
 
     /// Returns the public RPC URL of the Reth container.

--- a/etc/systems/src/l1/stack.rs
+++ b/etc/systems/src/l1/stack.rs
@@ -1,9 +1,7 @@
 //! L1 stack orchestration (Reth + Lighthouse).
 
-use std::{path::PathBuf, time::Duration};
+use std::path::PathBuf;
 
-use alloy_network::Ethereum;
-use alloy_provider::{Provider, RootProvider};
 use eyre::{Result, WrapErr};
 use url::Url;
 
@@ -116,36 +114,6 @@ impl L1Stack {
     /// Returns a reference to the Lighthouse beacon container.
     pub const fn beacon(&self) -> &LighthouseBeaconContainer {
         &self.beacon
-    }
-
-    /// Maximum time to wait for the L1 validator to propose its first block.
-    ///
-    /// Sized to cover the remaining beacon genesis lead once the containers are up. Every test
-    /// pays this on a stalled L1, so it stays tight enough that a suite-wide L1 failure still
-    /// reports per-test results inside the CI budget instead of timing the whole job out.
-    pub const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(90);
-
-    /// Poll interval while waiting for the first L1 block.
-    const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
-
-    /// Waits until the L1 validator has proposed at least one block after genesis.
-    ///
-    /// Beacon genesis is stamped when offline genesis generation begins, so the chain only
-    /// starts advancing once that timestamp passes. Reth serves RPC the whole time, so callers
-    /// that skip this gate see a live endpoint pinned at block 0: L2 derivation never finds an
-    /// L1 origin and L1 transactions never leave the pool.
-    pub async fn wait_for_block_production(&self) -> Result<()> {
-        let provider = RootProvider::<Ethereum>::new_http(self.rpc_url().await?);
-        tokio::time::timeout(Self::BLOCK_PRODUCTION_TIMEOUT, async {
-            loop {
-                if provider.get_block_number().await.is_ok_and(|number| number > 0) {
-                    return;
-                }
-                tokio::time::sleep(Self::BLOCK_POLL_INTERVAL).await;
-            }
-        })
-        .await
-        .wrap_err("L1 did not produce a block before the deadline")
     }
 
     /// Returns the public RPC URL of the Reth container.

--- a/etc/systems/src/l1/stack.rs
+++ b/etc/systems/src/l1/stack.rs
@@ -1,7 +1,9 @@
 //! L1 stack orchestration (Reth + Lighthouse).
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
+use alloy_network::Ethereum;
+use alloy_provider::{Provider, RootProvider};
 use eyre::{Result, WrapErr};
 use url::Url;
 
@@ -114,6 +116,32 @@ impl L1Stack {
     /// Returns a reference to the Lighthouse beacon container.
     pub const fn beacon(&self) -> &LighthouseBeaconContainer {
         &self.beacon
+    }
+
+    /// Maximum time to wait for the L1 validator to propose its first block.
+    pub const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(240);
+
+    /// Poll interval while waiting for the first L1 block.
+    const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+    /// Waits until the L1 validator has proposed at least one block after genesis.
+    ///
+    /// Beacon genesis is stamped when offline genesis generation begins, so the chain only
+    /// starts advancing once that timestamp passes. Reth serves RPC the whole time, so callers
+    /// that skip this gate see a live endpoint pinned at block 0: L2 derivation never finds an
+    /// L1 origin and L1 transactions never leave the pool.
+    pub async fn wait_for_block_production(&self) -> Result<()> {
+        let provider = RootProvider::<Ethereum>::new_http(self.rpc_url().await?);
+        tokio::time::timeout(Self::BLOCK_PRODUCTION_TIMEOUT, async {
+            loop {
+                if provider.get_block_number().await.is_ok_and(|number| number > 0) {
+                    return;
+                }
+                tokio::time::sleep(Self::BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("L1 did not produce a block before the deadline")
     }
 
     /// Returns the public RPC URL of the Reth container.

--- a/etc/systems/src/l1/stack.rs
+++ b/etc/systems/src/l1/stack.rs
@@ -119,7 +119,11 @@ impl L1Stack {
     }
 
     /// Maximum time to wait for the L1 validator to propose its first block.
-    pub const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(240);
+    ///
+    /// Sized to cover the remaining beacon genesis lead once the containers are up. Every test
+    /// pays this on a stalled L1, so it stays tight enough that a suite-wide L1 failure still
+    /// reports per-test results inside the CI budget instead of timing the whole job out.
+    pub const BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(90);
 
     /// Poll interval while waiting for the first L1 block.
     const BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);

--- a/etc/systems/src/prometheus_metrics.rs
+++ b/etc/systems/src/prometheus_metrics.rs
@@ -348,17 +348,17 @@ mod tests {
     #[test]
     fn computes_labeled_histogram_averages() {
         let previous = PrometheusSnapshot::parse(
-            "# TYPE build_duration histogram\n\\
-             build_duration_sum{stage=\"execution\"} 4\n\\
+            "# TYPE build_duration histogram\n\
+             build_duration_sum{stage=\"execution\"} 4\n\
              build_duration_count{stage=\"execution\"} 2\n",
         );
         let current = PrometheusSnapshot::parse(
-            "# TYPE build_duration histogram\n\\
-             build_duration_sum{stage=\"execution\"} 10\n\\
+            "# TYPE build_duration histogram\n\
+             build_duration_sum{stage=\"execution\"} 10\n\
              build_duration_count{stage=\"execution\"} 4\n",
         );
         let delta = current.delta(&previous);
-        assert_eq!(delta["build_duration_avg_stage_execution"], 3.0);
+        assert_eq!(delta["build_duration_stage_execution_avg"], 3.0);
     }
 
     #[test]

--- a/etc/systems/src/setup/container.rs
+++ b/etc/systems/src/setup/container.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     thread,
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant},
 };
 
 use eyre::{Result, WrapErr, ensure};
@@ -26,19 +26,6 @@ const SETUP_IMAGE_BUILD_LOCK_TIMEOUT: Duration = Duration::from_secs(600);
 const SETUP_IMAGE_BUILD_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const SETUP_DOCKERFILE_PATH: &str = "etc/docker/Dockerfile.devnet";
 const SETUP_TIMEOUT_SECS: u64 = 300;
-/// Seconds of lead time given to the generated beacon genesis.
-///
-/// `op-deployer` stamps `MIN_GENESIS_TIME` when generation starts, and the template sets
-/// `GENESIS_DELAY: 0`. Deploying the L2 contracts and booting Reth and Lighthouse all happen
-/// after that stamp, so a genesis anchored at "now" is already far in the past by the time the
-/// validator starts. At the one-second slot duration these tests use, every elapsed second is a
-/// missed slot, and the beacon node never reports itself synced, so it never proposes and L1
-/// stalls at block 0 forever. Anchoring genesis ahead of generation keeps the validator's first
-/// slot in the future. Lighthouse simply waits for a future genesis, so overshooting only costs
-/// startup latency while undershooting deadlocks the chain. Every second of overshoot is paid by
-/// each test, so this stays only slightly above the observed generation and boot cost; the whole
-/// suite shares a one hour CI budget.
-const GENESIS_LEAD_SECS: u64 = 120;
 
 /// Builder enode ID
 pub const BUILDER_ENODE_ID: &str = "3255458e24278e31d5940f304b16300fdff3f6efd3e2a030b5818310ac67af45e28d057e6a332d07e0c5ab09d6947fd4eed1a646edbf224e2d2fec6f49f90abc";
@@ -323,15 +310,6 @@ impl SetupContainer {
         self
     }
 
-    /// Returns the beacon genesis timestamp, anchored ahead of genesis generation.
-    pub fn genesis_timestamp() -> Result<u64> {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .wrap_err("System clock is before the Unix epoch")?
-            .as_secs();
-        Ok(now.saturating_add(GENESIS_LEAD_SECS))
-    }
-
     /// Generates both chains before starting L1, with deployed contracts in genesis.
     pub fn generate_genesis(&self) -> Result<(L1GenesisOutput, L2DeploymentOutput)> {
         SetupImage::ensure_built()?;
@@ -350,7 +328,6 @@ impl SetupContainer {
             .with_env_var("CHAIN_ID", self.chain_id.to_string())
             .with_env_var("L2_CHAIN_ID", self.l2_chain_id.to_string())
             .with_env_var("SLOT_DURATION", self.slot_duration.to_string())
-            .with_env_var("BASE_DEVNET_TIMESTAMP", Self::genesis_timestamp()?.to_string())
             // Upgrade-signal tests deploy their own configurable mock after L1 starts.
             .with_env_var("UPGRADE_SIGNAL_PREINSTALL", "false")
             .with_env_var("DEPLOYER_ADDR", format!("{:#x}", DEPLOYER.address))

--- a/etc/systems/src/setup/container.rs
+++ b/etc/systems/src/setup/container.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use eyre::{Result, WrapErr, ensure};
@@ -26,6 +26,17 @@ const SETUP_IMAGE_BUILD_LOCK_TIMEOUT: Duration = Duration::from_secs(600);
 const SETUP_IMAGE_BUILD_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const SETUP_DOCKERFILE_PATH: &str = "etc/docker/Dockerfile.devnet";
 const SETUP_TIMEOUT_SECS: u64 = 300;
+/// Seconds of lead time given to the generated beacon genesis.
+///
+/// `op-deployer` stamps `MIN_GENESIS_TIME` when generation starts, and the template sets
+/// `GENESIS_DELAY: 0`. Deploying the L2 contracts and booting Reth and Lighthouse all happen
+/// after that stamp, so a genesis anchored at "now" is already far in the past by the time the
+/// validator starts. At the one-second slot duration these tests use, every elapsed second is a
+/// missed slot, and the beacon node never reports itself synced, so it never proposes and L1
+/// stalls at block 0 forever. Anchoring genesis ahead of generation keeps the validator's first
+/// slot in the future. Lighthouse simply waits for a future genesis, so overshooting only costs
+/// startup latency while undershooting deadlocks the chain.
+const GENESIS_LEAD_SECS: u64 = 150;
 
 /// Builder enode ID
 pub const BUILDER_ENODE_ID: &str = "3255458e24278e31d5940f304b16300fdff3f6efd3e2a030b5818310ac67af45e28d057e6a332d07e0c5ab09d6947fd4eed1a646edbf224e2d2fec6f49f90abc";
@@ -310,6 +321,15 @@ impl SetupContainer {
         self
     }
 
+    /// Returns the beacon genesis timestamp, anchored ahead of genesis generation.
+    pub fn genesis_timestamp() -> Result<u64> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .wrap_err("System clock is before the Unix epoch")?
+            .as_secs();
+        Ok(now.saturating_add(GENESIS_LEAD_SECS))
+    }
+
     /// Generates both chains before starting L1, with deployed contracts in genesis.
     pub fn generate_genesis(&self) -> Result<(L1GenesisOutput, L2DeploymentOutput)> {
         SetupImage::ensure_built()?;
@@ -328,6 +348,7 @@ impl SetupContainer {
             .with_env_var("CHAIN_ID", self.chain_id.to_string())
             .with_env_var("L2_CHAIN_ID", self.l2_chain_id.to_string())
             .with_env_var("SLOT_DURATION", self.slot_duration.to_string())
+            .with_env_var("BASE_DEVNET_TIMESTAMP", Self::genesis_timestamp()?.to_string())
             // Upgrade-signal tests deploy their own configurable mock after L1 starts.
             .with_env_var("UPGRADE_SIGNAL_PREINSTALL", "false")
             .with_env_var("DEPLOYER_ADDR", format!("{:#x}", DEPLOYER.address))

--- a/etc/systems/src/setup/container.rs
+++ b/etc/systems/src/setup/container.rs
@@ -35,8 +35,10 @@ const SETUP_TIMEOUT_SECS: u64 = 300;
 /// missed slot, and the beacon node never reports itself synced, so it never proposes and L1
 /// stalls at block 0 forever. Anchoring genesis ahead of generation keeps the validator's first
 /// slot in the future. Lighthouse simply waits for a future genesis, so overshooting only costs
-/// startup latency while undershooting deadlocks the chain.
-const GENESIS_LEAD_SECS: u64 = 150;
+/// startup latency while undershooting deadlocks the chain. Every second of overshoot is paid by
+/// each test, so this stays only slightly above the observed generation and boot cost; the whole
+/// suite shares a one hour CI budget.
+const GENESIS_LEAD_SECS: u64 = 120;
 
 /// Builder enode ID
 pub const BUILDER_ENODE_ID: &str = "3255458e24278e31d5940f304b16300fdff3f6efd3e2a030b5818310ac67af45e28d057e6a332d07e0c5ab09d6947fd4eed1a646edbf224e2d2fec6f49f90abc";

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -690,6 +690,7 @@ impl SystemTestStackBuilder {
             L1Execution::start(l1_config).await.wrap_err("Failed to start L1 execution layer")?;
         let l1_stack =
             l1_execution.start_consensus().await.wrap_err("Failed to start L1 consensus")?;
+        l1_stack.log_diagnostics_if_stalled().await;
 
         let jwt_secret = JwtSecret::random();
 

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -690,6 +690,10 @@ impl SystemTestStackBuilder {
             L1Execution::start(l1_config).await.wrap_err("Failed to start L1 execution layer")?;
         let l1_stack =
             l1_execution.start_consensus().await.wrap_err("Failed to start L1 consensus")?;
+        l1_stack
+            .wait_for_block_production()
+            .await
+            .wrap_err("L1 stack did not start producing blocks")?;
 
         let jwt_secret = JwtSecret::random();
 

--- a/etc/systems/src/smoke.rs
+++ b/etc/systems/src/smoke.rs
@@ -690,10 +690,6 @@ impl SystemTestStackBuilder {
             L1Execution::start(l1_config).await.wrap_err("Failed to start L1 execution layer")?;
         let l1_stack =
             l1_execution.start_consensus().await.wrap_err("Failed to start L1 consensus")?;
-        l1_stack
-            .wait_for_block_production()
-            .await
-            .wrap_err("L1 stack did not start producing blocks")?;
 
         let jwt_secret = JwtSecret::random();
 

--- a/etc/systems/src/upgrade_signal.rs
+++ b/etc/systems/src/upgrade_signal.rs
@@ -145,19 +145,44 @@ pub struct MockProtocolVersionsClient {
 }
 
 impl MockProtocolVersionsClient {
+    /// Maximum time to wait for the devnet L1 to start producing blocks.
+    pub const L1_BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(90);
+
     /// Maximum time to wait for one upgrade signal L1 transaction to be mined.
     pub const L1_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(90);
 
+    /// Poll interval while waiting for the devnet L1 to start producing blocks.
+    const L1_BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+    /// Waits until the devnet L1 has produced at least one block after genesis.
+    ///
+    /// Lighthouse reports its HTTP API as ready well before the validator proposes its first
+    /// slot, and Reth accepts transactions into its pool the whole time. A transaction sent in
+    /// that window never gets a receipt, so every upgrade signal write waits for block
+    /// production first rather than blocking forever on an unmined transaction.
+    pub async fn wait_for_l1_block_production(l1_rpc_url: &Url) -> Result<()> {
+        let provider = Self::wallet_provider(l1_rpc_url)?;
+        tokio::time::timeout(Self::L1_BLOCK_PRODUCTION_TIMEOUT, async {
+            loop {
+                if provider.get_block_number().await.is_ok_and(|number| number > 0) {
+                    return;
+                }
+                tokio::time::sleep(Self::L1_BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("L1 did not produce a block before the upgrade signal deadline")
+    }
+
     /// Deploys the mock contract to L1 and seeds it with the rollup config baseline overlaid
     /// with the options' explicit schedule entries.
-    ///
-    /// The caller must have already waited for L1 block production, or these transactions sit
-    /// unmined forever.
     pub async fn deploy(
         l1_rpc_url: Url,
         options: &UpgradeSignalStackOptions,
         rollup_config: &RollupConfig,
     ) -> Result<Self> {
+        Self::wait_for_l1_block_production(&l1_rpc_url).await?;
+
         let provider = Self::wallet_provider(&l1_rpc_url)?;
         let contract = tokio::time::timeout(
             Self::L1_TRANSACTION_TIMEOUT,

--- a/etc/systems/src/upgrade_signal.rs
+++ b/etc/systems/src/upgrade_signal.rs
@@ -3,6 +3,8 @@
 //! Deploys the mock `ProtocolVersions` schedule contract to the L1 stack and builds the
 //! [`UpgradeSignalConfig`] consumed by the in-process consensus nodes.
 
+use std::time::Duration;
+
 use alloy_network::EthereumWallet;
 use alloy_primitives::{Address, U256};
 use alloy_provider::{Provider, ProviderBuilder};
@@ -13,7 +15,7 @@ use base_test_utils::MockProtocolVersions;
 use base_upgrade_signal::{
     UpgradeSignalBlockTag, UpgradeSignalConfig, UpgradeSignalDefaults, UpgradeSignalMode,
 };
-use eyre::{Result, WrapErr};
+use eyre::{Result, WrapErr, ensure};
 use url::Url;
 
 use crate::config::ANVIL_ACCOUNT_4;
@@ -143,6 +145,35 @@ pub struct MockProtocolVersionsClient {
 }
 
 impl MockProtocolVersionsClient {
+    /// Maximum time to wait for the devnet L1 to start producing blocks.
+    pub const L1_BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(90);
+
+    /// Maximum time to wait for one upgrade signal L1 transaction to be mined.
+    pub const L1_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(90);
+
+    /// Poll interval while waiting for the devnet L1 to start producing blocks.
+    const L1_BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+    /// Waits until the devnet L1 has produced at least one block after genesis.
+    ///
+    /// Lighthouse reports its HTTP API as ready well before the validator proposes its first
+    /// slot, and Reth accepts transactions into its pool the whole time. A transaction sent in
+    /// that window never gets a receipt, so every upgrade signal write waits for block
+    /// production first rather than blocking forever on an unmined transaction.
+    pub async fn wait_for_l1_block_production(l1_rpc_url: &Url) -> Result<()> {
+        let provider = Self::wallet_provider(l1_rpc_url)?;
+        tokio::time::timeout(Self::L1_BLOCK_PRODUCTION_TIMEOUT, async {
+            loop {
+                if provider.get_block_number().await.is_ok_and(|number| number > 0) {
+                    return;
+                }
+                tokio::time::sleep(Self::L1_BLOCK_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .wrap_err("L1 did not produce a block before the upgrade signal deadline")
+    }
+
     /// Deploys the mock contract to L1 and seeds it with the rollup config baseline overlaid
     /// with the options' explicit schedule entries.
     pub async fn deploy(
@@ -150,10 +181,16 @@ impl MockProtocolVersionsClient {
         options: &UpgradeSignalStackOptions,
         rollup_config: &RollupConfig,
     ) -> Result<Self> {
+        Self::wait_for_l1_block_production(&l1_rpc_url).await?;
+
         let provider = Self::wallet_provider(&l1_rpc_url)?;
-        let contract = MockProtocolVersions::deploy(provider)
-            .await
-            .wrap_err("Failed to deploy MockProtocolVersions to L1")?;
+        let contract = tokio::time::timeout(
+            Self::L1_TRANSACTION_TIMEOUT,
+            MockProtocolVersions::deploy(provider),
+        )
+        .await
+        .wrap_err("MockProtocolVersions deploy was not mined before the L1 deadline")?
+        .wrap_err("Failed to deploy MockProtocolVersions to L1")?;
 
         let client = Self {
             l1_rpc_url,
@@ -176,14 +213,16 @@ impl MockProtocolVersionsClient {
         let merged: Vec<_> = self.baseline.iter().chain(entries).copied().collect();
         let provider = Self::wallet_provider(&self.l1_rpc_url)?;
         let contract = MockProtocolVersions::new(self.address, provider);
-        contract
+        let pending = contract
             .setSchedule(Self::id_ordered_schedule(&merged)?)
             .send()
             .await
-            .wrap_err("Failed to send setSchedule")?
-            .get_receipt()
+            .wrap_err("Failed to send setSchedule")?;
+        let receipt = tokio::time::timeout(Self::L1_TRANSACTION_TIMEOUT, pending.get_receipt())
             .await
+            .wrap_err("setSchedule was not mined before the L1 deadline")?
             .wrap_err("setSchedule was not mined")?;
+        ensure!(receipt.status(), "setSchedule reverted on L1");
         Ok(())
     }
 
@@ -191,14 +230,16 @@ impl MockProtocolVersionsClient {
     pub async fn set_minimum_protocol_version(&self, version: U256) -> Result<()> {
         let provider = Self::wallet_provider(&self.l1_rpc_url)?;
         let contract = MockProtocolVersions::new(self.address, provider);
-        contract
+        let pending = contract
             .setMinimumProtocolVersion(version)
             .send()
             .await
-            .wrap_err("Failed to send setMinimumProtocolVersion")?
-            .get_receipt()
+            .wrap_err("Failed to send setMinimumProtocolVersion")?;
+        let receipt = tokio::time::timeout(Self::L1_TRANSACTION_TIMEOUT, pending.get_receipt())
             .await
+            .wrap_err("setMinimumProtocolVersion was not mined before the L1 deadline")?
             .wrap_err("setMinimumProtocolVersion was not mined")?;
+        ensure!(receipt.status(), "setMinimumProtocolVersion reverted on L1");
         Ok(())
     }
 

--- a/etc/systems/src/upgrade_signal.rs
+++ b/etc/systems/src/upgrade_signal.rs
@@ -145,44 +145,19 @@ pub struct MockProtocolVersionsClient {
 }
 
 impl MockProtocolVersionsClient {
-    /// Maximum time to wait for the devnet L1 to start producing blocks.
-    pub const L1_BLOCK_PRODUCTION_TIMEOUT: Duration = Duration::from_secs(90);
-
     /// Maximum time to wait for one upgrade signal L1 transaction to be mined.
     pub const L1_TRANSACTION_TIMEOUT: Duration = Duration::from_secs(90);
 
-    /// Poll interval while waiting for the devnet L1 to start producing blocks.
-    const L1_BLOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
-
-    /// Waits until the devnet L1 has produced at least one block after genesis.
-    ///
-    /// Lighthouse reports its HTTP API as ready well before the validator proposes its first
-    /// slot, and Reth accepts transactions into its pool the whole time. A transaction sent in
-    /// that window never gets a receipt, so every upgrade signal write waits for block
-    /// production first rather than blocking forever on an unmined transaction.
-    pub async fn wait_for_l1_block_production(l1_rpc_url: &Url) -> Result<()> {
-        let provider = Self::wallet_provider(l1_rpc_url)?;
-        tokio::time::timeout(Self::L1_BLOCK_PRODUCTION_TIMEOUT, async {
-            loop {
-                if provider.get_block_number().await.is_ok_and(|number| number > 0) {
-                    return;
-                }
-                tokio::time::sleep(Self::L1_BLOCK_POLL_INTERVAL).await;
-            }
-        })
-        .await
-        .wrap_err("L1 did not produce a block before the upgrade signal deadline")
-    }
-
     /// Deploys the mock contract to L1 and seeds it with the rollup config baseline overlaid
     /// with the options' explicit schedule entries.
+    ///
+    /// The caller must have already waited for L1 block production, or these transactions sit
+    /// unmined forever.
     pub async fn deploy(
         l1_rpc_url: Url,
         options: &UpgradeSignalStackOptions,
         rollup_config: &RollupConfig,
     ) -> Result<Self> {
-        Self::wait_for_l1_block_production(&l1_rpc_url).await?;
-
         let provider = Self::wallet_provider(&l1_rpc_url)?;
         let contract = tokio::time::timeout(
             Self::L1_TRANSACTION_TIMEOUT,


### PR DESCRIPTION
Fixes two `base-system-tests` unit tests that have never passed since they were introduced, and makes the `upgrade_signal` hangs diagnosable. `run_system_tests` is flipped to `true` so CI exercises the suite. **Revert that line before merge.**

Measured effect on CI: **95 passed → 97 passed**, and the 7 `upgrade_signal` 360s timeouts became fast, described errors.

- `benchmark_report`: the visualizer fixture omitted the required `transaction_submission_rpcs` field, so `TestConfig::from_yaml` always failed validation. Broken since #4900.
- `prometheus_metrics`: the labeled-histogram fixture used an escaped backslash instead of a line continuation, and asserted a key the module does not produce. Labels are appended to the family name, so the derived average is `build_duration_stage_execution_avg`. Broken since #4899.
- `upgrade_signal`: the mock `ProtocolVersions` deploy and its two schedule writes awaited receipts with no deadline, so a stalled L1 hung the test until nextest killed it at 360s with no output. Bounded each wait and made reverted transactions fail loudly.

Both unit tests were dead on arrival and went unnoticed because `run_system_tests` is normally `false`, so PRs never run this package.

## Remaining failures — not fixed

Ten integration tests still fail and this PR does not address them:

- `smoke::smoke_test_system_block_production_and_transactions` — `L1 block production timed out`
- `l1_reorg_recovery::sequencer_recovers_from_l1_outage_and_deep_reorg`
- `shadow_sequencer::late_shadow_catches_up_then_reconciles_private_blocks` — `safe=0, target=2, batcher_nonce=0`
- all 7 `upgrade_signal` tests — `Failed to deploy upgrade signal mock contract`

### What is established

A CI bisect over `main` pins when each group broke. Last fully green System Tests run was `6c0b5963f` (Sep 4).

- `d2edd099e` "Activate native block timing at Cobalt" (#4922) — first failure. 4 failures, all L2 timing (`builder_cutover`, `denim_and_zenith_activation_matches_el_and_cl_configs`, `snapshot_stack` unit test).
- `7a685ad2b` "chore(devnet): statically generate config files" (#4942) — jumps to 15 failures and is where the L1-dependent group first appears: `L1 block production timed out`, `l1_reorg_recovery`, `shadow_sequencer`, and all 7 `upgrade_signal`.

#4942 deleted `setup-l1.sh` and moved L2 contract deployment into a single offline pre-L1 step run by `op-deployer`.

### A hypothesis that was tested and rejected

`op-deployer` stamps `MIN_GENESIS_TIME` from `time.Now()` before deploying contracts (`main.go:121`, overridable via `BASE_DEVNET_TIMESTAMP`), and its beacon template sets `GENESIS_DELAY: 0`. Since these tests run one-second L1 slots, a stale genesis looked like it could leave the beacon permanently unsynced.

Anchoring genesis ahead of generation and gating startup on L1 block production **made things worse — 62 failures instead of 10** — so this is not the mechanism, and it has been reverted. The decisive counter-evidence: 97 tests pass without any gate, so L1 is *not* universally stalled. Whatever affects these ten is specific to them, not to L1 startup in general.

Next step is L1 container logs from an affected test; the Rust-side test output does not capture them.
