### PR TITLE
fix(txpool): bound validity predicate deserialization

### DIFF
--- a/crates/builder/cli/src/args.rs
+++ b/crates/builder/cli/src/args.rs
@@ -194,9 +194,15 @@ pub struct Args {
     pub enable_experimental_validity_transactions: bool,
 
     /// Maximum validity predicates accepted per experimental transaction.
+    ///
+    /// Capped at [`DEFAULT_MAX_VALIDITY_PREDICATES`], the fixed wire ceiling the
+    /// request deserializer enforces. Values above it can never be honored and
+    /// are rejected at startup rather than silently truncated.
     #[arg(
         long = "builder.experimental-validity-max-predicates",
         default_value_t = DEFAULT_MAX_VALIDITY_PREDICATES,
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new()
+            .range(1..=DEFAULT_MAX_VALIDITY_PREDICATES as u64),
         requires = "enable_experimental_validity_transactions"
     )]
     pub experimental_validity_max_predicates: usize,
@@ -481,6 +487,50 @@ mod tests {
 
         assert!(parsed.args.enable_experimental_validity_transactions);
         assert_eq!(parsed.args.experimental_validity_max_predicates, 8);
+    }
+
+    #[test]
+    fn experimental_validity_max_predicates_rejects_values_above_the_wire_ceiling() {
+        // The request deserializer bounds batches at DEFAULT_MAX_VALIDITY_PREDICATES,
+        // so a larger configured maximum could never be honored. Reject it at
+        // startup instead of silently accepting an unenforceable limit.
+        let error = CommandParser::try_parse_from([
+            "builder",
+            "--builder.enable-experimental-validity-transactions",
+            "--builder.experimental-validity-max-predicates",
+            &(DEFAULT_MAX_VALIDITY_PREDICATES + 1).to_string(),
+        ])
+        .expect_err("a maximum above the wire ceiling should be rejected");
+
+        assert!(error.to_string().contains("--builder.experimental-validity-max-predicates"));
+    }
+
+    #[test]
+    fn experimental_validity_max_predicates_rejects_zero() {
+        let error = CommandParser::try_parse_from([
+            "builder",
+            "--builder.enable-experimental-validity-transactions",
+            "--builder.experimental-validity-max-predicates",
+            "0",
+        ])
+        .expect_err("a maximum of zero should be rejected");
+
+        assert!(error.to_string().contains("--builder.experimental-validity-max-predicates"));
+    }
+
+    #[test]
+    fn experimental_validity_max_predicates_accepts_the_wire_ceiling() {
+        let parsed = CommandParser::parse_from([
+            "builder",
+            "--builder.enable-experimental-validity-transactions",
+            "--builder.experimental-validity-max-predicates",
+            &DEFAULT_MAX_VALIDITY_PREDICATES.to_string(),
+        ]);
+
+        assert_eq!(
+            parsed.args.experimental_validity_max_predicates,
+            DEFAULT_MAX_VALIDITY_PREDICATES
+        );
     }
 
     #[test]

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -353,9 +353,15 @@ pub struct RpcStandardNodeArgs {
     pub enable_experimental_validity_transactions: bool,
 
     /// Maximum validity predicates accepted per experimental transaction.
+    ///
+    /// Capped at [`DEFAULT_MAX_VALIDITY_PREDICATES`], the fixed wire ceiling the
+    /// request deserializer enforces. Values above it can never be honored and
+    /// are rejected at startup rather than silently truncated.
     #[arg(
         long = "experimental-validity-max-predicates",
         default_value_t = DEFAULT_MAX_VALIDITY_PREDICATES,
+        value_parser = clap::builder::RangedU64ValueParser::<usize>::new()
+            .range(1..=DEFAULT_MAX_VALIDITY_PREDICATES as u64),
         requires = "enable_experimental_validity_transactions"
     )]
     pub experimental_validity_max_predicates: usize,
