### PR TITLE
feat(node): install shadow-indexer ExEx in unified sequencer command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,7 @@ dependencies = [
  "base-execution-evm",
  "base-node-core",
  "base-node-runner",
+ "base-shadow-indexer",
  "base-txpool-rpc",
  "base-upgrade-signal",
  "clap",

--- a/bin/base/Cargo.toml
+++ b/bin/base/Cargo.toml
@@ -33,6 +33,7 @@ base-builder-metering.workspace = true
 base-builder-multiplex.workspace = true
 base-execution-chainspec.workspace = true
 base-execution-consensus.workspace = true
+base-shadow-indexer.workspace = true
 
 # alloy
 alloy-chains = { workspace = true, features = ["std"] }

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -15,6 +15,7 @@ use base_execution_cli::{
     ExecutionNodeConfigArgs, StandardBaseRethNode, chainspec::chain_value_parser,
 };
 use base_node_runner::BaseNodeRunner;
+use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
 use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
 use base_upgrade_signal::UpgradeSignalStartupMode;
 use clap::Args;
@@ -70,6 +71,10 @@ impl SequencerCommand {
         let metering_provider: base_builder_core::SharedMeteringProvider =
             Arc::new(builder.build_metering_store());
         let builder_api_config = builder.builder_api_config()?;
+        // Build the shadow-indexer config before `into_builder_config` consumes `builder`. The
+        // config carries an `enabled` flag (false unless ENABLE_SHADOW_INDEXER is set), so the
+        // ExEx is installed unconditionally and no-ops for non-shadow sequencers.
+        let shadow_indexer_config = ShadowIndexerConfig::try_from(&builder.shadow_indexer)?;
         let payload_builder_cutover = builder.payload_builder_cutover;
         let basic_payload_builder = builder.basic_payload_builder;
         let builder_config = builder.into_builder_config(Arc::clone(&metering_provider))?;
@@ -120,6 +125,7 @@ impl SequencerCommand {
                     builder_api_config.max_validity_predicates,
                 );
             }
+            runner.install_ext::<ShadowIndexerExtension>(shadow_indexer_config);
             StandardBaseRethNode::install_upgrade_signal_runtime_extension(
                 &mut runner,
                 &rollup_args,
@@ -233,6 +239,48 @@ mod tests {
             Some("http://localhost:9090/")
         );
         assert!(sequencer.consensus.p2p_flags.signer.sequencer_key.is_some());
+    }
+
+    #[test]
+    fn parses_shadow_indexer_args_and_builds_config() {
+        use base_shadow_indexer::ShadowIndexerConfig;
+
+        let cli = BaseCli::parse_from(sequencer_args(&[
+            "base",
+            "sequencer",
+            "--p2p.sequencer.key",
+            SEQUENCER_KEY,
+            "--enable-shadow-indexer",
+            "--shadow-indexer.db-host",
+            "shadow-db.internal",
+            "--shadow-indexer.db-password",
+            "hunter2",
+        ]));
+
+        let BaseCommand::Sequencer(sequencer) = cli.command else {
+            panic!("expected sequencer command");
+        };
+
+        assert!(sequencer.builder.shadow_indexer.enable_shadow_indexer);
+        let config = ShadowIndexerConfig::try_from(&sequencer.builder.shadow_indexer)
+            .expect("shadow indexer config should build from valid args");
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn shadow_indexer_defaults_to_disabled() {
+        let cli = BaseCli::parse_from(sequencer_args(&[
+            "base",
+            "sequencer",
+            "--p2p.sequencer.key",
+            SEQUENCER_KEY,
+        ]));
+
+        let BaseCommand::Sequencer(sequencer) = cli.command else {
+            panic!("expected sequencer command");
+        };
+
+        assert!(!sequencer.builder.shadow_indexer.enable_shadow_indexer);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

The unified `base sequencer` command already parses the flattened `ShadowIndexerArgs` (through `BuilderArgs`), but it never installed the `ShadowIndexerExtension`. As a result the shadow builder cannot run on the unified binary and must stay on the standalone `base-builder` binary (which is the only one that installs the ExEx today). This blocks migrating the shadow builder deployment to the unified `base` binary.

## Solution

Build `ShadowIndexerConfig` from the parsed shadow-indexer args and install `ShadowIndexerExtension` on the runner in `bin/base/src/commands/sequencer.rs`, mirroring how `bin/builder/src/main.rs` does it. The extension is installed unconditionally; `ShadowIndexerConfig`'s `enabled` flag is `false` unless `ENABLE_SHADOW_INDEXER` is set, so it no-ops for regular (non-shadow) sequencers such as the HA sequencer.

Adds the `base-shadow-indexer` dependency to `bin/base` and two parsing/config tests for the sequencer command.

## Testing

`cargo test -p base --bin base sequencer` (12 passing, including the two new tests), `cargo clippy -p base` clean.