### PR TITLE
refactor(shadow-indexer-db): make block hashes a typed ShadowHash

### DIFF
--- a/crates/execution/shadow-indexer-db/src/hash.rs
+++ b/crates/execution/shadow-indexer-db/src/hash.rs
@@ -1,38 +1,138 @@
-//! Hex formatting for the string mirrors of the BYTEA hash columns.
+//! The block hash type stored by `shadow_blocks`.
 
-use alloy_primitives::hex;
+use std::{fmt, str::FromStr};
 
-/// Formats block hashes for the `hash_hex` and `canonical_hash_hex` columns.
+use alloy_primitives::{B256, hex};
+use sqlx::{
+    Postgres,
+    encode::IsNull,
+    error::BoxDynError,
+    postgres::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueRef},
+};
+
+/// A block hash, held as bytes and stored as `0x`-prefixed lowercase hex text.
 ///
-/// The writer stores these and the reader looks rows up by string equality, so the two must agree
-/// on one spelling of a hash or a lookup silently misses instead of failing. That spelling is
-/// `0x`-prefixed lowercase hex: it is what the shadow-metrics JSON API already emits, it is how
-/// every other EVM hash in Snowflake is written, and `shadow_blocks_hash_hex_format` rejects
-/// anything else at the database.
-#[derive(Clone, Copy, Debug)]
-pub struct ShadowHash;
+/// The database side of this is TEXT and must stay TEXT: the Snowflake ETL reads the table with
+/// psycopg, which renders a BYTEA column as a `memoryview` that nothing in the pipeline unwraps,
+/// so the warehouse records the repr of a Python object instead of a hash.
+///
+/// Keeping the Rust side a [`B256`] behind a newtype is what makes that hard to undo by accident.
+/// `alloy-primitives` ships its own sqlx support, but it maps `FixedBytes` through `Vec<u8>` onto
+/// BYTEA; Cargo features are additive, so the day any crate in the workspace enables
+/// `alloy-primitives/sqlx`, a bare `B256` bound into a query starts silently writing bytes. This
+/// type never hands a bare `B256` to sqlx, and its [`sqlx::Type`] impl names TEXT outright.
+///
+/// The spelling matters beyond the column type. Lookups are string equality, so the writer and
+/// the reader have to agree on one rendering of a hash or a query misses instead of failing. That
+/// rendering is `0x`-prefixed lowercase hex, produced here and nowhere else, which is also what
+/// the shadow-metrics JSON API emits and how every other EVM hash in Snowflake is written.
+/// The field is private on purpose. Exposing it would let a caller reach past the newtype and
+/// bind the inner `B256` to a query directly, which is the BYTEA hazard this type exists to make
+/// impossible rather than merely discouraged.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ShadowHash(B256);
 
 impl ShadowHash {
-    /// Formats raw hash bytes as `0x`-prefixed lowercase hex.
+    /// Wraps raw hash bytes.
     #[must_use]
-    pub fn encode(bytes: &[u8]) -> String {
-        hex::encode_prefixed(bytes)
+    pub const fn new(hash: B256) -> Self {
+        Self(hash)
+    }
+}
+
+/// Renders the stored spelling. Parsing tolerates case, this never varies.
+///
+/// Delegates rather than calling `hex::encode_prefixed`, which would allocate a `String` only to
+/// copy it into the formatter; `B256` writes its hex digits straight out.
+impl fmt::Display for ShadowHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl FromStr for ShadowHash {
+    type Err = hex::FromHexError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value.parse::<B256>().map(Self)
+    }
+}
+
+impl From<B256> for ShadowHash {
+    fn from(hash: B256) -> Self {
+        Self(hash)
+    }
+}
+
+impl sqlx::Type<Postgres> for ShadowHash {
+    fn type_info() -> PgTypeInfo {
+        <String as sqlx::Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        <String as sqlx::Type<Postgres>>::compatible(ty)
+    }
+}
+
+/// Binds arrays, which `resolve_canonical_hashes` needs for its `UNNEST`.
+impl PgHasArrayType for ShadowHash {
+    fn array_type_info() -> PgTypeInfo {
+        <String as PgHasArrayType>::array_type_info()
+    }
+}
+
+impl sqlx::Encode<'_, Postgres> for ShadowHash {
+    fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> Result<IsNull, BoxDynError> {
+        <String as sqlx::Encode<'_, Postgres>>::encode_by_ref(&self.to_string(), buf)
+    }
+}
+
+impl<'r> sqlx::Decode<'r, Postgres> for ShadowHash {
+    fn decode(value: PgValueRef<'r>) -> Result<Self, BoxDynError> {
+        let stored = <&str as sqlx::Decode<'r, Postgres>>::decode(value)?;
+        stored.parse::<Self>().map_err(Into::into)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::B256;
+    use sqlx::{Postgres, Type};
+
     use super::ShadowHash;
 
     #[test]
-    fn encodes_lowercase_with_an_0x_prefix() {
-        assert_eq!(ShadowHash::encode(&[0xAB, 0xCD, 0xEF]), "0xabcdef");
+    fn renders_lowercase_with_an_0x_prefix() {
+        assert_eq!(
+            ShadowHash::new(B256::repeat_byte(0xab)).to_string(),
+            format!("0x{}", "ab".repeat(32))
+        );
     }
 
     #[test]
-    fn encodes_a_full_block_hash_to_the_width_the_check_constraint_expects() {
-        let encoded = ShadowHash::encode(&[0x0f; 32]);
-        assert_eq!(encoded.len(), 66, "0x plus 64 hex digits");
-        assert!(encoded.starts_with("0x0f0f"));
+    fn parsing_normalizes_a_hash_onto_the_stored_spelling() {
+        let upper: ShadowHash =
+            format!("0X{}", "AB".repeat(32)).parse().expect("uppercase input is still a hash");
+        assert_eq!(upper.to_string(), format!("0x{}", "ab".repeat(32)));
+        assert_eq!(upper, ShadowHash::new(B256::repeat_byte(0xab)));
+    }
+
+    #[test]
+    fn rejects_anything_that_is_not_a_32_byte_hash() {
+        assert!("0xabcd".parse::<ShadowHash>().is_err(), "a short value is not a block hash");
+        assert!("nothex".parse::<ShadowHash>().is_err());
+    }
+
+    #[test]
+    fn binds_as_text_so_the_etl_never_sees_bytes() {
+        assert_eq!(
+            <ShadowHash as Type<Postgres>>::type_info(),
+            <String as Type<Postgres>>::type_info(),
+            "the column must stay TEXT; BYTEA reaches Snowflake as a memoryview repr"
+        );
+        assert!(
+            !<ShadowHash as Type<Postgres>>::compatible(&<Vec<u8> as Type<Postgres>>::type_info()),
+            "a BYTEA column must not decode into a ShadowHash"
+        );
     }
 }

--- a/crates/execution/shadow-indexer-db/src/models.rs
+++ b/crates/execution/shadow-indexer-db/src/models.rs
@@ -3,15 +3,17 @@ use chrono::{DateTime, Utc};
 use reth_primitives_traits::RecoveredBlock;
 use serde::{Deserialize, Serialize};
 
+use crate::ShadowHash;
+
 /// Persisted shadow block row.
 #[derive(Clone, Debug, sqlx::FromRow)]
 pub struct ShadowBlockRow {
     /// Block number.
     pub number: i64,
-    /// Block hash, as `0x`-prefixed lowercase hex. See [`crate::ShadowHash`].
-    pub hash: String,
+    /// Block hash.
+    pub hash: ShadowHash,
     /// Replacement block hash at this height, absent until that block is canonical.
-    pub canonical_hash: Option<String>,
+    pub canonical_hash: Option<ShadowHash>,
     /// Creation time.
     pub created_at: DateTime<Utc>,
     /// Database-maintained update time.
@@ -28,8 +30,8 @@ pub struct ShadowBlockRow {
 pub struct ShadowCanonicalRef {
     /// Block number.
     pub number: i64,
-    /// Block hash, as `0x`-prefixed lowercase hex. See [`crate::ShadowHash`].
-    pub hash: String,
+    /// Block hash.
+    pub hash: ShadowHash,
 }
 
 /// A unit of work applied to `shadow_blocks`, carried in the order the `ExEx` produced it.

--- a/crates/execution/shadow-indexer-db/src/repo.rs
+++ b/crates/execution/shadow-indexer-db/src/repo.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use base_common_consensus::{BaseBlock, BaseTxEnvelope};
 use sqlx::{PgPool, Postgres, QueryBuilder, query, query_as, types::Json};
 
-use crate::{ShadowBlockRow, ShadowCanonicalRef, ShadowWrite};
+use crate::{ShadowBlockRow, ShadowCanonicalRef, ShadowHash, ShadowWrite};
 
 /// Rows written and rows resolved by a single flush.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -42,10 +42,10 @@ type BlockHeader = <BaseBlock as reth_primitives_traits::Block>::Header;
 pub struct ShadowSummaryRow {
     /// Persisted block number.
     pub number: i64,
-    /// Shadow block hash, as `0x`-prefixed lowercase hex.
-    pub hash: String,
-    /// Replacement (canonical) block hash after reorg, as `0x`-prefixed lowercase hex.
-    pub canonical_hash: Option<String>,
+    /// Shadow block hash.
+    pub hash: ShadowHash,
+    /// Replacement (canonical) block hash after reorg.
+    pub canonical_hash: Option<ShadowHash>,
     /// Writer-stamped builder version.
     pub builder_version: String,
     /// Block header extracted from the payload.
@@ -129,8 +129,8 @@ impl ShadowBlockRepo {
 
             query_builder.push_values(chunk, |mut row, entry| {
                 row.push_bind(entry.number)
-                    .push_bind(&entry.hash)
-                    .push_bind(&entry.canonical_hash)
+                    .push_bind(entry.hash)
+                    .push_bind(entry.canonical_hash)
                     .push_bind(entry.created_at)
                     .push_bind(Json(&entry.payload));
             });
@@ -196,13 +196,13 @@ impl ShadowBlockRepo {
     /// a height appearing twice in a flush must collapse to the last hash before binding.
     fn dedupe_canonical_last_write_wins(
         canonical: &[&ShadowCanonicalRef],
-    ) -> (Vec<i64>, Vec<String>) {
-        let mut by_number: HashMap<i64, &str> = HashMap::with_capacity(canonical.len());
+    ) -> (Vec<i64>, Vec<ShadowHash>) {
+        let mut by_number: HashMap<i64, ShadowHash> = HashMap::with_capacity(canonical.len());
         for entry in canonical {
-            by_number.insert(entry.number, entry.hash.as_str());
+            by_number.insert(entry.number, entry.hash);
         }
 
-        by_number.into_iter().map(|(number, hash)| (number, hash.to_owned())).unzip()
+        by_number.into_iter().unzip()
     }
 
     /// Postgres cannot upsert one key twice; retain its final state within each run.
@@ -295,7 +295,7 @@ impl ShadowBlockRepo {
     /// Returns an error when the query fails.
     pub async fn list_reorged_by_canonical(
         &self,
-        canonical_hash: &str,
+        canonical_hash: ShadowHash,
     ) -> Result<Vec<ShadowSummaryRow>> {
         let rows = query_as::<_, ShadowSummaryRow>(
             "SELECT number, hash, canonical_hash, \
@@ -322,7 +322,7 @@ impl ShadowBlockRepo {
     /// Returns an error when the query fails.
     pub async fn list_reorged_by_canonicals(
         &self,
-        canonical_hashes: &[String],
+        canonical_hashes: &[ShadowHash],
     ) -> Result<Vec<ShadowSummaryRow>> {
         if canonical_hashes.is_empty() {
             return Ok(Vec::new());
@@ -351,7 +351,7 @@ impl ShadowBlockRepo {
     ///
     /// # Errors
     /// Returns an error when the query fails.
-    pub async fn get_by_block_hash(&self, hash: &str) -> Result<Option<ShadowBlockRow>> {
+    pub async fn get_by_block_hash(&self, hash: ShadowHash) -> Result<Option<ShadowBlockRow>> {
         let row = query_as::<_, ShadowBlockRow>(
             "SELECT number, hash, canonical_hash, created_at, updated_at, payload \
              FROM shadow_blocks \
@@ -371,7 +371,10 @@ impl ShadowBlockRepo {
     ///
     /// # Errors
     /// Returns an error when the query fails.
-    pub async fn get_summary_by_block_hash(&self, hash: &str) -> Result<Option<ShadowSummaryRow>> {
+    pub async fn get_summary_by_block_hash(
+        &self,
+        hash: ShadowHash,
+    ) -> Result<Option<ShadowSummaryRow>> {
         let row = query_as::<_, ShadowSummaryRow>(
             "SELECT number, hash, canonical_hash, \
              payload->>'builder_version' AS builder_version, \
@@ -393,17 +396,22 @@ impl ShadowBlockRepo {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::B256;
     use chrono::Utc;
     use reth_primitives_traits::RecoveredBlock;
 
     use super::*;
     use crate::ShadowBlockPayload;
 
-    fn sample_row(number: i64, hash: &str, canonical_hash: Option<String>) -> ShadowBlockRow {
+    fn hash(byte: u8) -> ShadowHash {
+        ShadowHash::new(B256::repeat_byte(byte))
+    }
+
+    fn sample_row(number: i64, seed: u8, canonical_seed: Option<u8>) -> ShadowBlockRow {
         ShadowBlockRow {
             number,
-            hash: hash.to_owned(),
-            canonical_hash,
+            hash: hash(seed),
+            canonical_hash: canonical_seed.map(hash),
             created_at: Utc::now(),
             updated_at: Utc::now(),
             payload: ShadowBlockPayload {
@@ -416,41 +424,34 @@ mod tests {
 
     #[test]
     fn dedupe_collapses_duplicate_number_to_last_write() {
-        let rows = [
-            sample_row(1, "0xaa", None),
-            sample_row(2, "0xbb", None),
-            sample_row(1, "0xaa", Some("0xcc".to_owned())),
-        ];
+        let rows =
+            [sample_row(1, 0xaa, None), sample_row(2, 0xbb, None), sample_row(1, 0xaa, Some(0xcc))];
         let borrowed: Vec<&ShadowBlockRow> = rows.iter().collect();
 
         let deduped = ShadowBlockRepo::dedupe_last_write_wins(&borrowed);
 
         assert_eq!(deduped.len(), 2);
         let kept = deduped.iter().find(|row| row.number == 1).expect("duplicated key survives");
-        assert_eq!(
-            kept.canonical_hash,
-            Some("0xcc".to_owned()),
-            "duplicate key keeps the last write"
-        );
+        assert_eq!(kept.canonical_hash, Some(hash(0xcc)), "duplicate key keeps the last write");
     }
 
     #[test]
     fn dedupe_collapses_same_number_with_distinct_hash() {
-        let rows = [sample_row(1, "0xaa", None), sample_row(1, "0xbb", None)];
+        let rows = [sample_row(1, 0xaa, None), sample_row(1, 0xbb, None)];
         let borrowed: Vec<&ShadowBlockRow> = rows.iter().collect();
 
         let deduped = ShadowBlockRepo::dedupe_last_write_wins(&borrowed);
 
         assert_eq!(deduped.len(), 1, "a height keys one row regardless of hash");
-        assert_eq!(deduped[0].hash, "0xbb", "the later candidate at a height wins");
+        assert_eq!(deduped[0].hash, hash(0xbb), "the later candidate at a height wins");
     }
 
     #[test]
     fn dedupe_canonical_collapses_repeated_height_to_last_hash() {
         let entries = [
-            ShadowCanonicalRef { number: 5, hash: "0x01".to_owned() },
-            ShadowCanonicalRef { number: 6, hash: "0x02".to_owned() },
-            ShadowCanonicalRef { number: 5, hash: "0x03".to_owned() },
+            ShadowCanonicalRef { number: 5, hash: hash(0x01) },
+            ShadowCanonicalRef { number: 6, hash: hash(0x02) },
+            ShadowCanonicalRef { number: 5, hash: hash(0x03) },
         ];
         let canonical: Vec<&ShadowCanonicalRef> = entries.iter().collect();
 
@@ -458,12 +459,12 @@ mod tests {
 
         let mut pairs: Vec<_> = numbers.into_iter().zip(hashes).collect();
         pairs.sort_by_key(|(number, _)| *number);
-        assert_eq!(pairs, vec![(5, "0x03".to_owned()), (6, "0x02".to_owned())]);
+        assert_eq!(pairs, vec![(5, hash(0x03)), (6, hash(0x02))]);
     }
 
     #[test]
     fn payload_json_paths_expose_header_and_transactions() {
-        let payload = sample_row(1, "0xaa", None).payload;
+        let payload = sample_row(1, 0xaa, None).payload;
         let value = serde_json::to_value(&payload).expect("payload to json");
 
         let header_value = json_path(&value, &["block", "block", "header", "header"]);

--- a/crates/execution/shadow-indexer/src/exex.rs
+++ b/crates/execution/shadow-indexer/src/exex.rs
@@ -151,7 +151,7 @@ impl ShadowIndexerExEx {
         &self,
         block: &RecoveredBlock<BaseBlock>,
         receipts: &[BaseReceipt],
-        canonical_hash: Option<String>,
+        canonical_hash: Option<ShadowHash>,
     ) -> Result<ShadowBlockRow> {
         let _timer = base_metrics::timed!(ShadowExExMetrics::build_row_duration_seconds());
 
@@ -170,7 +170,7 @@ impl ShadowIndexerExEx {
 
         Ok(ShadowBlockRow {
             number,
-            hash: ShadowHash::encode(block.hash().as_slice()),
+            hash: ShadowHash::new(block.hash()),
             canonical_hash,
             created_at: now,
             updated_at: now,
@@ -189,7 +189,7 @@ impl ShadowIndexerExEx {
             let canonical_hash = new
                 .blocks()
                 .get(&block.header().number())
-                .map(|canonical_block| ShadowHash::encode(canonical_block.hash().as_slice()));
+                .map(|canonical_block| ShadowHash::new(canonical_block.hash()));
 
             if canonical_hash.is_none() {
                 unresolved = unresolved.saturating_add(1);
@@ -231,8 +231,7 @@ impl ShadowIndexerExEx {
             let number = i64::try_from(block.header().number()).map_err(|error| {
                 eyre::eyre!("block number overflow for shadow indexer canonical ref: {error}")
             })?;
-            let canonical =
-                ShadowCanonicalRef { number, hash: ShadowHash::encode(block.hash().as_slice()) };
+            let canonical = ShadowCanonicalRef { number, hash: ShadowHash::new(block.hash()) };
 
             if !self.send_write(ShadowWrite::Canonical(canonical)).await? {
                 return Ok(false);
@@ -356,12 +355,10 @@ mod tests {
         assert_eq!(rows.len(), old.blocks().len(), "only old-chain blocks are emitted");
 
         for row in &rows {
-            assert_eq!(row.hash, ShadowHash::encode(block_hash(row.number as u64, 0).as_slice()));
+            assert_eq!(row.hash, ShadowHash::new(block_hash(row.number as u64, 0)));
             assert_eq!(
                 row.canonical_hash,
-                Some(ShadowHash::encode(
-                    block_hash(row.number as u64, NEW_CHAIN_VARIANT).as_slice()
-                )),
+                Some(ShadowHash::new(block_hash(row.number as u64, NEW_CHAIN_VARIANT))),
                 "reorged-out row points at the new canonical hash at its height"
             );
         }
@@ -382,10 +379,7 @@ mod tests {
         assert_eq!(missing.canonical_hash, None, "no new block at height 9 => canonical hash None");
 
         let present = rows.iter().find(|row| row.number == 6).expect("old block 6 reorged out");
-        assert_eq!(
-            present.canonical_hash,
-            Some(ShadowHash::encode(block_hash(6, NEW_CHAIN_VARIANT).as_slice()))
-        );
+        assert_eq!(present.canonical_hash, Some(ShadowHash::new(block_hash(6, NEW_CHAIN_VARIANT))));
     }
 
     #[tokio::test]
@@ -427,7 +421,7 @@ mod tests {
         for entry in &canonical {
             assert_eq!(
                 entry.hash,
-                ShadowHash::encode(block_hash(entry.number as u64, NEW_CHAIN_VARIANT).as_slice())
+                ShadowHash::new(block_hash(entry.number as u64, NEW_CHAIN_VARIANT))
             );
         }
     }

--- a/crates/execution/shadow-indexer/src/writer.rs
+++ b/crates/execution/shadow-indexer/src/writer.rs
@@ -193,10 +193,11 @@ impl ShadowWriter {
 mod tests {
     use std::time::Duration;
 
+    use alloy_primitives::B256;
     use anyhow::anyhow;
     use base_shadow_indexer_db::{
         PgConnectionParams, ShadowBlockPayload, ShadowBlockRow, ShadowCanonicalRef, ShadowDbConfig,
-        ShadowFlushOutcome,
+        ShadowFlushOutcome, ShadowHash,
     };
     use chrono::{DateTime, Utc};
     use reth_primitives_traits::RecoveredBlock;
@@ -220,7 +221,7 @@ mod tests {
     fn sample_row(number: i64, created_at: DateTime<Utc>) -> ShadowBlockRow {
         ShadowBlockRow {
             number,
-            hash: "0xhash".to_owned(),
+            hash: ShadowHash::new(B256::repeat_byte(0x11)),
             canonical_hash: None,
             created_at,
             updated_at: created_at,
@@ -237,7 +238,10 @@ mod tests {
     }
 
     fn canonical(number: i64) -> ShadowWrite {
-        ShadowWrite::Canonical(ShadowCanonicalRef { number, hash: "0xcanonical".to_owned() })
+        ShadowWrite::Canonical(ShadowCanonicalRef {
+            number,
+            hash: ShadowHash::new(B256::repeat_byte(0x22)),
+        })
     }
 
     #[tokio::test]

--- a/crates/infra/shadow-metrics/src/api.rs
+++ b/crates/infra/shadow-metrics/src/api.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use alloy_consensus::{Transaction, TxReceipt, Typed2718};
-use alloy_primitives::{B256, hex};
+use alloy_primitives::hex;
 use axum::{
     Json, Router,
     extract::{Path, Query, State},
@@ -148,7 +148,7 @@ async fn get_shadow_candidates(
     let repo = state.repo()?;
     let canonical_hash = parse_block_id(&id)?;
 
-    let shadows = repo.list_reorged_by_canonical(&canonical_hash).await?;
+    let shadows = repo.list_reorged_by_canonical(canonical_hash).await?;
     tracing::info!(
         target: "shadow_metrics::api",
         endpoint = "shadow-candidates",
@@ -191,7 +191,7 @@ async fn get_shadow_candidates_batch(
         return Ok(Json(HashMap::new()));
     }
 
-    let hashes: Vec<String> = parsed;
+    let hashes: Vec<ShadowHash> = parsed;
     let repo = state.repo()?;
     let shadows = repo.list_reorged_by_canonicals(&hashes).await?;
 
@@ -200,7 +200,7 @@ async fn get_shadow_candidates_batch(
         let Some(canonical_hash) = shadow.canonical_hash.as_ref() else {
             continue;
         };
-        let key = canonical_hash.clone();
+        let key = canonical_hash.to_string();
         result.entry(key).or_default().push(shadow_block_summary(shadow));
     }
 
@@ -259,7 +259,7 @@ async fn get_shadow_block(
     let hash = parse_block_id(&id)?;
 
     let repo = state.repo()?;
-    let Some(row) = repo.get_summary_by_block_hash(&hash).await? else {
+    let Some(row) = repo.get_summary_by_block_hash(hash).await? else {
         tracing::info!(
             target: "shadow_metrics::api",
             endpoint = "shadow-blocks",
@@ -285,17 +285,14 @@ async fn get_shadow_block(
 /// Lookups are string equality against `shadow_blocks.hash`, so `0xAB..` from a caller must not
 /// miss a row written as `0xab..`. Going through `B256` both rejects anything that is not a hash
 /// and collapses every accepted spelling onto the one [`ShadowHash`] writes.
-fn parse_block_id(id: &str) -> Result<String, ApiError> {
-    id.trim()
-        .parse::<B256>()
-        .map(|hash| ShadowHash::encode(hash.as_slice()))
-        .map_err(|_| ApiError::BadRequest)
+fn parse_block_id(id: &str) -> Result<ShadowHash, ApiError> {
+    id.trim().parse::<ShadowHash>().map_err(|_| ApiError::BadRequest)
 }
 
 /// Resolves a stored block by hash (canonical or reorged-out shadow).
 async fn resolve_block(repo: &ShadowBlockRepo, id: &str) -> Result<ShadowBlockRow, ApiError> {
     let hash = parse_block_id(id)?;
-    repo.get_by_block_hash(&hash).await?.ok_or(ApiError::NotFound)
+    repo.get_by_block_hash(hash).await?.ok_or(ApiError::NotFound)
 }
 
 fn shadow_block_summary(row: &ShadowSummaryRow) -> ShadowBlockSummary {
@@ -308,8 +305,8 @@ fn shadow_block_summary(row: &ShadowSummaryRow) -> ShadowBlockSummary {
 
     ShadowBlockSummary {
         number: row.number,
-        hash: row.hash.clone(),
-        canonical_hash: row.canonical_hash.clone(),
+        hash: row.hash.to_string(),
+        canonical_hash: row.canonical_hash.map(|hash| hash.to_string()),
         timestamp: row.header.0.timestamp,
         builder_version: stats.builder_version,
         gas_used: stats.gas_used,
@@ -333,7 +330,7 @@ fn block_detail(row: &ShadowBlockRow) -> BlockDetail {
 
     BlockDetail {
         number: row.number,
-        hash: row.hash.clone(),
+        hash: row.hash.to_string(),
         parent_hash: hex::encode_prefixed(header.parent_hash),
         timestamp: header.timestamp,
         gas_used: header.gas_used,
@@ -342,7 +339,7 @@ fn block_detail(row: &ShadowBlockRow) -> BlockDetail {
         // Constant so the response shape survives the column drop: the table only ever holds
         // blocks the chain discarded.
         reorged_out: true,
-        canonical_hash: row.canonical_hash.clone(),
+        canonical_hash: row.canonical_hash.map(|hash| hash.to_string()),
         tx_count: block.body().transactions.len(),
         transactions,
     }
@@ -411,7 +408,7 @@ fn tx_type_str(tx: &BaseTxEnvelope) -> &'static str {
 #[cfg(test)]
 mod tests {
     use alloy_consensus::{Block, BlockBody, Header, Receipt, Sealable};
-    use alloy_primitives::{Address, TxKind, U256};
+    use alloy_primitives::{Address, B256, TxKind, U256};
     use base_common_consensus::{BaseReceipt, TxDeposit};
     use base_shadow_indexer_db::ShadowBlockPayload;
     use chrono::Utc;
@@ -427,7 +424,7 @@ mod tests {
         sample_row_with(None)
     }
 
-    fn sample_row_with(canonical_hash: Option<String>) -> ShadowBlockRow {
+    fn sample_row_with(canonical_hash: Option<ShadowHash>) -> ShadowBlockRow {
         sample_row_full(42, 21_000, "test", canonical_hash)
     }
 
@@ -435,7 +432,7 @@ mod tests {
         number: i64,
         gas_used: u64,
         builder_version: &str,
-        canonical_hash: Option<String>,
+        canonical_hash: Option<ShadowHash>,
     ) -> ShadowBlockRow {
         let deposit = TxDeposit {
             gas_limit: 21_000,
@@ -458,7 +455,7 @@ mod tests {
         let now = Utc::now();
         ShadowBlockRow {
             number,
-            hash: ShadowHash::encode(&[0xab; 32]),
+            hash: ShadowHash::new(B256::repeat_byte(0xab)),
             canonical_hash,
             created_at: now,
             updated_at: now,
@@ -503,7 +500,7 @@ mod tests {
 
     #[test]
     fn block_detail_exposes_replacement_hash() {
-        let detail = block_detail(&sample_row_with(Some(ShadowHash::encode(&[0xcd; 32]))));
+        let detail = block_detail(&sample_row_with(Some(ShadowHash::new(B256::repeat_byte(0xcd)))));
         assert_eq!(
             detail.canonical_hash.as_deref(),
             Some(format!("0x{}", "cd".repeat(32)).as_str())
@@ -524,8 +521,8 @@ mod tests {
     fn sample_summary_row(row: &ShadowBlockRow) -> ShadowSummaryRow {
         ShadowSummaryRow {
             number: row.number,
-            hash: row.hash.clone(),
-            canonical_hash: row.canonical_hash.clone(),
+            hash: row.hash,
+            canonical_hash: row.canonical_hash,
             builder_version: row.payload.builder_version.clone(),
             header: Json(row.payload.block.header().clone()),
             transactions: Json(row.payload.block.body().transactions.clone()),
@@ -543,7 +540,8 @@ mod tests {
 
     #[test]
     fn shadow_block_summary_reports_shadow_only_fields() {
-        let shadow = sample_row_full(100, 30_000, "shadow", Some(ShadowHash::encode(&[0xcd; 32])));
+        let shadow =
+            sample_row_full(100, 30_000, "shadow", Some(ShadowHash::new(B256::repeat_byte(0xcd))));
         let summary = shadow_block_summary(&sample_summary_row(&shadow));
 
         assert_eq!(summary.number, 100);

--- a/etc/systems/tests/shadow_blocks_reconciliation.rs
+++ b/etc/systems/tests/shadow_blocks_reconciliation.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use alloy_consensus::{Block, BlockBody, Header, SignableTransaction, TxEip1559};
-use alloy_primitives::{Address, Signature};
+use alloy_primitives::{Address, B256, Signature};
 use anyhow::Result;
 use base_common_consensus::{BaseTxEnvelope, TxDeposit};
 use base_shadow_indexer_db::{
@@ -76,8 +76,9 @@ impl ShadowBlockFixture {
 
         ShadowBlockRow {
             number,
-            hash: ShadowHash::encode(&[hash_seed; 32]),
-            canonical_hash: canonical_hash_seed.map(|seed| ShadowHash::encode(&[seed; 32])),
+            hash: ShadowHash::new(B256::repeat_byte(hash_seed)),
+            canonical_hash: canonical_hash_seed
+                .map(|seed| ShadowHash::new(B256::repeat_byte(seed))),
             created_at: now,
             updated_at: now,
             payload,
@@ -143,7 +144,7 @@ async fn canonical_block_never_clears_an_established_hash() -> Result<()> {
     assert_eq!(rows.len(), 1);
     assert_eq!(
         rows[0].canonical_hash,
-        Some(ShadowHash::encode(&[0x92; 32])),
+        Some(ShadowHash::new(B256::repeat_byte(0x92))),
         "canonical hash is monotonic"
     );
 
@@ -162,7 +163,7 @@ async fn a_later_candidate_at_a_height_does_not_inherit_the_replaced_hash() -> R
     assert_eq!(rows.len(), 1, "a height keys one row");
     assert_eq!(
         rows[0].hash,
-        ShadowHash::encode(&[0xa3; 32]),
+        ShadowHash::new(B256::repeat_byte(0xa3)),
         "the new candidate replaces the old one"
     );
     assert_eq!(
@@ -181,7 +182,7 @@ async fn a_canonical_ref_does_not_resolve_a_candidate_stored_after_it() -> Resul
     let mut writes = reorged([ShadowBlockFixture::new(91).into_row(0xb1, None)]);
     writes.extend(canonical([ShadowCanonicalRef {
         number: 91,
-        hash: ShadowHash::encode(&[0xb2; 32]),
+        hash: ShadowHash::new(B256::repeat_byte(0xb2)),
     }]));
     writes.extend(reorged([ShadowBlockFixture::new(91).into_row(0xb3, None)]));
     repo.flush(&writes).await?;
@@ -190,7 +191,7 @@ async fn a_canonical_ref_does_not_resolve_a_candidate_stored_after_it() -> Resul
     assert_eq!(rows.len(), 1);
     assert_eq!(
         rows[0].hash,
-        ShadowHash::encode(&[0xb3; 32]),
+        ShadowHash::new(B256::repeat_byte(0xb3)),
         "the last candidate at the height is stored"
     );
     assert_eq!(
@@ -242,7 +243,7 @@ async fn unresolved_backlog_counts_rows_awaiting_a_canonical_block() -> Result<(
 
     repo.flush(&canonical([ShadowCanonicalRef {
         number: 101,
-        hash: ShadowHash::encode(&[0xc4; 32]),
+        hash: ShadowHash::new(B256::repeat_byte(0xc4)),
     }]))
     .await?;
 
@@ -359,7 +360,7 @@ async fn an_unresolved_row_still_registers_in_the_backlog_after_the_contract() -
 
     repo.flush(&canonical([ShadowCanonicalRef {
         number: 501,
-        hash: ShadowHash::encode(&[0xf2; 32]),
+        hash: ShadowHash::new(B256::repeat_byte(0xf2)),
     }]))
     .await?;
 
@@ -377,12 +378,13 @@ async fn a_row_is_retrievable_by_the_hash_string_it_was_stored_under() -> Result
     repo.flush(&reorged([ShadowBlockFixture::new(502).into_row(0xd1, Some(0xd2))])).await?;
 
     let found = repo
-        .get_by_block_hash(&ShadowHash::encode(&[0xd1; 32]))
+        .get_by_block_hash(ShadowHash::new(B256::repeat_byte(0xd1)))
         .await?
         .expect("stored row is found by its hash");
     assert_eq!(found.number, 502);
 
-    let candidates = repo.list_reorged_by_canonical(&ShadowHash::encode(&[0xd2; 32])).await?;
+    let candidates =
+        repo.list_reorged_by_canonical(ShadowHash::new(B256::repeat_byte(0xd2))).await?;
     assert_eq!(
         candidates.iter().map(|row| row.number).collect::<Vec<_>>(),
         [502],

--- a/etc/systems/tests/shadow_retention.rs
+++ b/etc/systems/tests/shadow_retention.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use alloy_primitives::B256;
 use anyhow::Result;
 use base_shadow_indexer_db::{
     PgConnectionParams, SHADOW_RETENTION_LOCK_KEY, ShadowBlockPayload, ShadowBlockRepo,
@@ -93,12 +94,12 @@ impl TestDatabase {
 
 fn shadow_row(number: i64) -> ShadowBlockRow {
     let now = Utc::now();
-    let mut hash = vec![0; 32];
+    let mut hash = [0u8; 32];
     hash[24..].copy_from_slice(&number.to_be_bytes());
 
     ShadowBlockRow {
         number,
-        hash: ShadowHash::encode(&hash),
+        hash: ShadowHash::new(B256::new(hash)),
         canonical_hash: None,
         created_at: now,
         updated_at: now,


### PR DESCRIPTION
> Stacked on #4910.

Block hashes are a `String` on the Rust side, which is wider than the thing it holds: any string can be stored, the canonical rendering is a convention held up by call sites, and the only real guard against a mis-spelled hash is a CHECK constraint in the database. This replaces that with a newtype over `B256` that binds as TEXT, so the format contract lives in the type system instead. No schema change and no behaviour change — the column stays TEXT and the JSON the API emits is byte-identical.

- Adds `ShadowHash(B256)` with its own `sqlx::Type`/`Encode`/`Decode`/`PgHasArrayType` impls against TEXT, and uses it for `ShadowBlockRow`, `ShadowCanonicalRef` and `ShadowSummaryRow`.
- Deliberately does **not** use alloy's own sqlx support, which maps `FixedBytes` through `Vec<u8>` onto BYTEA; features are additive, so a bare `B256` would silently start writing bytes the day any crate enables `alloy-primitives/sqlx`, breaking the ETL again with no compile error.
- Collapses hash rendering to one place, which is what the writer and reader depend on agreeing about, since lookups are string equality.
- Simplifies the two call sites that were doing it by hand: the ExEx stores `block.hash()` directly, and `parse_block_id` normalizes by parsing into the type.
- Makes a wrong-width hash unrepresentable rather than a runtime constraint violation, which is how the retention fixture failed earlier.
