### PR TITLE
fix(proof): keep the Cobalt ZK guest no_std and gate precompile timing on metrics

### DIFF
--- a/crates/common/evm/Cargo.toml
+++ b/crates/common/evm/Cargo.toml
@@ -89,6 +89,7 @@ serde = [
 reth = [ "dep:reth-evm", "std" ]
 metrics = [
 	"base-metrics/metrics",
+	"base-common-precompiles/metrics",
 	"dep:base-metrics",
 	"dep:metrics",
 	"reth-evm?/metrics",

--- a/crates/common/evm/Cargo.toml
+++ b/crates/common/evm/Cargo.toml
@@ -88,8 +88,8 @@ serde = [
 ]
 reth = [ "dep:reth-evm", "std" ]
 metrics = [
-	"base-metrics/metrics",
 	"base-common-precompiles/metrics",
+	"base-metrics/metrics",
 	"dep:base-metrics",
 	"dep:metrics",
 	"reth-evm?/metrics",

--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -70,6 +70,7 @@ std = [
 	"alloy-primitives/std",
 	"alloy-sol-types/std",
 	"base-common-chains/std",
+	"base-common-eip8130/std",
 	"base-common-genesis/std",
 	"base-precompile-storage/std",
 	"revm/std",

--- a/crates/common/precompiles/Cargo.toml
+++ b/crates/common/precompiles/Cargo.toml
@@ -91,3 +91,5 @@ test-utils = [
 	"base-common-genesis/test-utils",
 	"base-precompile-storage/test-utils",
 ]
+# Node-only wall-clock call timing. Leave off in zkVM guests.
+metrics = [ "std" ]

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -690,10 +690,12 @@ mod tests {
     use alloy_sol_types::{SolCall, SolError, SolInterface};
     use base_precompile_storage::{BasePrecompileError, PrecompileError, PrecompileOutput};
 
+    #[cfg(not(feature = "metrics"))]
+    use crate::PrecompileCallTimer;
     use crate::{
         CALLDATA_WORD_GAS, IActivationRegistry, IB20, IB20Asset, IB20Factory, IPolicyRegistry,
         NoopPrecompileCallObserver, PrecompileCallRecorder, PrecompileCallStatus,
-        PrecompileCallTimer, PrecompileErrorKind, PrecompileMetricLabels, PrecompileSelector,
+        PrecompileErrorKind, PrecompileMetricLabels, PrecompileSelector,
     };
 
     #[cfg(not(feature = "metrics"))]

--- a/crates/common/precompiles/src/metrics.rs
+++ b/crates/common/precompiles/src/metrics.rs
@@ -1,7 +1,7 @@
 //! Low-cardinality metadata for observing native precompile calls.
 
 use alloc::{borrow::Cow, string::ToString};
-#[cfg(feature = "std")]
+#[cfg(feature = "metrics")]
 use std::time::Instant;
 
 use alloy_primitives::Bytes;
@@ -542,33 +542,35 @@ impl PrecompileMetricLabels {
 }
 
 /// Call timer used by precompile call recorders.
+///
+/// Wall-clock timing is gated on `metrics`. zkVM guests leave that feature off.
 #[derive(Debug)]
 pub struct PrecompileCallTimer {
-    #[cfg(feature = "std")]
+    #[cfg(feature = "metrics")]
     start: Instant,
 }
 
 impl PrecompileCallTimer {
     /// Starts a new call timer.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "metrics")]
     pub fn start() -> Self {
         Self { start: Instant::now() }
     }
 
     /// Starts a new no-op call timer.
-    #[cfg(not(feature = "std"))]
+    #[cfg(not(feature = "metrics"))]
     pub const fn start() -> Self {
         Self {}
     }
 
-    /// Returns elapsed wall-clock time in seconds when std timing is available.
-    #[cfg(feature = "std")]
+    /// Returns elapsed wall-clock time in seconds when metrics timing is available.
+    #[cfg(feature = "metrics")]
     pub fn elapsed_seconds(&self) -> Option<f64> {
         Some(self.start.elapsed().as_secs_f64())
     }
 
-    /// Returns no elapsed wall-clock time when std timing is unavailable.
-    #[cfg(not(feature = "std"))]
+    /// Returns no elapsed wall-clock time when metrics timing is unavailable.
+    #[cfg(not(feature = "metrics"))]
     pub const fn elapsed_seconds(&self) -> Option<f64> {
         None
     }
@@ -595,13 +597,13 @@ where
     O: crate::PrecompileCallObserver,
 {
     /// Starts a recorder for a precompile call.
-    #[cfg(feature = "std")]
+    #[cfg(feature = "metrics")]
     pub fn start(observer: O, call: PrecompileCallMetric) -> Self {
         Self { observer, timer: PrecompileCallTimer::start(), call, error: None }
     }
 
     /// Starts a recorder for a precompile call.
-    #[cfg(not(feature = "std"))]
+    #[cfg(not(feature = "metrics"))]
     pub const fn start(observer: O, call: PrecompileCallMetric) -> Self {
         Self { observer, timer: PrecompileCallTimer::start(), call, error: None }
     }
@@ -691,8 +693,14 @@ mod tests {
     use crate::{
         CALLDATA_WORD_GAS, IActivationRegistry, IB20, IB20Asset, IB20Factory, IPolicyRegistry,
         NoopPrecompileCallObserver, PrecompileCallRecorder, PrecompileCallStatus,
-        PrecompileErrorKind, PrecompileMetricLabels, PrecompileSelector,
+        PrecompileCallTimer, PrecompileErrorKind, PrecompileMetricLabels, PrecompileSelector,
     };
+
+    #[cfg(not(feature = "metrics"))]
+    #[test]
+    fn call_timer_is_noop_without_metrics() {
+        assert_eq!(PrecompileCallTimer::start().elapsed_seconds(), None);
+    }
 
     #[test]
     fn b20_method_labels_strip_precompile_prefixes() {

--- a/crates/execution/txpool/Cargo.toml
+++ b/crates/execution/txpool/Cargo.toml
@@ -75,6 +75,7 @@ tokio = { workspace = true, features = ["time", "rt-multi-thread", "macros"] }
 default = [ "metrics" ]
 metrics = [
 	"base-common-evm/metrics",
+	"base-common-precompiles/metrics",
 	"base-metrics/metrics",
 	"base-observability-events/metrics",
 	"dep:metrics",

--- a/crates/proof/proof/Cargo.toml
+++ b/crates/proof/proof/Cargo.toml
@@ -93,6 +93,5 @@ std = [
 	"thiserror/std",
 	"tracing/std",
 ]
-# EIP-8130 execution in the EVM without Tokio (`std` pulls Tokio). SP1 range
-# guests enable this; bare-metal FPVM builds (`check-no-std-proof`) leave it off.
+# 8130 without Tokio. Off in guests until Everest; do not pair with `metrics`.
 evm-std = [ "base-common-evm/std" ]

--- a/crates/proof/zk/programs/succinct/range/ethereum/Cargo.toml
+++ b/crates/proof/zk/programs/succinct/range/ethereum/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 rkyv.workspace = true
 
 # base-consensus / base-proof
-# EIP-8130 execution without Tokio (`base-proof/std` pulls Tokio).
-base-proof = { workspace = true, features = ["evm-std"] }
+# Cobalt guests stay no_std. `evm-std` (8130 without Tokio) waits for Everest.
+base-proof.workspace = true
 
 # sp1
 sp1-zkvm.workspace = true

--- a/etc/systems/tests/activation_registry.rs
+++ b/etc/systems/tests/activation_registry.rs
@@ -13,7 +13,9 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolCall, SolEvent};
 use base_common_precompiles::{ActivationFeature, ActivationRegistryStorage, IActivationRegistry};
 use base_common_rpc_types::BaseTransactionReceipt;
-use base_system_tests::{ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, B20PrecompileClient};
+use base_system_tests::{
+    ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, B20PrecompileClient, SystemTestStackBuilder,
+};
 use eyre::{Result, WrapErr};
 
 /// `isActivated` returns `false` for every feature id by default.
@@ -90,7 +92,7 @@ async fn test_activation_registry_set_admin_reverts_before_cobalt() -> Result<()
 /// At Cobalt, `setAdmin` updates the stored admin and future activation authority.
 #[tokio::test]
 async fn test_activation_registry_cobalt_admin_rotation() -> Result<()> {
-    let (_system, provider) = cobalt::start_cobalt_system().await?;
+    let (_system, provider) = cobalt::start_cobalt_stack(SystemTestStackBuilder::new()).await?;
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test admin private key")?;
     let new_admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_6.private_key)

--- a/etc/systems/tests/b20_zk.rs
+++ b/etc/systems/tests/b20_zk.rs
@@ -1,0 +1,102 @@
+//! System test that dry-run proves a block containing a B-20 transaction.
+
+#[path = "common/balance.rs"]
+mod balance;
+#[path = "common/beryl.rs"]
+mod beryl;
+#[path = "common/cobalt.rs"]
+mod cobalt;
+#[path = "common/zk_dry_run.rs"]
+mod zk_dry_run;
+mod common;
+
+use alloy_network::ReceiptResponse;
+use alloy_primitives::{B256, U256};
+use alloy_provider::RootProvider;
+use alloy_signer_local::PrivateKeySigner;
+use base_common_network::Base;
+use base_common_precompiles::{ActivationFeature, B20Variant, IB20};
+use base_common_rpc_types::BaseTransactionReceipt;
+use base_optimism_rpc::OptimismRollupProviderExt;
+use base_system_tests::{
+    ANVIL_ACCOUNT_5, ANVIL_ACCOUNT_6, B20PrecompileClient, InProcessProverService, InProcessZkHost,
+    SystemTestStackBuilder,
+};
+use eyre::{Result, WrapErr, ensure};
+
+const INITIAL_SUPPLY: u64 = 1_000_000_000;
+const TRANSFER_AMOUNT: u64 = 100_000_000;
+
+/// Dry-run SP1-executes a block that called the B-20 precompile.
+///
+/// Confirms native precompile dispatch proves in the `no_std` Cobalt guest.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "SP1 dry-run execute is too slow for merge-queue; run with --release"]
+async fn b20_block_dry_run_proves() -> Result<()> {
+    ensure!(
+        !cfg!(debug_assertions),
+        "SP1 dry-run execute does not finish in the unoptimized test profile. Re-run with --release:\n\
+         cargo nextest run --release -p base-system-tests --run-ignored all \\\n\
+         -E 'test(b20_block_dry_run)'"
+    );
+
+    let (system, provider) =
+        cobalt::start_cobalt_stack(SystemTestStackBuilder::new().with_force_batch_submission())
+            .await?;
+    let receipt = send_b20_transfer(&provider).await?;
+    let block_number = receipt.block_number().expect("mined B-20 transfer must have a block");
+
+    let rollup_provider =
+        RootProvider::<Base>::new_http(system.l2_stack().builder_consensus_rpc_url());
+    zk_dry_run::wait_for_safe_l2(&rollup_provider, block_number).await?;
+
+    let service = InProcessProverService::start().await?;
+    let _host = InProcessZkHost::start(&system, service.url()).await?;
+
+    // Pin rollup `head_l1`; local L1 finality lags the batches that made this block safe.
+    let l1_head = rollup_provider.optimism_sync_status().await?.head_l1.hash;
+    let stats = zk_dry_run::prove_block_range_with_dry_run_stats(
+        service.url().clone(),
+        block_number,
+        l1_head,
+        "b20-zk-dry-run",
+    )
+    .await?;
+    ensure!(
+        stats.total_instruction_cycles > 0,
+        "dry-run of a B-20 block must report non-zero instruction cycles"
+    );
+
+    Ok(())
+}
+
+async fn send_b20_transfer(provider: &RootProvider<Base>) -> Result<BaseTransactionReceipt> {
+    let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
+        .wrap_err("Failed to parse system test private key")?;
+    let recipient = ANVIL_ACCOUNT_6.address;
+    beryl::wait_for_balance(provider, admin.address()).await?;
+
+    let b20 = B20PrecompileClient::new(provider, &admin, common::L2_CHAIN_ID)
+        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
+    b20.activate_feature(ActivationFeature::B20Asset.id()).await?;
+
+    let params = B20PrecompileClient::token_params(
+        "ZK B20",
+        "ZKB20",
+        admin.address(),
+        U256::from(INITIAL_SUPPLY),
+        admin.address(),
+    );
+    let token = b20.create_token(B20Variant::Asset, params, B256::repeat_byte(0x21)).await?;
+    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+
+    let receipt = b20
+        .send_call_receipt(
+            token,
+            IB20::transferCall { to: recipient, amount: U256::from(TRANSFER_AMOUNT) },
+            "transfer B-20 token",
+        )
+        .await?;
+    ensure!(receipt.status(), "B-20 transfer receipt must report success");
+    Ok(receipt)
+}

--- a/etc/systems/tests/b20_zk.rs
+++ b/etc/systems/tests/b20_zk.rs
@@ -6,9 +6,9 @@ mod balance;
 mod beryl;
 #[path = "common/cobalt.rs"]
 mod cobalt;
+mod common;
 #[path = "common/zk_dry_run.rs"]
 mod zk_dry_run;
-mod common;
 
 use alloy_network::ReceiptResponse;
 use alloy_primitives::{B256, U256};

--- a/etc/systems/tests/b20_zk.rs
+++ b/etc/systems/tests/b20_zk.rs
@@ -2,8 +2,6 @@
 
 #[path = "common/balance.rs"]
 mod balance;
-#[path = "common/beryl.rs"]
-mod beryl;
 #[path = "common/cobalt.rs"]
 mod cobalt;
 mod common;
@@ -74,10 +72,10 @@ async fn send_b20_transfer(provider: &RootProvider<Base>) -> Result<BaseTransact
     let admin = PrivateKeySigner::from_bytes(&ANVIL_ACCOUNT_5.private_key)
         .wrap_err("Failed to parse system test private key")?;
     let recipient = ANVIL_ACCOUNT_6.address;
-    beryl::wait_for_balance(provider, admin.address()).await?;
+    balance::wait_for_balance(provider, admin.address()).await?;
 
     let b20 = B20PrecompileClient::new(provider, &admin, common::L2_CHAIN_ID)
-        .with_receipt_timeout(beryl::TX_RECEIPT_TIMEOUT);
+        .with_receipt_timeout(balance::TX_RECEIPT_TIMEOUT);
     b20.activate_feature(ActivationFeature::B20Asset.id()).await?;
 
     let params = B20PrecompileClient::token_params(
@@ -88,7 +86,8 @@ async fn send_b20_transfer(provider: &RootProvider<Base>) -> Result<BaseTransact
         admin.address(),
     );
     let token = b20.create_token(B20Variant::Asset, params, B256::repeat_byte(0x21)).await?;
-    b20.wait_for_token_code(token, beryl::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL).await?;
+    b20.wait_for_token_code(token, balance::TX_RECEIPT_TIMEOUT, common::BLOCK_POLL_INTERVAL)
+        .await?;
 
     let receipt = b20
         .send_call_receipt(

--- a/etc/systems/tests/common/cobalt.rs
+++ b/etc/systems/tests/common/cobalt.rs
@@ -16,11 +16,6 @@ pub(crate) const BASE_COBALT_ACTIVATION_BLOCK: u64 = 5;
 ///
 /// The returned [`SystemTestStack`] must be kept alive for the duration of the test;
 /// dropping it shuts down the underlying containers.
-pub(crate) async fn start_cobalt_system() -> Result<(SystemTestStack, RootProvider<Base>)> {
-    start_cobalt_stack(SystemTestStackBuilder::new()).await
-}
-
-/// Same as [`start_cobalt_system`], with extra [`SystemTestStackBuilder`] options applied first.
 pub(crate) async fn start_cobalt_stack(
     builder: SystemTestStackBuilder,
 ) -> Result<(SystemTestStack, RootProvider<Base>)> {

--- a/etc/systems/tests/common/zk_dry_run.rs
+++ b/etc/systems/tests/common/zk_dry_run.rs
@@ -1,0 +1,159 @@
+//! Shared SP1 dry-run prove helpers for system tests.
+
+use std::time::Duration;
+
+use alloy_eips::BlockNumberOrTag;
+use alloy_primitives::B256;
+use alloy_provider::RootProvider;
+use base_common_network::Base;
+use base_optimism_rpc::OptimismRollupProviderExt;
+use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
+use base_prover_service_protocol::{
+    ExecutionStats, GetProofRequest, GetProofResponse, ProofRequest, ProofRequestKind, ProofResult,
+    ProofStatus, ProveBlockRangeRequest, ZkBackend, ZkProofRequest, ZkVm,
+};
+use eyre::{Result, WrapErr};
+use nanoid::nanoid;
+use tokio::time::{sleep, timeout};
+use url::Url;
+
+const SAFE_L2_TIMEOUT: Duration = Duration::from_secs(120);
+const SAFE_L2_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const PROOF_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const PROOF_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Waits until `block_number` is safe and has an output root.
+pub(crate) async fn wait_for_safe_l2(
+    provider: &RootProvider<Base>,
+    block_number: u64,
+) -> Result<()> {
+    match timeout(SAFE_L2_TIMEOUT, async {
+        loop {
+            let status = provider.optimism_sync_status().await?;
+            if status.safe_l2.number >= block_number {
+                provider.optimism_output_at_block(BlockNumberOrTag::Number(block_number)).await?;
+                return Ok::<_, eyre::Error>(());
+            }
+            sleep(SAFE_L2_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            let status = provider.optimism_sync_status().await?;
+            eyre::bail!(
+                "timed out waiting for block {block_number} to become safe \
+                 (safe_l2={}, unsafe_l2={})",
+                status.safe_l2.number,
+                status.unsafe_l2.number
+            );
+        }
+    }
+}
+
+/// Dry-run proves a one-block range ending at `block_number`.
+pub(crate) async fn prove_block_range_with_dry_run_stats(
+    prover_url: Url,
+    block_number: u64,
+    l1_head: B256,
+    session_prefix: &str,
+) -> Result<ExecutionStats> {
+    let start_block_number = block_number
+        .checked_sub(1)
+        .ok_or_else(|| eyre::eyre!("cannot prove genesis block with one-block range"))?;
+    let client_config = ProverServiceClientConfig::new(prover_url.as_str())
+        .with_request_timeout(Duration::from_secs(30));
+    let client = ProofRequesterClient::connect(&client_config)?;
+    let session_id = format!("{session_prefix}-{}", nanoid!());
+    let response = client
+        .prove_block_range(ProveBlockRangeRequest {
+            proof: ProofRequest {
+                session_id,
+                request: ProofRequestKind::Compressed(ZkProofRequest {
+                    start_block_number,
+                    number_of_blocks_to_prove: 1,
+                    sequence_window: None,
+                    l1_head: Some(l1_head),
+                    intermediate_root_interval: None,
+                    schedule_l2_block_number: None,
+                    zk_vm: ZkVm::Sp1,
+                    zk_backend: ZkBackend::DryRun,
+                }),
+            },
+            retry_failed: true,
+        })
+        .await?;
+
+    poll_dry_run_stats(&client, response.session_id).await
+}
+
+async fn poll_dry_run_stats(
+    client: &ProofRequesterClient,
+    session_id: String,
+) -> Result<ExecutionStats> {
+    let timeout_session_id = session_id.clone();
+    match timeout(PROOF_TIMEOUT, async {
+        loop {
+            let response =
+                client.get_proof(GetProofRequest { session_id: session_id.clone() }).await?;
+            match response.status {
+                ProofStatus::Succeeded => {
+                    return execution_stats_from_response(&session_id, response);
+                }
+                ProofStatus::Failed => {
+                    return Err(eyre::eyre!(
+                        "proof request failed: {}",
+                        response
+                            .error_message
+                            .unwrap_or_else(|| "missing error message".to_string())
+                    ));
+                }
+                _ => sleep(PROOF_POLL_INTERVAL).await,
+            }
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => {
+            let last = client
+                .get_proof(GetProofRequest { session_id: timeout_session_id.clone() })
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "timed out waiting for proof request {timeout_session_id}; \
+                         also failed to fetch last status"
+                    )
+                })?;
+            eyre::bail!(
+                "timed out waiting for proof request {timeout_session_id} \
+                 (status={:?}, error={})",
+                last.status,
+                last.error_message.unwrap_or_else(|| "none".to_string())
+            );
+        }
+    }
+}
+
+fn execution_stats_from_response(
+    session_id: &str,
+    response: GetProofResponse,
+) -> Result<ExecutionStats> {
+    match response.result {
+        Some(ProofResult::Compressed(result)) => result.execution_stats.ok_or_else(|| {
+            eyre::eyre!(
+                "dry-run prover response for request {session_id} did not include execution_stats"
+            )
+        }),
+        Some(ProofResult::SnarkPlonk(_)) => Err(eyre::eyre!(
+            "dry-run prover response for request {session_id} returned snark_plonk result"
+        )),
+        Some(ProofResult::Tee(_)) => {
+            Err(eyre::eyre!("dry-run prover response for request {session_id} returned tee result"))
+        }
+        None => Err(eyre::eyre!(
+            "dry-run prover response for request {session_id} did not include a result"
+        )),
+    }
+}

--- a/etc/systems/tests/eip8130.rs
+++ b/etc/systems/tests/eip8130.rs
@@ -2,14 +2,14 @@
 
 #[path = "common/balance.rs"]
 mod balance;
+#[path = "common/zk_dry_run.rs"]
+mod zk_dry_run;
 mod common;
 #[path = "common/zenith.rs"]
 mod zenith;
 
-use std::time::Duration;
-
 use alloy_consensus::Typed2718;
-use alloy_eips::{BlockNumberOrTag, eip2718::Encodable2718};
+use alloy_eips::eip2718::Encodable2718;
 use alloy_network::ReceiptResponse;
 use alloy_primitives::{B256, Bytes, U256};
 use alloy_provider::{Provider, RootProvider};
@@ -19,26 +19,14 @@ use base_common_consensus::{Eip8130Signed, TxEip8130};
 use base_common_network::Base;
 use base_common_rpc_types::BaseTransactionReceipt;
 use base_optimism_rpc::OptimismRollupProviderExt;
-use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
-use base_prover_service_protocol::{
-    ExecutionStats, GetProofRequest, GetProofResponse, ProofRequest, ProofRequestKind, ProofResult,
-    ProofStatus, ProveBlockRangeRequest, ZkBackend, ZkProofRequest, ZkVm,
-};
 use base_system_tests::{
     ANVIL_ACCOUNT_1, InProcessProverService, InProcessZkHost, SystemTestProviderExt,
     SystemTestStackBuilder,
 };
 use eyre::{Result, WrapErr, ensure};
-use nanoid::nanoid;
-use tokio::time::{sleep, timeout};
-use url::Url;
 
 /// EIP-8130 transaction type byte.
 const EIP8130_TX_TYPE: u8 = 0x79;
-const SAFE_L2_TIMEOUT: Duration = Duration::from_secs(120);
-const SAFE_L2_POLL_INTERVAL: Duration = Duration::from_millis(500);
-const PROOF_TIMEOUT: Duration = Duration::from_secs(15 * 60);
-const PROOF_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Mines a minimal EOA-path EIP-8130 transaction on the Zenith system-test stack.
 #[tokio::test]
@@ -62,8 +50,10 @@ async fn eip8130_transaction_is_mined() -> Result<()> {
 }
 
 /// Dry-run SP1-executes the block that contains a type `0x79` transaction.
+///
+/// Guest 8130 execution is deferred to Everest (Cobalt ZK stays `no_std`).
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "SP1 dry-run execute is too slow for merge-queue; run with --release"]
+#[ignore = "8130 guest execution is deferred to Everest; also too slow for merge-queue"]
 async fn eip8130_block_dry_run_proves() -> Result<()> {
     ensure!(
         !cfg!(debug_assertions),
@@ -81,15 +71,20 @@ async fn eip8130_block_dry_run_proves() -> Result<()> {
 
     let rollup_provider =
         RootProvider::<Base>::new_http(system.l2_stack().builder_consensus_rpc_url());
-    wait_for_safe_l2(&rollup_provider, block_number).await?;
+    zk_dry_run::wait_for_safe_l2(&rollup_provider, block_number).await?;
 
     let service = InProcessProverService::start().await?;
     let _host = InProcessZkHost::start(&system, service.url()).await?;
 
     // Pin rollup `head_l1`; local L1 finality lags the batches that made this block safe.
     let l1_head = rollup_provider.optimism_sync_status().await?.head_l1.hash;
-    let stats =
-        prove_block_range_with_dry_run_stats(service.url().clone(), block_number, l1_head).await?;
+    let stats = zk_dry_run::prove_block_range_with_dry_run_stats(
+        service.url().clone(),
+        block_number,
+        l1_head,
+        "eip8130-zk-dry-run",
+    )
+    .await?;
     ensure!(
         stats.total_instruction_cycles > 0,
         "dry-run of an EIP-8130 block must report non-zero instruction cycles"
@@ -142,134 +137,4 @@ async fn send_minimal_eip8130(
         .await
         .wrap_err("EIP-8130 receipt timed out")?;
     Ok((tx_hash, receipt))
-}
-
-async fn wait_for_safe_l2(provider: &RootProvider<Base>, block_number: u64) -> Result<()> {
-    match timeout(SAFE_L2_TIMEOUT, async {
-        loop {
-            let status = provider.optimism_sync_status().await?;
-            if status.safe_l2.number >= block_number {
-                provider.optimism_output_at_block(BlockNumberOrTag::Number(block_number)).await?;
-                return Ok::<_, eyre::Error>(());
-            }
-            sleep(SAFE_L2_POLL_INTERVAL).await;
-        }
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(_) => {
-            let status = provider.optimism_sync_status().await?;
-            eyre::bail!(
-                "timed out waiting for EIP-8130 block {block_number} to become safe \
-                 (safe_l2={}, unsafe_l2={})",
-                status.safe_l2.number,
-                status.unsafe_l2.number
-            );
-        }
-    }
-}
-
-async fn prove_block_range_with_dry_run_stats(
-    prover_url: Url,
-    block_number: u64,
-    l1_head: B256,
-) -> Result<ExecutionStats> {
-    let start_block_number = block_number
-        .checked_sub(1)
-        .ok_or_else(|| eyre::eyre!("cannot prove genesis block with one-block range"))?;
-    let client_config = ProverServiceClientConfig::new(prover_url.as_str())
-        .with_request_timeout(Duration::from_secs(30));
-    let client = ProofRequesterClient::connect(&client_config)?;
-    let session_id = format!("eip8130-zk-dry-run-{}", nanoid!());
-    let response = client
-        .prove_block_range(ProveBlockRangeRequest {
-            proof: ProofRequest {
-                session_id,
-                request: ProofRequestKind::Compressed(ZkProofRequest {
-                    start_block_number,
-                    number_of_blocks_to_prove: 1,
-                    sequence_window: None,
-                    l1_head: Some(l1_head),
-                    intermediate_root_interval: None,
-                    schedule_l2_block_number: None,
-                    zk_vm: ZkVm::Sp1,
-                    zk_backend: ZkBackend::DryRun,
-                }),
-            },
-            retry_failed: true,
-        })
-        .await?;
-
-    poll_dry_run_stats(&client, response.session_id).await
-}
-
-async fn poll_dry_run_stats(
-    client: &ProofRequesterClient,
-    session_id: String,
-) -> Result<ExecutionStats> {
-    let timeout_session_id = session_id.clone();
-    match timeout(PROOF_TIMEOUT, async {
-        loop {
-            let response =
-                client.get_proof(GetProofRequest { session_id: session_id.clone() }).await?;
-            match response.status {
-                ProofStatus::Succeeded => {
-                    return execution_stats_from_response(&session_id, response);
-                }
-                ProofStatus::Failed => {
-                    return Err(eyre::eyre!(
-                        "proof request failed: {}",
-                        response
-                            .error_message
-                            .unwrap_or_else(|| "missing error message".to_string())
-                    ));
-                }
-                _ => sleep(PROOF_POLL_INTERVAL).await,
-            }
-        }
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(_) => {
-            let last = client
-                .get_proof(GetProofRequest { session_id: timeout_session_id.clone() })
-                .await
-                .wrap_err_with(|| {
-                    format!(
-                        "timed out waiting for proof request {timeout_session_id}; \
-                         also failed to fetch last status"
-                    )
-                })?;
-            eyre::bail!(
-                "timed out waiting for proof request {timeout_session_id} \
-                 (status={:?}, error={})",
-                last.status,
-                last.error_message.unwrap_or_else(|| "none".to_string())
-            );
-        }
-    }
-}
-
-fn execution_stats_from_response(
-    session_id: &str,
-    response: GetProofResponse,
-) -> Result<ExecutionStats> {
-    match response.result {
-        Some(ProofResult::Compressed(result)) => result.execution_stats.ok_or_else(|| {
-            eyre::eyre!(
-                "dry-run prover response for request {session_id} did not include execution_stats"
-            )
-        }),
-        Some(ProofResult::SnarkPlonk(_)) => Err(eyre::eyre!(
-            "dry-run prover response for request {session_id} returned snark_plonk result"
-        )),
-        Some(ProofResult::Tee(_)) => {
-            Err(eyre::eyre!("dry-run prover response for request {session_id} returned tee result"))
-        }
-        None => Err(eyre::eyre!(
-            "dry-run prover response for request {session_id} did not include a result"
-        )),
-    }
 }

--- a/etc/systems/tests/eip8130.rs
+++ b/etc/systems/tests/eip8130.rs
@@ -2,11 +2,11 @@
 
 #[path = "common/balance.rs"]
 mod balance;
-#[path = "common/zk_dry_run.rs"]
-mod zk_dry_run;
 mod common;
 #[path = "common/zenith.rs"]
 mod zenith;
+#[path = "common/zk_dry_run.rs"]
+mod zk_dry_run;
 
 use alloy_consensus::Typed2718;
 use alloy_eips::eip2718::Encodable2718;

--- a/etc/systems/tests/in_process_zk.rs
+++ b/etc/systems/tests/in_process_zk.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use base_prover_service_client::{ProofRequesterClient, ProverServiceClientConfig};
 use base_prover_service_protocol::GetProofRequest;
-use base_system_tests::{InProcessProverService, InProcessZkHost};
+use base_system_tests::{InProcessProverService, InProcessZkHost, SystemTestStackBuilder};
 use eyre::{Result, WrapErr, bail, ensure};
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -24,7 +24,7 @@ async fn in_process_prover_and_zk_host_start() -> Result<()> {
         .try_init();
 
     info!("starting Cobalt stack");
-    let (system, _provider) = cobalt::start_cobalt_system().await?;
+    let (system, _provider) = cobalt::start_cobalt_stack(SystemTestStackBuilder::new()).await?;
 
     info!("starting in-process prover-service");
     let service = InProcessProverService::start().await?;


### PR DESCRIPTION
## Summary
`evm-std` pulled `Instant::now()` into native precompile dispatch. Cobalt does not need 8130 in the guest, so leave `evm-std` off until Everest and only start the wall-clock timer when node metrics are enabled.


Made with [Cursor](https://cursor.com)