### PR TITLE
feat(chains): Accept Legacy Chain Name Aliases

### DIFF
--- a/bin/base/src/config.rs
+++ b/bin/base/src/config.rs
@@ -22,7 +22,9 @@ pub(crate) const BASE_CHAIN_ENV_PREFIX: &str = "BASE_CHAIN_";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ChainArg {
     /// Use one of the built-in static chains, identified by its Base network
-    /// selector (`mainnet`, `sepolia`, `zeronet`, `dev`).
+    /// selector (`mainnet`, `sepolia`, `zeronet`, `dev`). Legacy namespaced
+    /// names (`base`, `base-sepolia`, `base-zeronet`) are accepted for backwards
+    /// compatibility and normalized to the selector.
     BuiltIn(String),
     /// Load chain settings from a TOML file.
     File(PathBuf),
@@ -39,11 +41,21 @@ impl FromStr for ChainArg {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let selector = value.to_ascii_lowercase();
-        Ok(if ChainConfig::from_base_chain(&selector).is_some() {
-            Self::BuiltIn(selector)
-        } else {
-            Self::File(PathBuf::from(value))
-        })
+        // Accept both the Base-centric selectors (`mainnet`/`sepolia`/`zeronet`/
+        // `dev`) and the legacy namespaced names (`base`/`base-sepolia`/
+        // `base-zeronet`/`dev`) used by the former split `base-reth-node`,
+        // normalizing either to the canonical selector so the rest of the
+        // pipeline only ever sees a selector. Anything unrecognized is treated as
+        // a path to a TOML chain config file.
+        Ok(
+            match ChainConfig::from_base_chain(&selector)
+                .or_else(|| ChainConfig::by_name(&selector))
+                .and_then(ChainConfig::base_chain_selector)
+            {
+                Some(selector) => Self::BuiltIn(selector.to_owned()),
+                None => Self::File(PathBuf::from(value)),
+            },
+        )
     }
 }
 