@@ -1073,6 +1079,48 @@ mod tests {
         assert!(args.rpc.enable_experimental_validity_transactions);
         assert_eq!(args.rpc.experimental_validity_max_predicates, 8);
         assert_eq!(args.rpc.builder_rpc_urls.len(), 1);
+    }
+
+    #[test]
+    fn experimental_validity_max_predicates_rejects_values_above_the_wire_ceiling() {
+        // The request deserializer bounds batches at DEFAULT_MAX_VALIDITY_PREDICATES,
+        // so a larger configured maximum could never be honored. Reject it at
+        // startup instead of silently accepting an unenforceable limit.
+        let error = CommandParser::<StandardNodeArgs>::try_parse_from([
+            "base-reth",
+            "--enable-experimental-validity-transactions",
+            "--experimental-validity-max-predicates",
+            &(DEFAULT_MAX_VALIDITY_PREDICATES + 1).to_string(),
+        ])
+        .expect_err("a maximum above the wire ceiling should be rejected");
+
+        assert!(error.to_string().contains("--experimental-validity-max-predicates"));
+    }
+
+    #[test]
+    fn experimental_validity_max_predicates_rejects_zero() {
+        let error = CommandParser::<StandardNodeArgs>::try_parse_from([
+            "base-reth",
+            "--enable-experimental-validity-transactions",
+            "--experimental-validity-max-predicates",
+            "0",
+        ])
+        .expect_err("a maximum of zero should be rejected");
+
+        assert!(error.to_string().contains("--experimental-validity-max-predicates"));
+    }
+
+    #[test]
+    fn experimental_validity_max_predicates_accepts_the_wire_ceiling() {
+        let args = CommandParser::<StandardNodeArgs>::parse_from([
+            "base-reth",
+            "--enable-experimental-validity-transactions",
+            "--experimental-validity-max-predicates",
+            &DEFAULT_MAX_VALIDITY_PREDICATES.to_string(),
+        ])
+        .args;
+
+        assert_eq!(args.rpc.experimental_validity_max_predicates, DEFAULT_MAX_VALIDITY_PREDICATES);
     }
 
     #[test]

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -6,6 +6,7 @@ use base_common_chains::Upgrades;
 use base_common_consensus::EIP8130_TX_TYPE_ID;
 use base_execution_txpool::{
     BasePooledTransaction, DEFAULT_MAX_VALIDITY_PREDICATES, ValidityPredicate,
+    deserialize_bounded_predicates,
 };
 use base_observability_events::{
     TransactionEventProducer, TransactionEventType, transaction_event,
@@ -49,9 +50,17 @@ pub struct TransactionStatusResponse {
 }
 
 /// Options for `base_sendRawTransactionValidity` accompanying the raw transaction.
+///
+/// Unknown fields are rejected so a caller cannot pad the request body with
+/// irrelevant data, and `validity` is deserialized with a bounded visitor that
+/// aborts once the batch exceeds [`DEFAULT_MAX_VALIDITY_PREDICATES`], capping the
+/// allocation before the count is enforced by
+/// [`ValidityPredicate::validate_batch`].
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct SendRawTransactionValidityOptions {
     /// Experimental predicates transported to builders alongside the transaction.
+    #[serde(deserialize_with = "deserialize_bounded_predicates")]
     pub validity: Vec<ValidityPredicate>,
 }
 
@@ -673,6 +682,65 @@ mod tests {
 
         assert_eq!(error.code(), ErrorCode::InvalidParams.code());
         assert!(error.message().contains("can never be satisfied"));
+    }
+
+    /// A single storage predicate encoded as JSON, used to build oversized
+    /// `validity` arrays cheaply.
+    fn storage_predicate_json() -> String {
+        r#"{"type":"storage","params":{"address":"0xabababababababababababababababababababab","slot":"0x1","op":"=","value":"0x789"}}"#
+            .to_string()
+    }
+
+    /// Builds a JSON `SendRawTransactionValidityOptions` body carrying `count`
+    /// identical storage predicates.
+    fn options_json_with_predicates(count: usize) -> String {
+        let predicates = vec![storage_predicate_json(); count].join(",");
+        format!(r#"{{"validity":[{predicates}]}}"#)
+    }
+
+    #[test]
+    fn options_deserialize_accepts_exactly_the_maximum_predicates() {
+        let json = options_json_with_predicates(DEFAULT_MAX_VALIDITY_PREDICATES);
+        let options: SendRawTransactionValidityOptions =
+            serde_json::from_str(&json).expect("a full batch at the limit must decode");
+        assert_eq!(options.validity.len(), DEFAULT_MAX_VALIDITY_PREDICATES);
+    }
+
+    #[test]
+    fn options_deserialize_rejects_predicate_past_the_maximum() {
+        // One over the limit must be rejected during decoding, not after.
+        let json = options_json_with_predicates(DEFAULT_MAX_VALIDITY_PREDICATES + 1);
+        let error = serde_json::from_str::<SendRawTransactionValidityOptions>(&json)
+            .expect_err("a batch past the limit must fail to decode");
+        assert!(
+            error.to_string().contains("too many validity predicates"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn options_deserialize_stops_before_allocating_an_oversized_batch() {
+        // A grossly oversized body (the DoS shape) must be rejected without
+        // materializing every predicate. The bounded visitor aborts at item
+        // 65, so decoding fails regardless of how many follow.
+        let json = options_json_with_predicates(100_000);
+        let error = serde_json::from_str::<SendRawTransactionValidityOptions>(&json)
+            .expect_err("a massively oversized batch must fail to decode");
+        assert!(
+            error.to_string().contains("too many validity predicates"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn options_deserialize_rejects_unknown_fields() {
+        // Padding the options object with unrelated fields must be rejected so a
+        // caller cannot inflate the request body with ignored data.
+        let predicate = storage_predicate_json();
+        let json = format!(r#"{{"validity":[{predicate}],"padding":"junk"}}"#);
+        let error = serde_json::from_str::<SendRawTransactionValidityOptions>(&json)
+            .expect_err("unknown fields must be rejected");
+        assert!(error.to_string().contains("unknown field"), "unexpected error: {error}");
     }
 
     #[tokio::test]

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -31,6 +31,7 @@ mod validity;
 pub use validity::{
     DEFAULT_MAX_VALIDITY_PREDICATES, FIRST_POOL_FLASHBLOCK_INDEX, PredicateContext,
     TransactionValidity, ValidityOperator, ValidityPredicate, ValidityPredicateError,
+    deserialize_bounded_predicates,
 };
 
 mod block_expiry;

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -1,8 +1,11 @@
 //! State predicates carried by pooled transactions.
 
+use std::fmt;
+
 use alloy_primitives::{Address, U256};
 use reth_transaction_pool::ValidPoolTransaction;
 use revm::Database;
+use serde::{Deserializer, de};
 
 use crate::{BasePooledTransaction, ExtensionError, ValidatedTransactionExtensions};
 
@@ -347,12 +350,74 @@ impl ValidityPredicate {
     }
 }
 
+/// Deserializes a sequence of [`ValidityPredicate`] while rejecting the batch as
+/// soon as it exceeds [`DEFAULT_MAX_VALIDITY_PREDICATES`].
+///
+/// The count limit is otherwise enforced only after the whole vector has been
+/// deserialized (see [`ValidityPredicate::validate_batch`] and
+/// [`TransactionValidity::validate`]). That late check still allocates one
+/// object per submitted item, so an unauthenticated caller can force the node to
+/// parse and allocate tens of thousands of predicates that are ultimately
+/// rejected. Aborting mid-stream at item 65 bounds the allocation to at most
+/// `DEFAULT_MAX_VALIDITY_PREDICATES + 1` predicates regardless of the request
+/// body size.
+///
+/// The bound is the fixed wire ceiling ([`DEFAULT_MAX_VALIDITY_PREDICATES`]), not
+/// a node's configured maximum: deserialization has no access to runtime
+/// configuration, and a node's configured maximum can never exceed this ceiling.
+/// The configured maximum is still enforced afterward by the count check.
+pub fn deserialize_bounded_predicates<'de, D>(
+    deserializer: D,
+) -> Result<Vec<ValidityPredicate>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct BoundedPredicatesVisitor;
+
+    impl<'de> de::Visitor<'de> for BoundedPredicatesVisitor {
+        type Value = Vec<ValidityPredicate>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                formatter,
+                "a sequence of at most {DEFAULT_MAX_VALIDITY_PREDICATES} validity predicates"
+            )
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'de>,
+        {
+            // Cap the preallocation independently of the caller-reported length
+            // hint so a large hint cannot itself drive a large allocation.
+            let mut predicates = Vec::with_capacity(
+                seq.size_hint().unwrap_or(0).min(DEFAULT_MAX_VALIDITY_PREDICATES),
+            );
+            while let Some(predicate) = seq.next_element::<ValidityPredicate>()? {
+                if predicates.len() == DEFAULT_MAX_VALIDITY_PREDICATES {
+                    return Err(de::Error::custom(format!(
+                        "too many validity predicates: maximum {DEFAULT_MAX_VALIDITY_PREDICATES}"
+                    )));
+                }
+                predicates.push(predicate);
+            }
+            Ok(predicates)
+        }
+    }
+
+    deserializer.deserialize_seq(BoundedPredicatesVisitor)
+}
+
 /// Experimental validity predicates carried with a validated transaction.
 /// The builder evaluates these predicates against each candidate insertion point.
 #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct TransactionValidity {
     /// Predicates intended to control when the transaction is valid for inclusion.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_bounded_predicates"
+    )]
     pub validity: Vec<ValidityPredicate>,
 }
 
@@ -570,6 +635,70 @@ mod tests {
             }]
         );
         assert_eq!(serde_json::to_value(payload).unwrap(), value);
