### PR TITLE
fix(rpc): simulate Denim block timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11015,7 +11015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
 dependencies = [
  "bincode 1.3.3",
- "derive_more 2.1.1",
+ "derive_more 1.0.0",
  "iai-callgrind-macros",
  "iai-callgrind-runner",
 ]
@@ -11026,7 +11026,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
 dependencies = [
- "derive_more 2.1.1",
+ "derive_more 1.0.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -16106,7 +16106,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16133,7 +16133,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16164,7 +16164,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16184,7 +16184,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -16197,7 +16197,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16286,7 +16286,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -16296,7 +16296,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16347,7 +16347,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -16364,7 +16364,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16378,7 +16378,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16391,7 +16391,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16416,7 +16416,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -16445,7 +16445,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16471,7 +16471,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-genesis",
@@ -16501,7 +16501,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -16516,7 +16516,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16541,7 +16541,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -16565,7 +16565,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -16589,7 +16589,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16624,7 +16624,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16681,7 +16681,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -16708,7 +16708,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16731,7 +16731,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16758,7 +16758,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -16814,7 +16814,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16844,7 +16844,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16862,7 +16862,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -16878,7 +16878,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -16902,7 +16902,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -16913,7 +16913,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -16942,7 +16942,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -16968,7 +16968,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -16984,7 +16984,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17000,7 +17000,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks 0.4.7",
@@ -17014,7 +17014,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17044,7 +17044,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17058,7 +17058,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -17068,7 +17068,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17094,7 +17094,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17114,7 +17114,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -17132,7 +17132,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -17145,7 +17145,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17164,7 +17164,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17202,7 +17202,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "eyre",
@@ -17234,7 +17234,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -17248,7 +17248,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "serde",
  "serde_json",
@@ -17258,7 +17258,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17284,7 +17284,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "bytes",
  "futures",
@@ -17304,7 +17304,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -17321,7 +17321,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -17330,7 +17330,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "futures",
  "libc",
@@ -17344,7 +17344,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -17353,7 +17353,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -17367,7 +17367,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17426,7 +17426,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17451,7 +17451,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17475,7 +17475,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -17490,7 +17490,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -17504,7 +17504,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -17521,7 +17521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -17545,7 +17545,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17613,7 +17613,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17668,7 +17668,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17717,7 +17717,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17741,7 +17741,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17765,7 +17765,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "bytes",
  "eyre",
@@ -17794,7 +17794,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -17806,7 +17806,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17830,7 +17830,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -17842,7 +17842,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -17865,7 +17865,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17875,7 +17875,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-rpc-types-engine",
@@ -17918,7 +17918,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -17968,7 +17968,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -17995,7 +17995,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18011,7 +18011,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -18026,7 +18026,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -18102,7 +18102,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-genesis",
@@ -18132,7 +18132,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-network 2.4.1",
  "alloy-provider",
@@ -18175,7 +18175,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-evm",
@@ -18195,7 +18195,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18226,7 +18226,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-dyn-abi",
@@ -18273,7 +18273,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-chains",
  "alloy-consensus 2.4.1",
@@ -18324,7 +18324,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.2",
@@ -18338,7 +18338,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18369,7 +18369,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18420,7 +18420,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18448,7 +18448,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -18462,7 +18462,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -18482,7 +18482,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -18497,7 +18497,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eip7928 0.4.5",
@@ -18523,7 +18523,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18540,7 +18540,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-eips 2.4.1",
  "alloy-primitives",
@@ -18567,7 +18567,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -18588,7 +18588,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18604,7 +18604,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -18614,7 +18614,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "clap",
  "eyre",
@@ -18634,7 +18634,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -18653,7 +18653,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18696,7 +18696,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-eips 2.4.1",
@@ -18722,7 +18722,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-consensus 2.4.1",
  "alloy-primitives",
@@ -18749,7 +18749,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -18765,7 +18765,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -18789,7 +18789,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/base/reth?tag=base-v2.5.2.3#76a826109009c936c2ea98766e0b6b50d2803d26"
+source = "git+https://github.com/base/reth?rev=09cee98aa90ee1affe7b0585c7c76b012bf9d200#09cee98aa90ee1affe7b0585c7c76b012bf9d200"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,72 +342,72 @@ alloy-network-primitives = { version = "2.3.0", default-features = false }
 reth-zstd-compressors = { version = "0.6.0", default-features = false }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-codecs = { version = "0.6.0", default-features = false, features = ["alloy"] }
-reth-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-cli = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-ipc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-evm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-rpc = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-revm = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-trie = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-exex = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-tasks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-ecies = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-db-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-discv4 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-discv5 = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-trie-db = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-rpc-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-network = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-net-nat = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-tracing = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-eth-wire = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-provider = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-cli-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-node-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-db-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-rpc-layer = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-node-core = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-consensus = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-chainspec = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-cli-runner = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-rpc-convert = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-network-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-network-p2p = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-storage-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-rpc-eth-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-chain-state = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-trie-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-payload-util = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-node-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-node-metrics = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-cli-commands = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-evm-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-tracing-otlp = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-testing-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-rpc-eth-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-network-peers = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-node-ethereum = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-rpc-engine-api = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-e2e-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-eth-wire-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-execution-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-execution-cache = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-exex-test-utils = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-rpc-server-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-transaction-pool = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-execution-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-payload-validator = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-payload-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-ethereum-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-basic-payload-builder = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-payload-builder-primitives = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
-reth-prune-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
-reth-stages-types = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
-reth-storage-errors = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
-reth-ethereum-forks = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
-reth-consensus-common = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3", default-features = false }
-reth-trie-parallel = { git = "https://github.com/base/reth", tag = "base-v2.5.2.3" }
+reth-db = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-cli = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-ipc = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-evm = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-rpc = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-revm = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-trie = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-exex = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-tasks = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-ecies = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-db-api = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-discv4 = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-discv5 = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-trie-db = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-rpc-api = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-network = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-net-nat = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-tracing = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-eth-wire = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-provider = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-cli-util = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-node-api = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-db-common = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-rpc-layer = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-node-core = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-consensus = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-chainspec = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-cli-runner = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-rpc-convert = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-network-api = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-network-p2p = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-storage-api = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-rpc-eth-api = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-chain-state = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-trie-common = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-payload-util = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-node-builder = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-node-metrics = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-cli-commands = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-evm-ethereum = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-tracing-otlp = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-testing-utils = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-rpc-eth-types = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-network-peers = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-node-ethereum = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-rpc-engine-api = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-e2e-test-utils = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-eth-wire-types = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-payload-builder = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-execution-types = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-execution-cache = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-exex-test-utils = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-rpc-server-types = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-transaction-pool = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-execution-errors = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-payload-validator = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-payload-primitives = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-ethereum-primitives = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-basic-payload-builder = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-payload-builder-primitives = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
+reth-prune-types = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200", default-features = false }
+reth-stages-types = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200", default-features = false }
+reth-storage-errors = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200", default-features = false }
+reth-ethereum-forks = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200", default-features = false }
+reth-consensus-common = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200", default-features = false }
+reth-trie-parallel = { git = "https://github.com/base/reth", rev = "09cee98aa90ee1affe7b0585c7c76b012bf9d200" }
 
 # tokio
 tokio = "1.53.1"

--- a/crates/execution/rpc/src/eth/call.rs
+++ b/crates/execution/rpc/src/eth/call.rs
@@ -1,3 +1,7 @@
+use alloy_consensus::BlockHeader;
+use base_common_chains::BaseUpgrade;
+use base_protocol::BaseTimeUpdateTx;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec, Hardforks};
 use reth_rpc_eth_api::{
     FromEvmError, RpcConvert,
     helpers::{Call, EthCall, estimate::EstimateCall},
@@ -27,6 +31,46 @@ where
     BaseEthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = BaseEthApiError, Evm = N::Evm>,
 {
+    fn next_simulate_block_timestamp(
+        &self,
+        _parent_number: u64,
+        parent_timestamp: u64,
+        block_number: u64,
+        timestamp_increment: u64,
+    ) -> u64 {
+        let chain_spec = self.provider().chain_spec();
+        let Some(denim_timestamp) = chain_spec.fork(BaseUpgrade::Denim).as_timestamp() else {
+            return parent_timestamp.saturating_add(timestamp_increment);
+        };
+
+        let genesis = chain_spec.genesis_header();
+        let legacy_block_time = timestamp_increment.max(1);
+        let activation_offset =
+            denim_timestamp.saturating_sub(genesis.timestamp()).div_ceil(legacy_block_time);
+        let activation_block = genesis.number().saturating_add(activation_offset);
+
+        if block_number < activation_block {
+            return parent_timestamp.saturating_add(timestamp_increment);
+        }
+
+        let activation_timestamp =
+            genesis.timestamp().saturating_add(activation_offset.saturating_mul(legacy_block_time));
+        let blocks_since_activation = block_number.saturating_sub(activation_block);
+        activation_timestamp.saturating_add(
+            blocks_since_activation
+                .saturating_mul(u64::from(BaseTimeUpdateTx::BLOCK_INTERVAL_MILLIS))
+                / 1_000,
+        )
+    }
+
+    fn is_simulate_block_timestamp_valid(&self, timestamp: u64, parent_timestamp: u64) -> bool {
+        let denim = self.provider().chain_spec().fork(BaseUpgrade::Denim);
+        timestamp > parent_timestamp
+            || (timestamp == parent_timestamp
+                && denim.active_at_timestamp(timestamp)
+                && denim.active_at_timestamp(parent_timestamp))
+    }
+
     #[inline]
     fn call_gas_limit(&self) -> u64 {
         self.inner.eth_api.gas_cap()


### PR DESCRIPTION
Depends on base/reth#19.

Uses Base's deterministic Denim schedule when `eth_simulateV1` fills omitted block timestamps, and accepts equal consecutive whole-second timestamps once Denim is active. This keeps simulated `block.timestamp`, fork selection, and timestamp-dependent fee calculation aligned with the 200ms block cadence.

The Reth dependency is pinned to the review commit for this draft and should move to the next Base Reth tag before merge.