@@ -260,6 +272,49 @@ mod tests {
             assert_eq!(resolved.l2_chain_id, 84538453);
             assert_eq!(resolved.l1_chain_id, 1337);
             assert_eq!(resolved.source, ResolvedChainSource::BuiltIn("dev".to_owned()));
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn from_str_normalizes_legacy_names_to_selectors() {
+        // Legacy namespaced names (the former `base-reth-node` `--chain` surface)
+        // normalize to the Base-centric selectors.
+        assert_eq!("base".parse::<ChainArg>().unwrap(), ChainArg::BuiltIn("mainnet".to_owned()));
+        assert_eq!(
+            "base-sepolia".parse::<ChainArg>().unwrap(),
+            ChainArg::BuiltIn("sepolia".to_owned())
+        );
+        assert_eq!(
+            "base-zeronet".parse::<ChainArg>().unwrap(),
+            ChainArg::BuiltIn("zeronet".to_owned())
+        );
+
+        // Base-centric selectors keep resolving as before.
+        assert_eq!("mainnet".parse::<ChainArg>().unwrap(), ChainArg::BuiltIn("mainnet".to_owned()));
+
+        // Matching is case-insensitive.
+        assert_eq!("BASE".parse::<ChainArg>().unwrap(), ChainArg::BuiltIn("mainnet".to_owned()));
+
+        // Unrecognized values are still treated as TOML file paths.
+        assert_eq!(
+            "./chain.toml".parse::<ChainArg>().unwrap(),
+            ChainArg::File(PathBuf::from("./chain.toml"))
+        );
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn resolves_legacy_base_name_to_mainnet() {
+        with_cleared_env(|_| {
+            let chain: ChainArg = "base".parse().unwrap();
+            let resolved = ChainResolver::new(Some(chain)).resolve().unwrap();
+
+            assert_eq!(resolved.name, "mainnet");
+            assert_eq!(resolved.l2_chain_id, 8453);
+            assert_eq!(resolved.l1_chain_id, 1);
+            assert_eq!(resolved.source, ResolvedChainSource::BuiltIn("mainnet".to_owned()));
 
             Ok(())
         });

--- a/bin/base/src/config.rs
+++ b/bin/base/src/config.rs
@@ -47,15 +47,13 @@ impl FromStr for ChainArg {
         // normalizing either to the canonical selector so the rest of the
         // pipeline only ever sees a selector. Anything unrecognized is treated as
         // a path to a TOML chain config file.
-        Ok(
-            match ChainConfig::from_base_chain(&selector)
-                .or_else(|| ChainConfig::by_name(&selector))
-                .and_then(ChainConfig::base_chain_selector)
-            {
-                Some(selector) => Self::BuiltIn(selector.to_owned()),
-                None => Self::File(PathBuf::from(value)),
-            },
-        )
+        Ok(ChainConfig::from_base_chain(&selector)
+            .or_else(|| ChainConfig::by_name(&selector))
+            .and_then(ChainConfig::base_chain_selector)
+            .map_or_else(
+                || Self::File(PathBuf::from(value)),
+                |selector| Self::BuiltIn(selector.to_owned()),
+            ))
     }
 }
 

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -251,6 +251,25 @@ impl ChainConfig {
         }
     }
 
+    /// Returns the Base-centric operator selector (`mainnet`, `sepolia`,
+    /// `zeronet`, `dev`) for this chain — the inverse of
+    /// [`from_base_chain`](Self::from_base_chain).
+    ///
+    /// Use this to normalize any recognized chain input back to the canonical
+    /// selector understood by the `base` binary's `--chain` surface, for example
+    /// `from_base_chain(x).or_else(|| by_name(x)).and_then(Self::base_chain_selector)`.
+    ///
+    /// Returns `None` for chains that have no built-in selector.
+    pub fn base_chain_selector(&self) -> Option<&'static str> {
+        match self.chain_id {
+            8453 => Some("mainnet"),
+            84532 => Some("sepolia"),
+            763360 => Some("zeronet"),
+            84538453 => Some("dev"),
+            _ => None,
+        }
+    }
+
     /// Looks up a chain config by L2 chain ID.
     pub const fn by_chain_id(id: u64) -> Option<&'static Self> {
         match id {
@@ -761,6 +780,27 @@ mod tests {
         // namespaced names matched by `by_name`.
         assert_eq!(ChainConfig::by_name("mainnet"), None);
         assert_eq!(ChainConfig::from_base_chain(ChainConfig::MAINNET_NAME), None);
+    }
+
+    #[test]
+    fn base_chain_selector_is_inverse_of_from_base_chain() {
+        // Every selector round-trips through `from_base_chain`.
+        for selector in ["mainnet", "sepolia", "zeronet", "dev"] {
+            let config = ChainConfig::from_base_chain(selector).unwrap();
+            assert_eq!(config.base_chain_selector(), Some(selector));
+        }
+
+        // Legacy namespaced names normalize to the canonical selector, letting
+        // callers accept both surfaces: `by_name(x).and_then(base_chain_selector)`.
+        assert_eq!(ChainConfig::mainnet().base_chain_selector(), Some("mainnet"));
+        assert_eq!(
+            ChainConfig::by_name("base").and_then(ChainConfig::base_chain_selector),
+            Some("mainnet")
+        );
+        assert_eq!(
+            ChainConfig::by_name("base-sepolia").and_then(ChainConfig::base_chain_selector),
+            Some("sepolia")
+        );
     }
 
     #[test]

--- a/crates/common/chains/src/config.rs
+++ b/crates/common/chains/src/config.rs
@@ -260,7 +260,7 @@ impl ChainConfig {
     /// `from_base_chain(x).or_else(|| by_name(x)).and_then(Self::base_chain_selector)`.
     ///
     /// Returns `None` for chains that have no built-in selector.
-    pub fn base_chain_selector(&self) -> Option<&'static str> {
+    pub const fn base_chain_selector(&self) -> Option<&'static str> {
         match self.chain_id {
             8453 => Some("mainnet"),
             84532 => Some("sepolia"),

--- a/crates/infra/audit/tests/common/mod.rs
+++ b/crates/infra/audit/tests/common/mod.rs
@@ -1,7 +1,6 @@
 //! Common test harness for audit integration tests with S3 fixtures.
 
-use testcontainers::runners::AsyncRunner;
-use testcontainers::ImageExt;
+use testcontainers::{ImageExt, runners::AsyncRunner};
 use testcontainers_modules::minio::MinIO;
 use uuid::Uuid;
 

--- a/crates/infra/audit/tests/common/mod.rs
+++ b/crates/infra/audit/tests/common/mod.rs
@@ -1,6 +1,7 @@
 //! Common test harness for audit integration tests with S3 fixtures.
 
 use testcontainers::runners::AsyncRunner;
+use testcontainers::ImageExt;
 use testcontainers_modules::minio::MinIO;
 use uuid::Uuid;
 
@@ -12,7 +13,9 @@ pub(crate) struct TestHarness {
 
 impl TestHarness {
     pub(crate) async fn new() -> anyhow::Result<Self> {
-        let minio_container = MinIO::default().start().await?;
+        // MinIO removed the `minio/minio` image from Docker Hub, so pull the
+        // same tag from quay.io (their current official registry) instead.
+        let minio_container = MinIO::default().with_name("quay.io/minio/minio").start().await?;
         let s3_port = minio_container.get_host_port_ipv4(9000).await?;
         let s3_endpoint = format!("http://127.0.0.1:{s3_port}");
 

--- a/crates/infra/snapshotter/tests/common/mod.rs
+++ b/crates/infra/snapshotter/tests/common/mod.rs
@@ -1,8 +1,7 @@
 //! Common test harness for snapshotter integration tests with `MinIO`.
 
 use anyhow::Result;
-use testcontainers::runners::AsyncRunner;
-use testcontainers::ImageExt;
+use testcontainers::{ImageExt, runners::AsyncRunner};
 use testcontainers_modules::minio::MinIO;
 
 pub(crate) struct TestHarness {

--- a/crates/infra/snapshotter/tests/common/mod.rs
+++ b/crates/infra/snapshotter/tests/common/mod.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Result;
 use testcontainers::runners::AsyncRunner;
+use testcontainers::ImageExt;
 use testcontainers_modules::minio::MinIO;
 
 pub(crate) struct TestHarness {
@@ -12,7 +13,9 @@ pub(crate) struct TestHarness {
 
 impl TestHarness {
     pub(crate) async fn new() -> Result<Self> {
-        let minio_container = MinIO::default().start().await?;
+        // MinIO removed the `minio/minio` image from Docker Hub, so pull the
+        // same tag from quay.io (their current official registry) instead.
+        let minio_container = MinIO::default().with_name("quay.io/minio/minio").start().await?;
         let storage_port = minio_container.get_host_port_ipv4(9000).await?;
         let storage_endpoint = format!("http://127.0.0.1:{storage_port}");
 


### PR DESCRIPTION
## Summary

The `base` binary's `--chain` flag now accepts the legacy namespaced chain names (`base`, `base-sepolia`, `base-zeronet`) in addition to the Base-centric selectors (`mainnet`, `sepolia`, `zeronet`, `dev`). Both surfaces are normalized to the canonical selector so the rest of the pipeline only ever sees a selector, preserving backwards compatibility with the former split `base-reth-node`. This is backed by a new `ChainConfig::base_chain_selector` method that inverts `from_base_chain`. Matching remains case-insensitive and unrecognized values are still treated as paths to a TOML chain config file.

Also repoints the MinIO test containers at `quay.io/minio/minio` to fix CI, since the `minio/minio` Docker Hub image was removed.

Linear: CHAIN-5270