### PR TITLE
feat(txpool-rpc): bound validity transactions at ingress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6521,6 +6521,7 @@ dependencies = [
  "alloy-signer-local 2.4.1",
  "base-common-chains",
  "base-common-consensus",
+ "base-common-genesis",
  "base-execution-chainspec",
  "base-execution-txpool",
  "base-node-runner",

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -16,7 +16,10 @@ use base_execution_cli::{
 };
 use base_node_runner::BaseNodeRunner;
 use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
-use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{
+    SendRawTransactionValidityConfig, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    TxPoolRpcExtension,
+};
 use base_upgrade_signal::UpgradeSignalStartupMode;
 use clap::Args;
 use reth_cli_runner::CliRunner;
@@ -122,7 +125,10 @@ impl SequencerCommand {
             runner.install_ext::<BuilderApiExtension>(builder_api_config);
             if builder_api_config.accept_experimental_validity_transactions {
                 runner.install_ext::<SendRawTransactionValidityExtension>(
-                    builder_api_config.max_validity_predicates,
+                    SendRawTransactionValidityConfig {
+                        max_validity_predicates: builder_api_config.max_validity_predicates,
+                        ..Default::default()
+                    },
                 );
             }
             runner.install_ext::<ShadowIndexerExtension>(shadow_indexer_config);

--- a/bin/builder/src/main.rs
+++ b/bin/builder/src/main.rs
@@ -13,7 +13,10 @@ use base_execution_cli::{Cli, StandardBaseRethNode};
 use base_node_runner::BaseNodeRunner;
 use base_observability_events::GlobalTransactionEventWriter;
 use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
-use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{
+    SendRawTransactionValidityConfig, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    TxPoolRpcExtension,
+};
 
 type BuilderCli = Cli<Args>;
 
@@ -68,7 +71,10 @@ fn main() {
         runner.install_ext::<BuilderApiExtension>(builder_api_config);
         if builder_api_config.accept_experimental_validity_transactions {
             runner.install_ext::<SendRawTransactionValidityExtension>(
-                builder_api_config.max_validity_predicates,
+                SendRawTransactionValidityConfig {
+                    max_validity_predicates: builder_api_config.max_validity_predicates,
+                    ..Default::default()
+                },
             );
         }
         runner.install_ext::<ShadowIndexerExtension>(shadow_indexer_config);

--- a/crates/builder/core/tests/rpc.rs
+++ b/crates/builder/core/tests/rpc.rs
@@ -15,7 +15,10 @@ use base_execution_txpool::{
 };
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::Account;
-use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityOptions};
+use base_txpool_rpc::{
+    SendRawTransactionValidityConfig, SendRawTransactionValidityExtension,
+    SendRawTransactionValidityOptions,
+};
 
 /// Sets up a test harness with the `BuilderApiExtension` installed.
 async fn setup(
@@ -54,7 +57,9 @@ async fn setup_with_validity_ingress(
     let config = BuilderApiExtensionConfig::new(accept_validity, max_validity_predicates);
     let mut builder = TestHarness::builder().with_ext::<BuilderApiExtension>(config);
     if accept_validity {
-        builder = builder.with_ext::<SendRawTransactionValidityExtension>(max_validity_predicates);
+        builder = builder.with_ext::<SendRawTransactionValidityExtension>(
+            SendRawTransactionValidityConfig { max_validity_predicates, ..Default::default() },
+        );
     }
     let harness = builder.build().await?;
     let client = harness.rpc_client()?;
@@ -253,11 +258,17 @@ async fn test_send_raw_transaction_validity_requires_explicit_opt_in() -> eyre::
             (
                 signed_eip1559_tx(enabled_harness.chain_id()),
                 SendRawTransactionValidityOptions {
-                    validity: vec![ValidityPredicate::Balance {
-                        address: Account::Alice.address(),
-                        op: ValidityOperator::Equal,
-                        value: U256::ZERO,
-                    }],
+                    validity: vec![
+                        ValidityPredicate::Balance {
+                            address: Account::Alice.address(),
+                            op: ValidityOperator::Equal,
+                            value: U256::ZERO,
+                        },
+                        ValidityPredicate::BlockNumber {
+                            op: ValidityOperator::LessThanOrEqual,
+                            value: U256::from(31),
+                        },
+                    ],
                 },
             ),
         )

--- a/crates/execution/cli/src/standard_node.rs
+++ b/crates/execution/cli/src/standard_node.rs
@@ -30,7 +30,8 @@ use base_tx_forwarding::{
     TxForwardingExtension,
 };
 use base_txpool_rpc::{
-    DEFAULT_MAX_VALIDITY_PREDICATES, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    DEFAULT_MAX_VALIDITY_EXPIRY_SECS, DEFAULT_MAX_VALIDITY_PREDICATES,
+    SendRawTransactionValidityConfig, SendRawTransactionValidityExtension, TxPoolRpcConfig,
     TxPoolRpcExtension,
 };
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
@@ -365,6 +366,14 @@ pub struct RpcStandardNodeArgs {
         requires = "enable_experimental_validity_transactions"
     )]
     pub experimental_validity_max_predicates: usize,
+
+    /// Maximum lifetime, in seconds, for an experimental validity transaction.
+    #[arg(
+        long = "experimental-validity-max-expiry-secs",
+        default_value_t = DEFAULT_MAX_VALIDITY_EXPIRY_SECS,
+        requires = "enable_experimental_validity_transactions"
+    )]
+    pub experimental_validity_max_expiry_secs: u64,
 
     /// Builder RPC endpoints for transaction forwarding (one forwarder per URL), used by mempool nodes
     #[arg(
@@ -720,7 +729,10 @@ impl StandardBaseRethNode {
         let tx_forwarding_config: TxForwardingConfig = (&args).into();
         if args.rpc.enable_experimental_validity_transactions {
             runner.install_ext::<SendRawTransactionValidityExtension>(
-                args.rpc.experimental_validity_max_predicates,
+                SendRawTransactionValidityConfig {
+                    max_validity_predicates: args.rpc.experimental_validity_max_predicates,
+                    max_validity_expiry_secs: args.rpc.experimental_validity_max_expiry_secs,
+                },
             );
         }
         runner.install_ext::<TxForwardingExtension>(tx_forwarding_config);
@@ -920,6 +932,7 @@ mod tests {
             enable_tx_forwarding: false,
             enable_experimental_validity_transactions: false,
             experimental_validity_max_predicates: DEFAULT_MAX_VALIDITY_PREDICATES,
+            experimental_validity_max_expiry_secs: DEFAULT_MAX_VALIDITY_EXPIRY_SECS,
             builder_rpc_urls: Vec::new(),
             tx_forwarding_resend_after_ms: DEFAULT_RESEND_AFTER_MS,
             tx_forwarding_batch_size: DEFAULT_MAX_BATCH_SIZE,
@@ -1046,6 +1059,10 @@ mod tests {
             standard_args.rpc.experimental_validity_max_predicates,
             DEFAULT_MAX_VALIDITY_PREDICATES
         );
+        assert_eq!(
+            standard_args.rpc.experimental_validity_max_expiry_secs,
+            DEFAULT_MAX_VALIDITY_EXPIRY_SECS
+        );
         assert!(!config.enabled);
         assert!(config.builder_urls.is_empty());
     }
@@ -1072,12 +1089,15 @@ mod tests {
             "--enable-experimental-validity-transactions",
             "--experimental-validity-max-predicates",
             "8",
+            "--experimental-validity-max-expiry-secs",
+            "45",
         ])
         .args;
 
         assert!(args.rpc.enable_tx_forwarding);
         assert!(args.rpc.enable_experimental_validity_transactions);
         assert_eq!(args.rpc.experimental_validity_max_predicates, 8);
