### PR TITLE
feat(txpool): sort validity predicates timing-first on ingress

### DIFF
--- a/crates/execution/txpool/src/transaction.rs
+++ b/crates/execution/txpool/src/transaction.rs
@@ -97,17 +97,22 @@ impl<Cons: SignedTransaction, Pooled> BasePooledTransaction<Cons, Pooled> {
         }
     }
 
-    /// Sets the state predicates required for this transaction's inclusion.
+    /// Sets the validity predicates required for this transaction's inclusion.
+    ///
+    /// Predicates are stored in canonical evaluation order (timing before
+    /// state) via [`crate::ValidityPredicate::sort_batch`], so every ingress
+    /// path yields transactions whose cheap timing predicates gate state reads.
     #[must_use]
     pub fn with_validity_predicates(
         mut self,
-        validity_predicates: Vec<crate::ValidityPredicate>,
+        mut validity_predicates: Vec<crate::ValidityPredicate>,
     ) -> Self {
+        crate::ValidityPredicate::sort_batch(&mut validity_predicates);
         self.validity_predicates = validity_predicates;
         self
     }
 
-    /// Returns the state predicates required for this transaction's inclusion.
+    /// Returns the validity predicates required for this transaction's inclusion.
     #[must_use]
     pub fn validity_predicates(&self) -> &[crate::ValidityPredicate] {
         &self.validity_predicates

--- a/crates/execution/txpool/src/validity.rs
+++ b/crates/execution/txpool/src/validity.rs
@@ -345,6 +345,26 @@ impl ValidityPredicate {
         }
         upper.and_then(|bound| u64::try_from(bound).ok())
     }
+
+    /// Stable-sorts a predicate batch into canonical evaluation order: timing
+    /// predicates ([`Self::BlockNumber`], [`Self::FlashblockIndex`]) before state
+    /// predicates ([`Self::Balance`], [`Self::Storage`]). The batch is a pure
+    /// conjunction, so reordering only affects cost: a timing mismatch
+    /// short-circuits before any state read and parks under a context key that
+    /// per-transaction state changes never wake.
+    pub fn sort_batch(predicates: &mut [Self]) {
+        predicates.sort_by_key(Self::evaluation_rank);
+    }
+
+    /// Returns the canonical evaluation rank: block number, then flashblock
+    /// index, then state predicates.
+    const fn evaluation_rank(&self) -> u8 {
+        match self {
+            Self::BlockNumber { .. } => 0,
+            Self::FlashblockIndex { .. } => 1,
+            Self::Balance { .. } | Self::Storage { .. } => 2,
+        }
+    }
 }
 
 /// Experimental validity predicates carried with a validated transaction.
@@ -602,6 +622,81 @@ mod tests {
         let transaction = extension.apply(transaction).unwrap();
 
         assert_eq!(transaction.validity_predicates(), expected);
+    }
+
+    #[test]
+    fn sort_batch_orders_timing_predicates_before_state_predicates() {
+        let balance = |value: u64| ValidityPredicate::Balance {
+            address: Address::ZERO,
+            op: ValidityOperator::Equal,
+            value: U256::from(value),
+        };
+        let flashblock_index = ValidityPredicate::FlashblockIndex {
+            op: ValidityOperator::LessThan,
+            value: U256::from(5),
+        };
+        let block_number = ValidityPredicate::BlockNumber {
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: U256::from(100),
+        };
+        let storage = ValidityPredicate::Storage {
+            address: Address::ZERO,
+            slot: U256::ZERO,
+            mask: U256::MAX,
+            op: ValidityOperator::Equal,
+            value: U256::ZERO,
+        };
+        // Scrambled submission order.
+        let mut predicates = vec![
+            balance(1),
+            storage.clone(),
+            flashblock_index.clone(),
+            balance(2),
+            block_number.clone(),
+        ];
+
+        ValidityPredicate::sort_batch(&mut predicates);
+
+        // Timing predicates (block number, then flashblock index) lead; state
+        // predicates follow in stable submission order.
+        assert_eq!(predicates, [block_number, flashblock_index, balance(1), storage, balance(2)]);
+    }
+
+    #[test]
+    fn apply_stores_predicates_in_canonical_evaluation_order() {
+        let signed: BaseTransactionSigned = TxDeposit {
+            source_hash: Default::default(),
+            from: Address::ZERO,
+            to: TxKind::Create,
+            mint: 0,
+            value: U256::ZERO,
+            gas_limit: 21_000,
+            input: Default::default(),
+            is_system_transaction: false,
+        }
+        .into();
+        let encoded_length = signed.encode_2718_len();
+        let transaction = BasePooledTransaction::new(
+            Recovered::new_unchecked(signed, Address::ZERO),
+            encoded_length,
+        );
+        let state_predicate = ValidityPredicate::Balance {
+            address: Address::ZERO,
+            op: ValidityOperator::Equal,
+            value: U256::ZERO,
+        };
+        let timing_predicate = ValidityPredicate::BlockNumber {
+            op: ValidityOperator::GreaterThanOrEqual,
+            value: U256::from(100),
+        };
+        // Submitted state-first; stored timing-first.
+        let extension = TransactionValidity {
+            validity: vec![state_predicate.clone(), timing_predicate.clone()],
+        };
+
+        let transaction = extension.apply(transaction).unwrap();
+
+        assert_eq!(transaction.validity_predicates(), [timing_predicate, state_predicate]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Validity predicate batches are a pure conjunction, so evaluation order only affects cost — yet today predicates evaluate in submission order. A transaction mixing timing and state predicates could park under a **state** blocker even when its timing predicate was the one that could never hold this flashblock, causing pointless state re-reads after every transaction touching that account/slot.

This PR stable-sorts each predicate batch into canonical evaluation order on attachment — `block_number` → `flashblock_index` → `balance`/`storage` — so:

- A timing mismatch short-circuits before any state read.
- A timing-blocked transaction parks under a `BlockNumber`/`FlashblockIndex` context key, which `ParkedPredicateIndex::affected_by_state` never wakes; it resurfaces only as a fresh candidate next flashblock, where re-checking it is just integer comparisons.
- State predicates are evaluated only once the transaction is temporally relevant.

Sorting lives in `BasePooledTransaction::with_validity_predicates`, the single chokepoint shared by the mempool RPC (`base_sendRawTransactionValidity`) and builder (`TransactionValidity::apply`) ingress paths, and runs after validation so reported predicate indexes still match submission order. Expiry semantics (`is_batch_expired`, `BlockExpiryIndex`) are order-independent and unchanged.

## Testing

- New unit tests: `sort_batch_orders_timing_predicates_before_state_predicates` (order + stability within a class) and `apply_stores_predicates_in_canonical_evaluation_order`.
- `cargo test -p base-execution-txpool` (259 passed), `base-execution-payload-builder` (103), `base-builder-core` (66); clippy and fmt clean.

Generated with Toshi