### PR TITLE
ci: stop verifying releases on pull requests

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,7 +1,6 @@
 name: Verify Release
 
 on:
-  pull_request:
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Remove the `pull_request` trigger from the Verify Release workflow. Release verification remains available when a release is published and through manual dispatch.

## Root cause

The failures were unrelated to Depot or missing signatures. v1.3.2 was published at 22:22 UTC, while its release build did not upload assets until 00:08 UTC. During that window, every PR ran the workflow against the ambient latest release and failed because it had no assets yet.

The Depot release jobs successfully completed archive signing and SLSA attestation. Once upload completed, all 12 published archives passed checksum, GPG signature, and SLSA provenance verification.

## Verification

- `git diff --check`
- `GH_TOKEN="$(gh auth token)" GITHUB_TOKEN="$(gh auth token)" bash baseup/baseup verify-release -i v1.3.2`