+        assert_eq!(args.rpc.experimental_validity_max_expiry_secs, 45);
         assert_eq!(args.rpc.builder_rpc_urls.len(), 1);
     }
 

--- a/crates/execution/tx-forwarding/tests/forwarding.rs
+++ b/crates/execution/tx-forwarding/tests/forwarding.rs
@@ -5,18 +5,21 @@ use std::{sync::Arc, time::Duration};
 use alloy_consensus::SignableTransaction;
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::TransactionBuilder;
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, U256};
 use alloy_provider::Provider;
 use alloy_signer::SignerSync;
 use base_common_rpc_types::BaseTransactionRequest;
 use base_execution_chainspec::BaseChainSpec;
 use base_execution_txpool::{
-    DEFAULT_MAX_VALIDITY_PREDICATES, TransactionValidity, ValidatedTransaction,
+    TransactionValidity, ValidatedTransaction, ValidityOperator, ValidityPredicate,
 };
 use base_node_runner::test_utils::TestHarness;
 use base_test_utils::{Account, DEVNET_CHAIN_ID, build_test_genesis};
 use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
-use base_txpool_rpc::{SendRawTransactionValidityExtension, SendRawTransactionValidityOptions};
+use base_txpool_rpc::{
+    SendRawTransactionValidityConfig, SendRawTransactionValidityExtension,
+    SendRawTransactionValidityOptions,
+};
 use eyre::{Result, WrapErr};
 use jsonrpsee::{
     RpcModule,
@@ -156,12 +159,15 @@ async fn forwards_validity_to_every_builder() -> Result<()> {
     // EIP-1559 validity transactions are gated by the experimental flag alone (not Cobalt), so this
     // exercises the flow against a pre-Cobalt genesis.
     let chain_spec = Arc::new(BaseChainSpec::from_genesis(build_test_genesis()));
-    let harness = TestHarness::builder()
-        .with_ext::<SendRawTransactionValidityExtension>(DEFAULT_MAX_VALIDITY_PREDICATES)
-        .with_ext::<TxForwardingExtension>(config)
-        .with_chain_spec(chain_spec)
-        .build()
-        .await?;
+    let harness =
+        TestHarness::builder()
+            .with_ext::<SendRawTransactionValidityExtension>(
+                SendRawTransactionValidityConfig::default(),
+            )
+            .with_ext::<TxForwardingExtension>(config)
+            .with_chain_spec(chain_spec)
+            .build()
+            .await?;
     let raw = signed_eip1559_transaction();
     let validity = serde_json::from_value(serde_json::json!({
         "type": "storage",
@@ -172,7 +178,13 @@ async fn forwards_validity_to_every_builder() -> Result<()> {
             "value": "0x2"
         }
     }))?;
-    let expected = vec![validity];
+    let expected = vec![
+        ValidityPredicate::BlockNumber {
+            op: ValidityOperator::LessThanOrEqual,
+            value: U256::from(31),
+        },
+        validity,
+    ];
     let client = harness.rpc_client()?;
     let _: alloy_primitives::TxHash = client
         .request(

--- a/crates/execution/txpool-rpc/Cargo.toml
+++ b/crates/execution/txpool-rpc/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 # workspace
 base-node-runner.workspace = true
 base-common-chains.workspace = true
+base-common-genesis.workspace = true
 base-execution-txpool.workspace = true
 base-common-consensus.workspace = true
 base-observability-events.workspace = true

--- a/crates/execution/txpool-rpc/src/extension.rs
+++ b/crates/execution/txpool-rpc/src/extension.rs
@@ -1,6 +1,8 @@
 //! `TxPool` RPC extension for registering transaction pool management APIs.
 
-pub use base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES;
+pub use base_execution_txpool::{
+    DEFAULT_MAX_VALIDITY_EXPIRY_SECS, DEFAULT_MAX_VALIDITY_PREDICATES,
+};
 use base_node_runner::{BaseNodeExtension, BaseRpcContext, FromExtensionConfig, NodeHooks};
 use reth_rpc_server_types::RethRpcModule;
 
@@ -43,26 +45,39 @@ impl BaseNodeExtension for TxPoolRpcExtension {
     }
 }
 
-/// Extension registering local validity-bearing transaction ingress.
-#[derive(Debug)]
-pub struct SendRawTransactionValidityExtension {
-    max_validity_predicates: usize,
+/// Configuration for local validity-bearing transaction ingress.
+#[derive(Debug, Clone, Copy)]
+pub struct SendRawTransactionValidityConfig {
+    /// Maximum number of validity predicates accepted per transaction.
+    pub max_validity_predicates: usize,
+    /// Maximum validity-transaction lifetime, in seconds.
+    pub max_validity_expiry_secs: u64,
 }
 
-impl Default for SendRawTransactionValidityExtension {
+impl Default for SendRawTransactionValidityConfig {
     fn default() -> Self {
-        Self { max_validity_predicates: DEFAULT_MAX_VALIDITY_PREDICATES }
+        Self {
+            max_validity_predicates: DEFAULT_MAX_VALIDITY_PREDICATES,
+            max_validity_expiry_secs: DEFAULT_MAX_VALIDITY_EXPIRY_SECS,
+        }
     }
+}
+
+/// Extension registering local validity-bearing transaction ingress.
+#[derive(Debug, Default)]
+pub struct SendRawTransactionValidityExtension {
+    config: SendRawTransactionValidityConfig,
 }
 
 impl BaseNodeExtension for SendRawTransactionValidityExtension {
     fn apply(self: Box<Self>, builder: NodeHooks) -> NodeHooks {
-        let max_validity_predicates = self.max_validity_predicates;
+        let config = self.config;
         builder.add_rpc_module(move |ctx: &mut BaseRpcContext<'_>| {
-            let api = SendRawTransactionValidityApiImpl::with_max_validity_predicates(
+            let api = SendRawTransactionValidityApiImpl::with_validity_limits(
                 ctx.pool().clone(),
                 ctx.provider().clone(),
-                max_validity_predicates,
+                config.max_validity_predicates,
+                config.max_validity_expiry_secs,
             );
             ctx.modules.merge_configured(api.into_rpc())?;
             Ok(())
@@ -71,10 +86,10 @@ impl BaseNodeExtension for SendRawTransactionValidityExtension {
 }
 
 impl FromExtensionConfig for SendRawTransactionValidityExtension {
-    type Config = usize;
+    type Config = SendRawTransactionValidityConfig;
 
-    fn from_config(max_validity_predicates: Self::Config) -> Self {
-        Self { max_validity_predicates }
+    fn from_config(config: Self::Config) -> Self {
+        Self { config }
     }
 }
 

--- a/crates/execution/txpool-rpc/src/lib.rs
+++ b/crates/execution/txpool-rpc/src/lib.rs
@@ -17,6 +17,7 @@ pub use rpc::{
 
 mod extension;
 pub use extension::{
-    DEFAULT_MAX_VALIDITY_PREDICATES, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    DEFAULT_MAX_VALIDITY_EXPIRY_SECS, DEFAULT_MAX_VALIDITY_PREDICATES,
+    SendRawTransactionValidityConfig, SendRawTransactionValidityExtension, TxPoolRpcConfig,
     TxPoolRpcExtension,
 };

--- a/crates/execution/txpool-rpc/src/rpc.rs
+++ b/crates/execution/txpool-rpc/src/rpc.rs
@@ -4,9 +4,10 @@ use alloy_consensus::{BlockHeader, Typed2718};
 use alloy_primitives::{Address, Bytes, TxHash};
 use base_common_chains::Upgrades;
 use base_common_consensus::EIP8130_TX_TYPE_ID;
+use base_common_genesis::RollupConfig;
 use base_execution_txpool::{
-    BasePooledTransaction, DEFAULT_MAX_VALIDITY_PREDICATES, ValidityPredicate,
-    deserialize_bounded_predicates,
+    BasePooledTransaction, DEFAULT_MAX_VALIDITY_EXPIRY_SECS, DEFAULT_MAX_VALIDITY_PREDICATES,
+    ValidityPredicate, deserialize_bounded_predicates,
 };
 use base_observability_events::{
     TransactionEventProducer, TransactionEventType, transaction_event,
@@ -32,6 +33,9 @@ use tracing::{debug, info, warn};
 /// carry validity predicates under the experimental flag alone.
 pub const VALIDITY_TX_PRE_ZENITH_RPC_ERROR: &str = "EIP-8130 validity transactions are gated behind \
      the Zenith hard fork; they are not accepted before Zenith is active";
+
+/// Legacy full-block cadence used before Denim activates.
+const LEGACY_BLOCK_INTERVAL_MILLIS: u64 = 2_000;
 
 /// The status of a transaction.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Debug)]
@@ -112,17 +116,23 @@ pub struct SendRawTransactionValidityApiImpl<Pool, Provider> {
     pool: Pool,
     provider: Provider,
     max_validity_predicates: usize,
+    max_validity_expiry_secs: u64,
 }
 
 impl<Pool, Provider> SendRawTransactionValidityApiImpl<Pool, Provider> {
-    /// Creates a validity transaction ingress backed by the given pool and default predicate limit.
+    /// Creates a validity transaction ingress backed by the given pool and default limits.
     ///
     /// The provider fork-gates the RPC method on the Zenith hard fork.
     pub const fn new(pool: Pool, provider: Provider) -> Self {
-        Self { pool, provider, max_validity_predicates: DEFAULT_MAX_VALIDITY_PREDICATES }
+        Self::with_validity_limits(
+            pool,
+            provider,
+            DEFAULT_MAX_VALIDITY_PREDICATES,
+            DEFAULT_MAX_VALIDITY_EXPIRY_SECS,
+        )
     }
 
-    /// Creates a validity transaction ingress with a predicate limit.
+    /// Creates a validity transaction ingress with a predicate limit and default expiry window.
     ///
     /// The provider fork-gates the RPC method on the Zenith hard fork.
     pub const fn with_max_validity_predicates(
@@ -130,7 +140,25 @@ impl<Pool, Provider> SendRawTransactionValidityApiImpl<Pool, Provider> {
         provider: Provider,
         max_validity_predicates: usize,
     ) -> Self {
-        Self { pool, provider, max_validity_predicates }
+        Self::with_validity_limits(
+            pool,
+            provider,
+            max_validity_predicates,
+            DEFAULT_MAX_VALIDITY_EXPIRY_SECS,
+        )
+    }
+
+    /// Creates a validity transaction ingress with explicit predicate and expiry limits.
+    ///
+    /// The expiry limit is expressed in seconds and converted to blocks using the active full-
+    /// block cadence at submission time.
+    pub const fn with_validity_limits(
+        pool: Pool,
+        provider: Provider,
+        max_validity_predicates: usize,
+        max_validity_expiry_secs: u64,
+    ) -> Self {
+        Self { pool, provider, max_validity_predicates, max_validity_expiry_secs }
     }
 }
 
@@ -138,11 +166,9 @@ impl<Pool, Provider> SendRawTransactionValidityApiImpl<Pool, Provider>
 where
     Provider: BlockReaderIdExt + ChainSpecProvider<ChainSpec: Upgrades>,
 {
-    /// Returns whether the Zenith hard fork is active at the latest block's timestamp.
-    ///
-    /// Returns `false` when no latest header is available (e.g. before genesis is committed), which
-    /// keeps the fork-gated RPC method closed until a canonical head exists.
-    fn is_zenith_active_at_latest(&self) -> RpcResult<bool> {
+    /// Returns the latest committed header's `(number, timestamp)`, or `None` when no canonical
+    /// head exists (e.g. before genesis is committed).
+    fn latest_block_number_and_timestamp(&self) -> RpcResult<Option<(u64, u64)>> {
         let Some(header) = self.provider.latest_header().map_err(|error| {
             ErrorObjectOwned::owned(
                 ErrorCode::InternalError.code(),
@@ -151,9 +177,27 @@ where
             )
         })?
         else {
-            return Ok(false);
+            return Ok(None);
         };
-        Ok(self.provider.chain_spec().is_zenith_active_at_timestamp(header.timestamp()))
+        Ok(Some((header.number(), header.timestamp())))
+    }
+
+    /// Returns the maximum permitted expiry distance in full blocks for the block being built.
+    fn max_validity_expiry_blocks(&self, latest_timestamp: u64) -> u64 {
+        // The target build can be the first Denim block even though the latest committed header
+        // is pre-Denim. Check both its parent timestamp and the next legacy block timestamp so
+        // the window uses Denim's 200ms full-block cadence at that transition.
+        let next_legacy_timestamp =
+            latest_timestamp.saturating_add(LEGACY_BLOCK_INTERVAL_MILLIS.saturating_div(1_000));
+        let block_interval_millis =
+            if self.provider.chain_spec().is_denim_active_at_timestamp(latest_timestamp)
+                || self.provider.chain_spec().is_denim_active_at_timestamp(next_legacy_timestamp)
+            {
+                RollupConfig::NATIVE_SUBSECOND_BLOCK_INTERVAL_MILLIS
+            } else {
+                LEGACY_BLOCK_INTERVAL_MILLIS
+            };
+        self.max_validity_expiry_secs.saturating_mul(1_000).div_ceil(block_interval_millis)
     }
 }
 
@@ -228,6 +272,27 @@ where
                 )
             })?;
 
+        // Every validity transaction must carry a finite `block_number` expiry. When a canonical
+        // head exists, also reject bounds already in the past and bounds outside the configured
+        // wall-clock window. This validates the submission without injecting or rewriting a
+        // predicate.
+        let latest = self.latest_block_number_and_timestamp()?;
+        let expiry_validation = match latest {
+            Some((latest_block, latest_timestamp)) => {
+                ValidityPredicate::validate_block_expiry_bounds(
+                    &options.validity,
+                    latest_block.saturating_add(1),
+                    self.max_validity_expiry_blocks(latest_timestamp),
+                )
+            }
+            // Before genesis is committed there is no build target from which to measure the
+            // window, but a finite expiry is still mandatory.
+            None => ValidityPredicate::validate_has_block_expiry(&options.validity),
+        };
+        expiry_validation.map_err(|error| {
+            ErrorObjectOwned::owned(ErrorCode::InvalidParams.code(), error.to_string(), None::<()>)
+        })?;
+
         let transaction =
             BasePooledTransaction::recover_raw_transaction(tx.as_ref()).map_err(|error| {
                 ErrorObjectOwned::owned(
@@ -240,7 +305,10 @@ where
         // EIP-8130 (account abstraction) validity transactions are fork-gated on Zenith. Other
         // transaction types (e.g. EIP-1559) carry validity predicates under the experimental flag
         // alone and are accepted before Zenith activates.
-        if transaction.ty() == EIP8130_TX_TYPE_ID && !self.is_zenith_active_at_latest()? {
+        let zenith_active = latest.is_some_and(|(_, timestamp)| {
+            self.provider.chain_spec().is_zenith_active_at_timestamp(timestamp)
+        });
+        if transaction.ty() == EIP8130_TX_TYPE_ID && !zenith_active {
             return Err(ErrorObjectOwned::owned(
                 ErrorCode::InvalidParams.code(),
                 VALIDITY_TX_PRE_ZENITH_RPC_ERROR,
@@ -306,16 +374,17 @@ impl<Pool: TransactionPool + 'static> AdminTxPoolApiServer for AdminTxPoolApiImp
 mod tests {
     use std::sync::Arc;
 
-    use alloy_consensus::{SignableTransaction, TxEip1559};
+    use alloy_consensus::{BlockBody, Header, SignableTransaction, TxEip1559};
     use alloy_eips::eip2718::Encodable2718;
-    use alloy_primitives::{Address, Bytes, TxHash, TxKind, U256};
+    use alloy_primitives::{Address, B256, Bytes, TxHash, TxKind, U256};
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use base_common_chains::ChainConfig;
     use base_common_consensus::{
-        BasePooledTransaction as ConsensusPooledTransaction, BasePrimitives, Eip8130Signed,
-        TxEip8130,
+        BaseBlock, BasePooledTransaction as ConsensusPooledTransaction, BasePrimitives,
+        Eip8130Signed, TxEip8130,
     };
+    use base_common_genesis::BaseUpgrade;
     use base_execution_chainspec::{BaseChainSpec, BaseChainSpecBuilder};
     use base_observability_events::{
         TransactionEventBuilder, TransactionEventCapture, TransactionEventProducer,
@@ -323,6 +392,7 @@ mod tests {
     };
     use base_test_utils::build_test_genesis_zenith;
     use httpmock::prelude::*;
+    use reth_chainspec::ForkCondition;
     use reth_provider::test_utils::MockEthProvider;
     use reth_transaction_pool::{
         PoolTransaction, TransactionOrigin,
@@ -359,13 +429,19 @@ mod tests {
         (
             tx,
             SendRawTransactionValidityOptions {
-                validity: vec![ValidityPredicate::Storage {
-                    address: Address::repeat_byte(0xab),
-                    slot: U256::from(1),
-                    mask: U256::MAX,
-                    op: base_execution_txpool::ValidityOperator::Equal,
-                    value: U256::from(0x789),
-                }],
+                validity: vec![
+                    ValidityPredicate::Storage {
+                        address: Address::repeat_byte(0xab),
+                        slot: U256::from(1),
+                        mask: U256::MAX,
+                        op: base_execution_txpool::ValidityOperator::Equal,
+                        value: U256::from(0x789),
+                    },
+                    ValidityPredicate::BlockNumber {
+                        op: base_execution_txpool::ValidityOperator::LessThanOrEqual,
+                        value: U256::from(31),
+                    },
+                ],
             },
         )
     }
@@ -385,14 +461,41 @@ mod tests {
                 value: U256::from(0x789),
             },
             ValidityPredicate::BlockNumber {
-                op: base_execution_txpool::ValidityOperator::GreaterThanOrEqual,
-                value: U256::from(100),
+                op: base_execution_txpool::ValidityOperator::LessThan,
+                value: U256::from(32),
             },
             ValidityPredicate::FlashblockIndex {
                 op: base_execution_txpool::ValidityOperator::LessThan,
                 value: U256::from(5),
             },
         ]
+    }
+
+    #[test]
+    fn max_validity_expiry_blocks_uses_the_active_full_block_cadence() {
+        let legacy = SendRawTransactionValidityApiImpl::new(validity_pool(), pre_zenith_provider());
+        assert_eq!(legacy.max_validity_expiry_blocks(0), 30);
+
+        let denim_provider = MockEthProvider::<BasePrimitives>::new()
+            .with_chain_spec(Arc::new(
+                BaseChainSpecBuilder::base_mainnet()
+                    .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(0))
+                    .build(),
+            ))
+            .with_genesis_block();
+        let denim = SendRawTransactionValidityApiImpl::new(validity_pool(), denim_provider);
+        assert_eq!(denim.max_validity_expiry_blocks(0), 300);
+
+        let transition_provider = MockEthProvider::<BasePrimitives>::new()
+            .with_chain_spec(Arc::new(
+                BaseChainSpecBuilder::base_mainnet()
+                    .with_fork(BaseUpgrade::Denim, ForkCondition::Timestamp(2))
+                    .build(),
+            ))
+            .with_genesis_block();
+        let transition =
+            SendRawTransactionValidityApiImpl::new(validity_pool(), transition_provider);
+        assert_eq!(transition.max_validity_expiry_blocks(0), 300);
     }
 
     fn signed_eip1559(signer: &PrivateKeySigner, nonce: u64, priority_fee: u128) -> Bytes {
@@ -511,8 +614,8 @@ mod tests {
                 {
                     "type": "block_number",
                     "params": {
-                        "op": ">=",
-                        "value": "0x64",
+                        "op": "<",
+                        "value": "0x20",
                     },
                 },
                 {
@@ -675,6 +778,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn send_raw_transaction_validity_requires_block_number_expiry() {
+        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), zenith_provider());
+        let (raw, mut options) = validity_request(Bytes::from_static(&[0x02]));
+        options.validity = vec![ValidityPredicate::BlockNumber {
+            op: base_execution_txpool::ValidityOperator::GreaterThanOrEqual,
+            value: U256::ZERO,
+        }];
+
+        let error = rpc
+            .send_raw_transaction_validity(raw, options)
+            .await
+            .expect_err("a validity transaction without an upper block bound should be rejected");
+
+        assert_eq!(error.code(), ErrorCode::InvalidParams.code());
+        assert!(error.message().contains("require a block-number predicate"));
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_rejects_block_number_bound_outside_window() {
+        // Legacy blocks are 2 seconds, so the default 60-second window permits 30 blocks.
+        // With the head at 100, the build target is 101 and the maximum bound is 131.
+        let provider = pre_zenith_provider();
+        provider.add_block(
+            B256::repeat_byte(8),
+            BaseBlock {
+                header: Header { number: 100, ..Default::default() },
+                body: BlockBody::default(),
+            },
+        );
+        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), provider);
+        let (raw, mut options) = validity_request(Bytes::from_static(&[0x02]));
+        options.validity = vec![ValidityPredicate::BlockNumber {
+            op: base_execution_txpool::ValidityOperator::LessThanOrEqual,
+            value: U256::from(132),
+        }];
+
+        let error = rpc
+            .send_raw_transaction_validity(raw, options)
+            .await
+            .expect_err("a block bound beyond the configured window should be rejected");
+
+        assert_eq!(error.code(), ErrorCode::InvalidParams.code());
+        assert!(error.message().contains("expires too far in the future"));
+    }
+
+    #[tokio::test]
     async fn send_raw_transaction_validity_rejects_storage_value_outside_mask() {
         let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), zenith_provider());
         let (raw, mut options) = validity_request(Bytes::from_static(&[0x02]));
@@ -772,6 +921,96 @@ mod tests {
         let error = serde_json::from_str::<SendRawTransactionValidityOptions>(&json)
             .expect_err("unknown fields must be rejected");
         assert!(error.to_string().contains("unknown field"), "unexpected error: {error}");
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_rejects_expired_block_number_bound() {
+        // The genesis block is the latest committed block, so the block being built is 1.
+        // A predicate capping inclusion at block 0 can never be satisfied.
+        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), zenith_provider());
+        let (raw, mut options) = validity_request(Bytes::from_static(&[0x02]));
+        options.validity = vec![ValidityPredicate::BlockNumber {
+            op: base_execution_txpool::ValidityOperator::LessThanOrEqual,
+            value: U256::ZERO,
+        }];
+
+        let error = rpc
+            .send_raw_transaction_validity(raw, options)
+            .await
+            .expect_err("a block bound below the block being built should be rejected");
+
+        assert_eq!(error.code(), ErrorCode::InvalidParams.code());
+        assert!(error.message().contains("already expired"), "unexpected message: {error}");
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_rejects_bound_behind_a_later_head() {
+        // With the head at block 100, the block being built is 101; `block_number < 101`
+        // caps inclusion at block 100, which has already been sealed.
+        let provider = zenith_provider();
+        provider.add_block(
+            B256::repeat_byte(7),
+            BaseBlock {
+                header: Header { number: 100, ..Default::default() },
+                body: BlockBody::default(),
+            },
+        );
+        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), provider);
+        let (raw, mut options) = validity_request(Bytes::from_static(&[0x02]));
+        options.validity = vec![ValidityPredicate::BlockNumber {
+            op: base_execution_txpool::ValidityOperator::LessThan,
+            value: U256::from(101),
+        }];
+
+        let error = rpc
+            .send_raw_transaction_validity(raw, options)
+            .await
+            .expect_err("a block bound at the sealed head should be rejected");
+
+        assert_eq!(error.code(), ErrorCode::InvalidParams.code());
+        assert!(error.message().contains("already expired"), "unexpected message: {error}");
+    }
+
+    #[tokio::test]
+    async fn send_raw_transaction_validity_accepts_bound_on_the_block_being_built() {
+        // With the head at block 100, `block_number = 101` targets the block currently
+        // being built and may still land in one of its flashblocks, so validation passes
+        // and submission proceeds to the pool (which the noop pool then rejects).
+        let capture = TransactionEventCapture::install();
+        let signer = PrivateKeySigner::random();
+        let raw = signed_eip1559(&signer, 0, 1);
+        let provider = zenith_provider();
+        provider.add_block(
+            B256::repeat_byte(7),
+            BaseBlock {
+                header: Header { number: 100, ..Default::default() },
+                body: BlockBody::default(),
+            },
+        );
+        let rpc = SendRawTransactionValidityApiImpl::new(validity_pool(), provider);
+        let mut options = SendRawTransactionValidityOptions { validity: vec![] };
+        options.validity = vec![ValidityPredicate::BlockNumber {
+            op: base_execution_txpool::ValidityOperator::Equal,
+            value: U256::from(101),
+        }];
+
+        let error = rpc
+            .send_raw_transaction_validity(raw, options)
+            .await
+            .expect_err("the noop pool rejects insertion after expiry validation passes");
+
+        assert!(
+            !error.message().contains("already expired"),
+            "bound on the block being built should pass expiry validation: {error}"
+        );
+        assert!(
+            capture
+                .events()
+                .iter()
+                .any(|event| event.event_type
+                    == TransactionEventType::TxpoolSendRawTransactionValidity),
+            "the admission event should fire once expiry validation passes"
+        );
     }
 
     #[tokio::test]

--- a/crates/execution/txpool/src/lib.rs
+++ b/crates/execution/txpool/src/lib.rs
@@ -29,9 +29,9 @@ mod best;
 
 mod validity;
 pub use validity::{
-    DEFAULT_MAX_VALIDITY_PREDICATES, FIRST_POOL_FLASHBLOCK_INDEX, PredicateContext,
-    TransactionValidity, ValidityOperator, ValidityPredicate, ValidityPredicateError,
-    deserialize_bounded_predicates,
+    DEFAULT_MAX_VALIDITY_EXPIRY_SECS, DEFAULT_MAX_VALIDITY_PREDICATES, FIRST_POOL_FLASHBLOCK_INDEX,
+    PredicateContext, TransactionValidity, ValidityOperator, ValidityPredicate,
+    ValidityPredicateError, deserialize_bounded_predicates,
 };
 
 mod block_expiry;

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -12,6 +12,9 @@ use crate::{BasePooledTransaction, ExtensionError, ValidatedTransactionExtension
 /// Default maximum number of experimental validity predicates carried by one transaction.
 pub const DEFAULT_MAX_VALIDITY_PREDICATES: usize = 64;
 
+/// Default maximum lifetime, in seconds, for experimental validity transactions.
+pub const DEFAULT_MAX_VALIDITY_EXPIRY_SECS: u64 = 60;
+
 /// The first flashblock index at which pooled transactions are evaluated.
 ///
 /// The fallback block published at flashblock index `0` executes only sequencer
@@ -62,6 +65,40 @@ pub enum ValidityPredicateError {
     UnsatisfiableFlashblockIndex {
         /// Position of the offending predicate within the batch.
         index: usize,
+    },
+    /// A block-number predicate's upper bound is already in the past.
+    ///
+    /// `current_block` is the block currently being built (one past the latest
+    /// committed block); a predicate whose greatest satisfiable block is below
+    /// it can never hold again, so the transaction would park in the pool until
+    /// block-expiry eviction and is rejected at ingress instead. `index` is the
+    /// position of the offending predicate within the batch, `bound` the
+    /// greatest block number at which the predicate can still hold.
+    #[error(
+        "block-number predicate at index {index} already expired: last satisfiable block {bound} is before the block currently being built ({current_block})"
+    )]
+    ExpiredBlockBound {
+        /// Position of the offending predicate within the batch.
+        index: usize,
+        /// Greatest block number at which the predicate can still hold.
+        bound: U256,
+        /// Number of the block currently being built.
+        current_block: u64,
+    },
+    /// The submission has no block-number upper bound, so it does not have a bounded lifetime.
+    #[error("validity transactions require a block-number predicate with an upper bound")]
+    MissingBlockExpiry,
+    /// A block-number predicate's tightest upper bound exceeds the configured lifetime window.
+    #[error(
+        "block-number predicate at index {index} expires too far in the future: last satisfiable block {bound} exceeds the maximum permitted block {maximum_block}"
+    )]
+    BlockExpiryWindowExceeded {
+        /// Position of the predicate that establishes the tightest upper bound.
+        index: usize,
+        /// Greatest block number at which the predicate can still hold.
+        bound: U256,
+        /// Greatest permitted block number for this submission.
+        maximum_block: u64,
     },
 }
 
@@ -226,6 +263,90 @@ impl ValidityPredicate {
         }
         for (index, predicate) in predicates.iter().enumerate() {
             predicate.validate_params(index)?;
+        }
+        Ok(())
+    }
+
+    /// Validates that a batch contains a `block_number` upper-bound predicate.
+    ///
+    /// Upper-bound operators (`<`, `<=`, and `=`) establish a finite last
+    /// satisfiable block. Lower bounds and `!=` leave future blocks
+    /// satisfiable and therefore do not provide the required expiry.
+    pub fn validate_has_block_expiry(predicates: &[Self]) -> Result<(), ValidityPredicateError> {
+        if predicates.iter().any(|predicate| {
+            matches!(
+                predicate,
+                Self::BlockNumber {
+                    op: ValidityOperator::LessThan
+                        | ValidityOperator::LessThanOrEqual
+                        | ValidityOperator::Equal,
+                    ..
+                }
+            )
+        }) {
+            Ok(())
+        } else {
+            Err(ValidityPredicateError::MissingBlockExpiry)
+        }
+    }
+
+    /// Validates that a batch has a `block_number` upper bound and that its
+    /// lifetime falls within the configured maximum.
+    ///
+    /// This is a pure validation step: no expiry bound is injected into or
+    /// rewritten on the submission. `current_block` is the in-progress build
+    /// target — one past the latest committed block. A batch must contain at
+    /// least one [`Self::BlockNumber`] predicate with an upper bound (`<`,
+    /// `<=`, or `=`). The tightest such bound determines the batch's last
+    /// satisfiable block.
+    ///
+    /// The bound must not precede `current_block`, because every block it
+    /// permits has already been sealed. It must also be no later than
+    /// `current_block + max_expiry_blocks`, so the transaction has a bounded
+    /// lifetime. Lower bounds (`>`, `>=`) and `!=` do not establish expiry.
+    /// State predicates ([`Self::Balance`], [`Self::Storage`]) are recoverable
+    /// and flashblock indices reset each block, so neither establishes expiry.
+    ///
+    /// A bound equal to `current_block` is deliberately accepted: the
+    /// transaction can still land in a later flashblock of the block being
+    /// built. Callers convert their configured wall-clock window to
+    /// `max_expiry_blocks` using the active full-block cadence; flashblock
+    /// cadence must not be used for that conversion.
+    pub fn validate_block_expiry_bounds(
+        predicates: &[Self],
+        current_block: u64,
+        max_expiry_blocks: u64,
+    ) -> Result<(), ValidityPredicateError> {
+        let current = U256::from(current_block);
+        let mut upper = None;
+        for (index, predicate) in predicates.iter().enumerate() {
+            let Self::BlockNumber { op, value } = predicate else { continue };
+            // `< 0` can never hold because block numbers are non-negative, so it
+            // has an effective upper bound of zero.
+            let bound = match op {
+                ValidityOperator::LessThan => value.checked_sub(U256::from(1)).unwrap_or_default(),
+                ValidityOperator::LessThanOrEqual | ValidityOperator::Equal => *value,
+                ValidityOperator::NotEqual
+                | ValidityOperator::GreaterThan
+                | ValidityOperator::GreaterThanOrEqual => continue,
+            };
+            if upper.as_ref().is_none_or(|(_, upper_bound)| bound < *upper_bound) {
+                upper = Some((index, bound));
+            }
+        }
+        let Some((index, bound)) = upper else {
+            return Err(ValidityPredicateError::MissingBlockExpiry);
+        };
+        if bound < current {
+            return Err(ValidityPredicateError::ExpiredBlockBound { index, bound, current_block });
+        }
+        let maximum_block = current_block.saturating_add(max_expiry_blocks);
+        if bound > U256::from(maximum_block) {
+            return Err(ValidityPredicateError::BlockExpiryWindowExceeded {
+                index,
+                bound,
+                maximum_block,
+            });
         }
         Ok(())
     }
@@ -1210,6 +1331,98 @@ mod tests {
         assert_eq!(
             ValidityPredicate::validate_batch(&predicates, DEFAULT_MAX_VALIDITY_PREDICATES),
             Err(ValidityPredicateError::StorageValueOutsideMask { index: 1 })
+        );
+    }
+
+    #[test]
+    fn validate_block_expiry_bounds_rejects_bounds_before_the_current_block() {
+        // The block currently being built is 100; a predicate whose last
+        // satisfiable block is below 100 can never hold again.
+        let expired = [
+            (ValidityOperator::LessThan, 100), // last satisfiable block 99
+            (ValidityOperator::LessThanOrEqual, 99),
+            (ValidityOperator::Equal, 99),
+            (ValidityOperator::LessThan, 0), // never satisfiable, reported as bound 0
+        ];
+        for (op, value) in expired {
+            let predicates = vec![block_number(op, value)];
+            assert!(
+                matches!(
+                    ValidityPredicate::validate_block_expiry_bounds(&predicates, 100, 30),
+                    Err(ValidityPredicateError::ExpiredBlockBound {
+                        index: 0,
+                        current_block: 100,
+                        ..
+                    })
+                ),
+                "expected {op:?} {value} to be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_block_expiry_bounds_accepts_bounds_within_the_window() {
+        // A bound equal to the block currently being built may still land in a
+        // later flashblock. Bounds through 130 are within the 30-block window.
+        let within_window = [
+            (ValidityOperator::Equal, 100),
+            (ValidityOperator::LessThanOrEqual, 100),
+            (ValidityOperator::LessThan, 101),
+            (ValidityOperator::LessThanOrEqual, 130),
+        ];
+        for (op, value) in within_window {
+            let predicates = vec![block_number(op, value)];
+            assert_eq!(
+                ValidityPredicate::validate_block_expiry_bounds(&predicates, 100, 30),
+                Ok(()),
+                "expected {op:?} {value} to be accepted",
+            );
+        }
+    }
+
+    #[test]
+    fn validate_block_expiry_bounds_requires_an_upper_bound() {
+        let predicates = vec![
+            block_number(ValidityOperator::NotEqual, 0),
+            block_number(ValidityOperator::GreaterThan, 0),
+            block_number(ValidityOperator::GreaterThanOrEqual, 0),
+            ValidityPredicate::Balance {
+                address: Address::repeat_byte(0x11),
+                op: ValidityOperator::Equal,
+                value: U256::ZERO,
+            },
+        ];
+
+        assert_eq!(
+            ValidityPredicate::validate_block_expiry_bounds(&predicates, 100, 30),
+            Err(ValidityPredicateError::MissingBlockExpiry)
+        );
+    }
+
+    #[test]
+    fn validate_block_expiry_bounds_uses_the_tightest_upper_bound() {
+        let predicates = vec![
+            block_number(ValidityOperator::LessThanOrEqual, 150),
+            block_number(ValidityOperator::LessThanOrEqual, 130),
+        ];
+
+        assert_eq!(ValidityPredicate::validate_block_expiry_bounds(&predicates, 100, 30), Ok(()));
+    }
+
+    #[test]
+    fn validate_block_expiry_bounds_reports_the_tightest_bound_outside_the_window() {
+        let predicates = vec![
+            block_number(ValidityOperator::LessThanOrEqual, 150),
+            block_number(ValidityOperator::LessThanOrEqual, 140),
+        ];
+
+        assert_eq!(
+            ValidityPredicate::validate_block_expiry_bounds(&predicates, 100, 30),
+            Err(ValidityPredicateError::BlockExpiryWindowExceeded {
+                index: 1,
+                bound: U256::from(140),
+                maximum_block: 130,
+            })
         );
     }
 

--- a/etc/systems/src/l2/in_process_builder.rs
+++ b/etc/systems/src/l2/in_process_builder.rs
@@ -17,7 +17,7 @@ use base_execution_txpool::{
 };
 use base_node_core::{args::RollupArgs, node::BasePoolBuilder};
 use base_node_runner::{BaseNode, BaseNodeExtension, FromExtensionConfig, NodeHooks};
-use base_txpool_rpc::SendRawTransactionValidityExtension;
+use base_txpool_rpc::{SendRawTransactionValidityConfig, SendRawTransactionValidityExtension};
 use eyre::{Result, WrapErr, eyre};
 use reth_db::{
     ClientVersion, DatabaseEnv, init_db,
@@ -192,7 +192,7 @@ impl InProcessBuilder {
         let mut hooks = NodeHooks::new();
         if accept_validity_transactions {
             hooks = Box::new(SendRawTransactionValidityExtension::from_config(
-                DEFAULT_MAX_VALIDITY_PREDICATES,
+                SendRawTransactionValidityConfig::default(),
             ))
             .apply(hooks);
         }

--- a/etc/systems/src/l2/in_process_client.rs
+++ b/etc/systems/src/l2/in_process_client.rs
@@ -11,13 +11,15 @@ use base_execution_chainspec::BaseChainSpec;
 use base_execution_cli::{
     ExecutionUpgradeSignal, ExecutionUpgradeSignalConfig, ExecutionUpgradeSignalRuntimeExtension,
 };
-use base_execution_txpool::DEFAULT_MAX_VALIDITY_PREDICATES;
 use base_flashblocks::FlashblocksConfig;
 use base_flashblocks_node::FlashblocksExtension;
 use base_node_core::args::RollupArgs;
 use base_node_runner::{BaseNode, BaseNodeExtension, FromExtensionConfig, NodeHooks};
 use base_tx_forwarding::{TxForwardingConfig, TxForwardingExtension};
-use base_txpool_rpc::{SendRawTransactionValidityExtension, TxPoolRpcConfig, TxPoolRpcExtension};
+use base_txpool_rpc::{
+    SendRawTransactionValidityConfig, SendRawTransactionValidityExtension, TxPoolRpcConfig,
+    TxPoolRpcExtension,
+};
 use base_txpool_tracing::{TxPoolExtension, TxpoolConfig};
 use eyre::{Context, Result, eyre};
 use reth_db::{ClientVersion, DatabaseEnv, init_db, mdbx::DatabaseArguments};
@@ -426,7 +428,7 @@ impl InProcessClient {
                 && !tx_fwd_config.builder_urls.is_empty()
             {
                 extensions.push(Box::new(SendRawTransactionValidityExtension::from_config(
-                    DEFAULT_MAX_VALIDITY_PREDICATES,
+                    SendRawTransactionValidityConfig::default(),
                 )));
             }
             extensions.push(Box::new(TxForwardingExtension::from_config(tx_fwd_config.clone())));

--- a/etc/systems/tests/tx_forwarding.rs
+++ b/etc/systems/tests/tx_forwarding.rs
@@ -37,6 +37,9 @@ const ZENITH_ACTIVATION_BLOCK: u64 = 0;
 const TX_RECEIPT_TIMEOUT: Duration = Duration::from_secs(60);
 const PENDING_TX_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Number of Denim full blocks in the default 60-second validity window.
+const VALIDITY_EXPIRY_BLOCKS: u64 = 300;
+
 /// Waits until the builder knows a transaction, proving forwarding completed.
 async fn wait_for_pending_transaction(provider: &RootProvider<Base>, tx_hash: B256) -> Result<()> {
     timeout(PENDING_TX_TIMEOUT, async {
@@ -49,6 +52,14 @@ async fn wait_for_pending_transaction(provider: &RootProvider<Base>, tx_hash: B2
     })
     .await
     .wrap_err("transaction did not become pending on the builder")?
+}
+
+/// Builds the bounded block-number expiry required for validity transaction ingress.
+fn block_expiry_bound(current_block: u64) -> ValidityPredicate {
+    ValidityPredicate::BlockNumber {
+        op: ValidityOperator::LessThanOrEqual,
+        value: U256::from(current_block.saturating_add(VALIDITY_EXPIRY_BLOCKS)),
+    }
 }
 
 /// Starts a separate mempool and builder pair using the native Denim payload builder with validity
@@ -356,6 +367,7 @@ async fn test_matching_validity_predicates_are_forwarded_and_included() -> Resul
             op: ValidityOperator::GreaterThan,
             value: U256::from(current_block),
         },
+        block_expiry_bound(current_block),
     ];
     let rpc_client = RpcClient::builder().http(system.l2_client_rpc_url()?);
 
@@ -400,6 +412,7 @@ async fn test_validity_transaction_submitted_directly_to_builder_is_included() -
     let recipient_balance_before = builder_provider.get_balance(recipient).await?;
     let (_, raw_tx, expected_tx_hash) =
         create_signed_eip1559_tx(&signer, L2_CHAIN_ID, nonce, recipient)?;
+    let current_block = builder_provider.get_block_number().await?;
     let rpc_client = RpcClient::builder().http(system.l2_rpc_url()?);
     let tx_hash: B256 = rpc_client
         .request(
@@ -407,11 +420,14 @@ async fn test_validity_transaction_submitted_directly_to_builder_is_included() -
             (
                 raw_tx,
                 SendRawTransactionValidityOptions {
-                    validity: vec![ValidityPredicate::Balance {
-                        address: sender,
-                        op: ValidityOperator::GreaterThan,
-                        value: U256::ZERO,
-                    }],
+                    validity: vec![
+                        ValidityPredicate::Balance {
+                            address: sender,
+                            op: ValidityOperator::GreaterThan,
+                            value: U256::ZERO,
+                        },
+                        block_expiry_bound(current_block),
+                    ],
                 },
             ),
         )
@@ -449,6 +465,7 @@ async fn test_eip8130_validity_transaction_is_included_by_native_builder() -> Re
     let nonce_sequence = client_provider.get_transaction_count(sender).await?;
     let (raw_tx, expected_tx_hash) =
         create_signed_eip8130_tx(&signer, L2_CHAIN_ID, nonce_sequence)?;
+    let current_block = client_provider.get_block_number().await?;
     let rpc_client = RpcClient::builder().http(system.l2_client_rpc_url()?);
     let tx_hash: B256 = rpc_client
         .request(
@@ -456,11 +473,14 @@ async fn test_eip8130_validity_transaction_is_included_by_native_builder() -> Re
             (
                 raw_tx,
                 SendRawTransactionValidityOptions {
-                    validity: vec![ValidityPredicate::Balance {
-                        address: sender,
-                        op: ValidityOperator::GreaterThan,
-                        value: U256::ZERO,
-                    }],
+                    validity: vec![
+                        ValidityPredicate::Balance {
+                            address: sender,
+                            op: ValidityOperator::GreaterThan,
+                            value: U256::ZERO,
+                        },
+                        block_expiry_bound(current_block),
+                    ],
                 },
             ),
         )
@@ -496,6 +516,7 @@ async fn test_validity_transaction_lands_after_balance_predicate_becomes_true() 
     let recipient: Address = "0x000000000000000000000000000000000000dEaD".parse()?;
     let (_, raw_validity_tx, validity_tx_hash) =
         create_signed_eip1559_tx(&validity_signer, L2_CHAIN_ID, validity_nonce, recipient)?;
+    let current_block = client_provider.get_block_number().await?;
     let rpc_client = RpcClient::builder().http(system.l2_client_rpc_url()?);
     let submitted_hash: B256 = rpc_client
         .request(
@@ -503,11 +524,14 @@ async fn test_validity_transaction_lands_after_balance_predicate_becomes_true() 
             (
                 raw_validity_tx,
                 SendRawTransactionValidityOptions {
-                    validity: vec![ValidityPredicate::Balance {
-                        address: watched,
-                        op: ValidityOperator::GreaterThanOrEqual,
-                        value: U256::from(1),
-                    }],
+                    validity: vec![
+                        ValidityPredicate::Balance {
+                            address: watched,
+                            op: ValidityOperator::GreaterThanOrEqual,
+                            value: U256::from(1),
+                        },
+                        block_expiry_bound(current_block),
+                    ],
                 },
             ),
         )
@@ -583,10 +607,13 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
             (
                 raw_future_tx,
                 SendRawTransactionValidityOptions {
-                    validity: vec![ValidityPredicate::BlockNumber {
-                        op: ValidityOperator::GreaterThanOrEqual,
-                        value: U256::from(target_block),
-                    }],
+                    validity: vec![
+                        ValidityPredicate::BlockNumber {
+                            op: ValidityOperator::GreaterThanOrEqual,
+                            value: U256::from(target_block),
+                        },
+                        block_expiry_bound(current_block),
+                    ],
                 },
             ),
         )
@@ -621,13 +648,16 @@ async fn test_validity_block_predicates_defer_and_expire_transactions() -> Resul
             (
                 raw_storage_tx,
                 SendRawTransactionValidityOptions {
-                    validity: vec![ValidityPredicate::Storage {
-                        address: recipient,
-                        slot: U256::from(1),
-                        mask: U256::MAX,
-                        op: ValidityOperator::Equal,
-                        value: U256::from(2),
-                    }],
+                    validity: vec![
+                        ValidityPredicate::Storage {
+                            address: recipient,
+                            slot: U256::from(1),
+                            mask: U256::MAX,
+                            op: ValidityOperator::Equal,
+                            value: U256::from(2),
+                        },
+                        block_expiry_bound(current_block),
+                    ],
                 },
             ),
         )


### PR DESCRIPTION
## Summary

- require every `base_sendRawTransactionValidity` submission to include a finite `block_number` upper bound (`<`, `<=`, or `=`)
- reject already-expired bounds and bounds beyond the configurable maximum lifetime; the default is 60 seconds
- convert that duration using the full-block cadence: 30 blocks before Denim and 300 after Denim; the first Denim build uses the 200ms cadence
- add `--experimental-validity-max-expiry-secs` and retain submitted predicates unchanged

## Validation

- `cargo test -p base-execution-txpool --lib` (262 passed, 3 ignored)
- `cargo test -p base-txpool-rpc --lib` (26 passed)
- `cargo test -p base-execution-cli --lib` (74 passed)
- `cargo clippy -p base-execution-txpool -p base-txpool-rpc -p base-execution-cli --all-targets -- -D warnings`
- `cargo fmt --all`

Closes CHAIN-4932.

Generated with Toshi
