### PR TITLE
fix(sequencer): initialize the transaction event journal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,7 @@ dependencies = [
  "base-execution-evm",
  "base-node-core",
  "base-node-runner",
+ "base-observability-events",
  "base-shadow-indexer",
  "base-txpool-rpc",
  "base-upgrade-signal",

--- a/bin/base/Cargo.toml
+++ b/bin/base/Cargo.toml
@@ -33,6 +33,7 @@ base-builder-metering.workspace = true
 base-builder-multiplex.workspace = true
 base-execution-chainspec.workspace = true
 base-execution-consensus.workspace = true
+base-observability-events.workspace = true
 base-shadow-indexer.workspace = true
 
 # alloy

--- a/bin/base/src/commands/sequencer.rs
+++ b/bin/base/src/commands/sequencer.rs
@@ -15,6 +15,7 @@ use base_execution_cli::{
     ExecutionNodeConfigArgs, StandardBaseRethNode, chainspec::chain_value_parser,
 };
 use base_node_runner::BaseNodeRunner;
+use base_observability_events::GlobalTransactionEventWriter;
 use base_shadow_indexer::{ShadowIndexerConfig, ShadowIndexerExtension};
 use base_txpool_rpc::{
     SendRawTransactionValidityConfig, SendRawTransactionValidityExtension, TxPoolRpcConfig,
@@ -73,6 +74,16 @@ impl SequencerCommand {
         let sequencer_rpc = rollup_args.sequencer.clone();
         let metering_provider: base_builder_core::SharedMeteringProvider =
             Arc::new(builder.build_metering_store());
+        // Mirrors `bin/builder`: `BuilderArgs` carries the transaction-event journal
+        // settings, but the writer is a process-global that only emits once initialized.
+        // Without this the integrated sequencer parses
+        // `--builder.transaction-events.*` / `BUILDER_TRANSACTION_EVENTS_*` and then
+        // silently discards every event. Runs before the extensions install below so
+        // node-started hooks that emit events see a ready writer.
+        let transaction_events_enabled = builder.transaction_events.enabled;
+        GlobalTransactionEventWriter::init(
+            transaction_events_enabled.then(|| builder.transaction_events.writer_config()),
+        )?;
         let builder_api_config = builder.builder_api_config()?;
         // Build the shadow-indexer config before `into_builder_config` consumes `builder`. The
         // config carries an `enabled` flag (false unless ENABLE_SHADOW_INDEXER is set), so the


### PR DESCRIPTION
## Summary

`base sequencer` accepts the transaction-event journal configuration and then silently discards every event.

The command flattens `BuilderArgs`, so clap parses `--builder.transaction-events.*` / `BUILDER_TRANSACTION_EVENTS_*` into `builder.transaction_events` — but it never calls `GlobalTransactionEventWriter::init`. The writer is a process-global that drops events until initialized, so the configuration looks correct in `docker inspect` while nothing is ever written.

Only three call sites initialize the writer today:

| | |
|---|---|
| `bin/builder/src/main.rs:42` | standalone builder |
| `bin/ingress-rpc/src/main.rs:77` | TIPS ingress |
| `crates/execution/cli/src/standard_node.rs:662` | standard node |

The devnet's `base-builder` runs `base --chain dev sequencer ...`, which is none of them.

## Observed impact

On a devnet with `BUILDER_TRANSACTION_EVENTS_ENABLED=true` and `../../.devnet/transaction-events` mounted into both nodes:

```
$ docker inspect base-builder --format '{{range .Config.Env}}{{println .}}{{end}}' | grep TRANSACTION_EVENTS
BUILDER_TRANSACTION_EVENTS_NETWORK=base-devnet
BUILDER_TRANSACTION_EVENTS_PATH=/var/log/transaction-events/base-builder/events.jsonl
BUILDER_TRANSACTION_EVENTS_ENABLED=true

$ docker exec base-builder ls /var/log/transaction-events/
base-client
```

The mount is present and writable — the builder can see `base-client/` in it — but `base-builder/` is never created. Meanwhile `base-client`, which goes through `standard_node.rs`, journaled 1528 `TXPOOL_SEND_RAW_TRANSACTION_VALIDITY` events over the same period.

Confirmed with a live submission: `base_sendRawTransactionValidity` through proxyd (which routes the method to the builder) returned a transaction hash, so the tx was admitted and the event fired — but no journal file appeared.

Anything downstream of the journals inherits the gap, including the vector → `transaction-events-postgres` audit pipeline, since `etc/docker/transaction-events-vector.yaml` tails `/var/log/transaction-events/*/events.jsonl`. On a sequencer-based deployment there is no record of transactions admitted at the builder.

## Change

Mirror `bin/builder/src/main.rs:41-43` — init from the same args, in the same position relative to `metering_provider`, before extensions install so node-started hooks that emit events see a ready writer (the ordering `standard_node.rs:664` documents).

`required` flows through `writer_config()` unchanged, so the default stays best-effort and startup behavior is unaffected when the journal is disabled.

## Testing

- `rustfmt --check` clean.
- Verified statically: `Args::transaction_events` (`crates/builder/cli/src/args.rs:304`), the `GlobalTransactionEventWriter` re-export (`observability-events/src/lib.rs:14`), and `init(Option<TransactionEventWriterConfig>) -> eyre::Result<_>` against `run()`'s `eyre::Result<()>`.
- **Not compile-tested** — no room for a workspace build on the machine I wrote this on. Please confirm CI is green before merging.

## Questions for reviewers

1. Was the omission deliberate — is the integrated sequencer expected to journal by some other route? I found none, but "not wired up yet" and "intentionally excluded" look the same in the source.
2. I only checked `sequencer`. Do other `bin/base` subcommands that flatten `BuilderArgs` have the same gap?
