### PR TITLE
fix(baseup): Reject Unsupported Architectures

### DIFF
--- a/baseup/baseup
+++ b/baseup/baseup
@@ -663,8 +663,7 @@ detect_arch() {
             echo "arm64"
             ;;
         *)
-            warn "Unknown architecture: $arch, defaulting to amd64"
-            echo "amd64"
+            error "Unsupported architecture: $arch"
             ;;
     esac
 }


### PR DESCRIPTION
## Summary

Closes #4984.

`baseup`'s `detect_arch` previously treated any unrecognized `uname -m` value as `amd64`, so hosts like `riscv64`, `s390x`, or `ppc64le` would silently download the `x86_64` binary and only fail later with an `Exec format error`. This changes the default branch to call `error` and abort before any download, mirroring how `detect_platform` already rejects unsupported platforms. The supported `x86_64`/`arm64` aliases are unchanged, so only genuinely unsupported architectures now fail fast with a clear message.