+    }
+
+    /// A single storage predicate encoded as JSON, used to assemble oversized
+    /// `validity` arrays for the bounded-deserialization tests.
+    fn storage_predicate_json() -> &'static str {
+        r#"{"type":"storage","params":{"address":"0xabababababababababababababababababababab","slot":"0x1","op":"=","value":"0x789"}}"#
+    }
+
+    /// Builds a JSON `TransactionValidity` body carrying `count` predicates.
+    fn transaction_validity_json(count: usize) -> String {
+        let predicates = vec![storage_predicate_json(); count].join(",");
+        format!(r#"{{"validity":[{predicates}]}}"#)
+    }
+
+    #[test]
+    fn deserialize_accepts_exactly_the_maximum_predicates() {
+        let json = transaction_validity_json(DEFAULT_MAX_VALIDITY_PREDICATES);
+        let payload: TransactionValidity =
+            serde_json::from_str(&json).expect("a full batch at the limit must decode");
+        assert_eq!(payload.validity.len(), DEFAULT_MAX_VALIDITY_PREDICATES);
+    }
+
+    #[test]
+    fn deserialize_rejects_predicate_past_the_maximum() {
+        let json = transaction_validity_json(DEFAULT_MAX_VALIDITY_PREDICATES + 1);
+        let error = serde_json::from_str::<TransactionValidity>(&json)
+            .expect_err("a batch past the limit must fail to decode");
+        assert!(
+            error.to_string().contains("too many validity predicates"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn deserialize_stops_before_allocating_an_oversized_batch() {
+        // The DoS shape: a body far larger than the limit must be rejected
+        // without materializing every predicate. The bounded visitor aborts at
+        // item 65 regardless of how many follow.
+        let json = transaction_validity_json(100_000);
+        let error = serde_json::from_str::<TransactionValidity>(&json)
+            .expect_err("a massively oversized batch must fail to decode");
+        assert!(
+            error.to_string().contains("too many validity predicates"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn deserialize_bounded_predicates_directly_bounds_a_bare_sequence() {
+        // The helper is exercised directly on a bare predicate array to prove
+        // the bound is a property of the sequence visitor, independent of the
+        // wrapping struct.
+        let mut deserializer = serde_json::Deserializer::from_str("[]");
+        let empty =
+            deserialize_bounded_predicates(&mut deserializer).expect("an empty sequence decodes");
+        assert!(empty.is_empty());
+
+        let predicates =
+            vec![storage_predicate_json(); DEFAULT_MAX_VALIDITY_PREDICATES + 1].join(",");
+        let oversized = format!("[{predicates}]");
+        let mut deserializer = serde_json::Deserializer::from_str(&oversized);
+        let error = deserialize_bounded_predicates(&mut deserializer)
+            .expect_err("an oversized sequence is rejected");
+        assert!(error.to_string().contains("too many validity predicates"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes an unauthenticated DoS in `base_sendRawTransactionValidity` (CHAIN-5249), with regression tests (CHAIN-5251).

The RPC options and the builder wire `TransactionValidity` deserialized the entire `validity` array before enforcing the 64-predicate limit, so a single request could force the node to parse and allocate tens of thousands of predicates that were ultimately rejected (~14 MiB per request, multiplicative under concurrency). See the vibenet report: [Validity Transaction JSON Decoding DoS](https://bdocs.cbhq.net/d/validity-transactions-json-dos-report).

## Changes

- Added `deserialize_bounded_predicates` (`crates/execution/txpool/src/validity.rs`): a serde sequence visitor that aborts when predicate 65 is encountered, capping allocation at 65 predicates regardless of request body size. The preallocation hint is also capped so a large caller-reported length cannot itself drive a large allocation.
- Applied it to both deserialization sites:
  - `SendRawTransactionValidityOptions.validity` (mempool ingress RPC)
  - `TransactionValidity.validity` (builder wire path, `base_insertValidatedTransaction`)
- Added `#[serde(deny_unknown_fields)]` to `SendRawTransactionValidityOptions` so callers cannot pad the request body with ignored fields.
- Clamped the `--experimental-validity-max-predicates` CLI argument (execution and builder) to `1..=64` so a node cannot be configured above the wire ceiling.

## Why the deserializer bound is the constant, not the configured max

The per-node maximum cannot reach the deserializer: jsonrpsee deserializes params via a static `Deserialize` impl with no runtime context. So the bound must be the compile-time constant `DEFAULT_MAX_VALIDITY_PREDICATES` (64).

To make that constant provably correct rather than a silent behavior change, the CLI argument is now clamped to `1..=64`. A node's configured maximum can therefore never exceed the ceiling the deserializer enforces, and the configured value still applies as a lower limit afterward via `ValidityPredicate::validate_batch`. Previously the argument had no upper bound, so a value above 64 would have silently rejected valid 65-to-max batches mid-deserialization; that value is now rejected at startup instead.

## Tests

Deserialization (8 tests): decoding stops at predicate 65 including a 100k-predicate (DoS-shaped) body; a batch of exactly 64 still decodes; unknown fields on the RPC options are rejected; the bounded visitor applies on the bare sequence and the wire struct, not just the RPC options.

CLI clamp (6 tests, execution + builder): a max above 64 is rejected at startup, zero is rejected, and exactly 64 is accepted.

`cargo test` on `base-execution-txpool`, `base-txpool-rpc`, `base-execution-cli`, `base-builder-cli`, and `base-builder-core --test rpc` is green; `cargo clippy --all-targets` on the changed crates is clean; `cargo +nightly fmt --check` is clean.

## Notes

The report also recommends a lower request-body cap for this endpoint and per-IP rate limits (recs #3, #4); those are infra-level knobs deliberately left out of this PR.

Generated with Toshi
