### PR TITLE
fix(txpool-rpc): reject unknown SendRawTransactionValidityOptions fields

### DIFF
--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -50,6 +50,7 @@ pub struct TransactionStatusResponse {
 
 /// Options for `base_sendRawTransactionValidity` accompanying the raw transaction.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct SendRawTransactionValidityOptions {
     /// Experimental predicates transported to builders alongside the transaction.
     pub validity: Vec<ValidityPredicate>,
@@ -443,6 +444,37 @@ mod tests {
         assert!(options_value.get("tx").is_none());
         assert_eq!(options_value["validity"][0]["type"], "storage");
         assert_eq!(options_value["validity"][0]["params"]["slot"], "0x1");
+    }
+
+    #[test]
+    fn send_raw_transaction_validity_options_reject_unknown_fields() {
+        // An unknown top-level field must be rejected before any transaction
+        // processing, so an attacker cannot pad the request body with
+        // irrelevant data that still consumes the request-body budget.
+        let json = r#"{"validity":[],"unexpected":"padding"}"#;
+
+        let error = serde_json::from_str::<SendRawTransactionValidityOptions>(json)
+            .expect_err("unknown fields must be rejected");
+        assert!(
+            error.to_string().contains("unexpected"),
+            "error should name the unknown field: {error}"
+        );
+    }
+
+    #[test]
+    fn send_raw_transaction_validity_options_accept_known_fields() {
+        let json = r#"{"validity":[{"type":"balance","params":{"address":"0x1111111111111111111111111111111111111111","op":">=","value":"0x1"}}]}"#;
+
+        let options: SendRawTransactionValidityOptions =
+            serde_json::from_str(json).expect("known fields must deserialize");
+        assert_eq!(
+            options.validity,
+            vec![ValidityPredicate::Balance {
+                address: Address::repeat_byte(0x11),
+                op: base_execution_txpool::ValidityOperator::GreaterThanOrEqual,
+                value: U256::from(1),
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `#[serde(deny_unknown_fields)]` to `SendRawTransactionValidityOptions` so the `base_sendRawTransactionValidity` RPC rejects requests padded with irrelevant top-level fields that would otherwise consume the request-body budget.

This closes the unknown-fields portion of the validity-transaction JSON decoding DoS finding (CHAIN-5250), and adds the accompanying regression tests (a slice of CHAIN-5251).

## Changes

- `SendRawTransactionValidityOptions` now rejects unknown top-level fields during deserialization.
- Regression tests:
  - `send_raw_transaction_validity_options_reject_unknown_fields` — an unknown field is rejected before any transaction processing.
  - `send_raw_transaction_validity_options_accept_known_fields` — a well-formed options object still deserializes correctly.

## Notes on scope

The `eth_sendRawTransaction` and `eth_sendRawTransactionSync` paths were reviewed for a similar vector and do not have one: both take a single `Bytes` param (a hex string, not a JSON object/array) decoded 1:1 via `decode_2718_exact`, so there is no unbounded-allocation-from-small-input amplification and no options struct to harden.

The bounded-sequence-visitor change (rejecting at predicate 65 during decode) is tracked separately and is not part of this PR.

## Testing

`cargo test -p base-txpool-rpc --lib send_raw_transaction_validity_options` — both new tests pass.

Generated with Toshi
